### PR TITLE
UI統一（ハンバーガー/必須*/*?ツールチップ/生成=緑・反映=青）、loudnorm大改修（ICU/単純ゲイン分離・ハイレゾ外出し・単純ゲインをピーク基準＋軽いコンプ）、無音検出ツール追加＆index反映、バージョン表記削除

### DIFF
--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -189,6 +189,10 @@ Licensed under the Apache License, Version 2.0
       <p class="text-sm text-gray-600 mb-4">測定結果の input_tp を基準に、ピークが目標TPに到達する分だけゲインします。</p>
       <label class="block mb-2 font-semibold">目標TP (dBTP):</label>
       <input type="number" id="gainTargetTp" step="0.1" value="-1.0" class="border border-gray-300 rounded w-full p-2 mb-4">
+      <label class="inline-flex items-center gap-2 mb-4 font-semibold">
+        <input type="checkbox" id="gainUseCompressor" class="mr-2">
+        軽いコンプを追加（自然にピークを抑える）
+      </label>
     </div>
 
     <!-- 2. 測定フェーズ -->
@@ -340,11 +344,17 @@ ${outFile}`;
 
         const gain = Math.round((targetTP - inputTP) * 10) / 10;
         const gainLabel = `${gain >= 0 ? "+" : ""}${gain}dB`;
+        const useCompressor = document.getElementById("gainUseCompressor").checked;
 
         const { ar, sample_fmt, codec, rezTag } = getRezConfig();
         const tpTag = `tp${targetTP.toFixed(1).replace(".", "p")}`;
+        const compTag = useCompressor ? "comp" : "plain";
         const outFile = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${gainLabel}.wav`);
-        const cmd = `ffmpeg -i ${inputFile} -af volume=${gainLabel} -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFile}`;
+        const outFileWithComp = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${compTag}-${gainLabel}.wav`);
+        const filter = useCompressor
+          ? `volume=${gainLabel},acompressor=threshold=-20dB:ratio=2.5:attack=8:release=150`
+          : `volume=${gainLabel}`;
+        const cmd = `ffmpeg -i ${inputFile} -af "${filter}" -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFileWithComp}`;
 
         document.getElementById("gainCmd").textContent = cmd;
       } catch (e) {


### PR DESCRIPTION
ツールUIの統一: 右上ハンバーガーメニュー追加、必須表示を赤い*、?ツールチップ導入、コマンド生成=緑/反映=青のボタン色ルールを適用
ffmpeg-loudnorm-cmdline-gen.html を大幅改修: ICU/単純ゲインのタブ分離、ハイレゾ設定をタブ外へ、単純ゲインをピーク基準に変更、単純ゲインに軽いコンプ追加オプション
新ツール追加: 無音区間検出 (ffmpeg-silence-detect-gen.html) を作成し index.html に追加
バージョン表記削除: 各ツールのタイトルから (vYYYYMMDDx) を除去
ドキュメント更新: AGENTS.md と README.md に流れ/方針の追記、index.html に更新日追加