### PR TITLE
MD3リファレンスの実例同期とUI補強（md3/index.html）

### DIFF
--- a/md3/index.html
+++ b/md3/index.html
@@ -57,6 +57,7 @@
       border: 1px solid #e5e0ec;
       background: var(--md-sys-color-surface);
       padding: 16px;
+      position: relative;
       margin-bottom: 12px;
     }
 
@@ -87,6 +88,7 @@
     }
 
     .md-input,
+    .md-select,
     .md-textarea {
       width: 100%;
       border-radius: 12px;
@@ -99,6 +101,7 @@
     }
     .md-textarea { min-height: 6.5rem; }
     .md-input:focus,
+    .md-select:focus,
     .md-textarea:focus {
       outline: none;
       border-color: var(--md-sys-color-primary);
@@ -152,6 +155,49 @@
       cursor: pointer;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     }
+
+    .md-tab-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      border-bottom: 1px solid #e6e1ee;
+      margin-bottom: 1rem;
+    }
+    .md-tab-button {
+      border: 1px solid #e6e1ee;
+      border-bottom: none;
+      background: #f3f1f7;
+      padding: 0.4rem 0.9rem;
+      margin-bottom: -1px;
+      border-top-left-radius: 12px;
+      border-top-right-radius: 12px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #3f3b46;
+      cursor: pointer;
+    }
+    .md-tab-button[aria-selected="true"] {
+      background: #ffffff;
+      border-color: #c8c5d0;
+      color: #1c1b1f;
+    }
+
+    .md-menu-demo { position: relative; min-height: 88px; }
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
 
     .md-switch-label { display: inline-flex; align-items: center; gap: 0.5rem; font-size: 0.95rem; color: var(--md-sys-color-on-surface); }
     .md-switch { width: 44px; height: 24px; border-radius: 999px; background: #d7d2de; position: relative; transition: background 150ms ease; }
@@ -207,6 +253,8 @@
       margin-left: 0.2rem;
     }
     .md-help-icon { width: 18px; height: 18px; }
+
+    .md-hidden { display: none; }
 
     .md-code-block { position: relative; margin-top: 0.5rem; }
     .md-code {
@@ -618,6 +666,7 @@
 }
 
 .md-input, .md-select, .md-textarea {
+  display: block;
   width: 100%;
   border-radius: 12px;
   border: 1px solid var(--md-sys-color-outline);
@@ -626,6 +675,7 @@
   font-size: 0.95rem;
   color: var(--md-sys-color-on-surface);
   transition: border-color 150ms ease, box-shadow 150ms ease;
+  box-sizing: border-box;
 }
 
 .md-input:focus, .md-select:focus, .md-textarea:focus {
@@ -654,18 +704,16 @@
   display: none;
 }
 
-.md-sr-only {
-  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
-}
+    .md-sr-only {
+      position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+    }
+    .md-preview .md-sr-only { display: none !important; }
 
 .md-stack-sm > * + * {
   margin-top: 0.75rem;
 }
 
-.md-radio-row {
-  display: flex; align-items: flex-start; gap: 0.5rem;
-}
-
+.md-radio-row { display: flex; align-items: flex-start; gap: 0.5rem; }
 .md-radio {
   display: inline-flex;
   align-items: center;
@@ -769,6 +817,7 @@
 }
 
 .md-input, .md-select {
+  display: block;
   width: 100%;
   border-radius: 12px;
   border: 1px solid var(--md-sys-color-outline);
@@ -777,6 +826,7 @@
   font-size: 0.95rem;
   color: var(--md-sys-color-on-surface);
   transition: border-color 150ms ease, box-shadow 150ms ease;
+  box-sizing: border-box;
 }
 
 .md-input:focus, .md-select:focus {
@@ -924,7 +974,7 @@
   letter-spacing: 0.02em;
 }
 
