### PR TITLE
READMEの現状反映とpseudo-squashのチェックボックス順調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 - 基本はローカル動作で、インターネット接続は不要（※一部ツールはオンライン取得あり）
 - Static Web App（静的HTML/CSS/JSのみ）として構成され、サーバは不要
 - 各ツールは単一HTMLで完結して動作
-- 基本の流れ：「入力 → コマンド生成 → （必要に応じて）実行結果貼り付け → 次のステップのコマンド生成」で、画面要素は上から下へ流れに沿って並ぶ
-- ツールによっては「入力 → コマンド生成」だけで完結するものもある
+- 基本の流れ：「入力 → 生成 → （必要に応じて）実行結果貼り付け → 次のステップの生成」で、画面要素は上から下へ流れに沿って並ぶ
+- ツールによっては「入力 → 生成」だけで完結するものもある
 - **ベンダリング**: CSSフレームワークなどの外部CDN依存をできる限り排除し、必要な機能は自前で実装して完全オフライン化を実現しています
 
 ### UI設計ルール
@@ -131,7 +131,7 @@ Git補助ツールです。
 
 ## GitHub Pages
 
-GitHub Pages で公開する場合は `docs/index.html` が入口になります。ツール本体は `docs/ffmpeg/`、`docs/git/`、`docs/link/`、`docs/password/`、`docs/grep/`、`docs/img/`、`docs/life/` 配下にあります。  
+GitHub Pages で公開する場合は `docs/index.html` が入口になります。ツール本体は `docs/ffmpeg/`、`docs/git/`、`docs/link/`、`docs/password/`、`docs/grep/`、`docs/img/`、`docs/text/`、`docs/life/` 配下にあります。  
 公開URL: https://igapyon.github.io/local-html-tools/
 
 ## Third-Party Notices
@@ -142,6 +142,6 @@ GitHub Pages で公開する場合は `docs/index.html` が入口になります
 
 本リポジトリのライセンスは `LICENSE` を参照してください。
 
-## 将来の拡張
+## ツール群の構成
 
-このプロジェクトは将来的に FFmpeg 以外のツール群にも対応する予定です。現状の FFmpeg 系ツールはその一部です。
+本プロジェクトは複数カテゴリのツールで構成されており、FFmpeg、Git、リンク管理、パスワード、grep、画像、生活系などが並列に含まれます。FFmpeg 系ツールはその一部です。

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -252,6 +252,16 @@ limitations under the License.
       </div>
       <div class="flex flex-wrap items-center gap-3 text-sm text-gray-700">
         <label class="flex items-center gap-2">
+          <input type="checkbox" id="shellEnvPowerShell" class="rounded border-gray-300">
+          PowerShell
+          <span class="relative inline-flex items-center group">
+            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
+            <span class="absolute left-1/2 top-full mt-2 tooltip-wide -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              Windows PowerShell 用のコマンドを出力します。オフの場合は macOS / Linux の bash / zsh を想定します。
+            </span>
+          </span>
+        </label>
+        <label class="flex items-center gap-2">
           <input type="checkbox" id="lockOrigin" class="rounded border-gray-300" checked onchange="toggleOriginLock()">
           リモート + origin で作業
           <span class="relative inline-flex items-center group">
@@ -260,16 +270,6 @@ limitations under the License.
               よくある利用方法として リモートと origin の組み合わせでの利用です。通常はこのままで OK です。
               複数リモートを使い分ける場合だけ外して、対象のリモート名に切り替えます。
               チェックを外すと、基点のリモート名と squash 用リモート名を個別に指定できます。
-            </span>
-          </span>
-        </label>
-        <label class="flex items-center gap-2">
-          <input type="checkbox" id="shellEnvPowerShell" class="rounded border-gray-300">
-          PowerShell
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 tooltip-wide -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
-              Windows PowerShell 用のコマンドを出力します。オフの場合は macOS / Linux の bash / zsh を想定します。
             </span>
           </span>
         </label>


### PR DESCRIPTION
概要: READMEの記述を現状のツール構成に合わせ、git-pseudo-squashのUIチェックボックス順を整理しました。 変更点:

基本フローの説明を「コマンド生成」から汎用的な「生成」表現に変更
GitHub Pagesのツール配置に docs/text/ を追記
READMEの「将来の拡張」を現状のツール群構成説明に置換
git-pseudo-squash のチェックボックス順を「PowerShell → リモート + origin」で並べ替え