### PR TITLE
スマホ向けviewport追加 (#20)

### DIFF
--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg ファイル結合コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -7,6 +7,7 @@ Licensed under the Apache License, Version 2.0
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg Loudnorm スクリプトジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg MP4→WAV コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg 音声差し替え（WAV）コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -7,6 +7,7 @@ Licensed under the Apache License, Version 2.0
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg 無音区間検出コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg 切り出しコマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-wav2m4a-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-wav2m4a-cmdline-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg wav=>m4a コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFmpeg YouTube動画生成コマンドジェネレータ</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>local-html-tools</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -17,6 +17,7 @@ limitations under the License.
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>パスワードジェネレーター</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>


### PR DESCRIPTION
スマホ向けviewport追加
すべてのツールHTMLとトップページに viewport メタタグを追加し、スマホ表示のスケールを正しく設定。