### PR TITLE
index.html: セレクタ実例リンクを追加

### DIFF
--- a/md3/index.html
+++ b/md3/index.html
@@ -1948,8 +1948,8 @@
   &lt;span class="md-tooltip-content md-tooltip md-tooltip--wide"&gt;説明文（長め）…&lt;/span&gt;
 &lt;/span&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-help-icon</div></div><div><strong>Classes</strong><span class="md-chip">.md-help-icon</span></div><pre class="md-code"><code>.md-help-icon { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-hidden</div></div><div><strong>Classes</strong><span class="md-chip">.md-hidden</span></div><pre class="md-code"><code>.md-hidden { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-help-icon</div></div><div><strong>Classes</strong><span class="md-chip">.md-help-icon</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">3</a></div><pre class="md-code"><code>.md-help-icon { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-hidden</div></div><div><strong>Classes</strong><span class="md-chip">.md-hidden</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>.md-hidden { ... }</code></pre></div>
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: icon button + modifiers</div>
@@ -1960,13 +1960,14 @@
         </div>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span><span class="md-chip">.md-icon-btn:hover</span></div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
       <pre class="md-code"><code>&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;
 &lt;button class="md-icon-btn md-icon-btn--small" aria-label="コピー"&gt;📋&lt;/button&gt;
 &lt;button class="md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="設定"&gt;⚙️&lt;/button&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input-wrap .md-input</div></div><div><strong>Classes</strong><span class="md-chip">.md-input-wrap .md-input</span></div><pre class="md-code"><code>.md-input-wrap .md-input { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:disabled</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:disabled</span></div><pre class="md-code"><code>.md-input:disabled { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:focus</span></div><pre class="md-code"><code>.md-input:focus { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input-wrap .md-input</div></div><div><strong>Classes</strong><span class="md-chip">.md-input-wrap .md-input</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a></div><pre class="md-code"><code>.md-input-wrap .md-input { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:disabled</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:disabled</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a></div><pre class="md-code"><code>.md-input:disabled { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:focus</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/git/git-branch-diff.html">3</a></div><pre class="md-code"><code>.md-input:focus { ... }</code></pre></div>
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: label + modifiers</div>
@@ -1983,6 +1984,7 @@
         </div>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-label</span><span class="md-chip">.md-label--block</span><span class="md-chip">.md-label--full</span><span class="md-chip">.md-label--muted</span><span class="md-chip">.md-label--row</span><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-input</span><span class="md-chip">.md-textarea</span></div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/mime-base64.html">3</a></div>
       <pre class="md-code"><code>&lt;div class="md-field-stack"&gt;
   &lt;label class="md-label md-label--block"&gt;Label Block&lt;/label&gt;
   &lt;input class="md-input" placeholder="text" /&gt;
@@ -2007,13 +2009,14 @@
         </div>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-menu-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-menu-panel</span><span class="md-chip">.md-menu-link</span><span class="md-chip">.md-menu-link:hover</span></div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
       <pre class="md-code"><code>&lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;
 &lt;div class="md-menu-panel"&gt;
   &lt;a class="md-menu-link" href="#"&gt;メニュー 1&lt;/a&gt;
   &lt;a class="md-menu-link" href="#"&gt;メニュー 2&lt;/a&gt;
 &lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-page</div></div><div><strong>Classes</strong><span class="md-chip">.md-page</span></div><pre class="md-code"><code>.md-page { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-page</div></div><div><strong>Classes</strong><span class="md-chip">.md-page</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/text/text-processing.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-page { ... }</code></pre></div>
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: label + required</div>
@@ -2024,15 +2027,14 @@
         <input class="md-input" placeholder="例: sample.txt" />
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-label</span><span class="md-chip">.md-required</span><span class="md-chip">.md-input</span></div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
       <pre class="md-code"><code>&lt;label class="md-label"&gt;
   &lt;span&gt;タイトル&lt;/span&gt;
   &lt;span class="md-required"&gt;Required&lt;/span&gt;
 &lt;/label&gt;
 &lt;input class="md-input" placeholder="例: sample.txt" /&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-select:disabled</div></div><div><strong>Classes</strong><span class="md-chip">.md-select:disabled</span></div><pre class="md-code"><code>.md-select:disabled { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-select:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-select:focus</span></div><pre class="md-code"><code>.md-select:focus { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-shell</div></div><div><strong>Classes</strong><span class="md-chip">.md-shell</span></div><pre class="md-code"><code>.md-shell { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-shell</div></div><div><strong>Classes</strong><span class="md-chip">.md-shell</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-shell { ... }</code></pre></div>
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: snackbar + host</div>
@@ -2052,10 +2054,28 @@
   &lt;/div&gt;
 &lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-sr-only</div></div><div><strong>Classes</strong><span class="md-chip">.md-sr-only</span></div><pre class="md-code"><code>.md-sr-only { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-stack-lg > * + *</div></div><div><strong>Classes</strong><span class="md-chip">.md-stack-lg > * + *</span></div><pre class="md-code"><code>.md-stack-lg > * + * { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-stack-md > * + *</div></div><div><strong>Classes</strong><span class="md-chip">.md-stack-md > * + *</span></div><pre class="md-code"><code>.md-stack-md > * + * { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-stack-sm > * + *</div></div><div><strong>Classes</strong><span class="md-chip">.md-stack-sm > * + *</span></div><pre class="md-code"><code>.md-stack-sm > * + * { ... }</code></pre></div>
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-sr-only</div></div><div><strong>Classes</strong><span class="md-chip">.md-sr-only</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-sr-only { ... }</code></pre></div>
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: stack spacing</div>
+        <div class="md-stack-sm">
+          <div class="md-card" style="padding: 8px;">Stack SM</div>
+          <div class="md-card" style="padding: 8px;">Stack SM</div>
+        </div>
+        <div class="md-stack-md" style="margin-top: 10px;">
+          <div class="md-card" style="padding: 8px;">Stack MD</div>
+          <div class="md-card" style="padding: 8px;">Stack MD</div>
+        </div>
+        <div class="md-stack-lg" style="margin-top: 10px;">
+          <div class="md-card" style="padding: 8px;">Stack LG</div>
+          <div class="md-card" style="padding: 8px;">Stack LG</div>
+        </div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-stack-sm > * + *</span><span class="md-chip">.md-stack-md > * + *</span><span class="md-chip">.md-stack-lg > * + *</span></div>
+      <pre class="md-code"><code>&lt;div class="md-stack-sm"&gt;...&lt;/div&gt;
+&lt;div class="md-stack-md"&gt;...&lt;/div&gt;
+&lt;div class="md-stack-lg"&gt;...&lt;/div&gt;</code></pre>
+    </div>
     <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-surface-card</div></div><div><strong>Classes</strong><span class="md-chip">.md-surface-card</span></div><pre class="md-code"><code>.md-surface-card { ... }</code></pre></div>
     <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-tab-button[aria-selected="true"]</div></div><div><strong>Classes</strong><span class="md-chip">.md-tab-button[aria-selected="true"]</span></div><pre class="md-code"><code>.md-tab-button[aria-selected="true"] { ... }</code></pre></div>
     <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-textarea:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-textarea:focus</span></div><pre class="md-code"><code>.md-textarea:focus { ... }</code></pre></div>
@@ -2078,6 +2098,7 @@
             </div>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-page</span><span class="md-chip">md-shell</span><span class="md-chip">md-card</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
           <pre class="md-code"><code>&lt;body class="md-page"&gt;
   &lt;div class="md-shell md-card"&gt;...&lt;/div&gt;
 &lt;/body&gt;</code></pre>
@@ -2098,6 +2119,7 @@
             <input class="md-input" placeholder="例: sample.txt" />
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-label</span><span class="md-chip">md-input</span><span class="md-chip">md-field-block</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
           <pre class="md-code"><code>&lt;label class="md-label"&gt;タイトル&lt;/label&gt;
 &lt;input class="md-input md-field-block" /&gt;</code></pre>
         </div>
@@ -2107,7 +2129,8 @@
             <label class="md-label">詳細</label>
             <textarea class="md-textarea" placeholder="例: メモを入力"></textarea>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-textarea</span></div>
+          <div><strong>Classes</strong><span class="md-chip">md-textarea</span><span class="md-chip">md-field-block</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/link/mime-base64.html">3</a></div>
           <pre class="md-code"><code>&lt;textarea class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
         </div>
       </div>
@@ -2123,6 +2146,7 @@
             <button class="md-icon-btn" aria-label="メニュー">☰</button>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-button</span><span class="md-chip">md-button--primary</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/git/git-config-setup.html">3</a></div>
           <pre class="md-code"><code>&lt;button class="md-button md-button--primary"&gt;実行&lt;/button&gt;</code></pre>
         </div>
         <div class="md-example-card">
@@ -2131,6 +2155,7 @@
             <button class="md-icon-btn" aria-label="メニュー">☰</button>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-icon-btn</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/amazon-dp-extract.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
           <pre class="md-code"><code>&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;</code></pre>
         </div>
       </div>
@@ -2155,6 +2180,7 @@
             <span class="md-preview-note">ホバーで表示</span>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-tooltip-group</span><span class="md-chip">md-help-chip</span><span class="md-chip">md-tooltip</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
           <pre class="md-code"><code>&lt;span class="md-tooltip-group"&gt;
   &lt;span class="md-help-chip"&gt;...&lt;/span&gt;
   &lt;span class="md-tooltip-content md-tooltip"&gt;説明文&lt;/span&gt;
@@ -2175,6 +2201,7 @@
             </div>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-code-block</span><span class="md-chip">md-code</span><span class="md-chip">md-copy-button</span><span class="md-chip">md-icon-btn</span><span class="md-chip">md-icon-btn--small</span><span class="md-chip">md-icon-btn--surface</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
           <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
   &lt;code class="md-code"&gt;...&lt;/code&gt;
   &lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface"&gt;📋&lt;/button&gt;
@@ -2192,6 +2219,7 @@
             <div class="md-snackbar">コピーしました</div>
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-snackbar</span><span class="md-chip">md-hidden</span><span class="md-chip">md-visible</span></div>
+          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/utm-remove.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
           <pre class="md-code"><code>&lt;div class="md-snackbar md-hidden"&gt;コピーしました&lt;/div&gt;</code></pre>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- MD3リファレンス内の単体セレクタ・セット例に、実際の使用箇所リンクを追加

## Changes
- .md-help-icon / .md-hidden / .md-icon-btn / .md-input-wrap / .md-input:disabled / .md-input:focus / .md-label系 / .md-menu / .md-page / .md-required / .md-shell / .md-sr-only に実例リンクバッジを追加
- Layout/Form/Buttons/Tooltip/Code/Snackbar などのセクション側の実例にもリンクバッジを追加

## Scope
- 変更対象: `md3/index.html` のみ