### PR TITLE
Git pseudo-squash ツールのコマンドシーケンスに、push直後の`git pull`を追加しました。

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -340,6 +340,7 @@ limitations under the License.
         } else {
           lines.push(`git push --force-with-lease ${quoteIfNeeded(remoteName)} ${quoteIfNeeded(workBranch)}`);
         }
+        lines.push(`git pull`);
         if (useCurrent) {
           lines.push(`git branch -m "$(git branch --show-current)" "$(git branch --show-current)-done"`);
         } else {


### PR DESCRIPTION
## Summary
Git pseudo-squash ツールのコマンドシーケンスに、push直後の`git pull`を追加しました。

## Changes
- `git push --force-with-lease`実行直後に`git pull`を追加
- push後に基点ブランチが進んでいた場合、自動的にマージされるようになった
- これにより、diverged状態（ahead/behind）を回避できます
