### PR TITLE
Git ユーザー設定コマンドジェネレータを追加 (git-config-setup.html)

### DIFF
--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -1,0 +1,210 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Git ユーザー設定コマンドジェネレータ</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-800 p-6">
+  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </svg>
+    </button>
+    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
+      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    </div>
+
+    <h1 class="text-2xl font-bold mb-6 flex flex-wrap items-center gap-2">
+      <span aria-hidden="true" class="mr-2">⚙️</span>
+      <span>Git ユーザー設定コマンドジェネレータ</span>
+      <span class="relative inline-flex items-center group">
+        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+        <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+        </span>
+      </span>
+    </h1>
+
+    <section id="checkSection" class="space-y-3 mb-6">
+      <div class="flex items-center gap-3 py-2">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="32" r="4" fill="#93C5FD"/>
+          <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
+        </svg>
+        <p class="text-base font-semibold text-gray-700">現在の設定を確認</p>
+        <span class="relative inline-flex items-center group">
+          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            設定前に現在のユーザー名とメールアドレスを確認できます。
+          </span>
+        </span>
+      </div>
+      <button type="button" onclick="generateCheckCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+        確認コマンド生成
+      </button>
+      <div class="relative">
+        <code id="checkCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
+        <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('checkCmd')">📋</button>
+      </div>
+    </section>
+
+    <hr class="my-6" />
+
+    <section id="setupSection" class="space-y-3 mb-4">
+      <div class="flex items-center gap-3 py-2">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M24 20H34" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 20H44" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <p class="text-base font-semibold text-gray-700">ユーザー情報を設定</p>
+        <span class="relative inline-flex items-center group">
+          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
+          </span>
+        </span>
+      </div>
+
+      <div class="space-y-3">
+        <div>
+          <label class="flex flex-wrap items-center gap-2 font-semibold mb-2">
+            <span>ユーザー名</span>
+            <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
+            <span class="relative inline-flex items-center group">
+              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+                Gitコミットに記録される名前です。本名またはニックネームを入力してください。
+              </span>
+            </span>
+            <span>：</span>
+          </label>
+          <input type="text" id="userName" placeholder="例: Taro Yamada" class="border border-gray-300 rounded w-full p-2">
+        </div>
+
+        <div>
+          <label class="flex flex-wrap items-center gap-2 font-semibold mb-2">
+            <span>メールアドレス</span>
+            <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
+            <span class="relative inline-flex items-center group">
+              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+                Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。
+              </span>
+            </span>
+            <span>：</span>
+          </label>
+          <input type="email" id="userEmail" placeholder="例: taro@example.com" class="border border-gray-300 rounded w-full p-2">
+        </div>
+      </div>
+    </section>
+
+    <button onclick="generateSetupCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+      設定コマンド生成
+    </button>
+
+    <div class="relative mt-4">
+      <code id="setupCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
+      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('setupCmd')">📋</button>
+    </div>
+
+    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+      コピーしました
+    </div>
+  </div>
+
+  <script>
+    function quoteIfNeeded(value) {
+      if (!value) return value;
+      if (/[^\w@%+=:,./-]/.test(value)) {
+        const escaped = value.replace(/"/g, '\\"');
+        return `"${escaped}"`;
+      }
+      return value;
+    }
+
+    function generateCheckCommand() {
+      const lines = [
+        "git config --global user.name",
+        "git config --global user.email"
+      ];
+      document.getElementById("checkCmd").textContent = lines.join("\n");
+    }
+
+    function generateSetupCommand() {
+      const userName = document.getElementById("userName").value.trim();
+      const userEmail = document.getElementById("userEmail").value.trim();
+
+      if (!userName) {
+        alert("ユーザー名を入力してください。");
+        return;
+      }
+      if (!userEmail) {
+        alert("メールアドレスを入力してください。");
+        return;
+      }
+
+      const lines = [
+        `git config --global user.name ${quoteIfNeeded(userName)}`,
+        `git config --global user.email ${quoteIfNeeded(userEmail)}`
+      ];
+      document.getElementById("setupCmd").textContent = lines.join("\n");
+    }
+
+    function copyToClipboard(id) {
+      const text = document.getElementById(id).textContent;
+      if (!text) return;
+      const temp = document.createElement("textarea");
+      temp.value = text;
+      document.body.appendChild(temp);
+      temp.select();
+      document.execCommand("copy");
+      document.body.removeChild(temp);
+      showToast("コピーしました");
+    }
+
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.remove("opacity-0", "pointer-events-none");
+      toast.classList.add("opacity-100");
+      setTimeout(() => {
+        toast.classList.remove("opacity-100");
+        toast.classList.add("opacity-0", "pointer-events-none");
+      }, 2000);
+    }
+
+    function toggleMenu() {
+      const panel = document.getElementById("menuPanel");
+      if (!panel) return;
+      panel.classList.toggle("hidden");
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
    Git ユーザー設定コマンドジェネレータを追加 (git-config-setup.html)
    
    グローバル設定でユーザー名とメールアドレスを設定するためのコマンド生成ツール。
    - 現在の設定を確認するコマンド（git config --global user.name/email）を生成
    - グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成
    - 既存ツール（git-pseudo-squash.html）と同じUIパターンを踏襲
    