### PR TITLE
md3/docs UIカタログ整理: md-switch/md-visible統一と Selectors表示ルール再設計

### DIFF
--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -105,13 +105,13 @@
       font-weight: 600;
       transition: box-shadow 150ms ease, transform 150ms ease, background 150ms ease;
     }
-    .md-button-primary {
+    .md-button--primary {
       background: var(--md-sys-color-primary);
       color: var(--md-sys-color-on-primary);
       box-shadow: 0 2px 6px rgba(98, 0, 238, 0.3);
     }
-    .md-button-primary:hover { box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35); }
-    .md-button-secondary {
+    .md-button--primary:hover { box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35); }
+    .md-button--secondary {
       background: var(--md-sys-color-surface-variant);
       color: var(--md-sys-color-primary);
       border: 1px solid #ded7e6;
@@ -356,7 +356,7 @@
     </div>
 
     <div class="md-actions md-section">
-      <button id="convert" disabled class="md-button md-button-primary">
+      <button id="convert" disabled class="md-button md-button--primary">
         SVGに変換する
       </button>
     </div>
@@ -370,7 +370,7 @@
     </div>
 
     <div class="md-actions md-section" style="margin-top: 1.5rem;">
-      <button id="download" disabled class="md-button md-button-secondary">
+      <button id="download" disabled class="md-button md-button--secondary">
         SVGをダウンロード
       </button>
     </div>

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -90,16 +90,16 @@ limitations under the License.
       gap: 0.65rem;
       padding: 0.25rem 0;
     }
