### PR TITLE
index.html をMaterial Design基調に再調整（カード/状態/タイポ/構造）

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,155 +5,241 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>local-html-tools</title>
   <style>
-    /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化と軽量化のため、Tailwind CSS の CSS クラス定義を自前で実装しました（300-500KBから25KBへ削減）。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
-    */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-tertiary-container: #f3e8fd;
+      --md-sys-color-on-tertiary-container: #3d2e5a;
+      --md-sys-color-state-layer: rgba(98, 0, 238, 0.08);
+      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.35);
+
+      --md-typography-headline-large: 1.85rem;
+      --md-typography-title-medium: 1.1rem;
+      --md-typography-title-small: 1.05rem;
+      --md-typography-body-medium: 1rem;
+      --md-typography-body-small: 0.875rem;
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: var(--md-typography-body-medium); line-height: 1.5; }
 
-    /* Colors */
-    body { background-color: #f3f4f6; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-yellow-50 { background-color: #fefce8; }
-    .bg-gray-900 { background-color: #111827; }
-    .text-gray-800 { color: #1f2937; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-500 { color: #6b7280; }
-    .text-gray-400 { color: #9ca3af; }
-    .text-gray-300 { color: #d1d5db; }
-    .text-gray-100 { color: #f3f4f6; }
-    .text-blue-600 { color: #2563eb; }
-    .text-blue-800 { color: #1e40af; }
-    .text-white { color: #ffffff; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
-    .border-yellow-100 { border-color: #fef3c7; }
+    .md-page { background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); }
+    .md-container { max-width: 72rem; margin: 0 auto; padding: 1.5rem 1rem 2.5rem; }
 
-    /* Layout */
-    .w-full { width: 100%; }
-    .w-4 { width: 1rem; }
-    .w-5 { width: 1.25rem; }
-    .h-4 { height: 1rem; }
-    .h-5 { height: 1.25rem; }
-    .max-w-4xl { max-width: 56rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-8 { padding-top: 2rem; padding-bottom: 2rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
-    .p-4 { padding: 1rem; }
-    .p-6 { padding: 1.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-3 { margin-bottom: 0.75rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mb-8 { margin-bottom: 2rem; }
-    .mt-1 { margin-top: 0.25rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-8 { margin-top: 2rem; }
-    .my-10 { margin-top: 2.5rem; margin-bottom: 2.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-app-bar { margin-bottom: 1.75rem; }
+    .md-app-bar-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+      padding: 1.25rem 1.5rem;
+      border-radius: 20px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ede7f3;
+      box-shadow: 0 6px 20px rgba(41, 35, 58, 0.08);
+    }
+    .md-app-title {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: var(--md-typography-headline-large);
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+    .md-app-meta { font-size: 0.95rem; color: #6a6675; }
+    .md-icon-inline { margin-right: 0.5rem; }
+    .md-section-wrap { display: grid; gap: 1.75rem; }
 
-    /* Flexbox */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .justify-between { justify-content: space-between; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-1 { gap: 0.25rem; }
-    .gap-2 { gap: 0.5rem; }
-    .gap-4 { gap: 1rem; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      border: 1px solid #ece7f3;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+    }
 
-    /* Grid */
-    .grid { display: grid; }
-    .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-    .gap-4 { gap: 1rem; }
+    .md-info-card {
+      padding: 1.25rem 1.5rem;
+      margin-bottom: 1.75rem;
+      background: var(--md-sys-color-tertiary-container);
+      border-color: rgba(61, 46, 90, 0.08);
+      color: var(--md-sys-color-on-tertiary-container);
+    }
+    .md-info-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+
+    .md-section-card {
+      padding: 1.25rem 1.25rem 1.5rem;
+      border-radius: 24px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ece7f3;
+      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
+    }
+    .md-section-title {
+      font-size: var(--md-typography-title-medium);
+      font-weight: 600;
+      color: #3f3b46;
+      margin-bottom: 0.25rem;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .md-section-subtitle {
+      font-size: var(--md-typography-body-small);
+      color: #6a6675;
+      margin-bottom: 1rem;
+    }
+    .md-section-title--spaced { margin-top: 1rem; }
+
+    .md-grid { display: grid; gap: 1rem; }
+    .md-grid-3 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
     @media (min-width: 640px) {
-      .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .md-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     }
     @media (min-width: 1024px) {
-      .lg\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .md-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+    .md-section { margin-bottom: 0; }
+    .md-divider { border: none; border-top: 1px solid #e2dcec; margin: 2.5rem 0 1.5rem; }
+
+    .md-footer { text-align: center; font-size: 0.875rem; color: #6a6675; padding-bottom: 1.5rem; }
+    .md-footer-links { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 1rem; }
+    .md-footer-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #4a3d6b; text-decoration: none; font-weight: 600; }
+    a { text-decoration: none; color: inherit; }
+    .md-footer-link:hover { color: #2f2347; }
+    .md-footer-sep { color: #c8c2d0; }
+    .md-footer-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.6rem;
+      border-radius: 9999px;
+      background: #f4eef8;
+      border: 1px solid #e0d8ea;
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: #4a3d6b;
+    }
+    .md-footer-icon { width: 1rem; height: 1rem; }
+
+    .md-link-card {
+      position: relative;
+      display: block;
+      padding: 1rem;
+      border-radius: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ece7f3;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+      transition: box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
+      overflow: hidden;
+      outline: none;
+    }
+    .md-link-card:hover {
+      box-shadow: 0 6px 16px rgba(35, 29, 49, 0.12);
+      border-color: #d7cfee;
+    }
+    .md-link-card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: var(--md-sys-color-state-layer);
+      opacity: 0;
+      transition: opacity 150ms ease;
+    }
+    .md-link-card:hover::after { opacity: 1; }
+    .md-link-card:focus-visible {
+      border-color: rgba(98, 0, 238, 0.55);
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring), 0 6px 16px rgba(35, 29, 49, 0.12);
+    }
+    .md-link-card:focus-visible::after { opacity: 1; }
+    .md-link-card:active::after { opacity: 0.18; }
+    .md-link-card > * { position: relative; z-index: 1; }
+
+    .md-card-head { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
+    .md-card-title { font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35; }
+    .md-card-arrow { color: #8f8a98; font-size: 1.2rem; }
+    .md-link-card:hover .md-card-arrow { color: #6d6483; }
+
+    .md-card-desc {
+      margin-top: 0.5rem;
+      font-size: var(--md-typography-body-small);
+      color: #5f5a6b;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
     }
 
-    /* Typography */
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-base { font-size: 1rem; line-height: 1.5rem; }
-    .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-    .text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .text-center { text-align: center; }
-
-    /* Box model */
-    .block { display: block; }
-    .inline { display: inline; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow { box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06); }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .underline { text-decoration: underline !important; }
-
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .left-1\/2 { left: 50%; }
-    .top-full { top: 100%; }
-    .mt-2 { margin-top: 0.5rem; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
-    .pointer-events-none { pointer-events: none; }
-    .opacity-0 { opacity: 0; }
-    .opacity-100 { opacity: 1; }
-
-    /* Group & Hover */
-    .group:hover .group-hover\:block { display: block; }
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .hover\:shadow-md:hover { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .hover\:text-blue-800:hover { color: #1e40af; }
-    .hover\:bg-gray-200:hover { background-color: #e5e7eb; }
-    .hover\:translate-x-0\.5:hover { transform: translateX(0.125rem); }
-    a.hover\:text-blue-800:hover { color: #1e40af; }
-    .tooltip { width: min(32rem, 90vw); white-space: normal; line-height: 1.5; }
-
-    /* Links */
-    a { color: inherit; text-decoration: none !important; }
-    a h3 { text-decoration: none !important; }
-    a p { text-decoration: none !important; }
-    a:hover { text-decoration: none; }
-    a:hover > span { text-decoration: none; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: #f0edf5;
+      color: #4a4458;
+      font-size: 0.75rem;
+      font-weight: 600;
+      outline: none;
+      border: none;
+      cursor: help;
+      padding: 0;
+    }
+    .md-help-chip:focus-visible {
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
+    }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: min(32rem, 90vw);
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: min(32rem, 90vw); }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.5;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
   </style>
 </head>
-<body class="bg-gray-100 text-gray-800 w-full">
-  <div class="w-full px-4 py-8">
-    <header class="text-center mb-8">
-      <h1 class="text-4xl font-bold">
-        <span aria-hidden="true" class="mr-2">🗂️</span>local-html-tools
-      </h1>
-      <p class="mt-1 text-sm text-gray-500">更新日: 2026-02-05</p>
+<body class="md-page">
+  <div class="md-container">
+    <header class="md-app-bar">
+      <div class="md-app-bar-inner">
+        <div class="md-app-title">
+          <span aria-hidden="true" class="md-icon-inline">🗂️</span>
+          <span>local-html-tools</span>
+        </div>
+        <div class="md-app-meta">更新日: 2026-02-05</div>
+      </div>
     </header>
 
-    <div class="max-w-4xl mx-auto bg-yellow-50 p-6 rounded-lg shadow-md mb-8 border border-yellow-100">
-        <p class="mb-2 flex flex-wrap items-center gap-2">
+    <div class="md-info-card md-card">
+        <p class="md-info-row">
           <span>ウェブブラウザで動くローカルHTMLツール集（Static Web App）です。</span>
-          <span class="relative inline-flex items-center group">
-            <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-            <span class="tooltip absolute left-1/2 top-full mt-2 -translate-x-1/2 rounded bg-gray-900 text-white text-xs px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+          <span class="md-tooltip-group">
+            <button type="button" class="md-help-chip" aria-label="このツール集について">?</button>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
               各ツール（HTMLファイル）をウェブブラウザで開くと、専用の入力画面が表示されます。そこにファイル名などの必要な情報を入力するだけで、FFmpegで使えるコマンドラインのテキストが自動的に作成されます。
               主な特徴:
               ・ローカル動作: お使いのPC内で動作し、サーバは不要です。
@@ -164,288 +250,375 @@
         </p>
     </div>
 
-    <div class="w-full px-4">
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">🧰</span>Git
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="git/git-pseudo-squash.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧩</span>Git pseudo-squash
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。</p>
-        </a>
-        <a href="git/git-branch-diff.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧰</span>Git ブランチ比較
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。</p>
-        </a>
-        <a href="git/git-config-setup.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">⚙️</span>Git ユーザー設定
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。</p>
-        </a>
-        <a href="git/git-config-advanced-setup.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔧</span>Git 詳細設定
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。</p>
-        </a>
-      </div>
+    <div class="md-section-wrap">
+      
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">🔍</span>検索
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🧰</span>Git
       </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="grep/find-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔎</span>find 検索
+      <p class="md-section-subtitle">Git操作の補助ツール</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="git/git-pseudo-squash.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧩</span>Git pseudo-squash
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">findでファイル/ディレクトリを検索するコマンドを生成します。条件（名前/拡張子/サイズ/更新日時/内容検索）を組み合わせて作れます。</p>
-        </a>
-      </div>
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mt-2 mb-3">
-        <span aria-hidden="true" class="mr-2">🎬</span>メディア処理（FFmpeg）
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="ffmpeg/ffmpeg-concat-cmdline-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧩</span>FFmpeg ファイル結合
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">複数の.wavファイルを1つに結合するコマンドを生成します。</p>
+          <p class="md-card-desc">reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。</p>
         </a>
-        <a href="ffmpeg/ffmpeg-loudnorm-cmdline-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔊</span>FFmpeg 音量正規化 (Loudnorm)
+        <a href="git/git-branch-diff.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧰</span>Git ブランチ比較
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">.wavファイルの音量をラウドネス基準に合わせて正規化します。</p>
+          <p class="md-card-desc">2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。</p>
         </a>
-        <a href="ffmpeg/ffmpeg-trim-cmdline-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">✂️</span>FFmpeg 切り出し (Trim)
+        <a href="git/git-config-setup.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">⚙️</span>Git ユーザー設定
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">音声/動画ファイルの一部を時間指定で切り出すコマンドを生成します。</p>
+          <p class="md-card-desc">グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。</p>
         </a>
-        <a href="ffmpeg/ffmpeg-audio-convert-cmdline-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🎧</span>FFmpeg 音声変換
+        <a href="git/git-config-advanced-setup.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔧</span>Git 詳細設定
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">音声ファイルを指定の形式に変換するコマンドを生成します。</p>
-        </a>
-        <a href="ffmpeg/ffmpeg-youtube-mkv-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">📺</span>YouTube向け動画生成
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">一枚の画像と音声ファイルから、YouTube投稿用の動画ファイル(.mkv)を生成します。</p>
-        </a>
-        <a href="ffmpeg/ffmpeg-mp4-to-wav-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🎵</span>MP4からWAV抽出
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">mp4ファイルから音声をWAVとして取り出すコマンドを生成します。</p>
-        </a>
-        <a href="ffmpeg/ffmpeg-replace-audio-with-wav-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔁</span>MP4音声差し替え（WAV）
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">動画の映像はそのままに、WAV音声へ差し替えるコマンドを生成します。</p>
-        </a>
-        <a href="ffmpeg/ffmpeg-silence-detect-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔇</span>無音区間検出
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">silencedetect で無音区間を検出するコマンドを生成します。</p>
+          <p class="md-card-desc">core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。</p>
         </a>
       </div>
+      </section>
+      
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">🌐</span>Web/URL
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="link/amazon-dp-extract.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🛒</span>Amazon dp 抽出
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">Amazon URL から dp/ASIN を取り出します。</p>
-        </a>
-        <a href="link/facebook-fbclid-remove.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔗</span>Facebook識別子（fbclid）除去
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">URL から Facebook識別子（fbclid）を除去します。</p>
-        </a>
-        <a href="link/url-encode-decode.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🔤</span>URL エンコード/デコード
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">URLのエンコードとデコードを行います。</p>
-        </a>
-        <a href="link/mime-base64.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">📦</span>MIME Base64
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">MIME Base64のエンコード/デコードを行います。</p>
-        </a>
-        <a href="link/utm-remove.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧹</span>UTM除去
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">URL から utm_* パラメータを削除します。</p>
-        </a>
-      </div>
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">🖼️</span>画像/SVG
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🔍</span>検索
       </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="img/img2svg.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧩</span>画像 → SVG 変換
+      <p class="md-section-subtitle">ローカル検索コマンド生成</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="grep/find-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔎</span>find 検索
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">画像ファイルをSVGに変換します。これは困難なことを実現するツールです。アイコン・ロゴのようなものはよく再現できますが、イラスト・写真などは技術的な理由から再現度が高くないことをあらかじめご承知ください。</p>
-        </a>
-      </div>
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">📄</span>テキスト
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-        <a href="text/text-viewer.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">📄</span>テキスト表示
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。</p>
-        </a>
-        <a href="text/text-processing.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🧩</span>テキスト加工
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。</p>
+          <p class="md-card-desc">findでファイル/ディレクトリを検索するコマンドを生成します。条件（名前/拡張子/サイズ/更新日時/内容検索）を組み合わせて作れます。</p>
         </a>
       </div>
+      </section>
+      
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">
-        <span aria-hidden="true" class="mr-2">🔐</span>パスワード
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="password/password-gen.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🛡️</span>パスワードジェネレーター
-            </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
-          </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。</p>
-        </a>
-      </div>
+      
 
-      <h3 class="text-lg font-semibold text-gray-700 mt-8 mb-3">
-        <span aria-hidden="true" class="mr-2">🧳</span>日々の生活
-      </h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <a href="life/japan-weather.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">🌤️</span>Japan Weather
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title md-section-title--spaced">
+        <span aria-hidden="true" class="md-icon-inline">🎬</span>メディア処理（FFmpeg）
+      </h2>
+      <p class="md-section-subtitle">FFmpeg向けコマンド生成</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="ffmpeg/ffmpeg-concat-cmdline-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧩</span>FFmpeg ファイル結合
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">地域と府県を選んで天気予報を表示します（オンライン取得）。</p>
+      
+
+          <p class="md-card-desc">複数の.wavファイルを1つに結合するコマンドを生成します。</p>
         </a>
-        <a href="life/forgot-items-check.html" class="group block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
-          <div class="flex items-center justify-between">
-            <h3 class="font-semibold text-lg">
-              <span aria-hidden="true" class="mr-2">✅</span>忘れ物チェック
+        <a href="ffmpeg/ffmpeg-loudnorm-cmdline-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔊</span>FFmpeg 音量正規化 (Loudnorm)
             </h3>
-            <span class="text-gray-400 transition group-hover:translate-x-0.5">→</span>
+            <span class="md-card-arrow">→</span>
           </div>
-          <p class="mt-2 hidden text-sm text-gray-600 group-hover:block">持ち物を順番に確認して、忘れ物を防ぎます。</p>
+          <p class="md-card-desc">.wavファイルの音量をラウドネス基準に合わせて正規化します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-trim-cmdline-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">✂️</span>FFmpeg 切り出し (Trim)
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">音声/動画ファイルの一部を時間指定で切り出すコマンドを生成します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-audio-convert-cmdline-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎧</span>FFmpeg 音声変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">音声ファイルを指定の形式に変換するコマンドを生成します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-youtube-mkv-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">📺</span>YouTube向け動画生成
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">一枚の画像と音声ファイルから、YouTube投稿用の動画ファイル(.mkv)を生成します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-mp4-to-wav-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎵</span>MP4からWAV抽出
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">mp4ファイルから音声をWAVとして取り出すコマンドを生成します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-replace-audio-with-wav-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔁</span>MP4音声差し替え（WAV）
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">動画の映像はそのままに、WAV音声へ差し替えるコマンドを生成します。</p>
+        </a>
+        <a href="ffmpeg/ffmpeg-silence-detect-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔇</span>無音区間検出
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">silencedetect で無音区間を検出するコマンドを生成します。</p>
         </a>
       </div>
+      </section>
+      
+      
+
+      
+
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🌐</span>Web/URL
+      </h3>
+      <p class="md-section-subtitle">URL処理のユーティリティ</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="link/amazon-dp-extract.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🛒</span>Amazon dp 抽出
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+      
+
+          <p class="md-card-desc">Amazon URL から dp/ASIN を取り出します。</p>
+        </a>
+        <a href="link/facebook-fbclid-remove.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔗</span>Facebook識別子（fbclid）除去
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">URL から Facebook識別子（fbclid）を除去します。</p>
+        </a>
+        <a href="link/url-encode-decode.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🔤</span>URL エンコード/デコード
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">URLのエンコードとデコードを行います。</p>
+        </a>
+        <a href="link/mime-base64.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">📦</span>MIME Base64
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">MIME Base64のエンコード/デコードを行います。</p>
+        </a>
+        <a href="link/utm-remove.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧹</span>UTM除去
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">URL から utm_* パラメータを削除します。</p>
+        </a>
+      </div>
+      </section>
+      
+      
+
+      
+
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🖼️</span>画像/SVG
+      </h3>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="img/img2svg.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧩</span>画像 → SVG 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+      
+
+          <p class="md-card-desc">画像ファイルをSVGに変換します。これは困難なことを実現するツールです。アイコン・ロゴのようなものはよく再現できますが、イラスト・写真などは技術的な理由から再現度が高くないことをあらかじめご承知ください。</p>
+        </a>
+      </div>
+      </section>
+      
+      
+
+      
+
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">📄</span>テキスト
+      </h3>
+      <p class="md-section-subtitle">テキスト表示/加工</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="text/text-viewer.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">📄</span>テキスト表示
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+      
+
+          <p class="md-card-desc">テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。</p>
+        </a>
+        <a href="text/text-processing.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🧩</span>テキスト加工
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。</p>
+        </a>
+      </div>
+      </section>
+      
+      
+
+      
+
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🔐</span>パスワード
+      </h3>
+      <p class="md-section-subtitle">パスワード生成</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="password/password-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🛡️</span>パスワードジェネレーター
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+      
+
+          <p class="md-card-desc">選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。</p>
+        </a>
+      </div>
+      </section>
+      
+      
+
+      
+
+      
+      
+      <section class="md-section-card">
+      <h2 class="md-section-title md-section-title--spaced">
+        <span aria-hidden="true" class="md-icon-inline">🧳</span>日々の生活
+      </h2>
+      <p class="md-section-subtitle">生活系の小ツール</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="life/japan-weather.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🌤️</span>Japan Weather
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+      
+
+          <p class="md-card-desc">地域と府県を選んで天気予報を表示します（オンライン取得）。</p>
+        </a>
+        <a href="life/forgot-items-check.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">✅</span>忘れ物チェック
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">持ち物を順番に確認して、忘れ物を防ぎます。</p>
+        </a>
+      </div>
+      </section>
+      
     </div>
 
-    <hr class="my-10 border-gray-200">
-    <footer class="text-center text-sm text-gray-600 pb-6">
-      <div class="flex flex-wrap items-center justify-center gap-4">
-        <a href="https://github.com/igapyon/local-html-tools" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
-          <svg aria-hidden="true" viewBox="0 0 16 16" class="w-4 h-4" fill="currentColor">
+    <hr class="md-divider">
+    <footer class="md-footer">
+      <div class="md-footer-links">
+        <a href="https://github.com/igapyon/local-html-tools" class="md-footer-link" target="_blank" rel="noopener noreferrer">
+          <svg aria-hidden="true" viewBox="0 0 16 16" class="md-footer-icon" fill="currentColor">
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
           </svg>
           <span>GitHub</span>
         </a>
-        <span class="text-gray-300">|</span>
-        <a href="https://github.com/igapyon/local-html-tools/blob/main/THIRD_PARTY_NOTICES.md" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
-          <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-gray-100 text-xs font-semibold border border-gray-200 hover:bg-gray-200">Third-Party Notices</span>
+        <span class="md-footer-sep">|</span>
+        <a href="https://github.com/igapyon/local-html-tools/blob/main/THIRD_PARTY_NOTICES.md" class="md-footer-link" target="_blank" rel="noopener noreferrer">
+          <span class="md-footer-badge">Third-Party Notices</span>
         </a>
-        <span class="text-gray-300">|</span>
-        <a href="https://igapyon.github.io/local-html-tools/" class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer">
-          <svg aria-hidden="true" viewBox="0 0 24 24" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <span class="md-footer-sep">|</span>
+        <a href="https://igapyon.github.io/local-html-tools/" class="md-footer-link" target="_blank" rel="noopener noreferrer">
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="md-footer-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="9"/>
             <path d="M3 12h18"/>
             <path d="M12 3a14 14 0 0 1 0 18"/>


### PR DESCRIPTION
## 概要
- カタログページ（docs/index.html）を Material Design らしく再調整
- 状態レイヤーやフォーカス表示、タイポスケールを追加して一貫性を強化

## 変更内容
- App Bar 風ヘッダーの導入とレイアウト整理
- セクションをカード化し、サブタイトルを追加
- カード説明を常時2行表示（hover展開は廃止）
- hover/focus/active に対応した state layer を実装
- フォーカスリング追加でキーボード操作に対応
- 見出し階層を `h2`（セクション）/`h3`（カード）に整理
- Infoカード配色をMaterialトークン寄りに調整
- タイポグラフィ用トークンを追加し適用

## 影響範囲
- docs/index.html