-.md-select {
+.md-field .md-select {
   appearance: none;
   border-radius: 12px;
   border: 1px solid var(--md-sys-color-outline);
@@ -940,7 +990,7 @@
   background-repeat: no-repeat;
 }
 
-.md-select:focus {
+.md-field .md-select:focus {
   outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
 }
 
@@ -1748,345 +1798,587 @@
   <div class="md-grid md-grid-2">
     <div class="md-example-card">
       <div class="md-preview">
-        <div class="md-preview-note">Selector set: section layout + titles</div>
-        <div class="md-section-wrap">
-          <section class="md-section-card md-section">
-            <div class="md-section-title md-section-title-row">
-              <span>Section Title</span>
-              <span class="md-subtitle">Meta</span>
-            </div>
-            <div class="md-section-title md-section-title--lg md-section-title--spaced">Section Title (Large)</div>
-            <div class="md-section-subtitle">Section Subtitle</div>
-          </section>
+        <div class="md-preview-note">Selector: .md-input:disabled</div>
+        <input type="text" class="md-input" placeholder="disabled" disabled>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-input:disabled</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのdisabled表現を意識。</div>
+      <div><strong>使用箇所なし</strong> 実ファイルに disabled 入力の該当HTMLがない。</div>
+      <pre class="md-code"><code>&lt;input type="text" class="md-input" placeholder="disabled" disabled&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: textarea variants</div>
+        <textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="md-textarea md-field-block"></textarea>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-textarea</span><span class="md-chip">.md-field-block</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのテキスト入力に近い見た目を意識。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
+    </div>
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector: .md-textarea:focus</div>
+        <label class="md-label">ffprobe 出力（JSON/テキスト）:</label>
+        <textarea id="probeOutput" rows="6" placeholder="ffprobe の出力を貼り付けてください" class="md-textarea md-field-block"></textarea>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-textarea:focus</span></div>
+      <div><strong>Note (MD-inspired)</strong> 説明ラベル + 大きめテキストエリアの組み合わせで、複数行入力を想定。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/text/text-processing.html">3</a></div>
+      <pre class="md-code"><code>&lt;label class="md-label"&gt;ffprobe 出力（JSON/テキスト）:&lt;/label&gt;
+&lt;textarea id="probeOutput" rows="6" placeholder="ffprobe の出力を貼り付けてください" class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: select variants</div>
+        <label class="md-label">サンプルレートを選択:</label>
+        <select id="sampleRate" class="md-select md-field-block">
+          <option value="44100" selected>44.1 kHz（標準）</option>
+          <option value="48000">48 kHz</option>
+          <option value="96000">96 kHz</option>
+          <option value="192000">192 kHz</option>
+        </select>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-select</span><span class="md-chip">.md-field-block</span><span class="md-chip">.md-select--inline</span><span class="md-chip">.md-select.md-disabled</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designの選択UIに近い見た目を意識。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">2</a><a class="md-chip" href="../docs/life/japan-weather.html">3</a></div>
+      <pre class="md-code"><code>&lt;label class="md-label"&gt;サンプルレートを選択:&lt;/label&gt;
+&lt;select id="sampleRate" class="md-select md-field-block"&gt;
+  &lt;option value="44100" selected&gt;44.1 kHz（標準）&lt;/option&gt;
+  &lt;option value="48000"&gt;48 kHz&lt;/option&gt;
+  &lt;option value="96000"&gt;96 kHz&lt;/option&gt;
+  &lt;option value="192000"&gt;192 kHz&lt;/option&gt;
+&lt;/select&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+                      <div class="md-preview">
+                        <div class="md-preview-note">Selector set: field stack</div>
+                        <div class="md-field-stack">
+                          <input class="md-input" placeholder="text" />
+                          <select class="md-select">
+                            <option>Option</option>
+                          </select>
+                          <textarea class="md-textarea" rows="2" placeholder="multiline"></textarea>
+                        </div>
+                      </div>
+                      <div><strong>Classes</strong><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-field-stack .md-input</span><span class="md-chip">.md-field-stack .md-select</span><span class="md-chip">.md-textarea</span></div>
+          <div><strong>Note (Project-specific)</strong> 入力群を縦積みする独自レイアウト。</div>
+                      <div><strong>Examples</strong><span class="md-chip">使用箇所なし</span></div>
+                      <pre class="md-code"><code>&lt;div class="md-field-stack"&gt;
+                  &lt;input class="md-input" placeholder="text" /&gt;
+                  &lt;select class="md-select"&gt;
+                    &lt;option&gt;Option&lt;/option&gt;
+                  &lt;/select&gt;
+                  &lt;textarea class="md-textarea" rows="2" placeholder="multiline"&gt;&lt;/textarea&gt;
+                &lt;/div&gt;</code></pre>
+                    </div>
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: md-radio</div>
+        <div class="md-radio-row">
+          <label class="md-radio">
+            <input type="radio" name="mode" value="music_release" checked>
+            <span>音楽（配信用）</span>
+          </label>
+          <span class="md-tooltip-group">
+            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--wide">
+              配信や販売を意識した仕上げ用。ストリーミング基準の音圧で、安心できるピーク管理と適度なダイナミクスを両立します。
+            </span>
+          </span>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-section</span><span class="md-chip">.md-section-card</span><span class="md-chip">.md-section-subtitle</span><span class="md-chip">.md-section-title</span><span class="md-chip">.md-section-title--lg</span><span class="md-chip">.md-section-title--spaced</span><span class="md-chip">.md-section-title-row</span><span class="md-chip">.md-section-wrap</span><span class="md-chip">.md-subtitle</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/index.html">1</a><a class="md-chip" href="../docs/text/text-processing.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;div class="md-section-wrap"&gt;
-  &lt;section class="md-section-card md-section"&gt;
-    &lt;div class="md-section-title md-section-title-row"&gt;
-      &lt;span&gt;Section Title&lt;/span&gt;
-      &lt;span class="md-subtitle"&gt;Meta&lt;/span&gt;
-    &lt;/div&gt;
-    &lt;div class="md-section-title md-section-title--lg md-section-title--spaced"&gt;Section Title (Large)&lt;/div&gt;
-    &lt;div class="md-section-subtitle"&gt;Section Subtitle&lt;/div&gt;
-  &lt;/section&gt;
+      <div><strong>Classes</strong><span class="md-chip">.md-radio</span><span class="md-chip">.md-radio input</span><span class="md-chip">.md-radio-row</span></div>
+      <div><strong>Note (MD-inspired)</strong> ラジオ選択 + ヘルプチップを横並びにし、選択肢の補足説明を同列に置く。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a></div>
+      <pre class="md-code"><code>&lt;div class="md-radio-row"&gt;
+  &lt;label class="md-radio"&gt;
+    &lt;input type="radio" name="mode" value="music_release" checked&gt;
+    &lt;span&gt;音楽（配信用）&lt;/span&gt;
+  &lt;/label&gt;
+  &lt;span class="md-tooltip-group"&gt;
+    &lt;span class="md-help-chip"&gt;&lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;&lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;&lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;&lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;&lt;/svg&gt;&lt;/span&gt;
+    &lt;span class="md-tooltip-content md-tooltip md-tooltip--wide"&gt;
+      配信や販売を意識した仕上げ用。ストリーミング基準の音圧で、安心できるピーク管理と適度なダイナミクスを両立します。
+    &lt;/span&gt;
+  &lt;/span&gt;
 &lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: button + modifiers + states</div><div class="md-preview-row md-button-row"><button class="md-button">Base</button><button class="md-button md-button--primary">Primary</button><button class="md-button md-button--tonal">Tonal</button><button class="md-button md-button--surface">Surface</button><button class="md-button md-button--secondary">Secondary</button><button class="md-button md-button--primary md-button--hero">Hero</button><button class="md-button" disabled>Disabled</button></div></div><div><strong>Classes</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--hero</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-button--primary:hover</span><span class="md-chip">.md-button--secondary</span><span class="md-chip">.md-button--surface</span><span class="md-chip">.md-button--tonal</span><span class="md-chip">.md-button--tonal:hover</span><span class="md-chip">.md-button-primary</span><span class="md-chip">.md-button-primary:hover</span><span class="md-chip">.md-button-row</span><span class="md-chip">.md-button-secondary</span><span class="md-chip">.md-button:active</span><span class="md-chip">.md-button:disabled</span><span class="md-chip">.md-button:hover</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">1</a><a class="md-chip" href="../docs/life/forgot-items-check.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>&lt;div class="md-button-row"&gt;
-  &lt;button class="md-button md-button--primary"&gt;...&lt;/button&gt;
-&lt;/div&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: card layout</div><div class="md-card" style="padding: 16px; border-radius: 12px;"><div class="md-card-head" style="display:flex; align-items:center; justify-content:space-between;"><div class="md-card-title">Card Title</div><div class="md-card-arrow">→</div></div><div class="md-card-desc" style="margin-top: 8px;">Description text...</div></div></div><div><strong>Classes</strong><span class="md-chip">.md-card</span><span class="md-chip">.md-card-arrow</span><span class="md-chip">.md-card-desc</span><span class="md-chip">.md-card-head</span><span class="md-chip">.md-card-title</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>&lt;div class="md-card"&gt;
-  &lt;div class="md-card-head"&gt;
-    &lt;div class="md-card-title"&gt;Card Title&lt;/div&gt;
-    &lt;div class="md-card-arrow"&gt;→&lt;/div&gt;
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: md-choice</div>
+        <div class="md-choice-card md-stack-md">
+          <div class="md-form-row md-form-row--start">
+            <label for="enableAutocrlf" class="md-choice-row">
+              <input type="checkbox" id="enableAutocrlf" onchange="toggleAutocrlfOptions()">
+              <span class="md-label">
+                <span>core.autocrlf を設定</span>
+                <span class="md-tooltip-group">
+                  <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                  <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+                    改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+                  </span>
+                </span>
+              </span>
+            </label>
+          </div>
+          <div id="autocrlfOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
+            <div class="md-choice-row">
+              <input type="radio" id="autocrlf-true" name="autocrlf" value="true" disabled>
+              <label for="autocrlf-true" class="md-choice-sub">
+                <span>true</span>
+                <small>Windows用（LF ↔ CRLF 自動変換）</small>
+              </label>
+            </div>
+            <div class="md-choice-row">
+              <input type="radio" id="autocrlf-input" name="autocrlf" value="input" disabled>
+              <label for="autocrlf-input" class="md-choice-sub">
+                <span>input</span>
+                <small>Mac/Linux用（コミット時のみCRLF → LF）</small>
+                <span class="md-chip md-chip--primary">推奨</span>
+              </label>
+            </div>
+            <div class="md-choice-row">
+              <input type="radio" id="autocrlf-false" name="autocrlf" value="false" disabled>
+              <label for="autocrlf-false" class="md-choice-sub">
+                <span>false</span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-choice</span><span class="md-chip">.md-choice-card</span><span class="md-chip">.md-choice-card--muted</span><span class="md-chip">.md-choice-inline</span><span class="md-chip">.md-choice-row</span><span class="md-chip">.md-choice-row input</span><span class="md-chip">.md-choice-sub</span><span class="md-chip">.md-choice-sub small</span><span class="md-chip">.md-choice-text</span></div>
+      <div><strong>Note (MD-inspired)</strong> 大きめのカード内で、主選択（チェック）と補助選択（ラジオ）を段階的に提示する構成。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a><a class="md-chip" href="../docs/git/git-branch-diff.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;div class="md-choice-card md-stack-md"&gt;
+  &lt;div class="md-form-row md-form-row--start"&gt;
+    &lt;label for="enableAutocrlf" class="md-choice-row"&gt;
+      &lt;input type="checkbox" id="enableAutocrlf" onchange="toggleAutocrlfOptions()"&gt;
+      &lt;span class="md-label"&gt;
+        &lt;span&gt;core.autocrlf を設定&lt;/span&gt;
+        &lt;span class="md-tooltip-group"&gt;
+          &lt;span class="md-help-chip"&gt;&lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;&lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;&lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;&lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;&lt;/svg&gt;&lt;/span&gt;
+          &lt;span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide"&gt;
+            改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+          &lt;/span&gt;
+        &lt;/span&gt;
+      &lt;/span&gt;
+    &lt;/label&gt;
   &lt;/div&gt;
-  &lt;div class="md-card-desc"&gt;Description text...&lt;/div&gt;
-&lt;/div&gt;</code></pre></div>
+  &lt;div id="autocrlfOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed"&gt;
+    &lt;div class="md-choice-row"&gt;
+      &lt;input type="radio" id="autocrlf-true" name="autocrlf" value="true" disabled&gt;
+      &lt;label for="autocrlf-true" class="md-choice-sub"&gt;
+        &lt;span&gt;true&lt;/span&gt;
+        &lt;small&gt;Windows用（LF ↔ CRLF 自動変換）&lt;/small&gt;
+      &lt;/label&gt;
+    &lt;/div&gt;
+    &lt;div class="md-choice-row"&gt;
+      &lt;input type="radio" id="autocrlf-input" name="autocrlf" value="input" disabled&gt;
+      &lt;label for="autocrlf-input" class="md-choice-sub"&gt;
+        &lt;span&gt;input&lt;/span&gt;
+        &lt;small&gt;Mac/Linux用（コミット時のみCRLF → LF）&lt;/small&gt;
+        &lt;span class="md-chip md-chip--primary"&gt;推奨&lt;/span&gt;
+      &lt;/label&gt;
+    &lt;/div&gt;
+    &lt;div class="md-choice-row"&gt;
+      &lt;input type="radio" id="autocrlf-false" name="autocrlf" value="false" disabled&gt;
+      &lt;label for="autocrlf-false" class="md-choice-sub"&gt;
+        &lt;span&gt;false&lt;/span&gt;
+      &lt;/label&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: md-switch</div>
         <label class="md-switch-label">
-          <input type="checkbox" class="md-switch-input" checked />
+          <input type="checkbox" id="scopeA" class="md-switch-input" checked onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
-          <span>Switch</span>
+          リモートとして扱う
         </label>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-switch</span><span class="md-chip">.md-switch-input</span><span class="md-chip">.md-switch-input:checked + .md-switch</span><span class="md-chip">.md-switch-input:checked + .md-switch::after</span><span class="md-chip">.md-switch-label</span><span class="md-chip">.md-switch-row</span><span class="md-chip">.md-switch::after</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのスイッチ相当。</div>
       <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
       <pre class="md-code"><code>&lt;label class="md-switch-label"&gt;
-  &lt;input type="checkbox" class="md-switch-input" checked /&gt;
+  &lt;input type="checkbox" id="scopeA" class="md-switch-input" checked onchange="updateRemoteState()"&gt;
   &lt;span class="md-switch" aria-hidden="true"&gt;&lt;/span&gt;
-  &lt;span&gt;Switch&lt;/span&gt;
+  リモートとして扱う
 &lt;/label&gt;</code></pre>
     </div>
+                    
+                
+            
+        
     <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: md-toggle</div><label class="md-toggle"><input type="checkbox" class="md-toggle-input" checked /><span class="md-toggle-track"></span><span class="md-toggle-text">Toggle</span></label><div class="md-preview-note" style="margin-top: 6px; color: #b3261e; font-weight: 700;">Deprecated: md-toggle は廃止予定。md-switch を使用してください。</div></div><div><strong>Classes</strong><span class="md-chip">.md-toggle</span><span class="md-chip">.md-toggle-input</span><span class="md-chip">.md-toggle-input:checked + .md-toggle-track</span><span class="md-chip">.md-toggle-input:checked + .md-toggle-track::after</span><span class="md-chip">.md-toggle-row</span><span class="md-chip">.md-toggle-text</span><span class="md-chip">.md-toggle-track</span><span class="md-chip">.md-toggle-track::after</span></div><pre class="md-code"><code>&lt;label class="md-toggle"&gt;
-  &lt;input type="checkbox" class="md-toggle-input" checked /&gt;
-  &lt;span class="md-toggle-track"&gt;&lt;/span&gt;
-  &lt;span class="md-toggle-text"&gt;Toggle&lt;/span&gt;
-&lt;/label&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: md-radio</div><div class="md-radio-row"><label class="md-radio"><input type="radio" name="demo" checked /> Option A</label><label class="md-radio"><input type="radio" name="demo" /> Option B</label></div></div><div><strong>Classes</strong><span class="md-chip">.md-radio</span><span class="md-chip">.md-radio input</span><span class="md-chip">.md-radio-row</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a></div><pre class="md-code"><code>&lt;div class="md-radio-row"&gt;
-  &lt;label class="md-radio"&gt;&lt;input type="radio" name="demo" checked /&gt; Option A&lt;/label&gt;
-  &lt;label class="md-radio"&gt;&lt;input type="radio" name="demo" /&gt; Option B&lt;/label&gt;
+                  &lt;input type="checkbox" class="md-toggle-input" checked /&gt;
+                  &lt;span class="md-toggle-track"&gt;&lt;/span&gt;
+                  &lt;span class="md-toggle-text"&gt;Toggle&lt;/span&gt;
+                &lt;/label&gt;</code></pre></div>
+                    
+                
+            <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Buttons</div>
+            
+        
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: button + modifiers + states</div><div class="md-preview-row md-button-row"><button class="md-button">Base</button><button class="md-button md-button--primary">Primary</button><button class="md-button md-button--tonal">Tonal</button><button class="md-button md-button--surface">Surface</button><button class="md-button md-button--secondary">Secondary</button><button class="md-button md-button--primary md-button--hero">Hero</button><button class="md-button" disabled>Disabled</button></div></div><div><strong>Classes</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--hero</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-button--primary:hover</span><span class="md-chip">.md-button--secondary</span><span class="md-chip">.md-button--surface</span><span class="md-chip">.md-button--tonal</span><span class="md-chip">.md-button--tonal:hover</span><span class="md-chip">.md-button-primary</span><span class="md-chip">.md-button-primary:hover</span><span class="md-chip">.md-button-row</span><span class="md-chip">.md-button-secondary</span><span class="md-chip">.md-button:active</span><span class="md-chip">.md-button:disabled</span><span class="md-chip">.md-button:hover</span></div><div><strong>Note (MD-inspired)</strong> Material Designのボタン構成に準拠した自前実装。</div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">1</a><a class="md-chip" href="../docs/life/forgot-items-check.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>&lt;div class="md-button-row"&gt;
+  &lt;button class="md-button"&gt;Base&lt;/button&gt;
+  &lt;button class="md-button md-button--primary"&gt;Primary&lt;/button&gt;
+  &lt;button class="md-button md-button--tonal"&gt;Tonal&lt;/button&gt;
+  &lt;button class="md-button md-button--surface"&gt;Surface&lt;/button&gt;
+  &lt;button class="md-button md-button--secondary"&gt;Secondary&lt;/button&gt;
+  &lt;button class="md-button md-button--primary md-button--hero"&gt;Hero&lt;/button&gt;
+  &lt;button class="md-button" disabled&gt;Disabled&lt;/button&gt;
 &lt;/div&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: md-choice</div><div class="md-choice-row"><label class="md-choice"><input type="checkbox" /> Option A</label><label class="md-choice"><input type="checkbox" checked /> Option B</label></div></div><div><strong>Classes</strong><span class="md-chip">.md-choice</span><span class="md-chip">.md-choice-card</span><span class="md-chip">.md-choice-card--muted</span><span class="md-chip">.md-choice-inline</span><span class="md-chip">.md-choice-row</span><span class="md-chip">.md-choice-row input</span><span class="md-chip">.md-choice-sub</span><span class="md-chip">.md-choice-sub small</span><span class="md-chip">.md-choice-text</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a><a class="md-chip" href="../docs/git/git-branch-diff.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div><pre class="md-code"><code>&lt;div class="md-choice-row"&gt;
-  &lt;label class="md-choice"&gt;&lt;input type="checkbox" /&gt; Option A&lt;/label&gt;
-  &lt;label class="md-choice"&gt;&lt;input type="checkbox" checked /&gt; Option B&lt;/label&gt;
-&lt;/div&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: field container</div><div class="md-field"><label class="md-label">Label</label><input class="md-input" placeholder="text" /></div></div><div><strong>Classes</strong><span class="md-chip">.md-field</span><span class="md-chip">.md-field--dropdown</span><span class="md-chip">.md-field-block</span><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-field__label</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/grep/find-gen.html">1</a><a class="md-chip" href="../docs/life/japan-weather.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div><pre class="md-code"><code>&lt;div class="md-field"&gt;...&lt;/div&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: input variants</div><input class="md-input" placeholder="例: sample" /></div><div><strong>Classes</strong><span class="md-chip">.md-input</span><span class="md-chip">.md-input-action</span><span class="md-chip">.md-input-block</span><span class="md-chip">.md-input-wrap</span><span class="md-chip">.md-input.md-disabled</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">3</a></div><pre class="md-code"><code>&lt;input class="md-input" /&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: select variants</div><select class="md-select"><option>Option</option></select></div><div><strong>Classes</strong><span class="md-chip">.md-select</span><span class="md-chip">.md-select--inline</span><span class="md-chip">.md-select.md-disabled</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">2</a><a class="md-chip" href="../docs/life/japan-weather.html">3</a></div><pre class="md-code"><code>&lt;select class="md-select"&gt;...&lt;/select&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: textarea variants</div><textarea class="md-textarea" placeholder="..." ></textarea></div><div><strong>Classes</strong><span class="md-chip">.md-textarea</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>&lt;textarea class="md-textarea"&gt;&lt;/textarea&gt;</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: tooltip</div><span class="md-tooltip-group"><span class="md-help-chip">i</span><span class="md-tooltip-content md-tooltip">説明文…</span></span></div><div><strong>Classes</strong><span class="md-chip">.md-tooltip</span><span class="md-chip">.md-tooltip--narrow</span><span class="md-chip">.md-tooltip--rich</span><span class="md-chip">.md-tooltip--wide</span><span class="md-chip">.md-tooltip-content</span><span class="md-chip">.md-tooltip-group</span></div><pre class="md-code"><code>&lt;span class="md-tooltip-group"&gt;...&lt;/span&gt;</code></pre></div>
+
     <div class="md-example-card">
       <div class="md-preview">
-        <div class="md-preview-note">Selector set: code output</div>
-        <div class="md-code-block">
-          <code class="md-code">echo "Hello"</code>
-          <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="コピー">📋</button>
-        </div>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-code-block</span><span class="md-chip">.md-code</span><span class="md-chip">.md-copy-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
-      <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
-  &lt;code class="md-code"&gt;echo "Hello"&lt;/code&gt;
-  &lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="コピー"&gt;📋&lt;/button&gt;
-&lt;/div&gt;</code></pre>
-    </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-snackbar</div><div class="md-snackbar">コピーしました</div></div><div><strong>Classes</strong><span class="md-chip">.md-snackbar</span><span class="md-chip">.md-hidden</span><span class="md-chip">.md-visible</span></div><pre class="md-code"><code>&lt;div class="md-snackbar"&gt;...&lt;/div&gt;</code></pre></div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: field stack</div>
-        <div class="md-field-stack">
-          <input class="md-input" placeholder="text" />
-          <select class="md-select">
-            <option>Option</option>
-          </select>
-          <textarea class="md-textarea" rows="2" placeholder="multiline"></textarea>
-        </div>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-field-stack .md-input</span><span class="md-chip">.md-field-stack .md-select</span><span class="md-chip">.md-textarea</span></div>
-      <div><strong>Examples</strong><span class="md-chip">使用箇所なし</span></div>
-      <pre class="md-code"><code>&lt;div class="md-field-stack"&gt;
-  &lt;input class="md-input" placeholder="text" /&gt;
-  &lt;select class="md-select"&gt;
-    &lt;option&gt;Option&lt;/option&gt;
-  &lt;/select&gt;
-  &lt;textarea class="md-textarea" rows="2" placeholder="multiline"&gt;&lt;/textarea&gt;
-&lt;/div&gt;</code></pre>
-    </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-form-grid</div></div><div><strong>Classes</strong><span class="md-chip">.md-form-grid</span></div><pre class="md-code"><code>.md-form-grid { ... }</code></pre></div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: form row + modifiers</div>
-        <div class="md-form-row md-form-row--nowrap">
-          <label class="md-label">Label</label>
-          <input class="md-input" placeholder="text" />
-          <span class="md-sub-label">hint</span>
-        </div>
-        <div class="md-form-row md-form-row--start" style="margin-top: 8px;">
-          <label class="md-label">Label</label>
-          <div>
-            <textarea class="md-textarea" rows="2" placeholder="multiline"></textarea>
-            <div class="md-sub-label">note</div>
-          </div>
-        </div>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-form-row</span><span class="md-chip">.md-form-row--nowrap</span><span class="md-chip">.md-form-row--start</span></div>
-      <pre class="md-code"><code>&lt;div class="md-form-row md-form-row--nowrap"&gt;
-  &lt;label class="md-label"&gt;Label&lt;/label&gt;
-  &lt;input class="md-input" placeholder="text" /&gt;
-  &lt;span class="md-sub-label"&gt;hint&lt;/span&gt;
-&lt;/div&gt;
-&lt;div class="md-form-row md-form-row--start"&gt;
-  &lt;label class="md-label"&gt;Label&lt;/label&gt;
-  &lt;div&gt;
-    &lt;textarea class="md-textarea" rows="2" placeholder="multiline"&gt;&lt;/textarea&gt;
-    &lt;div class="md-sub-label"&gt;note&lt;/div&gt;
-  &lt;/div&gt;
-&lt;/div&gt;</code></pre>
-    </div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: headline + icon</div>
-        <h1 class="md-headline">
-          <span aria-hidden="true" class="md-headline__icon">🧩</span>
-          Headline Title
-        </h1>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-headline</span><span class="md-chip">.md-headline__icon</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
-      <pre class="md-code"><code>&lt;h1 class="md-headline"&gt;
-  &lt;span aria-hidden="true" class="md-headline__icon"&gt;🧩&lt;/span&gt;
-  Headline Title
-&lt;/h1&gt;</code></pre>
-    </div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: tooltip + help chip</div>
-        <span class="md-tooltip-group">
-          <span class="md-help-chip" aria-hidden="true">
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none">
-              <circle cx="12" cy="12" r="9" fill="#cbbcf0"/>
-              <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/>
-              <circle cx="12" cy="7.5" r="1" fill="#ffffff"/>
-            </svg>
-          </span>
-          <span class="md-tooltip-content md-tooltip">説明文…</span>
-        </span>
-        <span class="md-tooltip-group" style="margin-left: 12px;">
-          <button type="button" class="md-help-chip" aria-label="詳細">
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none">
-              <circle cx="12" cy="12" r="9" fill="#cbbcf0"/>
-              <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/>
-              <circle cx="12" cy="7.5" r="1" fill="#ffffff"/>
-            </svg>
+        <div class="md-preview-note">Selector set: button + modifiers (example)</div>
+        <div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;">
+          <button onclick="encodeText()" class="md-button md-button--primary">
+            エンコード
           </button>
-          <span class="md-tooltip-content md-tooltip md-tooltip--wide">説明文（長め）…</span>
-        </span>
+          <button onclick="decodeText()" class="md-button md-button--primary">
+            デコード
+          </button>
+        </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-tooltip-group</span><span class="md-chip">.md-help-chip</span><span class="md-chip">.md-help-chip:focus-visible</span><span class="md-chip">.md-tooltip</span><span class="md-chip">.md-tooltip--narrow</span><span class="md-chip">.md-tooltip--rich</span><span class="md-chip">.md-tooltip--wide</span><span class="md-chip">.md-tooltip-content</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
-      <pre class="md-code"><code>&lt;span class="md-tooltip-group"&gt;
-  &lt;span class="md-help-chip" aria-hidden="true"&gt;
-    &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;
-      &lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;
-      &lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;
-      &lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;
-    &lt;/svg&gt;
-  &lt;/span&gt;
-  &lt;span class="md-tooltip-content md-tooltip"&gt;説明文…&lt;/span&gt;
-&lt;/span&gt;
-&lt;span class="md-tooltip-group"&gt;
-  &lt;button type="button" class="md-help-chip" aria-label="詳細"&gt;
-    &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;
-      &lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;
-      &lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;
-      &lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;
-    &lt;/svg&gt;
+      <div><strong>Classes</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-field-block</span></div>
+      <div><strong>Note (MD-inspired)</strong> 実ファイルのボタン行レイアウト。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a></div>
+      <pre class="md-code"><code>&lt;div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;"&gt;
+  &lt;button onclick="encodeText()" class="md-button md-button--primary"&gt;
+    エンコード
   &lt;/button&gt;
-  &lt;span class="md-tooltip-content md-tooltip md-tooltip--wide"&gt;説明文（長め）…&lt;/span&gt;
-&lt;/span&gt;</code></pre>
+  &lt;button onclick="decodeText()" class="md-button md-button--primary"&gt;
+    デコード
+  &lt;/button&gt;
+&lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-help-icon</div></div><div><strong>Classes</strong><span class="md-chip">.md-help-icon</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">3</a></div><pre class="md-code"><code>.md-help-icon { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-hidden</div></div><div><strong>Classes</strong><span class="md-chip">.md-hidden</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>.md-hidden { ... }</code></pre></div>
+                    
+                
+            
+        
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: icon button + modifiers</div>
         <div class="md-button-row">
-          <button class="md-icon-btn" aria-label="メニュー">☰</button>
-          <button class="md-icon-btn md-icon-btn--small" aria-label="コピー">📋</button>
-          <button class="md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="設定">⚙️</button>
+          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu(this)">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <path d="M4 6h16"/>
+              <path d="M4 12h16"/>
+              <path d="M4 18h16"/>
+            </svg>
+          </button>
+          <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('createBranchCmd')">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="9" width="11" height="11" rx="2"/>
+              <rect x="4" y="4" width="11" height="11" rx="2"/>
+            </svg>
+          </button>
+          <button type="button" class="md-icon-btn md-icon-btn--small md-input-action" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+              <path d="M20 4v6h-6"/>
+            </svg>
+          </button>
         </div>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span><span class="md-chip">.md-icon-btn:hover</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのアイコンボタン相当。</div>
       <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;
-&lt;button class="md-icon-btn md-icon-btn--small" aria-label="コピー"&gt;📋&lt;/button&gt;
-&lt;button class="md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="設定"&gt;⚙️&lt;/button&gt;</code></pre>
+      <pre class="md-code"><code>&lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu(this)"&gt;
+  &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
+    &lt;path d="M4 6h16"/&gt;
+    &lt;path d="M4 12h16"/&gt;
+    &lt;path d="M4 18h16"/&gt;
+  &lt;/svg&gt;
+&lt;/button&gt;
+&lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('createBranchCmd')"&gt;
+  &lt;svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"&gt;
+    &lt;rect x="9" y="9" width="11" height="11" rx="2"/&gt;
+    &lt;rect x="4" y="4" width="11" height="11" rx="2"/&gt;
+  &lt;/svg&gt;
+&lt;/button&gt;
+&lt;button type="button" class="md-icon-btn md-icon-btn--small md-input-action" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新"&gt;
+  &lt;svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"&gt;
+    &lt;path d="M20 12a8 8 0 1 1-2.34-5.66"/&gt;
+    &lt;path d="M20 4v6h-6"/&gt;
+  &lt;/svg&gt;
+&lt;/button&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input-wrap .md-input</div></div><div><strong>Classes</strong><span class="md-chip">.md-input-wrap .md-input</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a></div><pre class="md-code"><code>.md-input-wrap .md-input { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:disabled</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:disabled</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a></div><pre class="md-code"><code>.md-input:disabled { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-input:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-input:focus</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/git/git-branch-diff.html">3</a></div><pre class="md-code"><code>.md-input:focus { ... }</code></pre></div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: label + modifiers</div>
-        <div class="md-field-stack">
-          <label class="md-label md-label--block">Label Block</label>
-          <input class="md-input" placeholder="text" />
-          <label class="md-label md-label--row">
-            <span>Label Row</span>
-            <span class="md-label md-label--muted">Muted</span>
-          </label>
-          <input class="md-input" placeholder="text" />
-          <label class="md-label md-label--full">Label Full</label>
-          <textarea class="md-textarea" rows="2" placeholder="multiline"></textarea>
-        </div>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-label</span><span class="md-chip">.md-label--block</span><span class="md-chip">.md-label--full</span><span class="md-chip">.md-label--muted</span><span class="md-chip">.md-label--row</span><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-input</span><span class="md-chip">.md-textarea</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/mime-base64.html">3</a></div>
-      <pre class="md-code"><code>&lt;div class="md-field-stack"&gt;
-  &lt;label class="md-label md-label--block"&gt;Label Block&lt;/label&gt;
-  &lt;input class="md-input" placeholder="text" /&gt;
-  &lt;label class="md-label md-label--row"&gt;
-    &lt;span&gt;Label Row&lt;/span&gt;
-    &lt;span class="md-label md-label--muted"&gt;Muted&lt;/span&gt;
-  &lt;/label&gt;
-  &lt;input class="md-input" placeholder="text" /&gt;
-  &lt;label class="md-label md-label--full"&gt;Label Full&lt;/label&gt;
-  &lt;textarea class="md-textarea" rows="2" placeholder="multiline"&gt;&lt;/textarea&gt;
-&lt;/div&gt;</code></pre>
-    </div>
+                    
+                
+            <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Navigation</div>
+            
+        
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: menu button + panel</div>
-        <div style="position: relative; min-height: 120px;">
-          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー">☰</button>
-          <div class="md-menu-panel" style="position: absolute; top: 44px; right: 12px;">
-            <a class="md-menu-link" href="#">メニュー 1</a>
-            <a class="md-menu-link" href="#">メニュー 2</a>
+        <div class="md-menu-demo" style="min-height: 120px;">
+          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <path d="M4 6h16"/>
+              <path d="M4 12h16"/>
+              <path d="M4 18h16"/>
+            </svg>
+          </button>
+          <div class="md-menu-panel md-hidden">
+            <a href="../index.html" class="md-menu-link">トップへ戻る</a>
           </div>
         </div>
       </div>
       <div><strong>Classes</strong><span class="md-chip">.md-menu-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-menu-panel</span><span class="md-chip">.md-menu-link</span><span class="md-chip">.md-menu-link:hover</span></div>
+      <div><strong>Note (Project-specific)</strong> メニューUIの独自セット。</div>
       <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;
-&lt;div class="md-menu-panel"&gt;
-  &lt;a class="md-menu-link" href="#"&gt;メニュー 1&lt;/a&gt;
-  &lt;a class="md-menu-link" href="#"&gt;メニュー 2&lt;/a&gt;
-&lt;/div&gt;</code></pre>
-    </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-page</div></div><div><strong>Classes</strong><span class="md-chip">.md-page</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/text/text-processing.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-page { ... }</code></pre></div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: label + required</div>
-        <label class="md-label">
-          <span>タイトル</span>
-          <span class="md-required">Required</span>
-        </label>
-        <input class="md-input" placeholder="例: sample.txt" />
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-label</span><span class="md-chip">.md-required</span><span class="md-chip">.md-input</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;label class="md-label"&gt;
-  &lt;span&gt;タイトル&lt;/span&gt;
-  &lt;span class="md-required"&gt;Required&lt;/span&gt;
-&lt;/label&gt;
-&lt;input class="md-input" placeholder="例: sample.txt" /&gt;</code></pre>
-    </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-shell</div></div><div><strong>Classes</strong><span class="md-chip">.md-shell</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-shell { ... }</code></pre></div>
-    <div class="md-example-card">
-      <div class="md-preview">
-        <div class="md-preview-note">Selector set: snackbar + host</div>
-        <div class="md-snackbar-host md-visible" style="position: relative; min-height: 72px;">
-          <div class="md-snackbar md-snackbar--visible md-visible">
-            <span>保存しました</span>
-            <button class="md-icon-btn md-icon-btn--small" aria-label="閉じる">✕</button>
-          </div>
-        </div>
-      </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-snackbar-host</span><span class="md-chip">.md-snackbar-host.md-visible</span><span class="md-chip">.md-snackbar</span><span class="md-chip">.md-snackbar--visible</span><span class="md-chip">.md-snackbar.md-visible</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;div class="md-snackbar-host md-visible"&gt;
-  &lt;div class="md-snackbar md-snackbar--visible md-visible"&gt;
-    &lt;span&gt;保存しました&lt;/span&gt;
-    &lt;button class="md-icon-btn md-icon-btn--small" aria-label="閉じる"&gt;✕&lt;/button&gt;
+      <pre class="md-code"><code>&lt;div class="md-menu-demo"&gt;
+  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;
+    &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
+      &lt;path d="M4 6h16"/&gt;
+      &lt;path d="M4 12h16"/&gt;
+      &lt;path d="M4 18h16"/&gt;
+    &lt;/svg&gt;
+  &lt;/button&gt;
+  &lt;div class="md-menu-panel md-hidden"&gt;
+    &lt;a href="../index.html" class="md-menu-link"&gt;トップへ戻る&lt;/a&gt;
   &lt;/div&gt;
 &lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-sr-only</div></div><div><strong>Classes</strong><span class="md-chip">.md-sr-only</span></div><div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div><pre class="md-code"><code>.md-sr-only { ... }</code></pre></div>
+            
+                    
+            
+        
     <div class="md-example-card">
       <div class="md-preview">
-        <div class="md-preview-note">Selector set: stack spacing</div>
-        <div class="md-stack-sm">
-          <div class="md-card" style="padding: 8px;">Stack SM</div>
-          <div class="md-card" style="padding: 8px;">Stack SM</div>
-        </div>
-        <div class="md-stack-md" style="margin-top: 10px;">
-          <div class="md-card" style="padding: 8px;">Stack MD</div>
-          <div class="md-card" style="padding: 8px;">Stack MD</div>
-        </div>
-        <div class="md-stack-lg" style="margin-top: 10px;">
-          <div class="md-card" style="padding: 8px;">Stack LG</div>
-          <div class="md-card" style="padding: 8px;">Stack LG</div>
+        <div class="md-preview-note">Selector: .md-tab-button[aria-selected="true"]</div>
+        <div class="md-tab-list" role="tablist" aria-label="処理方式の切り替え">
+          <button type="button" class="md-tab-button" data-target="tab-icu" aria-selected="true" aria-controls="tab-icu">
+            ICUラウドネス調整
+          </button>
+          <button type="button" class="md-tab-button" data-target="tab-gain" aria-selected="false" aria-controls="tab-gain">
+            単純ゲイン
+          </button>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-stack-sm > * + *</span><span class="md-chip">.md-stack-md > * + *</span><span class="md-chip">.md-stack-lg > * + *</span></div>
-      <pre class="md-code"><code>&lt;div class="md-stack-sm"&gt;...&lt;/div&gt;
-&lt;div class="md-stack-md"&gt;...&lt;/div&gt;
-&lt;div class="md-stack-lg"&gt;...&lt;/div&gt;</code></pre>
+      <div><strong>Classes</strong><span class="md-chip">.md-tab-button</span><span class="md-chip">.md-tab-button[aria-selected="true"]</span><span class="md-chip">.md-tab-list</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのタブ切替に近いUI。選択状態は `aria-selected="true"` で表現。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a></div>
+      <pre class="md-code"><code>&lt;div class="md-tab-list" role="tablist" aria-label="処理方式の切り替え"&gt;
+  &lt;button type="button" class="md-tab-button" data-target="tab-icu" aria-selected="true" aria-controls="tab-icu"&gt;
+    ICUラウドネス調整
+  &lt;/button&gt;
+  &lt;button type="button" class="md-tab-button" data-target="tab-gain" aria-selected="false" aria-controls="tab-gain"&gt;
+    単純ゲイン
+  &lt;/button&gt;
+&lt;/div&gt;</code></pre>
     </div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-surface-card</div></div><div><strong>Classes</strong><span class="md-chip">.md-surface-card</span></div><pre class="md-code"><code>.md-surface-card { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-tab-button[aria-selected="true"]</div></div><div><strong>Classes</strong><span class="md-chip">.md-tab-button[aria-selected="true"]</span></div><pre class="md-code"><code>.md-tab-button[aria-selected="true"] { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-textarea:focus</div></div><div><strong>Classes</strong><span class="md-chip">.md-textarea:focus</span></div><pre class="md-code"><code>.md-textarea:focus { ... }</code></pre></div>
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector: .md-tooltip-group:hover .md-tooltip-content</div></div><div><strong>Classes</strong><span class="md-chip">.md-tooltip-group:hover .md-tooltip-content</span></div><pre class="md-code"><code>.md-tooltip-group:hover .md-tooltip-content { ... }</code></pre></div>
+            
+                
+            <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Tooltip & Help</div>
+            
+        
+    <div class="md-example-card">
+                      <div class="md-preview">
+                        <div class="md-preview-note">Selector set: tooltip + help chip</div>
+                        <h1 class="md-headline">
+                          <span aria-hidden="true" class="md-headline__icon">⚙️</span>
+                          <span>Git ユーザー設定コマンドジェネレータ</span>
+                          <span class="md-tooltip-group">
+                            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+                              グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+                            </span>
+                          </span>
+                        </h1>
+                        <div class="md-flow-row">
+                          <p class="md-section-title">現在の設定を確認</p>
+                          <span class="md-tooltip-group">
+                            <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+                              設定前に現在のユーザー名とメールアドレスを確認できます。
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                      <div><strong>Classes</strong><span class="md-chip">.md-tooltip-group</span><span class="md-chip">.md-tooltip-group:hover .md-tooltip-content</span><span class="md-chip">.md-help-chip</span><span class="md-chip">.md-help-chip:focus-visible</span><span class="md-chip">.md-help-icon</span><span class="md-chip">.md-tooltip</span><span class="md-chip">.md-tooltip--narrow</span><span class="md-chip">.md-tooltip--rich</span><span class="md-chip">.md-tooltip--wide</span><span class="md-chip">.md-tooltip-content</span></div>
+              <div><strong>Note (MD-inspired)</strong> Material Designのツールチップ相当。ヘルプチップ併用は独自。</div>
+                      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+                      <pre class="md-code"><code>&lt;h1 class="md-headline"&gt;
+  &lt;span aria-hidden="true" class="md-headline__icon"&gt;⚙️&lt;/span&gt;
+  &lt;span&gt;Git ユーザー設定コマンドジェネレータ&lt;/span&gt;
+  &lt;span class="md-tooltip-group"&gt;
+    &lt;span class="md-help-chip"&gt;&lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;&lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;&lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;&lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;&lt;/svg&gt;&lt;/span&gt;
+    &lt;span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide"&gt;
+      グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+    &lt;/span&gt;
+  &lt;/span&gt;
+&lt;/h1&gt;
+&lt;div class="md-flow-row"&gt;
+  &lt;p class="md-section-title"&gt;現在の設定を確認&lt;/p&gt;
+  &lt;span class="md-tooltip-group"&gt;
+    &lt;span class="md-help-chip"&gt;&lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;&lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;&lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;&lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;&lt;/svg&gt;&lt;/span&gt;
+    &lt;span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide"&gt;
+      設定前に現在のユーザー名とメールアドレスを確認できます。
+    &lt;/span&gt;
+  &lt;/span&gt;
+&lt;/div&gt;</code></pre>
+                    </div>
+                    
+                
+            
+        
+            <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Utilities</div>
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector: .md-hidden</div>
+        <div class="md-menu-demo">
+          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <path d="M4 6h16"/>
+              <path d="M4 12h16"/>
+              <path d="M4 18h16"/>
+            </svg>
+          </button>
+          <div class="md-menu-panel md-hidden">
+            <a href="../index.html" class="md-menu-link">トップへ戻る</a>
+          </div>
+        </div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-hidden</span></div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;div class="md-menu-demo"&gt;
+  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;
+    &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
+      &lt;path d="M4 6h16"/&gt;
+      &lt;path d="M4 12h16"/&gt;
+      &lt;path d="M4 18h16"/&gt;
+    &lt;/svg&gt;
+  &lt;/button&gt;
+  &lt;div class="md-menu-panel md-hidden"&gt;
+    &lt;a href="../index.html" class="md-menu-link"&gt;トップへ戻る&lt;/a&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector: .md-sr-only</div>
+        <label class="md-label md-label--row">
+          <span>音声ファイル名</span>
+          <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only" style="display:none">必須</span>
+        </label>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-sr-only</span></div>
+      <div><strong>Note (MD-inspired)</strong> Required 表示は視認用、`md-sr-only` の「必須」は読み上げ用の補助。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+      <pre class="md-code"><code>&lt;label class="md-label md-label--row"&gt;
+  &lt;span&gt;音声ファイル名&lt;/span&gt;
+  &lt;span class="md-required" aria-hidden="true"&gt;Required&lt;/span&gt;&lt;span class="md-sr-only"&gt;必須&lt;/span&gt;
+&lt;/label&gt;</code></pre>
+    </div>
+                    
+                
+            <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Output & Feedback</div>
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: code output</div>
+        <div class="md-code-block">
+          <code id="diffCmd" class="md-code"></code>
+          <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('diffCmd')" aria-label="コピー">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="9" width="11" height="11" rx="2"/>
+              <rect x="4" y="4" width="11" height="11" rx="2"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-code-block</span><span class="md-chip">.md-code</span><span class="md-chip">.md-copy-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span></div>
+      <div><strong>Note (Project-specific)</strong> コード出力表示の独自コンポーネント。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
+  &lt;code id="diffCmd" class="md-code"&gt;&lt;/code&gt;
+  &lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('diffCmd')" aria-label="コピー"&gt;
+    &lt;svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"&gt;
+      &lt;rect x="9" y="9" width="11" height="11" rx="2"/&gt;
+      &lt;rect x="4" y="4" width="11" height="11" rx="2"/&gt;
+    &lt;/svg&gt;
+  &lt;/button&gt;
+&lt;/div&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector set: snackbar + host</div>
+        <div id="toast" class="md-snackbar-host md-snackbar">
+          コピーしました
+        </div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-snackbar-host</span><span class="md-chip">.md-snackbar</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのスナックバー相当。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;div id="toast" class="md-snackbar-host md-snackbar"&gt;
+  コピーしました
+&lt;/div&gt;</code></pre>
+    </div>
+                    
+                
+            
+        
+    <div class="md-example-card">
+      <div class="md-preview">
+        <div class="md-preview-note">Selector: .md-snackbar</div>
+        <div class="md-snackbar" id="toast">コピーしました</div>
+      </div>
+      <div><strong>Classes</strong><span class="md-chip">.md-snackbar</span></div>
+      <div><strong>Note (MD-inspired)</strong> Material Designのスナックバー相当。短いフィードバック表示に使う。</div>
+      <div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
+      <pre class="md-code"><code>&lt;div class="md-snackbar" id="toast"&gt;コピーしました&lt;/div&gt;</code></pre>
+    </div>
+                    
   </div>
 </div>
 <!-- core-catalog:end -->
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Layout</h2>
+      <h2 class="md-section-title">Layout Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2107,21 +2399,39 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Form</h2>
+      <h2 class="md-section-title">Form Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
-            <div class="md-preview-note">Source: docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html</div>
+            <div class="md-preview-note">Source: docs/ffmpeg/ffmpeg-trim-cmdline-gen.html</div>
             <label class="md-label">
-              <span>タイトル</span>
-              <span class="md-required">Required</span>
+              <span>入力ファイル名</span>
+          <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only" style="display:none">必須</span>
+              <span class="md-tooltip-group">
+                <span class="md-help-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+                <span class="md-tooltip-content md-tooltip md-tooltip--wide">
+                  例: 250503_130527_TrMic.wav / sample.mp4
+                </span>
+              </span>
+              <span>：</span>
             </label>
-            <input class="md-input" placeholder="例: sample.txt" />
+            <input type="text" id="filename" placeholder="例: 250503_130527_TrMic.wav / sample.mp4" class="md-input md-field-block">
           </div>
           <div><strong>Classes</strong><span class="md-chip">md-label</span><span class="md-chip">md-input</span><span class="md-chip">md-field-block</span></div>
+          <div><strong>Note (MD-inspired)</strong> ラベル + 必須表示 + 入力欄の基本セット。補足はツールチップで補う。</div>
           <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
-          <pre class="md-code"><code>&lt;label class="md-label"&gt;タイトル&lt;/label&gt;
-&lt;input class="md-input md-field-block" /&gt;</code></pre>
+          <pre class="md-code"><code>&lt;label class="md-label"&gt;
+  &lt;span&gt;入力ファイル名&lt;/span&gt;
+  &lt;span class="md-required" aria-hidden="true"&gt;Required&lt;/span&gt;&lt;span class="md-sr-only"&gt;必須&lt;/span&gt;
+  &lt;span class="md-tooltip-group"&gt;
+    &lt;span class="md-help-chip"&gt;&lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;&lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;&lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;&lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;&lt;/svg&gt;&lt;/span&gt;
+    &lt;span class="md-tooltip-content md-tooltip md-tooltip--wide"&gt;
+      例: 250503_130527_TrMic.wav / sample.mp4
+    &lt;/span&gt;
+  &lt;/span&gt;
+  &lt;span&gt;：&lt;/span&gt;
+&lt;/label&gt;
+&lt;input type="text" id="filename" placeholder="例: 250503_130527_TrMic.wav / sample.mp4" class="md-input md-field-block"&gt;</code></pre>
         </div>
         <div class="md-example-card">
           <div class="md-preview">
@@ -2137,11 +2447,11 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Buttons</h2>
+      <h2 class="md-section-title">Button Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview md-preview-row">
-            <div class="md-preview-note">Source: docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html</div>
+            <div class="md-preview-note">Source: docs/link/url-encode-decode.html</div>
             <button class="md-button md-button--primary">実行</button>
             <button class="md-icon-btn" aria-label="メニュー">☰</button>
           </div>
@@ -2162,11 +2472,11 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Tooltip (i)</h2>
+      <h2 class="md-section-title">Tooltip (i) Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
-            <div class="md-preview-note">Source: docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html</div>
+            <div class="md-preview-note">Source: docs/grep/find-gen.html</div>
             <span class="md-tooltip-group">
               <span class="md-help-chip">
                 <svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none">
@@ -2190,7 +2500,7 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Code Output</h2>
+      <h2 class="md-section-title">Code Output Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2211,7 +2521,7 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Snackbar</h2>
+      <h2 class="md-section-title">Snackbar Examples</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview md-preview-row">


### PR DESCRIPTION
# 概要
index.html の各コンポーネント例を、docs/* の実ファイルHTMLに合わせて更新
Tooltip/Choice/Radio/Select/Textarea/Code/Snackbar などのカードを実例・注記付きで整理 MD3リファレンス上で不足していたスタイル（タブ、メニュー、セレクト等）を反映し見た目を一致

# 変更点
実ファイルのHTMLをそのまま貼り、プレビューとコードの一致を強化
Tooltip関連は重複を整理し、1セットに統合
.md-select を含む入力系の見た目調整（display: block 等）
タブUI（.md-tab-list / .md-tab-button）のスタイル追加
メニューUIのスタイル追加とプレビュー配置の安定化（.md-menu-demo）
md-snackbar / md-code-block / md-textarea などにNote追加 md-sr-only はプレビューのみ非表示（実利用は維持）