### PR TITLE
git-pseudo-squash: PowerShellチェックの配置調整とdiff出力のPowerShell対応

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -250,18 +250,30 @@ limitations under the License.
           <input type="text" id="workBranch" placeholder="例: tiga0129a" class="border border-gray-300 rounded w-full p-2">
         </div>
       </div>
-      <label class="flex items-center gap-2 text-sm text-gray-700">
-        <input type="checkbox" id="lockOrigin" class="rounded border-gray-300" checked onchange="toggleOriginLock()">
-        リモート + origin で作業
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
-            よくある利用方法として リモートと origin の組み合わせでの利用です。通常はこのままで OK です。
-            複数リモートを使い分ける場合だけ外して、対象のリモート名に切り替えます。
-            チェックを外すと、基点のリモート名と squash 用リモート名を個別に指定できます。
+      <div class="flex flex-wrap items-center gap-3 text-sm text-gray-700">
+        <label class="flex items-center gap-2">
+          <input type="checkbox" id="lockOrigin" class="rounded border-gray-300" checked onchange="toggleOriginLock()">
+          リモート + origin で作業
+          <span class="relative inline-flex items-center group">
+            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+            <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              よくある利用方法として リモートと origin の組み合わせでの利用です。通常はこのままで OK です。
+              複数リモートを使い分ける場合だけ外して、対象のリモート名に切り替えます。
+              チェックを外すと、基点のリモート名と squash 用リモート名を個別に指定できます。
+            </span>
           </span>
-        </span>
-      </label>
+        </label>
+        <label class="flex items-center gap-2">
+          <input type="checkbox" id="shellEnvPowerShell" class="rounded border-gray-300">
+          PowerShell
+          <span class="relative inline-flex items-center group">
+            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+            <span class="absolute left-1/2 top-full mt-2 tooltip-wide -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              Windows PowerShell 用のコマンドを出力します。オフの場合は macOS / Linux の bash / zsh を想定します。
+            </span>
+          </span>
+        </label>
+      </div>
       <div id="baseRemoteRow" class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
         <div class="flex flex-wrap items-center gap-2">
           <label class="flex flex-wrap items-center gap-2 font-semibold text-gray-700">
@@ -402,16 +414,6 @@ limitations under the License.
             <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
             <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
               push --force-with-lease でコミット整理を反映した後、リモートと同期（pull）し、ブランチを -done サフィックスでリネームするコマンドが続きます。ローカルでコミットが1つにまとまっているため、GitHubのPRではsquashせず通常のmergeで完了です。
-            </span>
-          </span>
-        </label>
-        <label class="flex items-center gap-2 text-sm text-gray-700">
-          <input type="checkbox" id="shellEnvPowerShell" class="rounded border-gray-300">
-          PowerShell
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 tooltip-wide -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
-              Windows PowerShell 用のコマンドを出力します。オフの場合は macOS / Linux の bash / zsh を想定します。
             </span>
           </span>
         </label>
@@ -684,8 +686,11 @@ limitations under the License.
         lines.push(`git fetch ${quoteIfNeeded(baseRemote, shellEnv)}`);
       }
       lines.push(`git diff ${quoteIfNeeded(base, shellEnv)}..${quoteIfNeeded(target, shellEnv)}`);
-      lines.push(`echo ##基点ブランチのコミットID`);
-      lines.push(`git rev-parse ${quoteIfNeeded(base, shellEnv)}`);
+      if (shellEnv === "powershell") {
+        lines.push(`Write-Host ("## Base branch commit ID: " + (git rev-parse ${quoteIfNeeded(base, shellEnv)}))`);
+      } else {
+        lines.push(`echo "## Base branch commit ID: $(git rev-parse ${quoteIfNeeded(base, shellEnv)})"`);
+      }
       lines.push(`git status -sb`);
       output.textContent = lines.join("\n");
     }


### PR DESCRIPTION
## 概要
git-pseudo-squash のUIと「まとめる予定の作業 (diff)」出力をPowerShell向けに調整。

## 変更点
- 「リモート + origin で作業」チェックの右側に PowerShell チェックを移動
- diff出力で Base branch commit ID の表示を英語化し、rev-parse結果を1行に埋め込み
- PowerShell選択時は Write-Host を使うよう分岐