### PR TITLE
Gitツール群をMaterial Designへ統一（config/branch-diff/pseudo-squash/README）

### DIFF
--- a/docs/git/README.md
+++ b/docs/git/README.md
@@ -16,3 +16,34 @@
 ## 使い方
 
 対象の HTML をブラウザで開き、必要事項を入力して生成されたコマンドをそのままターミナルで実行します。
+
+## git-pseudo-squash.html の Material Design 実装方針
+
+`docs/git/git-pseudo-squash.html` は外部ライブラリに依存せず、単一 HTML 内で Material Design 仕様を再現しています。
+
+- 命名は `md-*` で統一し、レイアウト/フォーム/ボタン/ツールチップ/スナックバー/コード表示をコンポーネント単位で定義する
+- 色/角丸/影/タイポグラフィは CSS 変数 `--md-sys-*` に集約し、要素側はトークン参照のみで組み立てる
+- 主要コンポーネントは以下のクラスで構成する
+- `md-card` `md-input` `md-select` `md-textarea` `md-button` `md-icon-btn` `md-switch` `md-tooltip` `md-snackbar` `md-code`
+- 表示切替は `md-hidden` `md-visible` `md-disabled` を使い、JS 側はクラスの付け替えだけで制御する
+- 「i」アイコンはインライン SVG で実装し、色/サイズ/余白は `md-tooltip-trigger` 側で統一する
+
+## Tailwind CSS から Material Design への書き換えルール
+
+このプロジェクトでは、Tailwind 的ユーティリティをすべて撤去し、Material Design のコンポーネント指向に置き換えています。
+
+- ユーティリティ連打の構造はやめ、意味単位の `md-*` コンポーネントに再構成する
+- 色/角丸/影/タイポは `--md-sys-*` に集約し、要素側はトークン参照のみにする
+- `input/select/textarea` は `md-input` `md-select` `md-textarea` に統一する
+- 必須表示はラベル横の `md-required-chip` に統一する
+- ツールチップは `md-tooltip-group` + `md-tooltip-content` で構成し、`i` はインライン SVG を使う
+- ツールチップ本文は `md-tooltip` に `font-weight: 400` を指定し、細めの表現に統一する
+- 表示状態は `md-hidden` `md-visible` `md-disabled` に統一し、JS はクラス切替のみで制御する
+- コード出力は `md-code-block` と `md-code` を使い、コピーは `md-copy-button` に統一する
+
+## フォーム配置の実装メモ
+
+- ラベル右に入力を並べるときは `md-form-row md-form-row--nowrap` を使う
+- モバイル幅では `@media (max-width: 640px)` で wrap させて詰まりを防ぐ
+- `md-field-stack`（縦並び）の場合は `.md-field-stack .md-input` を `flex: 0 0 auto` にして縦に伸びるのを防ぐ
+- 入力右端にアクションボタンを半分埋める配置は `md-input-wrap` + `md-input-action` を使う

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -20,263 +20,399 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git ブランチ比較コマンドジェネレータ</title>
   <style>