-    .md-toggle {
+    .md-switch-label {
       justify-content: flex-start;
       gap: 0.75rem;
     }
-    .md-toggle-input {
+    .md-switch-input {
       position: absolute;
       opacity: 0;
       pointer-events: none;
     }
-    .md-toggle-track {
+    .md-switch {
       width: 44px;
       height: 24px;
       background: #f0ebf7;
@@ -109,7 +109,7 @@ limitations under the License.
       transition: background 150ms ease, box-shadow 150ms ease;
       flex-shrink: 0;
     }
-    .md-toggle-track::after {
+    .md-switch::after {
       content: "";
       width: 20px;
       height: 20px;
@@ -121,11 +121,11 @@ limitations under the License.
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
       transition: transform 150ms ease, background 150ms ease;
     }
-    .md-toggle-input:checked + .md-toggle-track {
+    .md-switch-input:checked + .md-switch {
       background: rgba(98, 0, 238, 0.32);
       box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
     }
-    .md-toggle-input:checked + .md-toggle-track::after {
+    .md-switch-input:checked + .md-switch::after {
       transform: translateX(20px);
       background: var(--md-sys-color-primary);
     }
@@ -247,7 +247,7 @@ limitations under the License.
       transition: opacity 200ms ease;
       z-index: 80;
     }
-    .md-snackbar--visible { opacity: 1; pointer-events: auto; }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
 
     .hidden { display: none; }
   </style>
@@ -287,25 +287,25 @@ limitations under the License.
       </span>
     </h2>
     <div class="md-grid md-grid-2" style="margin-bottom: 1rem;">
-      <label class="md-choice md-toggle">
-        <input type="checkbox" id="useUpper" class="md-toggle-input" checked>
-        <span class="md-toggle-track" aria-hidden="true"></span>
-        <span class="md-toggle-text">英大文字（A D E F H M N R T Y）</span>
+      <label class="md-choice md-switch-label">
+        <input type="checkbox" id="useUpper" class="md-switch-input" checked>
+        <span class="md-switch" aria-hidden="true"></span>
+        <span class="md-switch-text">英大文字（A D E F H M N R T Y）</span>
       </label>
-      <label class="md-choice md-toggle">
-        <input type="checkbox" id="useLower" class="md-toggle-input" checked>
-        <span class="md-toggle-track" aria-hidden="true"></span>
-        <span class="md-toggle-text">英小文字（a d e f h m n r t y）</span>
+      <label class="md-choice md-switch-label">
+        <input type="checkbox" id="useLower" class="md-switch-input" checked>
+        <span class="md-switch" aria-hidden="true"></span>
+        <span class="md-switch-text">英小文字（a d e f h m n r t y）</span>
       </label>
-      <label class="md-choice md-toggle">
-        <input type="checkbox" id="useDigits" class="md-toggle-input" checked>
-        <span class="md-toggle-track" aria-hidden="true"></span>
-        <span class="md-toggle-text">数字（0-9）</span>
+      <label class="md-choice md-switch-label">
+        <input type="checkbox" id="useDigits" class="md-switch-input" checked>
+        <span class="md-switch" aria-hidden="true"></span>
+        <span class="md-switch-text">数字（0-9）</span>
       </label>
-      <label class="md-choice md-toggle">
-        <input type="checkbox" id="useSymbols" class="md-toggle-input" checked>
-        <span class="md-toggle-track" aria-hidden="true"></span>
-        <span class="md-toggle-text">記号（@ # $）</span>
+      <label class="md-choice md-switch-label">
+        <input type="checkbox" id="useSymbols" class="md-switch-input" checked>
+        <span class="md-switch" aria-hidden="true"></span>
+        <span class="md-switch-text">記号（@ # $）</span>
       </label>
     </div>
 
@@ -470,9 +470,9 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById("toast");
       toast.textContent = message;
-      toast.classList.add("md-snackbar--visible");
+      toast.classList.add("md-visible");
       setTimeout(() => {
-        toast.classList.remove("md-snackbar--visible");
+        toast.classList.remove("md-visible");
       }, 2000);
     }
 

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -158,17 +158,17 @@ limitations under the License.
       color: #3f3b46;
     }
     .md-checkbox { accent-color: var(--md-sys-color-primary); }
-    .md-toggle {
+    .md-switch-label {
       justify-content: space-between;
       gap: 0.75rem;
     }
-    .md-toggle-text { flex: 1; }
-    .md-toggle-input {
+    .md-switch-text { flex: 1; }
+    .md-switch-input {
       position: absolute;
       opacity: 0;
       pointer-events: none;
     }
-    .md-toggle-track {
+    .md-switch {
       width: 44px;
       height: 24px;
       background: #f0ebf7;
@@ -178,7 +178,7 @@ limitations under the License.
       transition: background 150ms ease, box-shadow 150ms ease;
       flex-shrink: 0;
     }
-    .md-toggle-track::after {
+    .md-switch::after {
       content: "";
       width: 20px;
       height: 20px;
@@ -190,11 +190,11 @@ limitations under the License.
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
       transition: transform 150ms ease, background 150ms ease;
     }
-    .md-toggle-input:checked + .md-toggle-track {
+    .md-switch-input:checked + .md-switch {
       background: rgba(98, 0, 238, 0.32);
       box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
     }
-    .md-toggle-input:checked + .md-toggle-track::after {
+    .md-switch-input:checked + .md-switch::after {
       transform: translateX(20px);
       background: var(--md-sys-color-primary);
     }
@@ -259,7 +259,7 @@ limitations under the License.
       pointer-events: none;
       transition: opacity 200ms ease;
     }
-    .md-snackbar--visible { opacity: 1; pointer-events: auto; }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
 
     .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
     .md-help-chip {
@@ -368,10 +368,10 @@ limitations under the License.
 <option value="toFull">全角に変換</option>
 </select>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">仮名を含める</span>
-<input class="md-toggle-input" id="optIncludeKana" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">仮名を含める</span>
+<input class="md-switch-input" id="optIncludeKana" type="checkbox">
+<span class="md-switch"></span>
 </label>
 <label class="md-sub-label">ひらがな/カタカナ:
           <select class="md-select" id="optKana">
@@ -392,145 +392,145 @@ limitations under the License.
 <details class="md-accordion">
 <summary>記号を変換</summary>
 <div class="md-subpanel" id="symbolConvertPanel">
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">すべて切り替え</span>
-<input class="md-toggle-input" id="optSymbolAll" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">すべて切り替え</span>
+<input class="md-switch-input" id="optSymbolAll" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">セミコロン（； → ;）</span>
-<input class="md-toggle-input" id="optSymbolSemicolon" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">セミコロン（； → ;）</span>
+<input class="md-switch-input" id="optSymbolSemicolon" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">コロン（： → :）</span>
-<input class="md-toggle-input" id="optSymbolColon" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">コロン（： → :）</span>
+<input class="md-switch-input" id="optSymbolColon" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">クオート（＇ → '）</span>
-<input class="md-toggle-input" id="optSymbolSingleQuote" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">クオート（＇ → '）</span>
+<input class="md-switch-input" id="optSymbolSingleQuote" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">ダブルクオート（＂ → "）</span>
-<input class="md-toggle-input" id="optSymbolDoubleQuote" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">ダブルクオート（＂ → "）</span>
+<input class="md-switch-input" id="optSymbolDoubleQuote" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">バッククオート（｀ → `）</span>
-<input class="md-toggle-input" id="optSymbolBackQuote" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">バッククオート（｀ → `）</span>
+<input class="md-switch-input" id="optSymbolBackQuote" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">丸括弧（（ ） → ( )）</span>
-<input class="md-toggle-input" id="optSymbolParentheses" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">丸括弧（（ ） → ( )）</span>
+<input class="md-switch-input" id="optSymbolParentheses" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">感嘆符（！ → !）</span>
-<input class="md-toggle-input" id="optSymbolExclamation" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">感嘆符（！ → !）</span>
+<input class="md-switch-input" id="optSymbolExclamation" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">ドル（＄ → $）</span>
-<input class="md-toggle-input" id="optSymbolDollar" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">ドル（＄ → $）</span>
+<input class="md-switch-input" id="optSymbolDollar" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">クエスチョン（？ → ?）</span>
-<input class="md-toggle-input" id="optSymbolQuestion" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">クエスチョン（？ → ?）</span>
+<input class="md-switch-input" id="optSymbolQuestion" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">アンパサンド（＆ → &amp;）</span>
-<input class="md-toggle-input" id="optSymbolAmpersand" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">アンパサンド（＆ → &amp;）</span>
+<input class="md-switch-input" id="optSymbolAmpersand" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">アットマーク（＠ → @）</span>
-<input class="md-toggle-input" id="optSymbolAt" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">アットマーク（＠ → @）</span>
+<input class="md-switch-input" id="optSymbolAt" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">シャープ（＃ → #）</span>
-<input class="md-toggle-input" id="optSymbolHash" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">シャープ（＃ → #）</span>
+<input class="md-switch-input" id="optSymbolHash" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">パーセント（％ → %）</span>
-<input class="md-toggle-input" id="optSymbolPercent" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">パーセント（％ → %）</span>
+<input class="md-switch-input" id="optSymbolPercent" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">プラス（＋ → +）</span>
-<input class="md-toggle-input" id="optSymbolPlus" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">プラス（＋ → +）</span>
+<input class="md-switch-input" id="optSymbolPlus" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">イコール（＝ → =）</span>
-<input class="md-toggle-input" id="optSymbolEquals" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">イコール（＝ → =）</span>
+<input class="md-switch-input" id="optSymbolEquals" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">スラッシュ（／ → /）</span>
-<input class="md-toggle-input" id="optSymbolSlash" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">スラッシュ（／ → /）</span>
+<input class="md-switch-input" id="optSymbolSlash" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">バックスラッシュ（＼ → \\）</span>
-<input class="md-toggle-input" id="optSymbolBackslash" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">バックスラッシュ（＼ → \\）</span>
+<input class="md-switch-input" id="optSymbolBackslash" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">ハイフン（－ → -）</span>
-<input class="md-toggle-input" id="optSymbolHyphen" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">ハイフン（－ → -）</span>
+<input class="md-switch-input" id="optSymbolHyphen" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">アンダースコア（＿ → _）</span>
-<input class="md-toggle-input" id="optSymbolUnderscore" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">アンダースコア（＿ → _）</span>
+<input class="md-switch-input" id="optSymbolUnderscore" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">カンマ（， → ,）</span>
-<input class="md-toggle-input" id="optSymbolComma" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">カンマ（， → ,）</span>
+<input class="md-switch-input" id="optSymbolComma" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">ピリオド（． → .）</span>
-<input class="md-toggle-input" id="optSymbolPeriod" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">ピリオド（． → .）</span>
+<input class="md-switch-input" id="optSymbolPeriod" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">キャレット（＾ → ^）</span>
-<input class="md-toggle-input" id="optSymbolCaret" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">キャレット（＾ → ^）</span>
+<input class="md-switch-input" id="optSymbolCaret" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">パイプ（｜ → |）</span>
-<input class="md-toggle-input" id="optSymbolPipe" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">パイプ（｜ → |）</span>
+<input class="md-switch-input" id="optSymbolPipe" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">不等号（＜ ＞ → &lt; &gt;）</span>
-<input class="md-toggle-input" id="optSymbolAngle" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">不等号（＜ ＞ → &lt; &gt;）</span>
+<input class="md-switch-input" id="optSymbolAngle" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">波括弧（｛ ｝ → { }）</span>
-<input class="md-toggle-input" id="optSymbolBrace" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">波括弧（｛ ｝ → { }）</span>
+<input class="md-switch-input" id="optSymbolBrace" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">角括弧（［ ］ → [ ]）</span>
-<input class="md-toggle-input" id="optSymbolBracket" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">角括弧（［ ］ → [ ]）</span>
+<input class="md-switch-input" id="optSymbolBracket" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">チルダ（～ → ~）</span>
-<input class="md-toggle-input" id="optSymbolTilde" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">チルダ（～ → ~）</span>
+<input class="md-switch-input" id="optSymbolTilde" type="checkbox">
+<span class="md-switch"></span>
 </label>
 </div>
 </details>
@@ -551,50 +551,50 @@ limitations under the License.
 <option value="desc">降順</option>
 </select>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">空行を除去</span>
-<input class="md-toggle-input" id="optRemoveEmptyLines" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">空行を除去</span>
+<input class="md-switch-input" id="optRemoveEmptyLines" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">連続する空行を1行に</span>
-<input class="md-toggle-input" id="optCollapseEmptyLines" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">連続する空行を1行に</span>
+<input class="md-switch-input" id="optCollapseEmptyLines" type="checkbox">
+<span class="md-switch"></span>
 </label>
 </div>
 </details>
 <details class="md-accordion">
 <summary>空白の変換</summary>
 <div class="md-subpanel" id="spaceConvertPanel">
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">全角/特殊空白を半角空白に変換</span>
-<input class="md-toggle-input" id="optNormalizeUnicodeSpaces" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">全角/特殊空白を半角空白に変換</span>
+<input class="md-switch-input" id="optNormalizeUnicodeSpaces" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">サイズのない空白を除去</span>
-<input class="md-toggle-input" id="optRemoveZeroWidthSpaces" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">サイズのない空白を除去</span>
+<input class="md-switch-input" id="optRemoveZeroWidthSpaces" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">句読点/記号（。、？！）の直前の半角空白を除去</span>
-<input class="md-toggle-input" id="optRemoveSpaceBeforePunct" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">句読点/記号（。、？！）の直前の半角空白を除去</span>
+<input class="md-switch-input" id="optRemoveSpaceBeforePunct" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">前後の空白をトリム</span>
-<input class="md-toggle-input" id="optTrim" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">前後の空白をトリム</span>
+<input class="md-switch-input" id="optTrim" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">連続する空白・タブを1つにする</span>
-<input class="md-toggle-input" id="optNormalizeSpaces" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">連続する空白・タブを1つにする</span>
+<input class="md-switch-input" id="optNormalizeSpaces" type="checkbox">
+<span class="md-switch"></span>
 </label>
-<label class="md-check-row md-toggle">
-<span class="md-toggle-text">改行を空白に変換</span>
-<input class="md-toggle-input" id="optNewlineToSpace" type="checkbox">
-<span class="md-toggle-track"></span>
+<label class="md-check-row md-switch-label">
+<span class="md-switch-text">改行を空白に変換</span>
+<input class="md-switch-input" id="optNewlineToSpace" type="checkbox">
+<span class="md-switch"></span>
 </label>
 </div>
 </details>
@@ -1046,9 +1046,9 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById('toast');
       toast.textContent = message;
-      toast.classList.add('md-snackbar--visible');
+      toast.classList.add('md-visible');
       setTimeout(() => {
-        toast.classList.remove('md-snackbar--visible');
+        toast.classList.remove('md-visible');
       }, 2000);
     }
 

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -108,7 +108,7 @@ limitations under the License.
       box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
     }
 
-    .md-toggle-row { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .md-radio-row { display: flex; gap: 0.75rem; flex-wrap: wrap; }
     .md-radio {
       display: inline-flex;
       align-items: center;
@@ -160,7 +160,7 @@ limitations under the License.
       pointer-events: none;
       transition: opacity 200ms ease;
     }
-    .md-snackbar--visible { opacity: 1; pointer-events: auto; }
+    .md-snackbar.md-visible { opacity: 1; pointer-events: auto; }
 
     .hidden { display: none; }
     .leading-relaxed { line-height: 1.6; }
@@ -229,7 +229,7 @@ limitations under the License.
     <div class="md-section">
       <div class="md-toolbar" style="margin-bottom: 0.75rem;">
         <label class="md-label" style="margin-bottom: 0;">プレビュー</label>
-        <div class="md-toggle-row">
+        <div class="md-radio-row">
           <label class="md-radio">
             <input type="radio" name="format" value="plain" checked>
             <span>プレーンテキスト</span>
@@ -372,9 +372,9 @@ limitations under the License.
     function showToast(message) {
       const toast = document.getElementById('toast');
       toast.textContent = message;
-      toast.classList.add('md-snackbar--visible');
+      toast.classList.add('md-visible');
       setTimeout(() => {
-        toast.classList.remove('md-snackbar--visible');
+        toast.classList.remove('md-visible');
       }, 2000);
     }
 

--- a/md3/README.md
+++ b/md3/README.md
@@ -11,7 +11,7 @@
 ## 何をまとめたものか
 
 - 対象: `docs/` の各 HTML ツール（Git / FFmpeg / Link / Text / Grep / Password / Life など）
-- 形式: 「実物プレビュー + 使用クラス + HTML 記述例 + 実際の利用箇所リンク」
+- 形式: 「実物プレビュー + Selectors + Origin + Rationale + Preview Code + Usage（実利用リンク）」
 - 目的:
   - 画面ごとに散らばった UI パターンの再利用性を上げる
   - Material Design 風の見た目と操作感を、外部依存なしで統一する
@@ -36,16 +36,16 @@
 - ページタイトル: `MD3 Reference`
 - 主なセクション:
   - `Core Components`
-  - `Layout Examples`
-  - `Form Examples`
-  - `Button Examples`
-  - `Tooltip (i) Examples`
-  - `Code Output Examples`
-  - `Snackbar Examples`
+  - `Layout Usage`
+  - `Form Usage`
+  - `Button Usage`
+  - `Tooltip (i) Usage`
+  - `Code Output Usage`
+  - `Snackbar Usage`
 - 掲載要素（例）:
   - レイアウト: `md-page` `md-shell` `md-card`
   - 入力系: `md-label` `md-input` `md-select` `md-textarea` `md-required`
-  - 選択系: `md-radio` `md-choice` `md-switch`（`md-toggle` は廃止予定）
+  - 選択系: `md-radio` `md-choice` `md-switch`
   - 操作系: `md-button` `md-icon-btn` `md-menu-*`
   - 補助表示: `md-tooltip-*` `md-chip` `md-sr-only`
   - 出力/通知: `md-code-block` `md-copy-button` `md-snackbar`
@@ -56,11 +56,11 @@
   - トークン/セレクタ集約（`Core（共通）` と `Screen-specific（画面依存）` の提示）
   - `Core Selector Catalog`（コンポーネント単位の実物+コード）
   - 用途別サンプル（Layout / Form / Button / Tooltip / Code / Snackbar）
-- カタログカードは `Note (MD-inspired)` と `Note (Project-specific)` の2系統で意図を明示している
-- `Examples` の `../docs/*.html` 参照リンクは現状 25 件あり、リンク先は存在している
-- スイッチ系は `md-switch` を推奨しつつ、`md-toggle` は Deprecated 表示で併存している
-- ボタン系は `md-button--*` 修飾子スタイルと、旧来の `md-button-primary` / `md-button-secondary` が併存している
-- Snackbar 可視化クラスは `md-snackbar.md-visible` と `md-snackbar--visible` の2表現が残っている
+- カタログカードは `Origin`（`MD-inspired` / `Project-specific`）と `Rationale`（意図メモ）を分離している
+- `Usage` の `../docs/*.html` 参照リンクは現状 25 件あり、リンク先は存在している
+- スイッチ系は `md-switch` に統一済み
+- ボタン系は `md-button--*` 修飾子スタイルへ統一済み（旧来 `md-button-primary` / `md-button-secondary` は削除）
+- Snackbar 可視化は `md-visible` 系へ統一済み（`md-snackbar--visible` は削除）
 - このため、`md3/index.html` は「統一済み仕様書」ではなく「実運用知見の収集・移行中カタログ」として扱う
 
 ## 位置づけ（docs との関係）
@@ -104,7 +104,15 @@
   - 現時点では完全対応を目標にしない（必要時に段階的に対応する）
   - アクセシビリティに関する未整理事項は `md3/TODO.md` で管理する
 - カタログ運用:
-  - 各項目は「実物プレビュー + Classes + HTML例 + Examplesリンク」を1セットで揃える
+  - 各項目は「実物プレビュー + Selectors + Origin + Rationale + Preview Code + Usageリンク」を1セットで揃える
+  - `Selectors` は実体クラスを表示し、必要に応じて同カード内に `State Selectors` / `Composite Selectors` を分離表示する
+  - 実体クラスは `unused` 表示で、プレビュー内で直接使っていないものを区別する
+  - 疑似クラス/複合セレクタ（例: `:focus`, `.a .b`）は参照用として扱い、未使用判定の対象外にする
+  - `MD-inspired` で `unused` が出ることは許容する（状態・派生の説明として有効）
+  - `Project-specific` は `docs/*.html` に実利用があるものだけ採用する（未使用の独自実装は追加しない）
+  - `Project-specific` で実利用のない要素はカタログに載せない方針とする
+  - `Project-specific` で実利用のない要素は `docs/*.html` 側にも残さない（未使用定義は削除する）
+  - 表示整形の一部は `md3/index.html` のJSで実施する（`Source:` の `Usage` への吸収、`Usage` 重複リンク除去、`使用箇所なし` チップ整理 など）
   - 仕様として許容する例外（未定義関数参照・重複IDなど）はREADME/TODOで明示する
 
 ## 補足
@@ -116,4 +124,4 @@
 
 - `md3/index.html` の一部プレビューは、実運用HTMLから断片をそのまま引用している。
 - そのため、`onclick` / `onchange` がこのページ内で未定義の関数を参照する箇所がある（仕様として許容）。
-- 同じ理由で、プレビュー断片間で `id` が重複する場合がある（例: `toast`）。
+- 以前は同じ理由で、プレビュー断片間で `id` が重複する箇所（`toast`）があったが、現在は `toastHost` / `toastInline` へ分離済み。

--- a/md3/TODO.md
+++ b/md3/TODO.md
@@ -8,25 +8,28 @@
   - 背景: プレビュー時に理由不明で非表示化が必要になり暫定的に `display:none` を併用したが、`sr-only` の意図と矛盾していて納得できていない
   - 対応方針: プレビューで見た目を崩さず、かつアクセシビリティ上の意味を壊さない方法を調査する
 
-- [ ] ボタンの旧来クラス `md-button-primary` / `md-button-secondary` を削除し、`md-button--*` 系へ統一する
+- [x] ボタンの旧来クラス `md-button-primary` / `md-button-secondary` を削除し、`md-button--*` 系へ統一する
   - 背景: 命名系統が混在していて、実装ルールとカタログ運用の一貫性が崩れる
-  - 対応方針: 旧来クラスの定義・参照を除去し、必要な見た目は `md-button--primary` / `md-button--secondary` へ寄せる
+  - 対応済み: 旧来クラスの定義・参照を除去し、`md-button--primary` / `md-button--secondary` に統一
 
-- [ ] Snackbar 可視化クラスを一本化する（`md-snackbar.md-visible` と `md-snackbar--visible` の併存解消）
+- [x] Snackbar 可視化クラスを一本化する（`md-snackbar.md-visible` と `md-snackbar--visible` の併存解消）
   - 背景: 状態表現が2系統あり、どちらを正とするか判断しづらい
-  - 対応方針: 状態クラス運用に合わせて1系統に統一し、README と実装例を同時更新する
+  - 対応済み: 状態クラス運用に合わせ `md-visible` 系に統一し、README/実装例も更新
 
 ## Low（品質改善）
 
 - [x] テキスト中の `&` を `&amp;` に置換する
   - 対応済み: `Tooltip &amp; Help`, `Output &amp; Feedback`
 
-- [ ] `TODO: md-switch と md-toggle の重複` を解消する
-  - 方針: `md-switch` を標準化し、`md-toggle` は Deprecated 表示に寄せるか削除する
+- [x] `TODO: md-switch と md-toggle の重複` を解消する
+  - 対応済み: `md-switch` に統一し、`md-toggle` のカタログ項目を削除
 
 ## メモ
 
 - 未定義イベント関数参照は、実運用HTML断片をそのまま載せるプレビュー構造に起因するため、現時点では仕様として許容する
 - `id="toast"` 重複も同様にプレビュー断片由来で、現時点では仕様として許容する
+- `Origin: Project-specific` かつ `Usage: 使用箇所なし` のカードは、現時点ではカタログから削除運用にしている（再利用先ができた場合のみ再追加）
+- `Project-specific` で実利用のない要素は、`md3` だけでなく `docs/*.html` 側の定義・実装も削除対象とする
+- カタログ表示整形の一部を `md3/index.html` のJSで実施している（`Source:` の `Usage` への吸収、`Usage` 重複リンク除去、`使用箇所なし` チップ整理）
 - `../docs/*.html` への参照リンク自体は現状すべて存在している
 - コンポーネントカタログとしての構成（プレビュー + クラス + コード例 + 実利用リンク）は一貫している

--- a/md3/index.html
+++ b/md3/index.html
@@ -64,6 +64,29 @@
     .md-preview-stack { display: grid; gap: 12px; }
     .md-preview-row { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
     .md-preview-note { font-size: 0.85rem; color: var(--md-sys-color-on-surface-variant); }
+    .md-preview-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .md-preview-meta .md-preview-note {
+      margin: 0;
+      padding: 2px 8px;
+      border-radius: 999px;
+      background: rgba(103, 80, 164, 0.12);
+      color: var(--md-sys-color-primary);
+      font-weight: 600;
+    }
+    .md-selectors-block {
+      margin-bottom: 10px;
+    }
+    .md-selectors-sub-block {
+      margin-bottom: 8px;
+    }
+    .md-origin-block {
+      margin-bottom: 10px;
+    }
 
     .md-label {
       display: flex;
@@ -205,15 +228,6 @@
     .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
     .md-switch-input:checked + .md-switch { background: var(--md-sys-color-primary); }
     .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
-
-    .md-toggle { display: inline-flex; align-items: center; gap: 0.6rem; font-size: 0.95rem; color: var(--md-sys-color-on-surface); }
-    .md-toggle-input { position: absolute; opacity: 0; pointer-events: none; }
-    .md-toggle-track { width: 44px; height: 24px; border-radius: 999px; background: #d7d2de; position: relative; transition: background 150ms ease; }
-    .md-toggle-track::after { content: ""; width: 18px; height: 18px; border-radius: 50%; background: white; position: absolute; top: 3px; left: 3px; transition: transform 150ms ease; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
-    .md-toggle-input:checked + .md-toggle-track { background: var(--md-sys-color-primary); }
-    .md-toggle-input:checked + .md-toggle-track::after { transform: translateX(20px); }
-    .md-toggle-text { font-weight: 600; }
-
     .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
     .md-tooltip-content {
       position: absolute;
@@ -304,6 +318,26 @@
       background: rgba(98, 0, 238, 0.12);
       color: var(--md-sys-color-primary);
       margin-left: 6px;
+    }
+    .md-chip--unused {
+      opacity: 1;
+      border: 1px dashed rgba(103, 80, 164, 0.55);
+      background: #f2eef8;
+      color: #6b5f7a;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+    }
+    .md-chip--unused::before {
+      content: "unused ";
+      font-size: 0.62rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      margin-right: 0.18rem;
+      opacity: 0.85;
+    }
+    .md-chip--selector-meta {
+      opacity: 0.82;
+      font-weight: 600;
     }
   </style>
 </head>
@@ -868,51 +902,6 @@
   padding: 0.25rem 0;
 }
 
-.md-toggle {
-  justify-content: flex-start;
-  gap: 0.75rem;
-}
-
-.md-toggle-input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.md-toggle-track {
-  width: 44px;
-  height: 24px;
-  background: #f0ebf7;
-  border-radius: 9999px;
-  position: relative;
-  box-shadow: inset 0 0 0 1px #cfc7dc;
-  transition: background 150ms ease, box-shadow 150ms ease;
-  flex-shrink: 0;
-}
-
-.md-toggle-track::after {
-  content: "";
-  width: 20px;
-  height: 20px;
-  border-radius: 9999px;
-  background: #ffffff;
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  transition: transform 150ms ease, background 150ms ease;
-}
-
-.md-toggle-input:checked + .md-toggle-track {
-  background: rgba(98, 0, 238, 0.32);
-  box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
-}
-
-.md-toggle-input:checked + .md-toggle-track::after {
-  transform: translateX(20px);
-  background: var(--md-sys-color-primary);
-}
-
 .md-input {
   width: 100%;
   padding: 0.65rem 0.75rem;
@@ -932,10 +921,6 @@
 
 .md-button:hover {
   box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
-}
-
-.md-snackbar--visible {
-  opacity: 1; pointer-events: auto;
 }
 
 .md-button:active {
@@ -1032,22 +1017,6 @@
   opacity: 1; pointer-events: auto;
 }
 
-.md-button-primary {
-  background: var(--md-sys-color-primary);
-  color: var(--md-sys-color-on-primary);
-  box-shadow: 0 2px 6px rgba(98, 0, 238, 0.3);
-}
-
-.md-button-primary:hover {
-  box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
-}
-
-.md-button-secondary {
-  background: var(--md-sys-color-surface-variant);
-  color: var(--md-sys-color-primary);
-  border: 1px solid #ded7e6;
-}
-
 .md-button:disabled {
   background: #e6e1ee;
   color: #9a94a7;
@@ -1061,10 +1030,6 @@
   box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
 }
 
-.md-toggle-row {
-  display: flex; gap: 0.75rem; flex-wrap: wrap;
-}
-
 .md-input-block {
   margin-bottom: 1rem;
 }
@@ -1075,10 +1040,6 @@
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.md-toggle-text {
-  flex: 1;
 }
 
 .md-output-wrap {
@@ -1793,7 +1754,7 @@
         注: プレビューは実運用ページから断片的にコピーしているため、`onclick` / `onchange` が未定義関数を参照する場合があります（仕様として許容）。同じ理由で、`id` が重複する断片が含まれる場合があります。
       </div>
       <div class="md-preview-note" style="margin-top: 6px;">
-        TODO: トグル系が `md-switch` と `md-toggle` の2系統に分かれており重複。標準を統一すること。
+        トグル系は `md-switch` に統一済みです。
       </div>
       <!-- core-catalog:start -->
 <div class="md-section" style="margin-top: 16px;">
@@ -1804,9 +1765,11 @@
         <div class="md-preview-note">Selector: .md-input:disabled</div>
         <input type="text" class="md-input" placeholder="disabled" disabled>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-input:disabled</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのdisabled表現を意識。</div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-input:disabled</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのdisabled表現を意識。</div>
       <div><strong>使用箇所なし</strong> 実ファイルに disabled 入力の該当HTMLがない。</div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;input type="text" class="md-input" placeholder="disabled" disabled&gt;</code></pre>
     </div>
                     
@@ -1818,9 +1781,11 @@
         <div class="md-preview-note">Selector set: textarea variants</div>
         <textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="md-textarea md-field-block"></textarea>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-textarea</span><span class="md-chip">.md-field-block</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのテキスト入力に近い見た目を意識。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-textarea</span><span class="md-chip">.md-field-block</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのテキスト入力に近い見た目を意識。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;textarea id="inputText" rows="5" placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF" class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
     </div>
                 
@@ -1832,9 +1797,11 @@
         <label class="md-label">ffprobe 出力（JSON/テキスト）:</label>
         <textarea id="probeOutput" rows="6" placeholder="ffprobe の出力を貼り付けてください" class="md-textarea md-field-block"></textarea>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-textarea:focus</span></div>
-      <div><strong>Note (MD-inspired)</strong> 説明ラベル + 大きめテキストエリアの組み合わせで、複数行入力を想定。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/text/text-processing.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-textarea:focus</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> 説明ラベル + 大きめテキストエリアの組み合わせで、複数行入力を想定。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/mime-base64.html">2</a><a class="md-chip" href="../docs/text/text-processing.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;label class="md-label"&gt;ffprobe 出力（JSON/テキスト）:&lt;/label&gt;
 &lt;textarea id="probeOutput" rows="6" placeholder="ffprobe の出力を貼り付けてください" class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
     </div>
@@ -1853,9 +1820,11 @@
           <option value="192000">192 kHz</option>
         </select>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-select</span><span class="md-chip">.md-field-block</span><span class="md-chip">.md-select--inline</span><span class="md-chip">.md-select.md-disabled</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designの選択UIに近い見た目を意識。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">2</a><a class="md-chip" href="../docs/life/japan-weather.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-select</span><span class="md-chip">.md-field-block</span><span class="md-chip">.md-select--inline</span><span class="md-chip">.md-select.md-disabled</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designの選択UIに近い見た目を意識。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">2</a><a class="md-chip" href="../docs/life/japan-weather.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;label class="md-label"&gt;サンプルレートを選択:&lt;/label&gt;
 &lt;select id="sampleRate" class="md-select md-field-block"&gt;
   &lt;option value="44100" selected&gt;44.1 kHz（標準）&lt;/option&gt;
@@ -1865,31 +1834,6 @@
 &lt;/select&gt;</code></pre>
     </div>
                     
-                
-            
-        
-    <div class="md-example-card">
-                      <div class="md-preview">
-                        <div class="md-preview-note">Selector set: field stack</div>
-                        <div class="md-field-stack">
-                          <input class="md-input" placeholder="text" />
-                          <select class="md-select">
-                            <option>Option</option>
-                          </select>
-                          <textarea class="md-textarea" rows="2" placeholder="multiline"></textarea>
-                        </div>
-                      </div>
-                      <div><strong>Classes</strong><span class="md-chip">.md-field-stack</span><span class="md-chip">.md-field-stack .md-input</span><span class="md-chip">.md-field-stack .md-select</span><span class="md-chip">.md-textarea</span></div>
-          <div><strong>Note (Project-specific)</strong> 入力群を縦積みする独自レイアウト。</div>
-                      <div><strong>Examples</strong><span class="md-chip">使用箇所なし</span></div>
-                      <pre class="md-code"><code>&lt;div class="md-field-stack"&gt;
-                  &lt;input class="md-input" placeholder="text" /&gt;
-                  &lt;select class="md-select"&gt;
-                    &lt;option&gt;Option&lt;/option&gt;
-                  &lt;/select&gt;
-                  &lt;textarea class="md-textarea" rows="2" placeholder="multiline"&gt;&lt;/textarea&gt;
-                &lt;/div&gt;</code></pre>
-                    </div>
                 
             
         
@@ -1909,9 +1853,11 @@
           </span>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-radio</span><span class="md-chip">.md-radio input</span><span class="md-chip">.md-radio-row</span></div>
-      <div><strong>Note (MD-inspired)</strong> ラジオ選択 + ヘルプチップを横並びにし、選択肢の補足説明を同列に置く。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-radio</span><span class="md-chip">.md-radio input</span><span class="md-chip">.md-radio-row</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> ラジオ選択 + ヘルプチップを横並びにし、選択肢の補足説明を同列に置く。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-radio-row"&gt;
   &lt;label class="md-radio"&gt;
     &lt;input type="radio" name="mode" value="music_release" checked&gt;
@@ -1972,9 +1918,11 @@
           </div>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-choice</span><span class="md-chip">.md-choice-card</span><span class="md-chip">.md-choice-card--muted</span><span class="md-chip">.md-choice-inline</span><span class="md-chip">.md-choice-row</span><span class="md-chip">.md-choice-row input</span><span class="md-chip">.md-choice-sub</span><span class="md-chip">.md-choice-sub small</span><span class="md-chip">.md-choice-text</span></div>
-      <div><strong>Note (MD-inspired)</strong> 大きめのカード内で、主選択（チェック）と補助選択（ラジオ）を段階的に提示する構成。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a><a class="md-chip" href="../docs/git/git-branch-diff.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-choice</span><span class="md-chip">.md-choice-card</span><span class="md-chip">.md-choice-card--muted</span><span class="md-chip">.md-choice-inline</span><span class="md-chip">.md-choice-row</span><span class="md-chip">.md-choice-row input</span><span class="md-chip">.md-choice-sub</span><span class="md-chip">.md-choice-sub small</span><span class="md-chip">.md-choice-text</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> 大きめのカード内で、主選択（チェック）と補助選択（ラジオ）を段階的に提示する構成。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-config-advanced-setup.html">1</a><a class="md-chip" href="../docs/git/git-branch-diff.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-choice-card md-stack-md"&gt;
   &lt;div class="md-form-row md-form-row--start"&gt;
     &lt;label for="enableAutocrlf" class="md-choice-row"&gt;
@@ -2028,9 +1976,11 @@
           リモートとして扱う
         </label>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-switch</span><span class="md-chip">.md-switch-input</span><span class="md-chip">.md-switch-input:checked + .md-switch</span><span class="md-chip">.md-switch-input:checked + .md-switch::after</span><span class="md-chip">.md-switch-label</span><span class="md-chip">.md-switch-row</span><span class="md-chip">.md-switch::after</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのスイッチ相当。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-switch</span><span class="md-chip">.md-switch-input</span><span class="md-chip">.md-switch-input:checked + .md-switch</span><span class="md-chip">.md-switch-input:checked + .md-switch::after</span><span class="md-chip">.md-switch-label</span><span class="md-chip">.md-switch-row</span><span class="md-chip">.md-switch::after</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのスイッチ相当。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;label class="md-switch-label"&gt;
   &lt;input type="checkbox" id="scopeA" class="md-switch-input" checked onchange="updateRemoteState()"&gt;
   &lt;span class="md-switch" aria-hidden="true"&gt;&lt;/span&gt;
@@ -2041,17 +1991,12 @@
                 
             
         
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: md-toggle</div><label class="md-toggle"><input type="checkbox" class="md-toggle-input" checked /><span class="md-toggle-track"></span><span class="md-toggle-text">Toggle</span></label><div class="md-preview-note" style="margin-top: 6px; color: #b3261e; font-weight: 700;">Deprecated: md-toggle は廃止予定。md-switch を使用してください。</div></div><div><strong>Classes</strong><span class="md-chip">.md-toggle</span><span class="md-chip">.md-toggle-input</span><span class="md-chip">.md-toggle-input:checked + .md-toggle-track</span><span class="md-chip">.md-toggle-input:checked + .md-toggle-track::after</span><span class="md-chip">.md-toggle-row</span><span class="md-chip">.md-toggle-text</span><span class="md-chip">.md-toggle-track</span><span class="md-chip">.md-toggle-track::after</span></div><pre class="md-code"><code>&lt;label class="md-toggle"&gt;
-                  &lt;input type="checkbox" class="md-toggle-input" checked /&gt;
-                  &lt;span class="md-toggle-track"&gt;&lt;/span&gt;
-                  &lt;span class="md-toggle-text"&gt;Toggle&lt;/span&gt;
-                &lt;/label&gt;</code></pre></div>
-                    
-                
             <div class="md-section-title" style="grid-column: 1 / -1; margin-top: 10px;">Buttons</div>
             
         
-    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: button + modifiers + states</div><div class="md-preview-row md-button-row"><button class="md-button">Base</button><button class="md-button md-button--primary">Primary</button><button class="md-button md-button--tonal">Tonal</button><button class="md-button md-button--surface">Surface</button><button class="md-button md-button--secondary">Secondary</button><button class="md-button md-button--primary md-button--hero">Hero</button><button class="md-button" disabled>Disabled</button></div></div><div><strong>Classes</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--hero</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-button--primary:hover</span><span class="md-chip">.md-button--secondary</span><span class="md-chip">.md-button--surface</span><span class="md-chip">.md-button--tonal</span><span class="md-chip">.md-button--tonal:hover</span><span class="md-chip">.md-button-primary</span><span class="md-chip">.md-button-primary:hover</span><span class="md-chip">.md-button-row</span><span class="md-chip">.md-button-secondary</span><span class="md-chip">.md-button:active</span><span class="md-chip">.md-button:disabled</span><span class="md-chip">.md-button:hover</span></div><div><strong>Note (MD-inspired)</strong> Material Designのボタン構成に準拠した自前実装。</div><div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">1</a><a class="md-chip" href="../docs/life/forgot-items-check.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><pre class="md-code"><code>&lt;div class="md-button-row"&gt;
+    <div class="md-example-card"><div class="md-preview"><div class="md-preview-note">Selector set: button + modifiers + states</div><div class="md-preview-row md-button-row"><button class="md-button">Base</button><button class="md-button md-button--primary">Primary</button><button class="md-button md-button--tonal">Tonal</button><button class="md-button md-button--surface">Surface</button><button class="md-button md-button--secondary">Secondary</button><button class="md-button md-button--primary md-button--hero">Hero</button><button class="md-button" disabled>Disabled</button></div></div><div><strong>Selectors</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--hero</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-button--primary:hover</span><span class="md-chip">.md-button--secondary</span><span class="md-chip">.md-button--surface</span><span class="md-chip">.md-button--tonal</span><span class="md-chip">.md-button--tonal:hover</span><span class="md-chip">.md-button-row</span><span class="md-chip">.md-button:active</span><span class="md-chip">.md-button:disabled</span><span class="md-chip">.md-button:hover</span></div><div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのボタン構成に準拠した自前実装。</div><div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">1</a><a class="md-chip" href="../docs/life/forgot-items-check.html">2</a><a class="md-chip" href="../docs/link/url-encode-decode.html">3</a></div><div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div class="md-button-row"&gt;
   &lt;button class="md-button"&gt;Base&lt;/button&gt;
   &lt;button class="md-button md-button--primary"&gt;Primary&lt;/button&gt;
   &lt;button class="md-button md-button--tonal"&gt;Tonal&lt;/button&gt;
@@ -2073,9 +2018,11 @@
           </button>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-field-block</span></div>
-      <div><strong>Note (MD-inspired)</strong> 実ファイルのボタン行レイアウト。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-button</span><span class="md-chip">.md-button--primary</span><span class="md-chip">.md-field-block</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> 実ファイルのボタン行レイアウト。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;"&gt;
   &lt;button onclick="encodeText()" class="md-button md-button--primary"&gt;
     エンコード
@@ -2114,9 +2061,11 @@
           </button>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span><span class="md-chip">.md-icon-btn:hover</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのアイコンボタン相当。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span><span class="md-chip">.md-icon-btn:hover</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのアイコンボタン相当。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu(this)"&gt;
   &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
     &lt;path d="M4 6h16"/&gt;
@@ -2146,7 +2095,7 @@
       <div class="md-preview">
         <div class="md-preview-note">Selector set: menu button + panel</div>
         <div class="md-menu-demo" style="min-height: 120px;">
-          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー">
+          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" aria-expanded="false" onclick="toggleMenu(this)">
             <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
               <path d="M4 6h16"/>
               <path d="M4 12h16"/>
@@ -2158,11 +2107,13 @@
           </div>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-menu-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-menu-panel</span><span class="md-chip">.md-menu-link</span><span class="md-chip">.md-menu-link:hover</span></div>
-      <div><strong>Note (Project-specific)</strong> メニューUIの独自セット。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-menu-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-menu-panel</span><span class="md-chip">.md-menu-link</span><span class="md-chip">.md-menu-link:hover</span></div>
+      <div><strong>Origin</strong><span class="md-chip">Project-specific</span></div>
+      <div><strong>Rationale</strong> メニューUIの独自セット。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-pseudo-squash.html">1</a><a class="md-chip" href="../docs/link/amazon-dp-extract.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-menu-demo"&gt;
-  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;
+  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" aria-expanded="false" onclick="toggleMenu(this)"&gt;
     &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
       &lt;path d="M4 6h16"/&gt;
       &lt;path d="M4 12h16"/&gt;
@@ -2190,9 +2141,11 @@
           </button>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-tab-button</span><span class="md-chip">.md-tab-button[aria-selected="true"]</span><span class="md-chip">.md-tab-list</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのタブ切替に近いUI。選択状態は `aria-selected="true"` で表現。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-tab-button</span><span class="md-chip">.md-tab-button[aria-selected="true"]</span><span class="md-chip">.md-tab-list</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのタブ切替に近いUI。選択状態は `aria-selected="true"` で表現。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html">1</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-tab-list" role="tablist" aria-label="処理方式の切り替え"&gt;
   &lt;button type="button" class="md-tab-button" data-target="tab-icu" aria-selected="true" aria-controls="tab-icu"&gt;
     ICUラウドネス調整
@@ -2230,10 +2183,12 @@
                           </span>
                         </div>
                       </div>
-                      <div><strong>Classes</strong><span class="md-chip">.md-tooltip-group</span><span class="md-chip">.md-tooltip-group:hover .md-tooltip-content</span><span class="md-chip">.md-help-chip</span><span class="md-chip">.md-help-chip:focus-visible</span><span class="md-chip">.md-help-icon</span><span class="md-chip">.md-tooltip</span><span class="md-chip">.md-tooltip--narrow</span><span class="md-chip">.md-tooltip--rich</span><span class="md-chip">.md-tooltip--wide</span><span class="md-chip">.md-tooltip-content</span></div>
-              <div><strong>Note (MD-inspired)</strong> Material Designのツールチップ相当。ヘルプチップ併用は独自。</div>
-                      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
-                      <pre class="md-code"><code>&lt;h1 class="md-headline"&gt;
+                      <div><strong>Selectors</strong><span class="md-chip">.md-tooltip-group</span><span class="md-chip">.md-tooltip-group:hover .md-tooltip-content</span><span class="md-chip">.md-help-chip</span><span class="md-chip">.md-help-chip:focus-visible</span><span class="md-chip">.md-help-icon</span><span class="md-chip">.md-tooltip</span><span class="md-chip">.md-tooltip--narrow</span><span class="md-chip">.md-tooltip--rich</span><span class="md-chip">.md-tooltip--wide</span><span class="md-chip">.md-tooltip-content</span></div>
+              <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのツールチップ相当。ヘルプチップ併用は独自。</div>
+                      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+                      <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;h1 class="md-headline"&gt;
   &lt;span aria-hidden="true" class="md-headline__icon"&gt;⚙️&lt;/span&gt;
   &lt;span&gt;Git ユーザー設定コマンドジェネレータ&lt;/span&gt;
   &lt;span class="md-tooltip-group"&gt;
@@ -2264,7 +2219,7 @@
       <div class="md-preview">
         <div class="md-preview-note">Selector: .md-hidden</div>
         <div class="md-menu-demo">
-          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー">
+          <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" aria-expanded="false" onclick="toggleMenu(this)">
             <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
               <path d="M4 6h16"/>
               <path d="M4 12h16"/>
@@ -2276,10 +2231,11 @@
           </div>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-hidden</span></div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-hidden</span></div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-config-setup.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-menu-demo"&gt;
-  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー"&gt;
+  &lt;button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" aria-expanded="false" onclick="toggleMenu(this)"&gt;
     &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"&gt;
       &lt;path d="M4 6h16"/&gt;
       &lt;path d="M4 12h16"/&gt;
@@ -2303,9 +2259,11 @@
           <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only" style="display:none">必須</span>
         </label>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-sr-only</span></div>
-      <div><strong>Note (MD-inspired)</strong> Required 表示は視認用、`md-sr-only` の「必須」は読み上げ用の補助。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-sr-only</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Required 表示は視認用、`md-sr-only` の「必須」は読み上げ用の補助。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;label class="md-label md-label--row"&gt;
   &lt;span&gt;音声ファイル名&lt;/span&gt;
   &lt;span class="md-required" aria-hidden="true"&gt;Required&lt;/span&gt;&lt;span class="md-sr-only"&gt;必須&lt;/span&gt;
@@ -2329,9 +2287,11 @@
           </button>
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-code-block</span><span class="md-chip">.md-code</span><span class="md-chip">.md-copy-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span></div>
-      <div><strong>Note (Project-specific)</strong> コード出力表示の独自コンポーネント。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Selectors</strong><span class="md-chip">.md-code-block</span><span class="md-chip">.md-code</span><span class="md-chip">.md-copy-button</span><span class="md-chip">.md-icon-btn</span><span class="md-chip">.md-icon-btn--small</span><span class="md-chip">.md-icon-btn--surface</span></div>
+      <div><strong>Origin</strong><span class="md-chip">Project-specific</span></div>
+      <div><strong>Rationale</strong> コード出力表示の独自コンポーネント。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
       <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
   &lt;code id="diffCmd" class="md-code"&gt;&lt;/code&gt;
   &lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('diffCmd')" aria-label="コピー"&gt;
@@ -2349,14 +2309,16 @@
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector set: snackbar + host</div>
-        <div id="toast" class="md-snackbar-host md-snackbar">
+        <div id="toastHost" class="md-snackbar-host md-snackbar">
           コピーしました
         </div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-snackbar-host</span><span class="md-chip">.md-snackbar</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのスナックバー相当。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;div id="toast" class="md-snackbar-host md-snackbar"&gt;
+      <div><strong>Selectors</strong><span class="md-chip">.md-snackbar-host</span><span class="md-chip">.md-snackbar</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのスナックバー相当。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/git/git-branch-diff.html">1</a><a class="md-chip" href="../docs/git/git-config-setup.html">2</a><a class="md-chip" href="../docs/grep/find-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div id="toastHost" class="md-snackbar-host md-snackbar"&gt;
   コピーしました
 &lt;/div&gt;</code></pre>
     </div>
@@ -2367,12 +2329,14 @@
     <div class="md-example-card">
       <div class="md-preview">
         <div class="md-preview-note">Selector: .md-snackbar</div>
-        <div class="md-snackbar" id="toast">コピーしました</div>
+        <div class="md-snackbar" id="toastInline">コピーしました</div>
       </div>
-      <div><strong>Classes</strong><span class="md-chip">.md-snackbar</span></div>
-      <div><strong>Note (MD-inspired)</strong> Material Designのスナックバー相当。短いフィードバック表示に使う。</div>
-      <div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
-      <pre class="md-code"><code>&lt;div class="md-snackbar" id="toast"&gt;コピーしました&lt;/div&gt;</code></pre>
+      <div><strong>Selectors</strong><span class="md-chip">.md-snackbar</span></div>
+      <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> Material Designのスナックバー相当。短いフィードバック表示に使う。</div>
+      <div><strong>Usage</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/text/text-viewer.html">2</a><a class="md-chip" href="../docs/password/password-gen.html">3</a></div>
+      <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div class="md-snackbar" id="toastInline"&gt;コピーしました&lt;/div&gt;</code></pre>
     </div>
                     
   </div>
@@ -2381,7 +2345,7 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Layout Examples</h2>
+      <h2 class="md-section-title">Layout Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2392,17 +2356,21 @@
               </div>
             </div>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-page</span><span class="md-chip">md-shell</span><span class="md-chip">md-card</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-          <pre class="md-code"><code>&lt;body class="md-page"&gt;
-  &lt;div class="md-shell md-card"&gt;...&lt;/div&gt;
-&lt;/body&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-page</span><span class="md-chip">md-shell</span><span class="md-chip">md-card</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/text/text-processing.html">1</a><a class="md-chip" href="../docs/link/utm-remove.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div class="md-preview-stack"&gt;
+  &lt;div class="md-preview-note"&gt;Source: docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html&lt;/div&gt;
+  &lt;div class="md-card" style="padding: 16px; border-radius: 12px; box-shadow: none;"&gt;
+    コンテンツ領域
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
         </div>
       </div>
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Form Examples</h2>
+      <h2 class="md-section-title">Form Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2420,10 +2388,12 @@
             </label>
             <input type="text" id="filename" placeholder="例: 250503_130527_TrMic.wav / sample.mp4" class="md-input md-field-block">
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-label</span><span class="md-chip">md-input</span><span class="md-chip">md-field-block</span></div>
-          <div><strong>Note (MD-inspired)</strong> ラベル + 必須表示 + 入力欄の基本セット。補足はツールチップで補う。</div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
-          <pre class="md-code"><code>&lt;label class="md-label"&gt;
+          <div><strong>Selectors</strong><span class="md-chip">md-label</span><span class="md-chip">md-input</span><span class="md-chip">md-field-block</span></div>
+          <div><strong>Origin</strong><span class="md-chip">MD-inspired</span></div>
+      <div><strong>Rationale</strong> ラベル + 必須表示 + 入力欄の基本セット。補足はツールチップで補う。</div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-trim-cmdline-gen.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;label class="md-label"&gt;
   &lt;span&gt;入力ファイル名&lt;/span&gt;
   &lt;span class="md-required" aria-hidden="true"&gt;Required&lt;/span&gt;&lt;span class="md-sr-only"&gt;必須&lt;/span&gt;
   &lt;span class="md-tooltip-group"&gt;
@@ -2440,17 +2410,19 @@
           <div class="md-preview">
             <div class="md-preview-note">Source: docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html</div>
             <label class="md-label">詳細</label>
-            <textarea class="md-textarea" placeholder="例: メモを入力"></textarea>
+            <textarea class="md-textarea md-field-block" placeholder="例: メモを入力"></textarea>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-textarea</span><span class="md-chip">md-field-block</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/link/mime-base64.html">3</a></div>
-          <pre class="md-code"><code>&lt;textarea class="md-textarea md-field-block"&gt;&lt;/textarea&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-textarea</span><span class="md-chip">md-field-block</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/link/mime-base64.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;label class="md-label"&gt;詳細&lt;/label&gt;
+&lt;textarea class="md-textarea md-field-block" placeholder="例: メモを入力"&gt;&lt;/textarea&gt;</code></pre>
         </div>
       </div>
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Button Examples</h2>
+      <h2 class="md-section-title">Button Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview md-preview-row">
@@ -2458,24 +2430,27 @@
             <button class="md-button md-button--primary">実行</button>
             <button class="md-icon-btn" aria-label="メニュー">☰</button>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-button</span><span class="md-chip">md-button--primary</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/git/git-config-setup.html">3</a></div>
-          <pre class="md-code"><code>&lt;button class="md-button md-button--primary"&gt;実行&lt;/button&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-button</span><span class="md-chip">md-button--primary</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/link/url-encode-decode.html">2</a><a class="md-chip" href="../docs/git/git-config-setup.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;button class="md-button md-button--primary"&gt;実行&lt;/button&gt;
+&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;</code></pre>
         </div>
         <div class="md-example-card">
           <div class="md-preview md-preview-row">
             <div class="md-preview-note">Source: docs/link/amazon-dp-extract.html</div>
             <button class="md-icon-btn" aria-label="メニュー">☰</button>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-icon-btn</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/amazon-dp-extract.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
-          <pre class="md-code"><code>&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-icon-btn</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/link/amazon-dp-extract.html">1</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">2</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;button class="md-icon-btn" aria-label="メニュー"&gt;☰&lt;/button&gt;</code></pre>
         </div>
       </div>
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Tooltip (i) Examples</h2>
+      <h2 class="md-section-title">Tooltip (i) Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2492,18 +2467,26 @@
             </span>
             <span class="md-preview-note">ホバーで表示</span>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-tooltip-group</span><span class="md-chip">md-help-chip</span><span class="md-chip">md-tooltip</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
-          <pre class="md-code"><code>&lt;span class="md-tooltip-group"&gt;
-  &lt;span class="md-help-chip"&gt;...&lt;/span&gt;
-  &lt;span class="md-tooltip-content md-tooltip"&gt;説明文&lt;/span&gt;
-&lt;/span&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-tooltip-group</span><span class="md-chip">md-help-chip</span><span class="md-chip">md-tooltip</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">1</a><a class="md-chip" href="../docs/grep/find-gen.html">2</a><a class="md-chip" href="../docs/link/utm-remove.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;span class="md-tooltip-group"&gt;
+  &lt;span class="md-help-chip"&gt;
+    &lt;svg aria-hidden="true" viewBox="0 0 24 24" class="md-help-icon" fill="none"&gt;
+      &lt;circle cx="12" cy="12" r="9" fill="#cbbcf0"/&gt;
+      &lt;rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/&gt;
+      &lt;circle cx="12" cy="7.5" r="1" fill="#ffffff"/&gt;
+    &lt;/svg&gt;
+  &lt;/span&gt;
+  &lt;span class="md-tooltip-content md-tooltip"&gt;説明文…&lt;/span&gt;
+&lt;/span&gt;
+&lt;span class="md-preview-note"&gt;ホバーで表示&lt;/span&gt;</code></pre>
         </div>
       </div>
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Code Output Examples</h2>
+      <h2 class="md-section-title">Code Output Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview">
@@ -2513,10 +2496,11 @@
               <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" aria-label="コピー">📋</button>
             </div>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-code-block</span><span class="md-chip">md-code</span><span class="md-chip">md-copy-button</span><span class="md-chip">md-icon-btn</span><span class="md-chip">md-icon-btn--small</span><span class="md-chip">md-icon-btn--surface</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
-          <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
-  &lt;code class="md-code"&gt;...&lt;/code&gt;
+          <div><strong>Selectors</strong><span class="md-chip">md-code-block</span><span class="md-chip">md-code</span><span class="md-chip">md-copy-button</span><span class="md-chip">md-icon-btn</span><span class="md-chip">md-icon-btn--small</span><span class="md-chip">md-icon-btn--surface</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/link/url-encode-decode.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div class="md-code-block"&gt;
+  &lt;code class="md-code"&gt;echo "Hello"&lt;/code&gt;
   &lt;button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface"&gt;📋&lt;/button&gt;
 &lt;/div&gt;</code></pre>
         </div>
@@ -2524,19 +2508,253 @@
     </section>
 
     <section class="md-section">
-      <h2 class="md-section-title">Snackbar Examples</h2>
+      <h2 class="md-section-title">Snackbar Usage</h2>
       <div class="md-grid md-grid-2">
         <div class="md-example-card">
           <div class="md-preview md-preview-row">
             <div class="md-preview-note">Source: docs/link/utm-remove.html</div>
             <div class="md-snackbar">コピーしました</div>
           </div>
-          <div><strong>Classes</strong><span class="md-chip">md-snackbar</span><span class="md-chip">md-hidden</span><span class="md-chip">md-visible</span></div>
-          <div><strong>Examples</strong><a class="md-chip" href="../docs/link/utm-remove.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
-          <pre class="md-code"><code>&lt;div class="md-snackbar md-hidden"&gt;コピーしました&lt;/div&gt;</code></pre>
+          <div><strong>Selectors</strong><span class="md-chip">md-snackbar</span><span class="md-chip">md-hidden</span><span class="md-chip">md-visible</span></div>
+          <div><strong>Usage</strong><a class="md-chip" href="../docs/link/utm-remove.html">1</a><a class="md-chip" href="../docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html">2</a><a class="md-chip" href="../docs/git/git-pseudo-squash.html">3</a></div>
+          <div><strong>Preview Code</strong></div>
+      <pre class="md-code"><code>&lt;div class="md-snackbar"&gt;コピーしました&lt;/div&gt;</code></pre>
         </div>
       </div>
     </section>
   </div>
+  <script>
+    function selectorOrderGroup(selectorText) {
+      if (/^[A-Za-z][A-Za-z0-9_-]*$/.test(selectorText)) return 0;
+      if (!selectorText.startsWith('.')) return 3;
+      var isSimpleClass = /^\.[A-Za-z0-9_-]+$/.test(selectorText);
+      var hasState = /:/.test(selectorText);
+      var hasCombinator = /\s|[>+~]/.test(selectorText);
+      var hasMultiClass = /\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/.test(selectorText);
+
+      if (isSimpleClass) return 0; // 実体クラス
+      if ((hasState || hasMultiClass) && !hasCombinator) return 1; // 状態/同一要素バリエーション
+      if (hasCombinator) return 2; // 複合セレクタ
+      return 3;
+    }
+
+    function formatSelectorLabel(selectorText) {
+      var label = selectorText.trim();
+      // Readability: ".a.b" -> ".a .b"
+      label = label.replace(/(\.[A-Za-z0-9_-]+)(?=\.)/g, '$1 ');
+      // Readability: normalize combinator spacing.
+      label = label.replace(/\s*([>+~])\s*/g, ' $1 ');
+      label = label.replace(/\s{2,}/g, ' ');
+      return label;
+    }
+
+    function normalizeUsageHref(href) {
+      if (!href) return '';
+      var trimmed = href.trim();
+      if (trimmed.startsWith('../docs/')) return trimmed;
+      if (trimmed.startsWith('docs/')) return '../' + trimmed;
+      return trimmed;
+    }
+
+    // Deduplicate selector metadata and keep preview frames visually clean.
+    document.querySelectorAll('.md-preview-note').forEach(function (note) {
+      if (/^\s*Selector(?:\s+set)?\s*:/.test(note.textContent)) {
+        note.remove();
+      }
+    });
+
+    document.querySelectorAll('.md-example-card').forEach(function (card) {
+      var selectorsBlock = Array.from(card.children).find(function (child) {
+        return child.matches('div') && child.querySelector('strong') && child.querySelector('strong').textContent.trim() === 'Selectors';
+      });
+      if (!selectorsBlock) return;
+
+      var preview = card.querySelector('.md-preview');
+      var sourceRefs = [];
+      if (preview) {
+        Array.from(preview.querySelectorAll('.md-preview-note')).forEach(function (note) {
+          var m = note.textContent.match(/^\s*Source:\s*(docs\/[^\s]+)/);
+          if (m) {
+            sourceRefs.push(normalizeUsageHref(m[1]));
+            note.remove();
+          }
+        });
+      }
+
+      var selectorChips = Array.from(selectorsBlock.querySelectorAll('.md-chip'));
+      selectorChips.forEach(function (chip) {
+        var raw = chip.textContent.trim();
+        chip.dataset.selectorRaw = raw;
+        chip.textContent = formatSelectorLabel(raw);
+      });
+      selectorChips
+        .sort(function (a, b) {
+          var textA = a.dataset.selectorRaw || a.textContent.trim();
+          var textB = b.dataset.selectorRaw || b.textContent.trim();
+          var groupA = selectorOrderGroup(textA);
+          var groupB = selectorOrderGroup(textB);
+          if (groupA !== groupB) return groupA - groupB;
+          return textA.localeCompare(textB);
+        })
+        .forEach(function (chip) {
+          selectorsBlock.appendChild(chip);
+        });
+
+      var buckets = { base: [], state: [], composite: [], other: [] };
+      selectorChips.forEach(function (chip) {
+        var selectorText = chip.dataset.selectorRaw || chip.textContent.trim();
+        var group = selectorOrderGroup(selectorText);
+        if (group === 0) buckets.base.push(chip);
+        else if (group === 1) buckets.state.push(chip);
+        else if (group === 2) buckets.composite.push(chip);
+        else buckets.other.push(chip);
+      });
+
+      if (buckets.base.length === 0) {
+        buckets.base = buckets.state.concat(buckets.composite, buckets.other);
+        buckets.state = [];
+        buckets.composite = [];
+        buckets.other = [];
+      }
+
+      selectorsBlock.querySelectorAll('.md-chip').forEach(function (chip) { chip.remove(); });
+      buckets.base.forEach(function (chip) { selectorsBlock.appendChild(chip); });
+
+      selectorsBlock.classList.add('md-selectors-block');
+      card.insertBefore(selectorsBlock, card.firstChild);
+
+      var previousRow = selectorsBlock;
+      function appendSelectorSubRow(label, chips) {
+        if (!chips.length) return;
+        var row = document.createElement('div');
+        row.className = 'md-selectors-sub-block';
+        var strong = document.createElement('strong');
+        strong.textContent = label;
+        row.appendChild(strong);
+        chips.forEach(function (chip) {
+          row.appendChild(chip);
+          chip.classList.add('md-chip--selector-meta');
+          chip.title = '状態・複合セレクタの参照情報';
+        });
+        card.insertBefore(row, previousRow.nextSibling);
+        previousRow = row;
+      }
+
+      appendSelectorSubRow('State Selectors', buckets.state);
+      appendSelectorSubRow('Composite Selectors', buckets.composite.concat(buckets.other));
+
+      var originBlock = Array.from(card.children).find(function (child) {
+        return child.matches('div') && child.querySelector('strong') && child.querySelector('strong').textContent.trim() === 'Origin';
+      });
+      if (originBlock) {
+        originBlock.classList.add('md-origin-block');
+      }
+      if (preview && originBlock && originBlock !== preview.previousElementSibling) {
+        card.insertBefore(originBlock, preview);
+      }
+
+      var usageBlock = Array.from(card.children).find(function (child) {
+        return child.matches('div') && child.querySelector('strong') && child.querySelector('strong').textContent.trim() === 'Usage';
+      });
+      if (!usageBlock && sourceRefs.length) {
+        usageBlock = document.createElement('div');
+        usageBlock.innerHTML = '<strong>Usage</strong>';
+        if (preview) {
+          card.insertBefore(usageBlock, preview.nextSibling);
+        } else {
+          card.appendChild(usageBlock);
+        }
+      }
+      if (usageBlock) {
+        var seen = new Set();
+        Array.from(usageBlock.querySelectorAll('a.md-chip[href]')).forEach(function (link) {
+          var normalized = normalizeUsageHref(link.getAttribute('href'));
+          if (seen.has(normalized)) {
+            link.remove();
+            return;
+          }
+          seen.add(normalized);
+          if (normalized !== link.getAttribute('href')) {
+            link.setAttribute('href', normalized);
+          }
+        });
+
+        sourceRefs.forEach(function (href) {
+          if (!href || seen.has(href)) return;
+          seen.add(href);
+          var link = document.createElement('a');
+          link.className = 'md-chip';
+          link.href = href;
+          link.textContent = String(usageBlock.querySelectorAll('a.md-chip[href]').length + 1);
+          usageBlock.appendChild(link);
+        });
+
+        if (usageBlock.querySelector('a.md-chip[href]')) {
+          Array.from(usageBlock.querySelectorAll('span.md-chip')).forEach(function (chip) {
+            if (/使用箇所なし/.test(chip.textContent)) chip.remove();
+          });
+        }
+      }
+
+      if (!preview) return;
+      selectorsBlock.querySelectorAll('.md-chip').forEach(function (chip) {
+        var selectorText = chip.dataset.selectorRaw || chip.textContent.trim();
+        if (!(selectorText.startsWith('.') || /^[A-Za-z][A-Za-z0-9_-]*$/.test(selectorText))) return;
+
+        var simpleClass = selectorText.startsWith('.')
+          ? /^\.[A-Za-z0-9_-]+$/.test(selectorText)
+          : /^[A-Za-z][A-Za-z0-9_-]*$/.test(selectorText);
+        if (!simpleClass) return;
+        var className = selectorText.startsWith('.') ? selectorText.slice(1) : selectorText;
+        var usedInPreview = preview.querySelector('.' + className) !== null;
+        if (!usedInPreview) {
+          chip.classList.add('md-chip--unused');
+          chip.title = 'このプレビューでは直接使っていないセレクタ';
+        }
+      });
+    });
+
+    // Keep remaining metadata labels outside preview frames.
+    document.querySelectorAll('.md-example-card .md-preview').forEach(function (preview) {
+      var notes = Array.from(preview.querySelectorAll('.md-preview-note'));
+      if (!notes.length) return;
+      var meta = document.createElement('div');
+      meta.className = 'md-preview-meta';
+      notes.forEach(function (note) {
+        meta.appendChild(note);
+      });
+      preview.parentNode.insertBefore(meta, preview);
+    });
+
+    function toggleMenu(button) {
+      var menuDemo = button.closest('.md-menu-demo');
+      if (!menuDemo) return;
+      var panel = menuDemo.querySelector('.md-menu-panel');
+      if (!panel) return;
+
+      var willOpen = panel.classList.contains('md-hidden');
+      document.querySelectorAll('.md-menu-demo .md-menu-panel').forEach(function (p) {
+        p.classList.add('md-hidden');
+      });
+      document.querySelectorAll('.md-menu-demo .md-menu-button').forEach(function (b) {
+        b.setAttribute('aria-expanded', 'false');
+      });
+
+      if (willOpen) {
+        panel.classList.remove('md-hidden');
+        button.setAttribute('aria-expanded', 'true');
+      }
+    }
+
+    document.addEventListener('click', function (event) {
+      if (event.target.closest('.md-menu-demo')) return;
+      document.querySelectorAll('.md-menu-demo .md-menu-panel').forEach(function (p) {
+        p.classList.add('md-hidden');
+      });
+      document.querySelectorAll('.md-menu-demo .md-menu-button').forEach(function (b) {
+        b.setAttribute('aria-expanded', 'false');
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
# 概要
index.html を中心に、MD3カタログの表現を「実利用ベース + 可読性重視」に再設計しました。 合わせて docs 側の命名/状態クラスの統一（md-switch / md-visible / md-button--*）も実施しています。

# 変更ファイル
img2svg.html
password-gen.html
text-processing.html
text-viewer.html
README.md
TODO.md
index.html

# 主な変更内容

## 1. docs 側の命名・状態クラス統一
ボタン旧命名を md-button--* に統一
md-button-primary / md-button-secondary を置換
トグル系を md-switch 系へ統一
md-toggle* -> md-switch*
Snackbar 表示クラスを md-visible に統一
md-snackbar--visible を削除
一部レイアウト命名の整備
md-toggle-row -> md-radio-row（text-viewer）

## 2. md3 カタログ情報設計の刷新
カードの軸を統一
Selectors / Origin / Rationale / Usage / Preview Code セクション見出しを * Usage 系へ統一
Preview Code ラベルを追加し、コード意図を明示
Origin をプレビューより上に配置（優先情報として強調）
Selectors とプレビューコード間など、余白を整理

## 3. Selectors 表示ルールの明確化
1カード内での分離表示を導入
Selectors（実体クラス）
State Selectors
Composite Selectors
ソート順を統一
実体 -> 状態 -> 複合
未使用実体クラスを UNUSED 表示で可視化
複合セレクタ表示の可読性改善
例: .md-select.md-disabled を見やすく整形表示
Selector: / Selector set: 系の重複メタ表示を削除

## 4. Source/Usage 情報の一本化
Source: docs/... のプレビュー注記を除去
Source 情報を Usage に吸収
Usage 内の重複リンクを除去
Usage にリンクがある場合は「使用箇所なし」チップを整理

## 5. Project-specific 運用の厳格化
Project-specific かつ実利用なしのカードをカタログから除去
運用方針を README/TODO に明記
未使用 Project-specific は md3 だけでなく *.html 側でも削除対象

## 6. 既知課題・方針ドキュメント更新
README.md を現行運用に合わせて更新
TODO.md の完了/継続課題を更新
既知制約（未定義ハンドラ参照、プレビュー由来の例外など）を整理
変更規模（参考）

## 7 files changed
655 insertions, 426 deletions