### PR TITLE
Material Design化の適用範囲拡大と通知整理

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,30 +8,6 @@ This project includes the following third-party software:
 
 Material Design is a design specification by Google and is referenced in this project.
 
-## Tailwind CSS
-- Project: https://tailwindcss.com/
-- License: MIT
-
-Copyright (c) Tailwind Labs, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 ## ImageTracerJS
 - Project: https://jankovicsandras.github.io/imagetracerjs/
 - License: The Unlicense

--- a/docs/git/README.md
+++ b/docs/git/README.md
@@ -28,13 +28,13 @@
 - 表示切替は `md-hidden` `md-visible` `md-disabled` を使い、JS 側はクラスの付け替えだけで制御する
 - 「i」アイコンはインライン SVG で実装し、色/サイズ/余白は `md-tooltip-trigger` 側で統一する
 
-## Tailwind CSS から Material Design への書き換えルール
+## Material Design 実装ルール
 
-このプロジェクトでは、Tailwind 的ユーティリティをすべて撤去し、Material Design のコンポーネント指向に置き換えています。
+このプロジェクトでは、外部CSS依存を避け、Material Design のコンポーネント指向に統一しています。
 
 - チェックボックスとトグルの使い分けは行わず、選択肢はすべてトグルに統一する
 - トグルはラベルの左側に配置する（左右の違いで迷わないように固定）
-- ユーティリティ連打の構造はやめ、意味単位の `md-*` コンポーネントに再構成する
+- 意味単位の `md-*` コンポーネントに再構成する
 - 色/角丸/影/タイポは `--md-sys-*` に集約し、要素側はトークン参照のみにする
 - `input/select/textarea` は `md-input` `md-select` `md-textarea` に統一する
 - 必須表示はラベル横の `md-required-chip` に統一する

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -6,60 +6,121 @@
     <title>Smart Check - Final Edition</title>
     <style>
         :root {
-            --bg-main: #121212;
-            --bg-card: #1e1e1e;
-            --bg-card-lighter: #2c2c2c;
-            --accent-cyan: #00bcd4;
-            --accent-orange: #ff9800;
-            --accent-green: #4caf50;
-            --text-main: #e0e0e0;
-            --text-sub: #aaaaaa;
+            --md-sys-color-primary: #6750A4;
+            --md-sys-color-on-primary: #FFFFFF;
+            --md-sys-color-secondary: #625B71;
+            --md-sys-color-on-secondary: #FFFFFF;
+            --md-sys-color-tertiary: #7D5260;
+            --md-sys-color-on-tertiary: #FFFFFF;
+            --md-sys-color-surface: #FFFBFE;
+            --md-sys-color-surface-variant: #E7E0EC;
+            --md-sys-color-background: #FFFBFE;
+            --md-sys-color-on-surface: #1C1B1F;
+            --md-sys-color-on-surface-variant: #49454F;
+            --md-sys-color-outline: #CAC4D0;
+            --status-todo: #00bcd4;
+            --status-ok: #4caf50;
+            --status-later: #ff9800;
         }
 
-        body { 
-            font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
-            background: var(--bg-main); color: var(--text-main); margin: 0; display: flex; justify-content: center; height: 100dvh; overflow: hidden; user-select: none; -webkit-tap-highlight-color: transparent;
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif;
+            background: var(--md-sys-color-background);
+            color: var(--md-sys-color-on-surface);
+            margin: 0;
+            display: flex;
+            justify-content: center;
+            height: 100dvh;
+            overflow: hidden;
+            user-select: none;
+            -webkit-tap-highlight-color: transparent;
         }
-        
-        .container { 
-            width: 100%; max-width: 500px; height: 100%; display: flex; flex-direction: column; padding: 20px; padding-bottom: calc(20px + env(safe-area-inset-bottom)); box-sizing: border-box;
+
+        .md-page { width: 100%; height: 100%; }
+        .md-shell {
+            width: 100%;
+            max-width: 500px;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            padding: 20px;
+            padding-bottom: calc(20px + env(safe-area-inset-bottom));
+            box-sizing: border-box;
         }
 
-        .matte-card { background: var(--bg-card); border-radius: 16px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); border: 1px solid #333; }
-        .btn { border: none; border-radius: 12px; font-size: clamp(1rem, 2.8vw, 1.3rem); font-weight: bold; cursor: pointer; transition: opacity 0.2s; flex-shrink: 0; }
-        .btn:active { opacity: 0.7; }
+        .md-card {
+            background: var(--md-sys-color-surface);
+            border-radius: 16px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08), 0 8px 20px rgba(0,0,0,0.06);
+            border: 1px solid var(--md-sys-color-outline);
+        }
 