-    /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
-    */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .gap-4 { gap: 1rem; }
-    .gap-6 { gap: 1.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-full { width: 100%; }
-    .w-80 { width: 20rem; }
-    .w-72 { width: 18rem; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .pr-6 { padding-right: 1.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-4 { margin-top: 1rem; }
-    .mr-2 { margin-right: 0.5rem; }
-    .mr-5 { margin-right: 1.25rem; }
-    .ml-8 { margin-left: 2rem; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+    }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .opacity-100 { opacity: 1; }
-    .pointer-events-none { pointer-events: none; }
-    .z-50 { z-index: 50; }
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--block { margin-bottom: 0.5rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-input,
+    .md-select {
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid var(--md-sys-color-outline);
+      border-radius: 12px;
+      padding: 0.625rem 0.75rem;
+      font: inherit;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-select--inline { flex: 1 1 18rem; min-width: 14rem; }
+    .md-input { flex: 1 1 16rem; min-width: 12rem; }
+    .md-input:focus,
+    .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
+    .md-input.md-disabled,
+    .md-select.md-disabled {
+      background: #f3f0f7;
+    }
 
-    /* Group hover */
-    .group {}
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
+    .md-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.4rem;
+      border-radius: 9999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.22);
+    }
+    .md-button--primary:hover { background: #5a00d6; }
 
-    /* Space-y utility */
-    .space-y-2 > * + * { margin-top: 0.5rem; }
-    .space-y-3 > * + * { margin-top: 0.75rem; }
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+    .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
 
-    /* Responsive */
-    @media (min-width: 640px) {
-      .sm\:w-64 { width: 16rem; }
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-small { width: 16px; height: 16px; }
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.1rem 0.45rem;
+      border-radius: 9999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: #f7e9e7;
+      color: #8c1d18;
+      border: 1px solid #f0c9c5;
+    }
+
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .md-choice-inline { display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem; }
+    .md-choice-text { font-size: 0.9rem; color: #4a4458; }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transform: translateX(0);
+      transition: transform 150ms ease;
+    }
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
+      background: #8b5cf6;
+      box-shadow: inset 0 0 0 1px #7c3aed;
+    }
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
+    .md-switch-label { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.95rem; color: var(--md-sys-color-on-surface); white-space: nowrap; }
+
+    .md-snackbar {
+      background: #2b2831;
+      color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      letter-spacing: 0.01em;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+      .md-switch-label { white-space: normal; }
     }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+<body class="md-page">
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6 flex flex-wrap items-center gap-2">
-      <span aria-hidden="true" class="mr-2">🧰</span>
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">🧰</span>
       <span>Git ブランチ比較コマンドジェネレータ</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
           2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。
         </span>
       </span>
     </h1>
 
-    <div class="space-y-3 mb-4">
-      <div class="flex flex-wrap items-center gap-2">
-        <label class="flex flex-wrap items-center gap-2 font-semibold">
+    <div class="md-section md-stack-md">
+      <div class="md-form-row md-form-row--nowrap">
+        <label class="md-label">
           <span>基準ブランチ</span>
-          <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               比較の基準にするブランチです。差分の「片側」として使われます。
               例: main / devel
             </span>
           </span>
           <span>：</span>
         </label>
-        <input type="text" id="branchA" placeholder="例: main" class="border border-gray-300 rounded w-full sm:w-64 p-2">
-        <label class="flex items-center gap-2 text-sm text-gray-700">
-          <input type="checkbox" id="scopeA" class="rounded border-gray-300" checked onchange="updateRemoteState()">
+        <input type="text" id="branchA" placeholder="例: main" class="md-input">
+        <label class="md-switch-label">
+          <input type="checkbox" id="scopeA" class="md-switch-input" checked onchange="updateRemoteState()">
+          <span class="md-switch" aria-hidden="true"></span>
           リモートとして扱う
         </label>
       </div>
 
-      <div class="flex flex-wrap items-center gap-2">
-        <label class="flex flex-wrap items-center gap-2 font-semibold">
+      <div class="md-form-row md-form-row--nowrap">
+        <label class="md-label">
           <span>比較ブランチ</span>
-          <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               比較対象のブランチです。2つのブランチ差分を表示します。
               例: feature123 / release
             </span>
           </span>
           <span>：</span>
         </label>
-        <input type="text" id="branchB" placeholder="例: devel" class="border border-gray-300 rounded w-full sm:w-64 p-2">
-        <label class="flex items-center gap-2 text-sm text-gray-700">
-          <input type="checkbox" id="scopeB" class="rounded border-gray-300" checked onchange="updateRemoteState()">
+        <input type="text" id="branchB" placeholder="例: devel" class="md-input">
+        <label class="md-switch-label">
+          <input type="checkbox" id="scopeB" class="md-switch-input" checked onchange="updateRemoteState()">
+          <span class="md-switch" aria-hidden="true"></span>
           リモートとして扱う
         </label>
       </div>
     </div>
 
-    <div class="space-y-3 mb-4">
-      <div class="flex flex-wrap items-center text-sm text-gray-700" style="column-gap: 2ch; row-gap: 0.5rem;">
-        <label class="flex items-center gap-2">
-          <input type="checkbox" id="lockOrigin" class="rounded border-gray-300" checked onchange="updateRemoteState()">
+    <div class="md-section md-stack-md">
+      <div class="md-choice-inline md-choice-text">
+        <label class="md-switch-label">
+          <input type="checkbox" id="lockOrigin" class="md-switch-input" checked onchange="updateRemoteState()">
+          <span class="md-switch" aria-hidden="true"></span>
           リモート名は origin 固定
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               origin 固定で使う場合にオンにします。オフにすると任意のリモート名を入力できます。
               ふだんは origin を使うケースが多いです。
             </span>
           </span>
         </label>
-        <label class="flex items-center gap-2">
-          <input type="checkbox" id="useTripleDot" class="rounded border-gray-300">
+        <label class="md-switch-label">
+          <input type="checkbox" id="useTripleDot" class="md-switch-input">
+          <span class="md-switch" aria-hidden="true"></span>
           共通祖先からの差分比較
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
               オフ時は A と B のスナップショット差分で、A/B の両方の変更が見えます。
               オン時は共通祖先から B までの差分になり、B 側で増えた変更だけが見え、A だけの変更は見えません。
             </span>
           </span>
         </label>
       </div>
-      <div id="remoteNameBlock" class="space-y-2">
-        <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+      <div id="remoteNameBlock" class="md-form-row md-form-row--nowrap">
+        <label class="md-label">
           <span>リモート名</span>
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               fetch と差分比較に使うリモート名です。
             </span>
           </span>
           <span>：</span>
         </label>
-        <input type="text" id="remoteName" placeholder="例: origin" class="border border-gray-300 rounded w-full p-2" value="origin">
+        <input type="text" id="remoteName" placeholder="例: origin" class="md-input" value="origin">
       </div>
     </div>
 
-    <div class="flex flex-wrap items-center gap-2 mb-4">
-      <p class="text-sm text-gray-600">出力形式：</p>
-      <select id="diffMode" class="border border-gray-300 rounded w-full sm:w-64 p-2">
+    <div class="md-section md-form-row md-form-row--nowrap">
+      <p class="md-choice-text">出力形式：</p>
+      <select id="diffMode" class="md-select md-select--inline">
         <option value="" selected>内容差分 (git diff)</option>
         <option value="--stat">差分統計 (git diff --stat)</option>
         <option value="--name-only">変更ファイル一覧 (git diff --name-only)</option>
       </select>
     </div>
 
-
-    <div class="relative mt-4">
-      <code id="diffCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('diffCmd')">📋</button>
+    <div class="md-code-block">
+      <code id="diffCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('diffCmd')" aria-label="コピー">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="11" height="11" rx="2"/>
+          <rect x="4" y="4" width="11" height="11" rx="2"/>
+        </svg>
+      </button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar-host md-snackbar">
       コピーしました
     </div>
   </div>
@@ -298,9 +434,9 @@ limitations under the License.
       const useRemote = scopeA || scopeB;
       const remoteInput = document.getElementById("remoteName");
       const remoteBlock = document.getElementById("remoteNameBlock");
-      remoteBlock.classList.toggle("hidden", lockOrigin);
+      remoteBlock.classList.toggle("md-hidden", lockOrigin);
       remoteInput.disabled = lockOrigin || !useRemote;
-      remoteInput.classList.toggle("bg-gray-100", lockOrigin || !useRemote);
+      remoteInput.classList.toggle("md-disabled", lockOrigin || !useRemote);
       if (lockOrigin) {
         remoteInput.value = "origin";
       }
@@ -373,18 +509,16 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
 
     updateRemoteState();

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -20,244 +20,325 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git 詳細設定コマンドジェネレータ</title>
   <style>
-    /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
-    */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .text-gray-500 { color: #6b7280; }
-    .text-blue-800 { color: #1e40af; }
-    .text-yellow-800 { color: #713f12; }
-    .bg-blue-100 { background-color: #dbeafe; }
-    .bg-yellow-100 { background-color: #fef3c7; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .items-start { align-items: flex-start; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-1 { gap: 0.25rem; }
-    .gap-2 { gap: 0.5rem; }
-    .gap-3 { gap: 0.75rem; }
-    .gap-4 { gap: 1rem; }
-    .w-5 { width: 1.25rem; }
-    .w-12 { width: 3rem; }
-    .w-14 { width: 3.5rem; }
-    .w-80 { width: 20rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .h-10 { height: 2.5rem; }
-    .h-12 { height: 3rem; }
-    .h-14 { height: 3.5rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .max-w-xl { max-width: 36rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-4 { padding: 1rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-1 { margin-top: 0.25rem; }
-    .mt-4 { margin-top: 1rem; }
-    .mr-2 { margin-right: 0.5rem; }
-    .ml-8 { margin-left: 2rem; }
-    .py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
-
-    /* Grid & Spacing */
-    .grid { display: grid; }
-    .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-    .space-y-2 > * + * { margin-top: 0.5rem; }
-    .space-y-3 > * + * { margin-top: 0.75rem; }
-    .space-y-6 > * + * { margin-top: 1.5rem; }
-    @media (min-width: 640px) {
-      .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-    @media (min-width: 768px) {
-      .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
     }
 
-    /* Typography */
-    .text-base { font-size: 1rem; line-height: 1.5rem; }
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
+    .md-stack-lg > * + * { margin-top: 1.5rem; }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .opacity-50 { opacity: 0.5; }
-    .opacity-100 { opacity: 1; }
-    .pointer-events-none { pointer-events: none; }
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--start { align-items: flex-start; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--block { margin-bottom: 0.5rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; }
+    .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
+    .md-flow-strip { width: 100%; max-width: 36rem; height: 2.5rem; }
 
-    /* Z-index */
-    .z-50 { z-index: 50; }
-
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    .hover\:text-gray-800:hover { color: #1f2937; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
-
-    /* Group hover */
-    .group {}
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-
-    /* Disabled state */
-    input:disabled { background-color: #f3f4f6; }
-    select:disabled { background-color: #f3f4f6; }
-
-    /* Input elements */
-    input[type="checkbox"],
-    input[type="radio"] {
-      flex-shrink: 0;
-      margin-top: 0;
-      margin-left: 0;
-      cursor: pointer;
-      accent-color: #2563eb;
-      align-self: center;
-      vertical-align: middle;
+    .md-input,
+    .md-select {
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid var(--md-sys-color-outline);
+      border-radius: 12px;
+      padding: 0.625rem 0.75rem;
+      font: inherit;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input:focus,
+    .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
+    .md-input:disabled,
+    .md-select:disabled {
+      background: #f3f0f7;
     }
 
-    /* Flex container with checkboxes */
-    .flex > input[type="checkbox"],
-    .flex > input[type="radio"] {
-      margin-left: 0.75rem;
+    .md-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.4rem;
+      border-radius: 9999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.22);
+    }
+    .md-button--primary:hover { background: #5a00d6; }
+
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
+
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-small { width: 16px; height: 16px; }
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.1rem 0.45rem;
+      border-radius: 9999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: #f7e9e7;
+      color: #8c1d18;
+      border: 1px solid #f0c9c5;
     }
 
-    /* Disabled section spacing */
-    .disabled-section {
-      margin-right: 0.75rem;
-      margin-bottom: 0.75rem;
+    .md-choice-card {
+      border: 1px solid #e2dcec;
+      border-radius: 16px;
+      padding: 1rem;
+      background: #ffffff;
+    }
+    .md-choice-card--muted {
+      background: #f7f3fb;
+    }
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; }
+    .md-choice-row input { margin: 0; }
+
+    .md-choice-sub { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675; }
+    .md-choice-sub small { font-size: 0.75rem; color: #7b7784; }
+
+    .md-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.6rem;
+      border-radius: 9999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .md-chip--primary {
+      background: #e2d9f7;
+      color: #4a1e9e;
+    }
+    .md-chip--warn {
+      background: #f7ece1;
+      color: #8a4b0f;
     }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-snackbar {
+      background: #2b2831;
+      color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      letter-spacing: 0.01em;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-divider { border: none; border-top: 1px solid #e6e1ee; margin: 1.5rem 0; }
+    .md-hidden { display: none; }
+    .md-dimmed { opacity: 0.6; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+<body class="md-page">
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6 flex flex-wrap items-center gap-2">
-      <span aria-hidden="true" class="mr-2">🔧</span>
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">🔧</span>
       <span>Git 詳細設定コマンドジェネレータ</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
           core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
         </span>
       </span>
     </h1>
 
-    <section id="checkSection" class="space-y-3 mb-6">
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <section id="checkSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="20" cy="32" r="4" fill="#93C5FD"/>
           <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">現在の設定を確認</p>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <p class="md-section-title">現在の設定を確認</p>
+        <span class="md-tooltip-group">
+          <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
             設定前に現在の値を確認できます。
           </span>
         </span>
       </div>
-      <button type="button" onclick="generateCheckCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">
         確認コマンド生成
       </button>
-      <div class="relative">
-        <code id="checkCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-        <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('checkCmd')">📋</button>
+      <div class="md-code-block">
+        <code id="checkCmd" class="md-code"></code>
+        <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
+          <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="9" y="9" width="11" height="11" rx="2"/>
+            <rect x="4" y="4" width="11" height="11" rx="2"/>
+          </svg>
+        </button>
       </div>
     </section>
 
-    <div class="flex items-center justify-center py-2">
-      <svg aria-hidden="true" viewBox="0 0 420 64" class="w-full max-w-xl h-10" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <div class="md-flow-divider">
+      <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
         <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
         <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
         <rect x="96" y="18" width="110" height="28" rx="8" fill="#E8DDF7" />
@@ -271,9 +352,9 @@ limitations under the License.
       </svg>
     </div>
 
-    <section class="space-y-6 mb-6">
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <section class="md-section md-stack-lg">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="20" cy="20" r="4" fill="#A78BFA"/>
           <path d="M24 20H34" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
@@ -281,116 +362,125 @@ limitations under the License.
           <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
           <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">詳細設定を行う</p>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <p class="md-section-title">詳細設定を行う</p>
+        <span class="md-tooltip-group">
+          <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
             必要な詳細設定を選択して、コマンドを生成します。
           </span>
         </span>
       </div>
 
       <!-- core.autocrlf セクション -->
-      <div class="border border-gray-200 rounded-lg p-4 space-y-3">
-        <div class="flex items-start gap-3">
-          <input type="checkbox" id="enableAutocrlf" class="rounded border-gray-300 mt-1" onchange="toggleAutocrlfOptions()">
-          <label for="enableAutocrlf" class="flex flex-wrap items-center gap-2 font-semibold">
-            <span>core.autocrlf を設定</span>
-            <span class="relative inline-flex items-center group">
-              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
-                改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+      <div class="md-choice-card md-stack-md">
+        <div class="md-form-row md-form-row--start">
+          <label for="enableAutocrlf" class="md-choice-row">
+            <input type="checkbox" id="enableAutocrlf" onchange="toggleAutocrlfOptions()">
+            <span class="md-label">
+              <span>core.autocrlf を設定</span>
+              <span class="md-tooltip-group">
+                <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+                  改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+                </span>
               </span>
             </span>
           </label>
         </div>
 
-        <div id="autocrlfOptions" class="space-y-2 ml-8 p-3 bg-gray-50 rounded disabled-section">
-          <div class="flex items-center gap-2">
+        <div id="autocrlfOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
+          <div class="md-choice-row">
             <input type="radio" id="autocrlf-true" name="autocrlf" value="true" disabled>
-            <label for="autocrlf-true" class="flex items-center gap-2 text-sm">
+            <label for="autocrlf-true" class="md-choice-sub">
               <span>true</span>
-              <span class="text-gray-500 text-xs">Windows用（LF ↔ CRLF 自動変換）</span>
+              <small>Windows用（LF ↔ CRLF 自動変換）</small>
             </label>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="md-choice-row">
             <input type="radio" id="autocrlf-input" name="autocrlf" value="input" disabled>
-            <label for="autocrlf-input" class="flex items-center gap-2 text-sm">
+            <label for="autocrlf-input" class="md-choice-sub">
               <span>input</span>
-              <span class="text-gray-500 text-xs">Mac/Linux用（コミット時のみCRLF → LF）</span>
-              <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-blue-100 text-xs font-semibold text-blue-800">推奨</span>
+              <small>Mac/Linux用（コミット時のみCRLF → LF）</small>
+              <span class="md-chip md-chip--primary">推奨</span>
             </label>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="md-choice-row">
             <input type="radio" id="autocrlf-false" name="autocrlf" value="false" disabled>
-            <label for="autocrlf-false" class="flex items-center gap-2 text-sm">
+            <label for="autocrlf-false" class="md-choice-sub">
               <span>false</span>
-              <span class="text-gray-500 text-xs">変換なし（デフォルト）</span>
+              <small>変換なし（デフォルト）</small>
             </label>
           </div>
         </div>
       </div>
 
       <!-- push.default セクション -->
-      <div class="border border-gray-200 rounded-lg p-4 space-y-3">
-        <div class="flex items-start gap-3">
-          <input type="checkbox" id="enablePushDefault" class="rounded border-gray-300 mt-1" onchange="togglePushDefaultOptions()">
-          <label for="enablePushDefault" class="flex flex-wrap items-center gap-2 font-semibold">
-            <span>push.default を設定</span>
-            <span class="relative inline-flex items-center group">
-              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
-                push時のデフォルト動作を指定します。指定しないと予期しない動作をすることがあります。
+      <div class="md-choice-card md-stack-md">
+        <div class="md-form-row md-form-row--start">
+          <label for="enablePushDefault" class="md-choice-row">
+            <input type="checkbox" id="enablePushDefault" onchange="togglePushDefaultOptions()">
+            <span class="md-label">
+              <span>push.default を設定</span>
+              <span class="md-tooltip-group">
+                <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+                  push時のデフォルト動作を指定します。指定しないと予期しない動作をすることがあります。
+                </span>
               </span>
             </span>
           </label>
         </div>
 
-        <div id="pushDefaultOptions" class="space-y-2 ml-8 p-3 bg-gray-50 rounded disabled-section">
-          <div class="flex items-center gap-2">
+        <div id="pushDefaultOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
+          <div class="md-choice-row">
             <input type="radio" id="pushdefault-simple" name="pushdefault" value="simple" disabled>
-            <label for="pushdefault-simple" class="flex items-center gap-2 text-sm">
+            <label for="pushdefault-simple" class="md-choice-sub">
               <span>simple</span>
-              <span class="text-gray-500 text-xs">同名ブランチにpush（Git 2.0以降のデフォルト）</span>
-              <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-blue-100 text-xs font-semibold text-blue-800">推奨</span>
+              <small>同名ブランチにpush（Git 2.0以降のデフォルト）</small>
+              <span class="md-chip md-chip--primary">推奨</span>
             </label>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="md-choice-row">
             <input type="radio" id="pushdefault-current" name="pushdefault" value="current" disabled>
-            <label for="pushdefault-current" class="flex items-center gap-2 text-sm">
+            <label for="pushdefault-current" class="md-choice-sub">
               <span>current</span>
-              <span class="text-gray-500 text-xs">現在のブランチ名でpush</span>
+              <small>現在のブランチ名でpush</small>
             </label>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="md-choice-row">
             <input type="radio" id="pushdefault-upstream" name="pushdefault" value="upstream" disabled>
-            <label for="pushdefault-upstream" class="flex items-center gap-2 text-sm">
+            <label for="pushdefault-upstream" class="md-choice-sub">
               <span>upstream</span>
-              <span class="text-gray-500 text-xs">追跡ブランチにpush</span>
+              <small>追跡ブランチにpush</small>
             </label>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="md-choice-row">
             <input type="radio" id="pushdefault-matching" name="pushdefault" value="matching" disabled>
-            <label for="pushdefault-matching" class="flex items-center gap-2 text-sm">
+            <label for="pushdefault-matching" class="md-choice-sub">
               <span>matching</span>
-              <span class="text-gray-500 text-xs">マッチングブランチすべてをpush</span>
-              <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-yellow-100 text-xs font-semibold text-yellow-800">非推奨</span>
+              <small>マッチングブランチすべてをpush</small>
+              <span class="md-chip md-chip--warn">非推奨</span>
             </label>
           </div>
         </div>
       </div>
     </section>
 
-    <button onclick="generateConfigCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+    <button onclick="generateConfigCommand()" class="md-button md-button--primary">
       設定コマンド生成
     </button>
 
-    <div class="relative mt-4">
-      <code id="configCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('configCmd')">📋</button>
+    <div class="md-code-block">
+      <code id="configCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('configCmd')" aria-label="コピー">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="11" height="11" rx="2"/>
+          <rect x="4" y="4" width="11" height="11" rx="2"/>
+        </svg>
+      </button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar-host md-snackbar">
       コピーしました
     </div>
   </div>
@@ -410,7 +500,7 @@ limitations under the License.
       options.forEach(opt => {
         opt.disabled = !enabled;
       });
-      document.getElementById("autocrlfOptions").classList.toggle("opacity-50", !enabled);
+      document.getElementById("autocrlfOptions").classList.toggle("md-dimmed", !enabled);
     }
 
     function togglePushDefaultOptions() {
@@ -419,7 +509,7 @@ limitations under the License.
       options.forEach(opt => {
         opt.disabled = !enabled;
       });
-      document.getElementById("pushDefaultOptions").classList.toggle("opacity-50", !enabled);
+      document.getElementById("pushDefaultOptions").classList.toggle("md-dimmed", !enabled);
     }
 
     function generateConfigCommand() {
@@ -465,18 +555,16 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
 
     // Initialize

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -20,194 +20,289 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git ユーザー設定コマンドジェネレータ</title>
   <style>
-    /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
-    */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .gap-3 { gap: 0.75rem; }
-    .w-5 { width: 1.25rem; }
-    .w-12 { width: 3rem; }
-    .w-full { width: 100%; }
-    .w-80 { width: 20rem; }
-    .h-5 { height: 1.25rem; }
-    .h-12 { height: 3rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-4 { margin-top: 1rem; }
-    .mr-2 { margin-right: 0.5rem; }
-    .my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+    }
 
-    /* Typography */
-    .text-base { font-size: 1rem; line-height: 1.5rem; }
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .opacity-100 { opacity: 1; }
-    .pointer-events-none { pointer-events: none; }
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--block { margin-bottom: 0.5rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; }
 
-    /* Z-index */
-    .z-50 { z-index: 50; }
+    .md-input {
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid var(--md-sys-color-outline);
+      border-radius: 12px;
+      padding: 0.625rem 0.75rem;
+      font: inherit;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input { flex: 1 1 16rem; min-width: 12rem; }
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.4rem;
+      border-radius: 9999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.22);
+    }
+    .md-button--primary:hover { background: #5a00d6; }
 
-    /* Group hover */
-    .group {}
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Space-y utility */
-    .space-y-3 > * + * { margin-top: 0.75rem; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-small { width: 16px; height: 16px; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* hr element */
-    hr { border: none; border-top: 1px solid #e5e7eb; margin: 1.5rem 0; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.1rem 0.45rem;
+      border-radius: 9999px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: #f7e9e7;
+      color: #8c1d18;
+      border: 1px solid #f0c9c5;
+    }
+
+    .md-snackbar {
+      background: #2b2831;
+      color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      letter-spacing: 0.01em;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-divider { border: none; border-top: 1px solid #e6e1ee; margin: 1.5rem 0; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+    }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+<body class="md-page">
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6 flex flex-wrap items-center gap-2">
-      <span aria-hidden="true" class="mr-2">⚙️</span>
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">⚙️</span>
       <span>Git ユーザー設定コマンドジェネレータ</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
           グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
         </span>
       </span>
     </h1>
 
-    <section id="checkSection" class="space-y-3 mb-6">
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <section id="checkSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="20" cy="32" r="4" fill="#93C5FD"/>
           <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">現在の設定を確認</p>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <p class="md-section-title">現在の設定を確認</p>
+        <span class="md-tooltip-group">
+          <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
             設定前に現在のユーザー名とメールアドレスを確認できます。
           </span>
         </span>
       </div>
-      <button type="button" onclick="generateCheckCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">
         確認コマンド生成
       </button>
-      <div class="relative">
-        <code id="checkCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-        <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('checkCmd')">📋</button>
+      <div class="md-code-block">
+        <code id="checkCmd" class="md-code"></code>
+        <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
+          <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="9" y="9" width="11" height="11" rx="2"/>
+            <rect x="4" y="4" width="11" height="11" rx="2"/>
+          </svg>
+        </button>
       </div>
     </section>
 
-    <hr class="my-6" />
+    <hr class="md-divider" />
 
-    <section id="setupSection" class="space-y-3 mb-4">
-      <div class="flex items-center gap-3 py-2">
-        <svg aria-hidden="true" viewBox="0 0 64 64" class="w-12 h-12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <section id="setupSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <circle cx="20" cy="20" r="4" fill="#A78BFA"/>
           <path d="M24 20H34" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
@@ -215,58 +310,63 @@ limitations under the License.
           <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
           <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="text-base font-semibold text-gray-700">ユーザー情報を設定</p>
-        <span class="relative inline-flex items-center group">
-          <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-          <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+        <p class="md-section-title">ユーザー情報を設定</p>
+        <span class="md-tooltip-group">
+          <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
             グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
           </span>
         </span>
       </div>
 
-      <div class="space-y-3">
-        <div>
-          <label class="flex flex-wrap items-center gap-2 font-semibold mb-2">
+      <div class="md-stack-md">
+        <div class="md-form-row md-form-row--nowrap">
+          <label class="md-label">
             <span>ユーザー名</span>
-            <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-            <span class="relative inline-flex items-center group">
-              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+            <span class="md-tooltip-group">
+              <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
                 Gitコミットに記録される名前です。本名またはニックネームを入力してください。
               </span>
             </span>
             <span>：</span>
           </label>
-          <input type="text" id="userName" placeholder="例: Taro Yamada" class="border border-gray-300 rounded w-full p-2">
+          <input type="text" id="userName" placeholder="例: Taro Yamada" class="md-input">
         </div>
 
-        <div>
-          <label class="flex flex-wrap items-center gap-2 font-semibold mb-2">
+        <div class="md-form-row md-form-row--nowrap">
+          <label class="md-label">
             <span>メールアドレス</span>
-            <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-            <span class="relative inline-flex items-center group">
-              <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-              <span class="absolute left-1/2 top-full mt-2 w-80 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none z-50">
+            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+            <span class="md-tooltip-group">
+              <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+              <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
                 Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。
               </span>
             </span>
             <span>：</span>
           </label>
-          <input type="email" id="userEmail" placeholder="例: taro@example.com" class="border border-gray-300 rounded w-full p-2">
+          <input type="email" id="userEmail" placeholder="例: taro@example.com" class="md-input">
         </div>
       </div>
     </section>
 
-    <button onclick="generateSetupCommand()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+    <button onclick="generateSetupCommand()" class="md-button md-button--primary">
       設定コマンド生成
     </button>
 
-    <div class="relative mt-4">
-      <code id="setupCmd" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('setupCmd')">📋</button>
+    <div class="md-code-block">
+      <code id="setupCmd" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('setupCmd')" aria-label="コピー">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="11" height="11" rx="2"/>
+          <rect x="4" y="4" width="11" height="11" rx="2"/>
+        </svg>
+      </button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar-host md-snackbar">
       コピーしました
     </div>
   </div>
@@ -324,18 +424,16 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -89,9 +89,12 @@ limitations under the License.
     }
 
     .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
+    .md-field-stack { display: flex; flex-direction: column; align-items: stretch; gap: 0.5rem; }
     .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
     .md-label--muted { color: #3f3b46; }
     .md-label--block { margin-bottom: 0.5rem; }
+    .md-label--full { width: 100%; }
 
     .md-switch-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem; }
 
@@ -158,6 +161,7 @@ limitations under the License.
       border-radius: 12px;
       padding: 0.75rem 1rem;
       font-size: 0.8125rem;
+      font-weight: 400;
       line-height: 1.35;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       letter-spacing: 0.01em;
@@ -223,6 +227,20 @@ limitations under the License.
       border: 1px solid #f0c9c5;
     }
 
+    .md-input-wrap {
+      position: relative;
+      flex: 1 1 16rem;
+      min-width: 12rem;
+    }
+    .md-input-wrap .md-input { padding-right: 3rem; }
+    .md-input-action {
+      position: absolute;
+      top: 50%;
+      right: -0.5rem;
+      transform: translateY(-50%);
+      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+    }
+
     .md-snackbar {
       background: #2b2831;
       color: #ffffff;
@@ -242,6 +260,19 @@ limitations under the License.
       font: inherit;
       color: var(--md-sys-color-on-surface);
       transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input {
+      flex: 1 1 16rem;
+      min-width: 12rem;
+      height: 2.75rem;
+      min-height: 2.75rem;
+      line-height: 1.2;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+    .md-field-stack .md-input,
+    .md-field-stack .md-select {
+      flex: 0 0 auto;
     }
     .md-field--dropdown {
       background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23635b75' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
@@ -273,6 +304,10 @@ limitations under the License.
     .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
 
     .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+    }
   </style>
 </head>
 <body class="md-page">
@@ -301,8 +336,8 @@ limitations under the License.
     </h1>
 
     <section id="baseBlock" class="md-section md-stack-md">
-      <div class="md-form-grid md-form-grid-2">
-        <div class="md-form-row">
+      <div class="md-stack-md">
+        <div class="md-form-row md-form-row--nowrap">
           <label class="md-label">
             <span>基点ブランチ</span>
             <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
@@ -338,7 +373,7 @@ limitations under the License.
             <option value="stable"></option>
           </datalist>
         </div>
-        <div class="md-form-row">
+        <div class="md-form-row md-form-row--nowrap">
           <label class="md-label">
             <span>作業ブランチ</span>
             <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
@@ -349,15 +384,17 @@ limitations under the License.
                 生成コマンドにそのまま反映されます。
               </span>
             </span>
-            <button type="button" class="md-icon-btn md-icon-btn--small" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新">
+            <span>：</span>
+          </label>
+          <div class="md-input-wrap">
+            <input type="text" id="workBranch" placeholder="例: tiga0129a" class="md-input">
+            <button type="button" class="md-icon-btn md-icon-btn--small md-input-action" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
                 <path d="M20 4v6h-6"/>
               </svg>
             </button>
-            <span>：</span>
-          </label>
-          <input type="text" id="workBranch" placeholder="例: tiga0129a" class="md-input">
+          </div>
         </div>
       </div>
       <div class="md-switch-row">


### PR DESCRIPTION
# Summary

git-config-setup.html / git-config-advanced-setup.html / git-branch-diff.html を Material Design ベースへ刷新 git-pseudo-squash.html の入力レイアウト・アクション配置を調整
README.md に設計ルールと実装メモを追記

# Changes

Tailwind風ユーティリティを撤去し、md-* コンポーネントへ統一
フォーム/ツールチップ/コード出力/トーストなどのスタイルと構造をMaterial仕様に寄せて整理
ブランチ比較のトグルや入力行の横並び調整を反映
pseudo-squash の入力行を安定化し、リロードボタンを入力右端に埋め込み配置
READMEに変換ルール・フォーム配置の実装メモ・ツールチップフォント統一を追加