### PR TITLE
Git差分ツールUI調整とボタン文言整理 / 概要: Git関連ツールの入力UIを整理し用語と配置を調整 / 変更点: pseudo-sq…

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -125,7 +125,7 @@ limitations under the License.
         </span>
       </div>
       <button type="button" onclick="generateCreateBranchCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
-        リモートからブランチ作成コマンド生成
+        ブランチ作成コマンド生成
       </button>
       <div class="relative">
         <code id="createBranchCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>

--- a/docs/git/git-remote-branch-diff.html
+++ b/docs/git/git-remote-branch-diff.html
@@ -66,44 +66,48 @@ limitations under the License.
     </div>
 
     <div class="space-y-3 mb-4">
-      <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
-        <span>ブランチA</span>
-        <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
-            例: main
+      <div class="flex flex-wrap items-center gap-2">
+        <label class="flex flex-wrap items-center gap-2 font-semibold">
+          <span>基準ブランチ</span>
+          <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
+          <span class="relative inline-flex items-center group">
+            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+              例: main
+            </span>
           </span>
-        </span>
-        <span>：</span>
-      </label>
-      <label class="flex items-center gap-2 text-sm text-gray-700">
-        <input type="checkbox" id="scopeA" class="rounded border-gray-300" checked onchange="updateRemoteState()">
-        リモートとして扱う
-      </label>
-      <input type="text" id="branchA" placeholder="例: main" class="border border-gray-300 rounded w-full p-2">
+          <span>：</span>
+        </label>
+        <input type="text" id="branchA" placeholder="例: main" class="border border-gray-300 rounded w-full sm:w-64 p-2">
+        <label class="flex items-center gap-2 text-sm text-gray-700">
+          <input type="checkbox" id="scopeA" class="rounded border-gray-300" checked onchange="updateRemoteState()">
+          リモートとして扱う
+        </label>
+      </div>
 
-      <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
-        <span>ブランチB</span>
-        <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
-            例: feature/abc
+      <div class="flex flex-wrap items-center gap-2">
+        <label class="flex flex-wrap items-center gap-2 font-semibold">
+          <span>比較ブランチ</span>
+          <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
+          <span class="relative inline-flex items-center group">
+            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+              例: feature123
+            </span>
           </span>
-        </span>
-        <span>：</span>
-      </label>
-      <label class="flex items-center gap-2 text-sm text-gray-700">
-        <input type="checkbox" id="scopeB" class="rounded border-gray-300" checked onchange="updateRemoteState()">
-        リモートとして扱う
-      </label>
-      <input type="text" id="branchB" placeholder="例: feature/abc" class="border border-gray-300 rounded w-full p-2">
+          <span>：</span>
+        </label>
+        <input type="text" id="branchB" placeholder="例: feature123" class="border border-gray-300 rounded w-full sm:w-64 p-2">
+        <label class="flex items-center gap-2 text-sm text-gray-700">
+          <input type="checkbox" id="scopeB" class="rounded border-gray-300" checked onchange="updateRemoteState()">
+          リモートとして扱う
+        </label>
+      </div>
     </div>
 
-    <div class="space-y-2 mb-4">
-      <p class="text-sm text-gray-600">出力形式</p>
-      <select id="diffMode" class="border border-gray-300 rounded w-full p-2">
+    <div class="flex flex-wrap items-center gap-2 mb-4">
+      <p class="text-sm text-gray-600">出力形式：</p>
+      <select id="diffMode" class="border border-gray-300 rounded w-full sm:w-64 p-2">
         <option value="" selected>内容差分 (git diff)</option>
         <option value="--stat">差分統計 (git diff --stat)</option>
         <option value="--name-only">変更ファイル一覧 (git diff --name-only)</option>


### PR DESCRIPTION
Git差分ツールUI調整とボタン文言整理 / 概要: Git関連ツールの入力UIを整理し用語と配置を調整 / 変更点: pseudo-squashのボタン文言簡素化、remote-diffの基準/比較ブランチ表記変更、入力欄と「リモートとして扱う」の同一行配置、出力形式ラベルとドロップダウンの横並び＋「：」追加、プレースホルダ例をfeature123に更新 / 影響: 表示・文言のみ（機能ロジック変更なし）