### PR TITLE
トップページフッターに外部リンクを追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -132,6 +132,27 @@
       </div>
     </div>
 
+    <hr class="my-10 border-gray-200">
+    <footer class="text-center text-sm text-gray-600 pb-6">
+      <div class="flex flex-wrap items-center justify-center gap-4">
+        <a href="https://github.com/igapyon/local-html-tools" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
+          <svg aria-hidden="true" viewBox="0 0 16 16" class="w-4 h-4" fill="currentColor">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+          </svg>
+          <span>GitHub</span>
+        </a>
+        <span class="text-gray-300">|</span>
+        <a href="https://igapyon.github.io/local-html-tools/" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="9"/>
+            <path d="M3 12h18"/>
+            <path d="M12 3a14 14 0 0 1 0 18"/>
+            <path d="M12 3a14 14 0 0 0 0 18"/>
+          </svg>
+          <span>GitHub Pages</span>
+        </a>
+      </div>
+    </footer>
   </div>
 </body>
 </html>


### PR DESCRIPTION
タイトル:
トップページフッターに外部リンクを追加

概要:
トップページ下部に水平線とフッターを追加し、GitHub/GitHub Pages へのリンクを配置。リンクはSVGアイコン付きで表示。

変更点:
- `docs/index.html` にフッターを追加
- GitHub/GitHub Pages へのリンクを追加（SVGアイコン付き）
- ヘッダーからリンクを移動し、ページ下部に集約

影響:
- トップページの外部リンク位置が下部に変更