-        .check-btn { background: var(--accent-cyan); color: #000; }
-        .skip-btn { background: var(--bg-card-lighter); color: var(--text-main); border: 1px solid #444; }
-        .retry-btn { background: var(--accent-orange); color: #000; margin-bottom: 10px; }
+        .md-button {
+            border: none;
+            border-radius: 12px;
+            font-size: clamp(1rem, 2.8vw, 1.3rem);
+            font-weight: 700;
+            cursor: pointer;
+            transition: opacity 0.2s;
+            flex-shrink: 0;
+        }
+        .md-button:active { opacity: 0.7; }
+        .md-button--primary { background: var(--md-sys-color-primary); color: var(--md-sys-color-on-primary); }
+        .md-button--surface { background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline); }
+        .md-button--secondary { background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px; }
 
-        .scroll-list { text-align: left; margin: 15px 0; padding: 15px; overflow-y: auto; flex-grow: 1; background: var(--bg-card); border-radius: 16px; border: 1px solid #333; }
-        .category-label { font-size: 0.75rem; color: var(--accent-cyan); font-weight: bold; margin-top: 15px; margin-bottom: 5px; letter-spacing: 1px; }
-        .list-item { display: flex; align-items: center; padding: 12px 0; border-bottom: 1px solid #2a2a2a; }
-        .status-badge { font-size: 0.65rem; padding: 3px 8px; border-radius: 5px; margin-right: 12px; min-width: 48px; text-align: center; font-weight: bold; color: #000; }
-        .badge-todo { background: var(--accent-cyan); }
-        .badge-done { background: var(--accent-green); }
-        .badge-skip { background: var(--accent-orange); }
-        
+        .md-list {
+            text-align: left;
+            margin: 15px 0;
+            padding: 15px;
+            overflow-y: auto;
+            flex-grow: 1;
+            background: var(--md-sys-color-surface);
+            border-radius: 16px;
+            border: 1px solid var(--md-sys-color-outline);
+        }
+        .md-category-label {
+            font-size: 0.75rem;
+            color: var(--md-sys-color-primary);
+            font-weight: 700;
+            margin-top: 15px;
+            margin-bottom: 5px;
+            letter-spacing: 1px;
+        }
+        .md-list-item { display: flex; align-items: center; padding: 12px 0; border-bottom: 1px solid var(--md-sys-color-surface-variant); }
+        .md-status-badge {
+            font-size: 0.65rem;
+            padding: 3px 8px;
+            border-radius: 5px;
+            margin-right: 12px;
+            min-width: 48px;
+            text-align: center;
+            font-weight: 700;
+        }
+        .md-badge-todo { background: var(--status-todo); color: #000; }
+        .md-badge-done { background: var(--status-ok); color: #000; }
+        .md-badge-skip { background: var(--status-later); color: #000; }
+
         #start-screen, #check-screen, #finish-screen { display: flex; flex-direction: column; height: 100%; }
-        .hidden { display: none !important; }
+        .md-hidden { display: none !important; }
 
-        .logo-area { text-align: center; padding: 30px 0; }
-        .logo-text { font-size: 1.4rem; font-weight: 900; letter-spacing: 3px; color: var(--accent-cyan); }
+        .md-logo { text-align: center; padding: 30px 0; }
+        .md-logo-text { font-size: 1.4rem; font-weight: 900; letter-spacing: 3px; color: var(--md-sys-color-primary); }
 
-        .counter-display { font-size: 1rem; font-weight: bold; color: var(--accent-cyan); margin-bottom: 10px; font-family: 'Courier New', Courier, monospace; }
+        .md-counter { font-size: 1rem; font-weight: 700; color: var(--md-sys-color-primary); margin-bottom: 10px; font-family: "Courier New", Courier, monospace; }
 
-        .dots-container { display: flex; justify-content: center; gap: 6px; padding: 5px 0; flex-wrap: wrap; }
-        .dot { width: 6px; height: 6px; border-radius: 50%; background: #444; }
-        .dot.current { background: var(--accent-cyan); transform: scale(1.3); }
-        .dot.done { background: var(--accent-green); }
-        .dot.skipped { background: var(--accent-orange); }
-        
-        .item-display-card { flex-grow: 1; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; padding: 20px; margin-bottom: 20px; }
-        .item-text-main { font-size: 1.8rem; font-weight: 900; line-height: 1.3; }
-        .button-area { display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px; }
-        .btn-primary { font-size: clamp(1.2rem, 4vw, 1.6rem); }
-        .summary-header { display: flex; justify-content: space-around; padding: 15px; margin-top: 10px; background: var(--bg-card); border-radius: 16px; border: 1px solid #333; }
+        .md-dots { display: flex; justify-content: center; gap: 6px; padding: 5px 0; flex-wrap: wrap; }
+        .md-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--md-sys-color-outline); }
+        .md-dot.current { background: var(--status-todo); transform: scale(1.3); }
+        .md-dot.done { background: var(--status-ok); }
+        .md-dot.skipped { background: var(--status-later); }
+
+        .md-item-card { flex-grow: 1; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; padding: 20px; margin-bottom: 20px; }
+        .md-item-text { font-size: 1.8rem; font-weight: 900; line-height: 1.3; }
+        .md-button-row { display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px; }
+        .md-button--hero { font-size: clamp(1.2rem, 4vw, 1.6rem); }
+        .md-summary { display: flex; justify-content: space-around; padding: 15px; margin-top: 10px; background: var(--md-sys-color-surface); border-radius: 16px; border: 1px solid var(--md-sys-color-outline); }
 
         .burst {
             position: fixed;
@@ -90,38 +151,40 @@
 </head>
 <body>
 
-<div class="container">
+<div class="md-page">
+    <div class="md-shell">
     <div id="start-screen">
-        <div class="logo-area"><span style="font-size:3rem;">💼</span><br><span class="logo-text">READY TO GO</span></div>
-        <div class="scroll-list" id="previewList"></div>
-        <button class="btn check-btn" style="height: 70px; width: 100%;" onclick="app.start('all')">CHECK START</button>
+        <div class="md-logo"><span style="font-size:3rem;">💼</span><br><span class="md-logo-text">READY TO GO</span></div>
+        <div class="md-list" id="previewList"></div>
+        <button class="md-button md-button--primary" style="height: 70px; width: 100%;" onclick="app.start('all')">CHECK START</button>
     </div>
 
-    <div id="check-screen" class="hidden">
-        <div class="counter-display" id="counterDisplay" style="text-align: center;">0 / 0</div>
-        <div class="dots-container" id="dotsContainer"></div>
-        <div class="matte-card item-display-card">
-            <div id="itemCategory" style="color:var(--accent-cyan); font-size:0.8rem; font-weight:bold; margin-bottom:8px;"></div>
-            <div id="targetItem" class="item-text-main"></div>
+    <div id="check-screen" class="md-hidden">
+        <div class="md-counter" id="counterDisplay" style="text-align: center;">0 / 0</div>
+        <div class="md-dots" id="dotsContainer"></div>
+        <div class="md-card md-item-card">
+            <div id="itemCategory" style="color:var(--md-sys-color-primary); font-size:0.8rem; font-weight:bold; margin-bottom:8px;"></div>
+            <div id="targetItem" class="md-item-text"></div>
         </div>
-        <div class="button-area">
-            <button class="btn skip-btn" style="flex:2;" onclick="app.handleAction('skip', event)">あとで</button>
-            <button class="btn check-btn btn-primary" style="flex:3;" onclick="app.handleAction('check', event)">OK</button>
+        <div class="md-button-row">
+            <button class="md-button md-button--surface" style="flex:2;" onclick="app.handleAction('skip', event)">あとで</button>
+            <button class="md-button md-button--primary md-button--hero" style="flex:3;" onclick="app.handleAction('check', event)">OK</button>
         </div>
     </div>
 
-    <div id="finish-screen" class="hidden">
-        <h2 style="text-align:center; color: var(--accent-cyan); margin: 15px 0 5px 0;">RESULT</h2>
-        <div class="summary-header">
-            <div style="text-align:center;"><span id="countDone" style="font-size:2.2rem; font-weight:900; color:var(--accent-green);">0</span><br><span style="font-size:0.7rem;">COMPLETE</span></div>
-            <div style="text-align:center;"><span id="countSkip" style="font-size:2.2rem; font-weight:900; color:var(--accent-orange);">0</span><br><span style="font-size:0.7rem;">SKIPPED</span></div>
+    <div id="finish-screen" class="md-hidden">
+        <h2 style="text-align:center; color: var(--md-sys-color-primary); margin: 15px 0 5px 0;">RESULT</h2>
+        <div class="md-summary">
+            <div style="text-align:center;"><span id="countDone" style="font-size:2.2rem; font-weight:900; color:var(--status-ok);">0</span><br><span style="font-size:0.7rem;">COMPLETE</span></div>
+            <div style="text-align:center;"><span id="countSkip" style="font-size:2.2rem; font-weight:900; color:var(--status-later);">0</span><br><span style="font-size:0.7rem;">SKIPPED</span></div>
         </div>
-        <div class="scroll-list" id="resultList"></div>
+        <div class="md-list" id="resultList"></div>
         <div id="actionArea">
-            <button id="retryBtn" class="btn retry-btn" style="height: 60px; width: 100%; display:none;" onclick="app.start('retry')">「あとで」を再チェック</button>
-            <button class="btn check-btn" style="height: 60px; width: 100%;" onclick="app.reset()">TOPに戻る</button>
+            <button id="retryBtn" class="md-button md-button--secondary" style="height: 60px; width: 100%; display:none;" onclick="app.start('retry')">「あとで」を再チェック</button>
+            <button class="md-button md-button--primary" style="height: 60px; width: 100%;" onclick="app.reset()">TOPに戻る</button>
         </div>
     </div>
+</div>
 </div>
 
 <script>
@@ -147,8 +210,8 @@
         showPreview: function() {
             let html = "";
             CONFIG.categories.forEach(cat => {
-                html += `<div class="category-label">${cat.name}</div>`;
-                cat.items.forEach(name => html += `<div class="list-item"><span class="status-badge badge-todo">TODO</span><span>${name}</span></div>`);
+                html += `<div class="md-category-label">${cat.name}</div>`;
+                cat.items.forEach(name => html += `<div class="md-list-item"><span class="md-status-badge md-badge-todo">TODO</span><span>${name}</span></div>`);
             });
             document.getElementById('previewList').innerHTML = html;
         },
@@ -167,7 +230,7 @@
         },
 
         renderDots: function() {
-            document.getElementById('dotsContainer').innerHTML = this.activeIndices.map((_, i) => `<div class="dot" id="dot-${i}"></div>`).join('');
+            document.getElementById('dotsContainer').innerHTML = this.activeIndices.map((_, i) => `<div class="md-dot" id="dot-${i}"></div>`).join('');
         },
 
         updateDisplay: function() {
@@ -181,7 +244,7 @@
                 this.activeIndices.forEach((_, i) => {
                     const dot = document.getElementById(`dot-${i}`);
                     const originalState = this.states[this.activeIndices[i]];
-                    dot.className = 'dot' + (i === this.currentIndex ? ' current' : '') + (originalState === 'done' ? ' done' : '') + (originalState === 'skipped' ? ' skipped' : '');
+                    dot.className = 'md-dot' + (i === this.currentIndex ? ' current' : '') + (originalState === 'done' ? ' done' : '') + (originalState === 'skipped' ? ' skipped' : '');
                 });
             } else { this.showFinish(); }
         },
@@ -205,15 +268,15 @@
             let html = "";
             let currentCat = "";
             flatItems.forEach((item, i) => {
-                if (currentCat !== item.category) { currentCat = item.category; html += `<div class="category-label">${currentCat}</div>`; }
+                if (currentCat !== item.category) { currentCat = item.category; html += `<div class="md-category-label">${currentCat}</div>`; }
                 const isDone = this.states[i] === 'done';
-                html += `<div class="list-item"><span class="status-badge ${isDone ? 'badge-done' : 'badge-skip'}">${isDone ? 'OK' : '後で'}</span><span style="color:${isDone ? '' : 'var(--accent-orange)'}">${item.name}</span></div>`;
+                html += `<div class="md-list-item"><span class="md-status-badge ${isDone ? 'md-badge-done' : 'md-badge-skip'}">${isDone ? 'OK' : '後で'}</span><span style="color:${isDone ? '' : 'var(--md-sys-color-secondary)'}">${item.name}</span></div>`;
             });
             document.getElementById('resultList').innerHTML = html;
         },
 
         switchScreen: function(id) {
-            ['start-screen', 'check-screen', 'finish-screen'].forEach(s => document.getElementById(s).classList.toggle('hidden', s !== id));
+            ['start-screen', 'check-screen', 'finish-screen'].forEach(s => document.getElementById(s).classList.toggle('md-hidden', s !== id));
         },
 
         playTapEffect: function(type, event) {
@@ -221,7 +284,7 @@
             const rect = event.currentTarget.getBoundingClientRect();
             const x = rect.left + rect.width / 2;
             const y = rect.top + rect.height / 2;
-            const color = type === 'check' ? 'rgba(160, 245, 255, 0.95)' : 'rgba(255, 194, 112, 0.95)';
+            const color = type === 'check' ? 'var(--status-ok)' : 'var(--status-later)';
             const baseParticles = 32;
             const sparkleParticles = 22;
 

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -6,181 +6,197 @@
   <title>埼玉県お天気ボード</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .text-gray-500 { color: #6b7280; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-slate-500 { color: #64748b; }
-    .text-slate-600 { color: #475569; }
-    .text-slate-700 { color: #334155; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
-    .border-white { border-color: #ffffff; }
-
-    /* Layout */
-    .flex { display: flex; }
-    .flex-col { flex-direction: column; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .grid { display: grid; }
-    .grid-cols-1 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-    .gap-2 { gap: 0.5rem; }
-    .gap-3 { gap: 0.75rem; }
-    .gap-6 { gap: 1.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-24 { width: 6rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .h-24 { height: 6rem; }
-    .max-w-5xl { max-width: 64rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-6 { padding: 1.5rem; }
-    .p-8 { padding: 2rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pt-8 { padding-top: 2rem; }
-    .pb-4 { padding-bottom: 1rem; }
-    .pr-3 { padding-right: 0.75rem; }
-    .mb-1 { margin-bottom: 0.25rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mt-4 { margin-top: 1rem; }
-    .mt-6 { margin-top: 1.5rem; }
-    .mt-12 { margin-top: 3rem; }
-    .space-y-1 > * + * { margin-top: 0.25rem; }
-
-    /* Typography */
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
-    .text-xl { font-size: 1.25rem; line-height: 1.75rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-medium { font-weight: 500; }
-    .font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-    .italic { font-style: italic; }
-    .uppercase { text-transform: uppercase; }
-    .tracking-tight { letter-spacing: -0.025em; }
-    .tracking-widest { letter-spacing: 0.1em; }
-    .leading-relaxed { line-height: 1.625; }
-    .text-center { text-align: center; }
-    .text-opacity-80 { opacity: 0.8; }
-
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-2xl { border-radius: 1rem; }
-    .rounded-3xl { border-radius: 1.5rem; }
-    .border { border-width: 1px; border-style: solid; }
-    .border-2 { border-width: 2px; border-style: solid; }
-    .border-b { border-bottom-width: 1px; border-bottom-style: solid; }
-    .border-dashed { border-style: dashed; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-xl { box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04); }
-    .shadow-sky-900\/5 { box-shadow: 0 20px 25px -5px rgba(12, 74, 110, 0.05), 0 10px 10px -5px rgba(12, 74, 110, 0.04); }
-    .drop-shadow-lg { filter: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.04)) drop-shadow(0 4px 3px rgba(0, 0, 0, 0.1)); }
-    .object-contain { object-fit: contain; }
-
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .right-4 { right: 1rem; }
-
-    /* Z-index */
-    .z-20 { z-index: 20; }
-
-    /* Transitions */
-    .transition-transform { transition-property: transform; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .duration-300 { transition-duration: 300ms; }
-
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    .hover\:scale-105:hover { transform: scale(1.05); }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
-
-    /* Links */
-    a { text-decoration: none !important; }
-
-    /* Responsive */
-    @media (min-width: 640px) {
-      .sm\:flex-row { flex-direction: row; }
+    .md-page { background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 64rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 20px;
+      border: 1px solid #ece7f3;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 32px rgba(0, 0, 0, 0.06);
+      padding: 28px;
+      position: relative;
     }
+
+    .md-menu-button { position: absolute; top: 18px; right: 18px; }
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+      transition: background 150ms ease, transform 150ms ease;
+    }
+    .md-icon-btn:hover { background: #e6e1ee; transform: translateY(-1px); }
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-menu-panel {
+      position: absolute;
+      top: 60px;
+      right: 18px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 180px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 10px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
+    .md-hidden { display: none !important; }
+
+    .md-header { text-align: center; margin-bottom: 24px; }
+    .md-headline {
+      font-size: 1.6rem;
+      font-weight: 700;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      margin-bottom: 0.4rem;
+    }
+    .md-subtitle { color: var(--md-sys-color-on-surface-variant); font-size: 0.9rem; font-style: italic; }
+
+    .md-filters { display: flex; flex-wrap: wrap; gap: 16px; justify-content: center; margin-top: 18px; }
+    .md-field { position: relative; min-width: 200px; }
+    .md-field__label {
+      position: absolute;
+      top: -9px;
+      left: 12px;
+      padding: 0 6px;
+      background: var(--md-sys-color-surface);
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+      letter-spacing: 0.02em;
+    }
+    .md-select {
+      appearance: none;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.8rem 2.2rem 0.8rem 0.9rem;
+      font-size: 0.9rem;
+      color: var(--md-sys-color-on-surface);
+      min-width: 200px;
+      line-height: 1.2;
+      background-image: linear-gradient(45deg, transparent 50%, #6c6775 50%), linear-gradient(135deg, #6c6775 50%, transparent 50%);
+      background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
+      background-size: 6px 6px, 6px 6px;
+      background-repeat: no-repeat;
+    }
+    .md-select:focus { outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2); }
+
+    .md-weather-grid { display: grid; grid-template-columns: repeat(1, minmax(0, 1fr)); gap: 20px; }
+    .md-weather-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 20px;
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+      transition: transform 200ms ease, box-shadow 200ms ease;
+    }
+    .md-weather-card:hover { transform: translateY(-4px); box-shadow: 0 16px 28px rgba(0, 0, 0, 0.12); }
+    .md-weather-title { font-size: 1.1rem; font-weight: 700; color: #3f3b46; border-bottom: 1px solid #e7e1ef; padding-bottom: 12px; margin-bottom: 16px; }
+    .md-weather-body { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 12px; }
+    .md-weather-icon { width: 96px; height: 96px; object-fit: contain; filter: drop-shadow(0 10px 8px rgba(0, 0, 0, 0.06)); }
+    .md-weather-text { font-size: 1rem; font-weight: 600; color: #5a5564; line-height: 1.6; }
+    .md-weather-meta { width: 100%; font-size: 0.9rem; color: var(--md-sys-color-on-surface-variant); display: grid; gap: 6px; text-align: left; }
+    .md-weather-meta span { font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-temp-block { width: 100%; margin-top: 8px; text-align: left; }
+    .md-temp-title { font-size: 0.85rem; font-weight: 600; color: var(--md-sys-color-on-surface-variant); margin-bottom: 6px; }
+    .md-temp-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+    .md-temp-time { padding: 4px 12px 4px 0; color: var(--md-sys-color-on-surface-variant); }
+    .md-temp-value { padding: 4px 0; font-weight: 600; color: var(--md-sys-color-on-surface); }
+
+    .md-note {
+      margin-top: 32px;
+      padding: 20px;
+      background: var(--md-sys-color-surface-variant);
+      border-radius: 16px;
+      border: 1px dashed #d9d2e6;
+    }
+    .md-note-title { font-size: 0.75rem; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: #5a5564; margin-bottom: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+    .md-note-body { font-size: 0.9rem; color: var(--md-sys-color-on-surface-variant); line-height: 1.6; }
+
+    .md-footer { margin-top: 32px; text-align: center; font-size: 0.75rem; color: var(--md-sys-color-on-surface-variant); }
+    .md-error { text-align: center; color: #b3261e; font-weight: 600; grid-column: 1 / -1; }
+
     @media (min-width: 768px) {
-      .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .md-weather-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-5xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+<body>
+  <div class="md-page">
+    <div class="md-shell">
+      <div class="md-card">
+        <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+          <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/>
-      </svg>
-    </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden z-20">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+          </svg>
+        </button>
+        <div id="menuPanel" class="md-menu-panel md-hidden">
+          <a href="../index.html" class="md-menu-link">トップへ戻る</a>
+        </div>
+
+        <header class="md-header">
+          <div class="md-headline"><span aria-hidden="true">🌦️</span>Japan Weather</div>
+          <p id="update-time" class="md-subtitle"></p>
+          <div class="md-filters">
+            <label class="md-field">
+              <span class="md-field__label">地域</span>
+              <select id="region-select" class="md-select"></select>
+            </label>
+            <label class="md-field">
+              <span class="md-field__label">府県/地方</span>
+              <select id="area-select" class="md-select"></select>
+            </label>
+          </div>
+        </header>
+
+        <main>
+          <div id="weather-grid" class="md-weather-grid"></div>
+
+          <section class="md-note">
+            <h2 class="md-note-title">Dev Note</h2>
+            <p class="md-note-body">
+              気象庁の府県予報区コードで取得し、`timeSeries[0].areas` 配列から各エリアの天気を抽出しています。
+            </p>
+          </section>
+        </main>
+
+        <footer class="md-footer">
+          このツールは気象庁のAPIと天気アイコン画像を取得するため、インターネット接続が必要です。
+        </footer>
+      </div>
     </div>
-
-    <header class="text-center mb-6">
-      <h1 class="text-2xl font-bold tracking-tight">Japan Weather</h1>
-      <p id="update-time" class="text-gray-500 mt-2 text-sm italic"></p>
-      <div class="mt-4 flex flex-col sm:flex-row gap-3 items-center justify-center">
-        <label class="flex items-center gap-2 text-sm text-gray-600">
-          <span class="font-semibold">地域</span>
-          <select id="region-select" class="border border-gray-300 rounded px-3 py-1 bg-white">
-          </select>
-        </label>
-        <label class="flex items-center gap-2 text-sm text-gray-600">
-          <span class="font-semibold">府県/地方</span>
-          <select id="area-select" class="border border-gray-300 rounded px-3 py-1 bg-white">
-          </select>
-        </label>
-      </div>
-    </header>
-
-    <main>
-      <div id="weather-grid" class="grid grid-cols-1 md:grid-cols-3 gap-6"></div>
-
-
-      <div class="mt-12 p-6 bg-gray-50 rounded-2xl border-2 border-dashed border-gray-200">
-        <h2 class="font-bold text-gray-700 mb-2 font-mono text-sm uppercase tracking-widest">Dev Note</h2>
-        <p class="text-sm text-gray-700 leading-relaxed text-opacity-80">
-          気象庁の府県予報区コードで取得し、`timeSeries[0].areas` 配列から各エリアの天気を抽出しています。
-        </p>
-      </div>
-    </main>
-
-    <footer class="pt-8">
-      <div class="text-center text-xs text-gray-500">
-        このツールは気象庁のAPIと天気アイコン画像を取得するため、インターネット接続が必要です。
-      </div>
-    </footer>
   </div>
 
   <script>
@@ -404,10 +420,10 @@
           rowsData.sort((a, b) => String(a.rawTime).localeCompare(String(b.rawTime)));
           let rows = "";
           rowsData.forEach((row) => {
-            rows += `<tr><td class="py-1 pr-3 text-slate-500">${formatTimeLabel(row.rawTime)}</td><td class="py-1 font-semibold text-slate-700">${row.temp}℃</td></tr>`;
+            rows += `<tr><td class="md-temp-time">${formatTimeLabel(row.rawTime)}</td><td class="md-temp-value">${row.temp}℃</td></tr>`;
           });
           if (!rows) return "";
-          return `<table class="w-full text-sm"><tbody>${rows}</tbody></table>`;
+          return `<table class="md-temp-table"><tbody>${rows}</tbody></table>`;
         }
 
         areas.forEach((area, index) => {
@@ -427,18 +443,18 @@
           const tempTable = buildTempTable(tempArea, tempSeries?.timeDefines);
 
           const card = `
-            <div class="bg-white rounded-3xl p-8 shadow-xl shadow-sky-900/5 border border-white hover:scale-105 transition-transform duration-300">
-              <h3 class="text-xl font-bold text-slate-700 border-b pb-4 mb-6">${name}</h3>
-              <div class="flex flex-col items-center">
-                <img src="${icon}" alt="${weather}" class="w-24 h-24 object-contain drop-shadow-lg" loading="lazy" onerror="this.onerror=null; this.src='${fallbackIcon}'">
-                <p class="mt-6 text-lg font-medium text-center leading-relaxed text-slate-600">${weather}</p>
-                <div class="mt-4 w-full text-sm text-slate-600 space-y-1">
-                  ${pop ? `<div><span class="font-semibold">降水確率</span>: ${pop}%</div>` : ""}
-                  ${temp ? `<div><span class="font-semibold">気温（要約）</span>: ${temp}</div>` : ""}
-                  ${wind ? `<div><span class="font-semibold">風</span>: ${wind}</div>` : ""}
-                  ${wave ? `<div><span class="font-semibold">波</span>: ${wave}</div>` : ""}
+            <div class="md-weather-card">
+              <h3 class="md-weather-title">${name}</h3>
+              <div class="md-weather-body">
+                <img src="${icon}" alt="${weather}" class="md-weather-icon" loading="lazy" onerror="this.onerror=null; this.src='${fallbackIcon}'">
+                <p class="md-weather-text">${weather}</p>
+                <div class="md-weather-meta">
+                  ${pop ? `<div><span>降水確率</span>: ${pop}%</div>` : ""}
+                  ${temp ? `<div><span>気温（要約）</span>: ${temp}</div>` : ""}
+                  ${wind ? `<div><span>風</span>: ${wind}</div>` : ""}
+                  ${wave ? `<div><span>波</span>: ${wave}</div>` : ""}
                 </div>
-                ${tempTable ? `<div class="mt-4 w-full"><div class="text-sm font-semibold text-slate-600 mb-1">気温（時系列）</div>${tempTable}</div>` : ""}
+                ${tempTable ? `<div class="md-temp-block"><div class="md-temp-title">気温（時系列）</div>${tempTable}</div>` : ""}
               </div>
             </div>
           `;
@@ -447,7 +463,7 @@
 
       } catch (e) {
         console.error("データの読み込みに失敗:", e);
-        document.getElementById("weather-grid").innerHTML = "<p class='col-span-3 text-center text-red-400'>気象データの取得に失敗しました。</p>";
+        document.getElementById("weather-grid").innerHTML = "<p class='md-error'>気象データの取得に失敗しました。</p>";
       }
     }
 
@@ -506,7 +522,7 @@
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
-      if (panel) panel.classList.toggle("hidden");
+      if (panel) panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -21,162 +21,255 @@ limitations under the License.
   <title>Amazon URL dp 抽出ツール</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 42rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      position: relative;
+    }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-72 { width: 18rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.5rem;
+    }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: var(--md-state-layer);
+      color: var(--md-sys-color-primary);
+    }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .pointer-events-none { pointer-events: none; }
+    .md-input {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+    .md-field-block { margin-bottom: 1rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+    .md-button--primary:hover { background: #4f00c9; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-code-block { position: relative; margin-top: 0.5rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 2.5rem;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Group hover */
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .group {}
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-snackbar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<body class="md-page">
+  <div class="md-shell md-card">
 
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6"><span aria-hidden="true" class="mr-2">🛒</span>Amazon URL dp 抽出ツール</h1>
+    <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🛒</span>Amazon URL dp 抽出ツール</h1>
 
-    <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <label class="md-label">
       <span>AmazonのURL</span>
-      <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           例: https://www.amazon.co.jp/.../dp/B0XXXXXXX<br>
           ASIN（10文字）だけでもOK
         </span>
       </span>
       <span>：</span>
     </label>
-    <input type="text" id="amazonUrl" placeholder="例: https://www.amazon.co.jp/dp/B0XXXXXXX" class="border border-gray-300 rounded w-full p-2 mb-4">
+    <input type="text" id="amazonUrl" placeholder="例: https://www.amazon.co.jp/dp/B0XXXXXXX" class="md-input md-field-block">
 
-    <button onclick="generateDpPath()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded mb-4">
+    <button onclick="generateDpPath()" class="md-button md-button--primary md-field-block">
       Amazonの短いURLにする
     </button>
 
-    <div class="relative">
-      <code id="dpPath" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('dpPath')">📋</button>
+    <div class="md-code-block md-field-block">
+      <code id="dpPath" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('dpPath')" aria-label="コピー">📋</button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -227,18 +320,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -21,161 +21,254 @@ limitations under the License.
   <title>Facebook fbclid 除去ツール</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 42rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      position: relative;
+    }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-72 { width: 18rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.5rem;
+    }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: var(--md-state-layer);
+      color: var(--md-sys-color-primary);
+    }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .pointer-events-none { pointer-events: none; }
+    .md-input {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+    .md-field-block { margin-bottom: 1rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+    .md-button--primary:hover { background: #4f00c9; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-code-block { position: relative; margin-top: 0.5rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 2.5rem;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Group hover */
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .group {}
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-snackbar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<body class="md-page">
+  <div class="md-shell md-card">
 
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6"><span aria-hidden="true" class="mr-2">🔗</span>Facebook fbclid 除去ツール</h1>
+    <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔗</span>Facebook fbclid 除去ツール</h1>
 
-    <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <label class="md-label">
       <span>URL</span>
-      <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           fbclid パラメータだけを削除します
         </span>
       </span>
       <span>：</span>
     </label>
-    <input type="text" id="inputUrl" placeholder="例: https://example.com/?a=1&fbclid=..." class="border border-gray-300 rounded w-full p-2 mb-4">
+    <input type="text" id="inputUrl" placeholder="例: https://example.com/?a=1&fbclid=..." class="md-input md-field-block">
 
-    <button onclick="generateCleanUrl()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded mb-4">
+    <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       Facebook識別子（fbclid）を除去
     </button>
 
-    <div class="relative">
-      <code id="cleanUrl" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('cleanUrl')">📋</button>
+    <div class="md-code-block md-field-block">
+      <code id="cleanUrl" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('cleanUrl')" aria-label="コピー">📋</button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -221,18 +314,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -21,177 +21,300 @@ limitations under the License.
   <title>MIME Base64 エンコード/デコード ツール</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 42rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      position: relative;
+    }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-72 { width: 18rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.5rem;
+    }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: var(--md-state-layer);
+      color: var(--md-sys-color-primary);
+    }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .pointer-events-none { pointer-events: none; }
+    .md-input,
+    .md-textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-textarea { min-height: 7.5rem; }
+    .md-input:focus,
+    .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+    .md-field-block { margin-bottom: 1rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+    .md-button--primary:hover { background: #4f00c9; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-code-block { position: relative; margin-top: 0.5rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 2.5rem;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Group hover */
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .group {}
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-checkbox {
+      width: 18px;
+      height: 18px;
+      border-radius: 4px;
+      border: 2px solid var(--md-sys-color-outline);
+      appearance: none;
+      display: inline-grid;
+      place-items: center;
+      background: var(--md-sys-color-surface);
+      cursor: pointer;
+      transition: border-color 150ms ease, background 150ms ease;
+    }
+    .md-checkbox:checked {
+      background: var(--md-sys-color-primary);
+      border-color: var(--md-sys-color-primary);
+    }
+    .md-checkbox:checked::after {
+      content: "";
+      width: 6px;
+      height: 10px;
+      border: 2px solid var(--md-sys-color-on-primary);
+      border-top: none;
+      border-left: none;
+      transform: rotate(45deg);
+      margin-top: -1px;
+    }
+
+    .md-snackbar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<body class="md-page">
+  <div class="md-shell md-card">
 
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6"><span aria-hidden="true" class="mr-2">📦</span>MIME Base64 エンコード/デコード</h1>
+    <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">📦</span>MIME Base64 エンコード/デコード</h1>
 
-    <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <label class="md-label">
       <span>入力テキスト</span>
-      <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           Base64 をエンコード/デコードします
         </span>
       </span>
       <span>：</span>
     </label>
-    <textarea id="inputText" rows="6" placeholder="例: こんにちは / SGVsbG8=" class="border border-gray-300 rounded w-full p-2 mb-4"></textarea>
+    <textarea id="inputText" rows="6" placeholder="例: こんにちは / SGVsbG8=" class="md-textarea md-field-block"></textarea>
 
-    <label class="flex items-center gap-2 mb-4 font-semibold">
-      <input type="checkbox" id="mimeWrap" class="rounded border-gray-300">
+    <label class="md-label md-field-block">
+      <input type="checkbox" id="mimeWrap" class="md-checkbox">
       <span>76文字で改行（MIME形式）</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           エンコード時のみ適用されます
         </span>
       </span>
     </label>
 
-    <div class="flex flex-wrap gap-2 mb-4">
-      <button onclick="encodeText()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+    <div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;">
+      <button onclick="encodeText()" class="md-button md-button--primary">
         エンコード
       </button>
-      <button onclick="decodeText()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+      <button onclick="decodeText()" class="md-button md-button--primary">
         デコード
       </button>
     </div>
 
-    <div class="relative">
-      <code id="outputText" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('outputText')">📋</button>
+    <div class="md-code-block md-field-block">
+      <code id="outputText" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('outputText')" aria-label="コピー">📋</button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -254,18 +377,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -21,166 +21,260 @@ limitations under the License.
   <title>URL エンコード/デコード ツール</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 42rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 18px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
+      border: 1px solid #e9e3f0;
+      padding: 28px;
+      position: relative;
+    }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-72 { width: 18rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 180px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.75rem;
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.6rem;
+    }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: var(--md-state-layer);
+      color: var(--md-sys-color-primary);
+    }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .pointer-events-none { pointer-events: none; }
+    .md-textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+      min-height: 8.5rem;
+    }
+    .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+    .md-field-block { margin-bottom: 1.2rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-button {
+      border-radius: 999px;
+      padding: 0.65rem 1.4rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+    .md-button--primary:hover { background: #4f00c9; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-code-block { position: relative; margin-top: 0.5rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 3rem;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Group hover */
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .group {}
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 22rem;
+      max-width: 90vw;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-snackbar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<body class="md-page">
+  <div class="md-shell md-card">
 
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6"><span aria-hidden="true" class="mr-2">🔤</span>URL エンコード/デコード ツール</h1>
+    <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔤</span>URL エンコード/デコード ツール</h1>
 
-    <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <label class="md-label">
       <span>入力テキスト</span>
-      <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           日本語をURLエンコード/デコードします
         </span>
       </span>
       <span>：</span>
     </label>
-    <textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="border border-gray-300 rounded w-full p-2 mb-4"></textarea>
+    <textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="md-textarea md-field-block"></textarea>
 
-    <div class="flex flex-wrap gap-2 mb-4">
-      <button onclick="encodeText()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+    <div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;">
+      <button onclick="encodeText()" class="md-button md-button--primary">
         エンコード
       </button>
-      <button onclick="decodeText()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded">
+      <button onclick="decodeText()" class="md-button md-button--primary">
         デコード
       </button>
     </div>
 
-    <div class="relative">
-      <code id="outputText" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('outputText')">📋</button>
+    <div class="md-code-block md-field-block">
+      <code id="outputText" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('outputText')" aria-label="コピー">📋</button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -222,18 +316,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -21,161 +21,254 @@ limitations under the License.
   <title>UTM パラメータ除去ツール</title>
   <style>
     /*
-      ベンダリング（Vendoring）: このHTMLファイルは、かつてTailwind CSSをCDNから動的に読み込んでいましたが、
-      完全なオフライン化のため、Tailwind CSS の CSS クラス定義を自前で実装しました。
-      Tailwind CSS のライセンス情報は THIRD_PARTY_NOTICES.md を参照してください。
-      外部CDNに依存せず、単一のHTMLファイルで完結して動作する設計が、このプロジェクトのコア機能です。
+      ベンダリング（Vendoring）: このHTMLファイルは外部CSSに依存せず、単一HTML内でMaterial Designのスタイルを再現しています。
+      オフラインで完結して動作する設計が、このプロジェクトのコア機能です。
     */
-    /* Reset */
+    :root {
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+    }
+
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-size: 1rem; line-height: 1.5; }
-    button { border: none; cursor: pointer; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; font: inherit; }
+    a { text-decoration: none; color: inherit; }
 
-    /* Colors */
-    body { background-color: #f9fafb; color: #1f2937; }
-    .bg-white { background-color: #ffffff; }
-    .bg-gray-50 { background-color: #f9fafb; }
-    .bg-gray-100 { background-color: #f3f4f6; }
-    .bg-gray-200 { background-color: #e5e7eb; }
-    .bg-gray-800 { background-color: #1f2937; }
-    .bg-gray-900 { background-color: #111827; }
-    .bg-green-600 { background-color: #16a34a; }
-    .text-white { color: #ffffff; }
-    .text-gray-600 { color: #4b5563; }
-    .text-gray-700 { color: #374151; }
-    .text-gray-800 { color: #1f2937; }
-    .text-red-500 { color: #ef4444; }
-    .border-gray-200 { border-color: #e5e7eb; }
-    .border-gray-300 { border-color: #d1d5db; }
+    .md-page { background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh; }
+    .md-shell { max-width: 42rem; margin: 0 auto; }
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 18px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
+      border: 1px solid #e9e3f0;
+      padding: 28px;
+      position: relative;
+    }
 
-    /* Layout */
-    .flex { display: flex; }
-    .inline-flex { display: inline-flex; }
-    .items-center { align-items: center; }
-    .justify-center { justify-content: center; }
-    .flex-wrap { flex-wrap: wrap; }
-    .gap-2 { gap: 0.5rem; }
-    .w-5 { width: 1.25rem; }
-    .w-72 { width: 18rem; }
-    .w-full { width: 100%; }
-    .h-5 { height: 1.25rem; }
-    .max-w-2xl { max-width: 42rem; }
-    .mx-auto { margin-left: auto; margin-right: auto; }
-    .p-2 { padding: 0.5rem; }
-    .p-3 { padding: 0.75rem; }
-    .p-6 { padding: 1.5rem; }
-    .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
-    .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
-    .px-4 { padding-left: 1rem; padding-right: 1rem; }
-    .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-    .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
-    .pr-10 { padding-right: 2.5rem; }
-    .mb-2 { margin-bottom: 0.5rem; }
-    .mb-4 { margin-bottom: 1rem; }
-    .mb-6 { margin-bottom: 1.5rem; }
-    .mt-2 { margin-top: 0.5rem; }
-    .mr-2 { margin-right: 0.5rem; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 180px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
-    /* Typography */
-    .text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-xs { font-size: 0.75rem; line-height: 1rem; }
-    .text-2xl { font-size: 1.5rem; line-height: 2rem; }
-    .leading-5 { line-height: 1.25rem; }
-    .font-bold { font-weight: 700; }
-    .font-semibold { font-weight: 600; }
-    .font-normal { font-weight: 400; }
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.75rem;
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
 
-    /* Box model */
-    .block { display: block; }
-    .hidden { display: none; }
-    .rounded { border-radius: 0.375rem; }
-    .rounded-lg { border-radius: 0.5rem; }
-    .rounded-full { border-radius: 9999px; }
-    .border { border-width: 1px; border-style: solid; }
-    .shadow-md { box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); }
-    .shadow-lg { box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); }
-    .overflow-x-auto { overflow-x: auto; }
-    .whitespace-pre { white-space: pre; }
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.6rem;
+    }
 
-    /* Position */
-    .relative { position: relative; }
-    .absolute { position: absolute; }
-    .fixed { position: fixed; }
-    .top-2 { top: 0.5rem; }
-    .top-4 { top: 1rem; }
-    .top-12 { top: 3rem; }
-    .top-full { top: 100%; }
-    .right-2 { right: 0.5rem; }
-    .right-4 { right: 1rem; }
-    .right-5 { right: 1.25rem; }
-    .bottom-5 { bottom: 1.25rem; }
-    .left-1\/2 { left: 50%; }
-    .-translate-x-1\/2 { transform: translateX(-50%); }
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: var(--md-state-layer);
+      color: var(--md-sys-color-primary);
+    }
 
-    /* Visibility */
-    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
-    .opacity-0 { opacity: 0; }
-    .pointer-events-none { pointer-events: none; }
+    .md-input {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+    .md-field-block { margin-bottom: 1.2rem; }
 
-    /* Transitions */
-    .transition { transition-property: all; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-    .transition-opacity { transition-property: opacity; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
-    .duration-300 { transition-duration: 300ms; }
+    .md-button {
+      border-radius: 999px;
+      padding: 0.65rem 1.4rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+    .md-button--primary:hover { background: #4f00c9; }
 
-    /* Hover effects */
-    .hover\:bg-gray-300:hover { background-color: #d1d5db; }
-    .hover\:bg-green-700:hover { background-color: #15803d; }
-    .hover\:bg-gray-100:hover { background-color: #f3f4f6; }
-    button.hover\:bg-gray-300:hover { background-color: #d1d5db; }
+    .md-code-block { position: relative; margin-top: 0.5rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 3rem;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
 
-    /* Group hover */
-    .group:hover .group-hover\:opacity-100 { opacity: 1; }
-    .group {}
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-20 { width: 20px; height: 20px; }
 
-    /* Links */
-    a { text-decoration: none !important; }
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 22rem;
+      max-width: 90vw;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-help-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-help-icon { width: 18px; height: 18px; }
+
+    .md-snackbar {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.75rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-800 p-6">
-  <div class="max-w-2xl mx-auto bg-white shadow-md rounded-lg p-6 relative">
+<body class="md-page">
+  <div class="md-shell md-card">
 
-    <button type="button" class="absolute top-4 right-4 bg-gray-200 hover:bg-gray-300 text-gray-800 font-semibold py-1 px-2 rounded" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
       </svg>
     </button>
-    <div id="menuPanel" class="absolute top-12 right-4 bg-white border border-gray-200 rounded shadow-md hidden">
-      <a href="../index.html" class="block px-4 py-2 text-gray-700 hover:bg-gray-100">トップへ戻る</a>
+    <div id="menuPanel" class="md-menu-panel md-hidden">
+      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
     </div>
 
-    <h1 class="text-2xl font-bold mb-6"><span aria-hidden="true" class="mr-2">🧹</span>UTM パラメータ除去ツール</h1>
+    <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🧹</span>UTM パラメータ除去ツール</h1>
 
-    <label class="flex flex-wrap items-center gap-2 mb-2 font-semibold">
+    <label class="md-label">
       <span>URL</span>
-      <span class="text-red-500 font-bold" aria-hidden="true">*</span><span class="sr-only">必須</span>
-      <span class="relative inline-flex items-center group">
-        <span class="inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-gray-600 bg-gray-200 rounded-full">?</span>
-        <span class="absolute left-1/2 top-full mt-2 w-72 -translate-x-1/2 rounded-lg shadow-lg bg-gray-900 text-white text-xs leading-5 font-normal px-3 py-2 opacity-0 group-hover:opacity-100 transition pointer-events-none">
+      <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
+      <span class="md-tooltip-group">
+        <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+        <span class="md-tooltip-content md-tooltip">
           utm_* パラメータを削除します
         </span>
       </span>
       <span>：</span>
     </label>
-    <input type="text" id="inputUrl" placeholder="例: https://example.com/?utm_source=aaa&x=1" class="border border-gray-300 rounded w-full p-2 mb-4">
+    <input type="text" id="inputUrl" placeholder="例: https://example.com/?utm_source=aaa&x=1" class="md-input md-field-block">
 
-    <button onclick="generateCleanUrl()" class="bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded mb-4">
+    <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       UTMを除去
     </button>
 
-    <div class="relative">
-      <code id="cleanUrl" class="bg-gray-100 p-3 block rounded overflow-x-auto whitespace-pre pr-10"></code>
-      <button class="absolute top-2 right-2 bg-gray-200 px-2 py-1 rounded text-sm hover:bg-gray-300" onclick="copyToClipboard('cleanUrl')">📋</button>
+    <div class="md-code-block md-field-block">
+      <code id="cleanUrl" class="md-code"></code>
+      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('cleanUrl')" aria-label="コピー">📋</button>
     </div>
 
-    <div id="toast" class="fixed bottom-5 right-5 bg-gray-800 text-white px-4 py-2 rounded shadow-lg opacity-0 transition-opacity duration-300 pointer-events-none">
+    <div id="toast" class="md-snackbar md-hidden">
       コピーしました
     </div>
   </div>
@@ -220,18 +313,18 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.remove("opacity-0", "pointer-events-none");
-      toast.classList.add("opacity-100");
+      toast.classList.remove("md-hidden");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("opacity-100");
-        toast.classList.add("opacity-0", "pointer-events-none");
+        toast.classList.remove("md-visible");
+        toast.classList.add("md-hidden");
       }, 2000);
     }
 
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
-      panel.classList.toggle("hidden");
+      panel.classList.toggle("md-hidden");
     }
   </script>
 </body>


### PR DESCRIPTION
# 概要

docs/life と docs/link の主要ツール群を Material Design ベースに統一 UIコンポーネント（メニュー、入力、ボタン、ツールチップ、トースト等）を md-* に刷新
Tailwind依存前提の記述を撤去し、Material Design前提の説明に更新

# 変更内容

forgot-items-check.html

Material Design配色に統一し、UI要素・バッジ・進捗表示を整理
操作フィードバックや見た目の一貫性を改善
japan-weather.html

既存Tailwind系レイアウトをMDコンポーネント構成へ移行
メニュー/フォーム/カード/エラー表示のデザイン統一
ドロップダウンをMD3寄りのフローティングラベル型に調整
docs/link/*

amazon-dp-extract.html
facebook-fbclid-remove.html
mime-base64.html
url-encode-decode.html
utm-remove.html
上記全てを md-* 構成に統一し、ツールチップ/トースト/入力/ボタンのMD化を実施
一部は余白/影/ツールチップ幅など見た目を詰めてffmpeg系列に寄せた

# ドキュメント整理

README.md の「Tailwind→MD」文言を「Material Design 実装ルール」に更新 THIRD_PARTY_NOTICES.md から Tailwind CSS 記載を削除

# 変更ファイル

forgot-items-check.html
japan-weather.html
amazon-dp-extract.html
facebook-fbclid-remove.html
mime-base64.html
url-encode-decode.html
utm-remove.html
README.md
THIRD_PARTY_NOTICES.md