### PR TITLE
Material Design準拠に全面リファクタ（git-pseudo-squash.html）

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -19,13 +19,8 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git pseudo-squash コマンドジェネレータ</title>
+  
   <style>
-    /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
-    */
     :root {
       --md-sys-color-primary: #6200ee;
       --md-sys-color-on-primary: #ffffff;
@@ -41,147 +36,106 @@ limitations under the License.
       --md-state-layer: rgba(98, 0, 238, 0.12);
     }
 
-    /* Reset */
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
     body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); }
-    .bg-white { background-color: var(--md-sys-color-surface); }
-    .bg-gray-50 { background-color: var(--md-sys-color-background); }
-    .bg-gray-100 { background-color: var(--md-sys-color-surface-variant); }
-    .bg-gray-200 { background-color: #ede9f5; }
-    .bg-gray-800 { background-color: #2a2730; }
-    .bg-gray-900 { background-color: #1b1820; }
-    .bg-green-600 { background-color: var(--md-sys-color-primary); }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: var(--md-sys-color-on-surface-variant); }
-    .text-gray-700 { color: #3f3b46; }
-    .text-gray-800 { color: var(--md-sys-color-on-surface); }
-    .text-red-500 { color: #b3261e; }
-    .border-gray-200 { border-color: #e6e1ee; }
-    .border-gray-300 { border-color: var(--md-sys-color-outline); }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-1 { gap: 0.25rem; }
-    .gap-2 { gap: 0.5rem; }
-    .gap-3 { gap: 0.75rem; }
-    .gap-4 { gap: 1rem; }
-    .w-5 { width: 1.25rem; }
-    .w-14 { width: 3.5rem; }
-    .w-80 { width: 20rem; }
-    .tooltip-wide { width: 24rem; max-width: 90vw; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .h-10 { height: 2.5rem; }
-    .h-14 { height: 3.5rem; }
-    .max-w-3xl { max-width: 48rem; }
-    .max-w-xl { max-width: 36rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-4 { margin-top: 1rem; }
-    .mr-2 { margin-right: 0.5rem; }
-
-    /* Grid & Spacing */
-    .grid { display: grid; }
-    .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-    .space-y-2 > * + * { margin-top: 0.5rem; }
-    .space-y-3 > * + * { margin-top: 0.75rem; }
-    @media (min-width: 640px) {
-      .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-    @media (min-width: 768px) {
-      .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-
-    /* Typography */
-    .text-base { font-size: 1rem; line-height: 1.5rem; }
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
-    .font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08), 0 6px 14px rgba(0, 0, 0, 0.08); }
-    .shadow-lg { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.14); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
-
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
-
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .opacity-100 { opacity: 1; }
-    .pointer-events-none { pointer-events: none; }
-
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
-
-    /* Z-index */
-    .z-50 { z-index: 50; }
-
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:text-gray-800:hover { color: #1f2937; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
-
-    /* Group hover */
-    .group {}
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-
-    /* Material components */
     .md-card {
       background: var(--md-sys-color-surface);
       border-radius: 16px;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
       border: 1px solid #ece7f3;
     }
+
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .menu-link:hover { background: #f2edf8; }
+
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
+
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
+
+    .md-form-grid { display: grid; gap: 1rem; align-items: center; }
+    @media (min-width: 768px) {
+      .md-form-grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--muted { color: #3f3b46; }
+    .md-label--block { margin-bottom: 0.5rem; }
+
+    .md-switch-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem; }
+
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
+
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
+
+    .md-step-icon { width: 3.5rem; height: 3.5rem; }
+    .md-flow-strip { width: 100%; max-width: 36rem; height: 2.5rem; }
+
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
+
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+
     .md-icon-btn {
       width: 40px;
       height: 40px;
@@ -195,14 +149,9 @@ limitations under the License.
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     }
     .md-icon-btn:hover { background: #e6e1ee; }
-    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; font-size: 0.875rem; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
     .md-icon-btn--surface { background: #f7f2fa; }
-    .md-code {
-      background: var(--md-sys-color-surface-variant);
-      border: 1px solid #e5e0ec;
-      border-radius: 12px;
-      color: #1f1b2d;
-    }
+
     .md-tooltip {
       background: #2b2831;
       color: #f7f4fb;
@@ -213,15 +162,23 @@ limitations under the License.
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       letter-spacing: 0.01em;
     }
-    .md-help-chip { display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 9999px; background: transparent; color: #4a4458; box-shadow: none; margin-left: 0.2rem; }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
     .md-help-icon { width: 18px; height: 18px; }
     .md-inline-icon { width: 20px; height: 20px; display: inline-block; }
     .md-icon-small { width: 16px; height: 16px; }
 
-    .md-tooltip--rich {
-      max-width: 22rem;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-    }
     .md-switch {
       position: relative;
       width: 44px;
@@ -244,26 +201,14 @@ limitations under the License.
       transform: translateX(0);
       transition: transform 150ms ease;
     }
-    input[type="checkbox"].md-switch-input {
-      position: absolute;
-      opacity: 0;
-      pointer-events: none;
-    }
-    input[type="checkbox"].md-switch-input:checked + .md-switch {
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
       background: #8b5cf6;
       box-shadow: inset 0 0 0 1px #7c3aed;
     }
-    input[type="checkbox"].md-switch-input:checked + .md-switch::after {
-      transform: translateX(20px);
-      background: #ffffff;
-    }
-    .md-switch-label {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-size: 0.95rem;
-      color: var(--md-sys-color-on-surface);
-    }
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
+    .md-switch-label { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.95rem; color: var(--md-sys-color-on-surface); }
+
     .md-required {
       display: inline-flex;
       align-items: center;
@@ -277,6 +222,7 @@ limitations under the License.
       color: #8c1d18;
       border: 1px solid #f0c9c5;
     }
+
     .md-snackbar {
       background: #2b2831;
       color: #ffffff;
@@ -285,10 +231,10 @@ limitations under the License.
       letter-spacing: 0.01em;
     }
 
-    input[type="text"],
-    input[type="number"],
-    select,
-    textarea {
+    .md-input,
+    .md-select,
+    .md-textarea {
+      width: 100%;
       background: #ffffff;
       border: 1px solid var(--md-sys-color-outline);
       border-radius: 12px;
@@ -304,70 +250,72 @@ limitations under the License.
       background-size: 1rem 1rem;
       padding-right: 2.25rem;
     }
-    input[type="text"]:focus,
-    input[type="number"]:focus,
-    select:focus,
-    textarea:focus {
+    .md-input:focus,
+    .md-select:focus,
+    .md-textarea:focus {
       outline: none;
       border-color: var(--md-sys-color-primary);
       box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
     }
-    input[type="checkbox"],
-    input[type="radio"] {
-      accent-color: var(--md-sys-color-primary);
+
+    .md-hidden { display: none; }
+    .md-disabled { background-color: #f3f0f7; }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
     }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
 
-    /* Disabled state */
-    input:disabled { background-color: #f3f0f7; }
-    select:disabled { background-color: #f3f0f7; }
-    textarea:focus { outline: none; }
-    .selectable-code { cursor: text; }
-
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-3xl mx-auto bg-white shadow-md rounded-lg p-6 relative md-card">
-    <button type="button" class="absolute top-4 right-4 md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+<body class="md-page">
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6 pr-10 flex flex-wrap items-center gap-2">
-      <span aria-hidden="true" class="mr-2">🧩</span>
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">🧩</span>
       <span>Git pseudo-squash コマンドジェネレータ</span>
-      <span class="relative inline-flex items-center group">
+      <span class="md-tooltip-group">
         <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-        <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <span class="md-tooltip-content md-tooltip md-tooltip--rich">
           reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。
           運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。
         </span>
       </span>
     </h1>
 
-    <section id="baseBlock" class="space-y-3 mb-4">
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
-        <div class="flex flex-wrap items-center gap-2">
-          <label class="flex flex-wrap items-center gap-2 font-semibold">
+    <section id="baseBlock" class="md-section md-stack-md">
+      <div class="md-form-grid md-form-grid-2">
+        <div class="md-form-row">
+          <label class="md-label">
             <span>基点ブランチ</span>
-            <span class="md-required" aria-hidden="true">Required</span><span class="sr-only">必須</span>
-            <span class="relative inline-flex items-center group">
+            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+            <span class="md-tooltip-group">
               <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich">
                 基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。
                 基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。
               </span>
             </span>
             <span>：</span>
           </label>
-          <input type="text" id="squashBaseBranch" list="baseBranchSuggestions" placeholder="例: devel" class="border border-gray-300 rounded w-full p-2 md-field--dropdown" value="devel">
+          <input type="text" id="squashBaseBranch" list="baseBranchSuggestions" placeholder="例: devel" class="md-input md-field--dropdown" value="devel">
           <datalist id="baseBranchSuggestions">
             <option value="main"></option>
             <option value="master"></option>
@@ -390,13 +338,13 @@ limitations under the License.
             <option value="stable"></option>
           </datalist>
         </div>
-        <div class="flex flex-wrap items-center gap-2">
-          <label class="flex flex-wrap items-center gap-2 font-semibold">
+        <div class="md-form-row">
+          <label class="md-label">
             <span>作業ブランチ</span>
-            <span class="md-required" aria-hidden="true">Required</span><span class="sr-only">必須</span>
-            <span class="relative inline-flex items-center group">
+            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+            <span class="md-tooltip-group">
               <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich">
                 これから作業するブランチ名です。未作成なら作成先として使います。
                 生成コマンドにそのまま反映されます。
               </span>
@@ -409,17 +357,17 @@ limitations under the License.
             </button>
             <span>：</span>
           </label>
-          <input type="text" id="workBranch" placeholder="例: tiga0129a" class="border border-gray-300 rounded w-full p-2">
+          <input type="text" id="workBranch" placeholder="例: tiga0129a" class="md-input">
         </div>
       </div>
-      <div class="flex flex-wrap items-center gap-3 text-sm text-gray-700">
+      <div class="md-switch-row">
         <label class="md-switch-label">
           <input type="checkbox" id="shellEnvPowerShell" class="md-switch-input">
           <span class="md-switch" aria-hidden="true"></span>
           PowerShell
-          <span class="relative inline-flex items-center group">
+          <span class="md-tooltip-group">
             <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 tooltip-wide -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
               Windows PowerShell 用のコマンドを出力します。オフの場合は macOS / Linux の bash / zsh を想定します。
             </span>
           </span>
@@ -428,9 +376,9 @@ limitations under the License.
           <input type="checkbox" id="lockOrigin" class="md-switch-input" checked onchange="toggleOriginLock()">
           <span class="md-switch" aria-hidden="true"></span>
           リモート + origin で作業
-          <span class="relative inline-flex items-center group">
+          <span class="md-tooltip-group">
             <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich">
               よくある利用方法として リモートと origin の組み合わせでの利用です。通常はこのままで OK です。
               複数リモートを使い分ける場合だけ外して、対象のリモート名に切り替えます。
               チェックを外すと、基点のリモート名と squash 用リモート名を個別に指定できます。
@@ -438,30 +386,30 @@ limitations under the License.
           </span>
         </label>
       </div>
-      <div id="baseRemoteRow" class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
-        <div class="flex flex-wrap items-center gap-2">
-          <label class="flex flex-wrap items-center gap-2 font-semibold text-gray-700">
+      <div id="baseRemoteRow" class="md-form-grid md-form-grid-2">
+        <div class="md-form-row">
+          <label class="md-label md-label--muted">
             <span>基点の参照先</span>
-            <span class="relative inline-flex items-center group">
+            <span class="md-tooltip-group">
               <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich">
                 基点ブランチをリモートから参照するか、ローカルで参照するかを指定します。
                 ふだんは最新のリモート状態で切りたいので、リモート基点を選ぶケースが多いです。
               </span>
             </span>
             <span>：</span>
           </label>
-          <select id="squashBaseScope" class="border border-gray-300 rounded w-full p-2" onchange="updateBaseScope()">
+          <select id="squashBaseScope" class="md-select" onchange="updateBaseScope()">
             <option value="remote" selected>リモート</option>
             <option value="local">ローカル</option>
           </select>
         </div>
-        <div class="flex flex-wrap items-center gap-2">
-          <label class="flex flex-wrap items-center gap-2 font-semibold text-gray-700">
+        <div class="md-form-row">
+          <label class="md-label md-label--muted">
             <span>基点リモート</span>
-            <span class="relative inline-flex items-center group">
+            <span class="md-tooltip-group">
               <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich">
                 基点ブランチを参照するリモート名です（例: origin）。
                 「作業開始」と「まとめる予定の作業 (diff)」の基準になります。
                 リモート基点を選ぶ場合は、最新の origin/devel などを参照する想定です。
@@ -469,16 +417,16 @@ limitations under the License.
             </span>
             <span>：</span>
           </label>
-          <input type="text" id="baseRemote" placeholder="例: origin" class="border border-gray-300 rounded w-full p-2" value="origin">
+          <input type="text" id="baseRemote" placeholder="例: origin" class="md-input" value="origin">
         </div>
       </div>
     </section>
-    <div id="extraOptions" class="space-y-3 mb-4">
-      <label id="squashRemoteLabel" class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <div id="extraOptions" class="md-section md-stack-md">
+      <label id="squashRemoteLabel" class="md-label md-label--block">
         <span>squashリモート</span>
-        <span class="relative inline-flex items-center group">
+        <span class="md-tooltip-group">
           <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich">
             squash 作業で使う fetch / push のリモート名です。通常は origin です。
             「作業をまとめる（squash）」のコマンドに反映されます。
             基点のリモートと同じにしておくと混乱しにくいです。
@@ -487,14 +435,14 @@ limitations under the License.
         <span>：</span>
       </label>
       <div id="squashRemoteRow">
-        <input type="text" id="squashRemote" placeholder="例: origin" class="border border-gray-300 rounded w-full p-2" value="origin">
+        <input type="text" id="squashRemote" placeholder="例: origin" class="md-input" value="origin">
       </div>
     </div>
 
-    <section id="commonFields" class="space-y-3 mb-4">
+    <section id="commonFields" class="md-section md-stack-md">
 
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-14 h-14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="18" cy="32" r="5" fill="#93C5FD"/>
           <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
@@ -503,17 +451,17 @@ limitations under the License.
           <circle cx="48" cy="22" r="4" fill="#A78BFA"/>
           <circle cx="48" cy="42" r="4" fill="#34D399"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">作業開始（基準ブランチから作成）</p>
-        <span class="relative inline-flex items-center group">
+        <p class="md-section-title">作業開始（基準ブランチから作成）</p>
+        <span class="md-tooltip-group">
           <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich">
             基点から作業ブランチを切るステップです。この下で作成コマンドを生成します。
           </span>
         </span>
       </div>
-      <div class="relative">
-      <code id="createBranchCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10 md-code"></code>
-      <button class="absolute top-2 right-2 md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('createBranchCmd')">
+      <div class="md-code-block">
+      <code id="createBranchCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('createBranchCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
           <rect x="9" y="9" width="11" height="11" rx="2"/>
           <rect x="4" y="4" width="11" height="11" rx="2"/>
@@ -521,8 +469,8 @@ limitations under the License.
       </button>
       </div>
 
-      <div class="flex items-center justify-center py-2">
-        <svg aria-hidden="true" viewBox="0 0 420 64" class="w-full max-w-xl h-10" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <div class="md-flow-divider">
+        <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
           <rect x="96" y="18" width="110" height="28" rx="8" fill="#E8DDF7" />
@@ -535,8 +483,8 @@ limitations under the License.
           <circle cx="384" cy="32" r="6" fill="#86EFAC"/>
         </svg>
       </div>
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-14 h-14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="20" cy="22" r="4" fill="#93C5FD"/>
           <circle cx="20" cy="42" r="4" fill="#FCA5A5"/>
@@ -546,22 +494,22 @@ limitations under the License.
           <path d="M34 42C40 42 42 36 46 32" stroke="#34D399" stroke-width="3" stroke-linecap="round"/>
           <circle cx="50" cy="32" r="5" fill="#86EFAC"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">作業をまとめる（squash）</p>
-        <span class="relative inline-flex items-center group">
+        <p class="md-section-title">作業をまとめる（squash）</p>
+        <span class="md-tooltip-group">
           <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich">
             ローカルの複数のコミットを1つにまとめます。
             reset --soft で履歴だけ戻し、変更は残したまま1コミット化します。
           </span>
         </span>
       </div>
-      <div class="flex flex-wrap items-center gap-2">
-        <label class="flex flex-wrap items-center gap-2 font-semibold">
+      <div class="md-form-row">
+        <label class="md-label">
           <span>コミットメッセージ</span>
-          <span class="md-required" aria-hidden="true">Required</span><span class="sr-only">必須</span>
-          <span class="relative inline-flex items-center group">
+          <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+          <span class="md-tooltip-group">
             <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich">
               まとめ後の1コミットの説明文です。複数行入力が可能で、内容は一時ファイルに書き込んで git commit -F で渡されます。
               macOS / Linux は mktemp + ヒアドキュメント、Windows は PowerShell の New-TemporaryFile で対応します。
               ヒアドキュメント経由で渡すため、シェルのクォート解析の影響を受けにくくしています。
@@ -570,19 +518,19 @@ limitations under the License.
           </span>
           <span>：</span>
         </label>
-        <textarea id='commitMessage' placeholder='コミットの内容を表す一文&#10;&#10;コミットの内容の説明' class='border border-gray-300 rounded w-full p-2' rows='12'></textarea>
+        <textarea id='commitMessage' placeholder='コミットの内容を表す一文&#10;&#10;コミットの内容の説明' class='md-textarea' rows='12'></textarea>
       </div>
     </section>
 
-    <div class="space-y-2 mb-4">
-      <div class="flex flex-wrap items-center gap-2">
+    <div class="md-section md-stack-sm">
+      <div class="md-form-row">
         <label class="md-switch-label">
           <input type="checkbox" id="optPush" class="md-switch-input">
           <span class="md-switch" aria-hidden="true"></span>
           push を追加
-          <span class="relative inline-flex items-center group">
+          <span class="md-tooltip-group">
             <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich">
               push --force-with-lease でコミット整理を反映した後、リモートと同期（pull）し、ブランチを -done サフィックスでリネームするコマンドが続きます。ローカルでコミットが1つにまとまっているため、GitHubのPRではsquashせず通常のmergeで完了です。
             </span>
           </span>
@@ -591,9 +539,9 @@ limitations under the License.
           <input type="checkbox" id="useCurrentBranch" class="md-switch-input" checked onchange="toggleCurrentBranch()">
           <span class="md-switch" aria-hidden="true"></span>
           現在ブランチで作業
-          <span class="relative inline-flex items-center group">
+          <span class="md-tooltip-group">
             <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich">
               現在チェックアウト中のブランチを作業ブランチとして扱います。チェックを外すと、作業ブランチ名で switch するコマンドが含まれます。
             </span>
           </span>
@@ -601,9 +549,9 @@ limitations under the License.
       </div>
     </div>
 
-    <div class="relative mt-4">
-      <code id="rebaseCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10 md-code"></code>
-      <button class="absolute top-2 right-2 md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('rebaseCmd')">
+    <div class="md-code-block">
+      <code id="rebaseCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('rebaseCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
           <rect x="9" y="9" width="11" height="11" rx="2"/>
           <rect x="4" y="4" width="11" height="11" rx="2"/>
@@ -611,8 +559,8 @@ limitations under the License.
       </button>
     </div>
 
-    <div class="flex items-center justify-center py-2">
-      <svg aria-hidden="true" viewBox="0 0 420 64" class="w-full max-w-xl h-10" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <div class="md-flow-divider">
+      <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
         <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
         <rect x="96" y="18" width="110" height="28" rx="8" fill="#E8DDF7" />
@@ -625,8 +573,8 @@ limitations under the License.
         <circle cx="384" cy="32" r="6" fill="#86EFAC"/>
       </svg>
     </div>
-    <div class="flex items-center gap-3 py-2">
-      <svg aria-hidden="true" viewBox="0 0 64 64" class="w-14 h-14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <div class="md-flow-row">
+      <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
         <path d="M16 22h32" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
         <path d="M16 32h26" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
@@ -635,17 +583,17 @@ limitations under the License.
         <circle cx="42" cy="32" r="4" fill="#A78BFA"/>
         <circle cx="36" cy="42" r="4" fill="#34D399"/>
       </svg>
-      <p class="text-base font-semibold text-gray-700">まとめる予定の作業 (diff)</p>
-      <span class="relative inline-flex items-center group">
+      <p class="md-section-title">まとめる予定の作業 (diff)</p>
+      <span class="md-tooltip-group">
         <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-        <span class="absolute md-tooltip md-tooltip--rich left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <span class="md-tooltip-content md-tooltip md-tooltip--rich">
           基点ブランチと作業ブランチの差分を表示するコマンドです。squash 後に1コミットへまとめる内容の目安になります。
         </span>
       </span>
     </div>
-    <div class="relative">
-      <code id="plannedDiffCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10 md-code"></code>
-      <button class="absolute top-2 right-2 md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('plannedDiffCmd')">
+    <div class="md-code-block">
+      <code id="plannedDiffCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('plannedDiffCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
           <rect x="9" y="9" width="11" height="11" rx="2"/>
           <rect x="4" y="4" width="11" height="11" rx="2"/>
@@ -653,7 +601,7 @@ limitations under the License.
       </button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none md-snackbar">
+    <div id="toast" class="md-snackbar-host md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -684,7 +632,7 @@ limitations under the License.
       const workBranch = document.getElementById("workBranch");
       if (workBranch) {
         // 編集は常に可能にする（現在のブランチ使用時も入力は保持）
-        workBranch.classList.remove("bg-gray-100");
+        workBranch.classList.remove("md-disabled");
       }
     }
 
@@ -696,7 +644,7 @@ limitations under the License.
       if (scope && baseRemote) {
         const disableRemote = scope.value !== "remote" || (lockOrigin && lockOrigin.checked);
         baseRemote.disabled = disableRemote;
-        baseRemote.classList.toggle("bg-gray-100", disableRemote);
+        baseRemote.classList.toggle("md-disabled", disableRemote);
       }
       if (scope && lockOrigin && lockOrigin.checked) {
         baseRemote.value = "origin";
@@ -706,20 +654,20 @@ limitations under the License.
       if (squashRemote && lockOrigin) {
         const disableRemoteName = lockOrigin.checked;
         squashRemote.disabled = disableRemoteName;
-        squashRemote.classList.toggle("bg-gray-100", disableRemoteName);
+        squashRemote.classList.toggle("md-disabled", disableRemoteName);
         if (disableRemoteName) {
           squashRemote.value = "origin";
         }
       }
       if (baseRemoteRow && lockOrigin) {
-        baseRemoteRow.classList.toggle("hidden", lockOrigin.checked);
+        baseRemoteRow.classList.toggle("md-hidden", lockOrigin.checked);
       }
       if (squashRemoteRow && lockOrigin) {
-        squashRemoteRow.classList.toggle("hidden", lockOrigin.checked);
+        squashRemoteRow.classList.toggle("md-hidden", lockOrigin.checked);
       }
       const squashRemoteLabel = document.getElementById("squashRemoteLabel");
       if (squashRemoteLabel && lockOrigin) {
-        squashRemoteLabel.classList.toggle("hidden", lockOrigin.checked);
+        squashRemoteLabel.classList.toggle("md-hidden", lockOrigin.checked);
       }
     }
 
@@ -956,18 +904,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
 
     function setupCodeSelectAll() {


### PR DESCRIPTION
# Summary

git-pseudo-squash.html を Tailwind依存なしの Material Design 構成へ全面刷新 md-* 命名に統一し、レイアウト/フォーム/コード表示/トースト/ツールチップ等を一貫化
JSのクラス切替も md-hidden / md-disabled / md-visible に合わせて更新

# Changes

Tailwind風ユーティリティを完全撤去し、トークン/コンポーネントCSSへ移行
フォーム要素、ツールチップ、スナックバー、メニュー、コード出力UIをMaterial準拠で再設計
互換のため、機能・文言・挙動は維持