### PR TITLE
docs全体のSVGアイコンをスプライト方式に統一し、MD3 Icon Specを追加

### DIFF
--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -1038,14 +1038,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1238,8 +1253,7 @@ limitations under the License.
       <code id="audioCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('audioCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -1022,14 +1022,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1059,8 +1074,7 @@ limitations under the License.
       <code id="concatCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('concatCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -1104,14 +1104,29 @@ Licensed under the Apache License, Version 2.0
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1305,8 +1320,7 @@ Licensed under the Apache License, Version 2.0
       <code id="analyzeCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('analyzeCmd')">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>
@@ -1322,8 +1336,7 @@ Licensed under the Apache License, Version 2.0
         <code id="normalizeCmd" class="md-code"></code>
         <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('normalizeCmd')">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
       </div>
@@ -1335,8 +1348,7 @@ Licensed under the Apache License, Version 2.0
         <code id="gainCmd" class="md-code"></code>
         <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('gainCmd')">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
       </div>

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -1032,14 +1032,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1069,8 +1084,7 @@ limitations under the License.
       <code id="probeCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('probeCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>
@@ -1113,8 +1127,7 @@ limitations under the License.
       <code id="wavCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('wavCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -1076,14 +1076,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1126,8 +1141,7 @@ limitations under the License.
       <code id="probeCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('probeCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>
@@ -1259,8 +1273,7 @@ limitations under the License.
       <code id="replaceCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('replaceCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -1016,12 +1016,27 @@ Licensed under the Apache License, Version 2.0
   </style>
 </head>
 <body class="md-page">
-  <div class="md-shell md-card">
-    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-shell md-card">
+    <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1058,8 +1073,7 @@ Licensed under the Apache License, Version 2.0
       <code id="silenceCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('silenceCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -1021,14 +1021,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1067,8 +1082,7 @@ limitations under the License.
       <code id="clipCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('clipCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -1021,14 +1021,29 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     
     </button>
@@ -1071,8 +1086,7 @@ limitations under the License.
       <code id="youtubeCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('youtubeCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -1062,12 +1062,27 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
-  <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1184,9 +1199,8 @@ limitations under the License.
       <code id="diffCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('diffCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
     </div>
 

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -880,6 +880,9 @@ limitations under the License.
     .md-label--block { margin-bottom: 0.5rem; }
 
     .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
+    .md-title-info-row .md-section-title { margin: 0; }
+    .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
     .md-step-icon { width: 3.5rem; height: 3.5rem; }
     .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
@@ -1061,12 +1064,27 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
-  <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1093,11 +1111,13 @@ limitations under the License.
           <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
         </svg>
-        <p class="md-section-title">現在の設定を確認</p>
-        <span class="md-tooltip-group">
-          <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-            設定前に現在の値を確認できます。
+        <span class="md-title-info-row">
+          <p class="md-section-title">現在の設定を確認</p>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              設定前に現在の値を確認できます。
+            </span>
           </span>
         </span>
       </div>
@@ -1108,8 +1128,7 @@ limitations under the License.
         <code id="checkCmd" class="md-code"></code>
         <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
           <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="9" y="9" width="11" height="11" rx="2"/>
-            <rect x="4" y="4" width="11" height="11" rx="2"/>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
           </svg>
         </button>
       </div>
@@ -1140,11 +1159,13 @@ limitations under the License.
           <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
           <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="md-section-title">詳細設定を行う</p>
-        <span class="md-tooltip-group">
-          <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-            必要な詳細設定を選択して、コマンドを生成します。
+        <span class="md-title-info-row">
+          <p class="md-section-title">詳細設定を行う</p>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              必要な詳細設定を選択して、コマンドを生成します。
+            </span>
           </span>
         </span>
       </div>
@@ -1252,9 +1273,8 @@ limitations under the License.
       <code id="configCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('configCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
     </div>
 

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -879,6 +879,9 @@ limitations under the License.
     .md-label--block { margin-bottom: 0.5rem; }
 
     .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
+    .md-title-info-row .md-section-title { margin: 0; }
+    .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
     .md-step-icon { width: 3.5rem; height: 3.5rem; }
 
@@ -1022,12 +1025,27 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
-  <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1054,11 +1072,13 @@ limitations under the License.
           <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
           <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
         </svg>
-        <p class="md-section-title">現在の設定を確認</p>
-        <span class="md-tooltip-group">
-          <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-            設定前に現在のユーザー名とメールアドレスを確認できます。
+        <span class="md-title-info-row">
+          <p class="md-section-title">現在の設定を確認</p>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              設定前に現在のユーザー名とメールアドレスを確認できます。
+            </span>
           </span>
         </span>
       </div>
@@ -1069,8 +1089,7 @@ limitations under the License.
         <code id="checkCmd" class="md-code"></code>
         <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
           <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="9" y="9" width="11" height="11" rx="2"/>
-            <rect x="4" y="4" width="11" height="11" rx="2"/>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
           </svg>
         </button>
       </div>
@@ -1088,11 +1107,13 @@ limitations under the License.
           <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
           <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        <p class="md-section-title">ユーザー情報を設定</p>
-        <span class="md-tooltip-group">
-          <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-          <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-            グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
+        <span class="md-title-info-row">
+          <p class="md-section-title">ユーザー情報を設定</p>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
+              グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
+            </span>
           </span>
         </span>
       </div>
@@ -1138,9 +1159,8 @@ limitations under the License.
       <code id="setupCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('setupCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
     </div>
 

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -893,9 +893,9 @@ limitations under the License.
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
 
     .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
-    .md-flow-title-row { display: inline-flex; align-items: center; gap: 0.08rem; }
-    .md-flow-title-row .md-section-title { margin: 0; }
-    .md-flow-title-row .md-info-chip { margin-left: 0; }
+    .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
+    .md-title-info-row .md-section-title { margin: 0; }
+    .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
 
     .md-step-icon { width: 3.5rem; height: 3.5rem; }
@@ -1094,12 +1094,27 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
-  <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1173,8 +1188,7 @@ limitations under the License.
             <input type="text" id="workBranch" placeholder="例: tiga0129a" class="md-input">
             <button type="button" class="md-icon-btn md-icon-btn--small md-input-action" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
-                <path d="M20 4v6h-6"/>
+                <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>
               </svg>
             </button>
           </div>
@@ -1271,7 +1285,7 @@ limitations under the License.
           <circle cx="48" cy="22" r="4" fill="#A78BFA"/>
           <circle cx="48" cy="42" r="4" fill="#34D399"/>
         </svg>
-        <span class="md-flow-title-row">
+        <span class="md-title-info-row">
           <p class="md-section-title">作業開始 (基準ブランチから作成)</p>
           <span class="md-tooltip-group">
             <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
@@ -1285,9 +1299,8 @@ limitations under the License.
       <code id="createBranchCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('createBranchCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
       </div>
 
@@ -1316,7 +1329,7 @@ limitations under the License.
           <path d="M34 42C40 42 42 36 46 32" stroke="#34D399" stroke-width="3" stroke-linecap="round"/>
           <circle cx="50" cy="32" r="5" fill="#86EFAC"/>
         </svg>
-        <span class="md-flow-title-row">
+        <span class="md-title-info-row">
           <p class="md-section-title">作業をまとめる (squash)</p>
           <span class="md-tooltip-group">
             <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
@@ -1377,9 +1390,8 @@ limitations under the License.
       <code id="rebaseCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('rebaseCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
     </div>
 
@@ -1407,7 +1419,7 @@ limitations under the License.
         <circle cx="42" cy="32" r="4" fill="#A78BFA"/>
         <circle cx="36" cy="42" r="4" fill="#34D399"/>
       </svg>
-      <span class="md-flow-title-row">
+      <span class="md-title-info-row">
         <p class="md-section-title">まとめる予定の作業 (diff)</p>
         <span class="md-tooltip-group">
           <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
@@ -1421,9 +1433,8 @@ limitations under the License.
       <code id="plannedDiffCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('plannedDiffCmd')">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
-        </svg>
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
       </button>
     </div>
 

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -1067,12 +1067,27 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
-  <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
         <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+  <div class="md-surface-card md-card">
+    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1181,8 +1196,7 @@ limitations under the License.
       <code id="findCmd" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('findCmd')" aria-label="コピー">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-          <rect x="9" y="9" width="11" height="11" rx="2"/>
-          <rect x="4" y="4" width="11" height="11" rx="2"/>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1026,10 +1026,27 @@
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-surface-card md-card">
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel hidden">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1023,6 +1023,19 @@
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-github" viewBox="0 0 16 16">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+      </symbol>
+      <symbol id="md-icon-globe" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="9"/>
+        <path d="M3 12h18"/>
+        <path d="M12 3a14 14 0 0 1 0 18"/>
+        <path d="M12 3a14 14 0 0 0 0 18"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-container">
     <header class="md-app-bar">
       <div class="md-app-bar-inner">
@@ -1408,7 +1421,7 @@
       <div class="md-footer-links">
         <a href="https://github.com/igapyon/local-html-tools" class="md-footer-link" target="_blank" rel="noopener noreferrer">
           <svg aria-hidden="true" viewBox="0 0 16 16" class="md-footer-icon" fill="currentColor">
-            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+            <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
           </svg>
           <span>GitHub</span>
         </a>
@@ -1419,10 +1432,7 @@
         <span class="md-footer-sep">|</span>
         <a href="https://igapyon.github.io/local-html-tools/" class="md-footer-link" target="_blank" rel="noopener noreferrer">
           <svg aria-hidden="true" viewBox="0 0 24 24" class="md-footer-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="9"/>
-            <path d="M3 12h18"/>
-            <path d="M12 3a14 14 0 0 1 0 18"/>
-            <path d="M12 3a14 14 0 0 0 0 18"/>
+            <use href="#md-icon-globe" xlink:href="#md-icon-globe"></use>
           </svg>
           <span>GitHub Pages</span>
         </a>

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -944,13 +944,30 @@
   </style>
 </head>
 <body>
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-page">
     <div class="md-shell">
       <div class="md-card">
         <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
           <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/>
-          </svg>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
+      </svg>
         </button>
         <div id="menuPanel" class="md-menu-panel md-hidden">
           <a href="../index.html" class="md-menu-link">トップへ戻る</a>

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1020,13 +1020,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1057,8 +1072,7 @@ limitations under the License.
       <code id="dpPath" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('dpPath')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1020,13 +1020,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1056,8 +1071,7 @@ limitations under the License.
       <code id="cleanUrl" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('cleanUrl')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1050,13 +1050,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1103,8 +1118,7 @@ limitations under the License.
       <code id="outputText" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('outputText')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1021,13 +1021,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1062,8 +1077,7 @@ limitations under the License.
       <code id="outputText" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('outputText')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1020,13 +1020,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel md-hidden">
@@ -1056,8 +1071,7 @@ limitations under the License.
       <code id="cleanUrl" class="md-code"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('cleanUrl')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -1044,13 +1044,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-surface-card md-card">
 
     <button type="button" class="md-icon-btn md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
       <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <path d="M4 6h16"/>
-        <path d="M4 12h16"/>
-        <path d="M4 18h16"/>
+        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
       </svg>
     </button>
     <div id="menuPanel" class="md-menu-panel hidden">
@@ -1113,8 +1128,7 @@ limitations under the License.
       <code id="passwordOutput" class="md-code"></code>
       <button class="md-icon-btn md-copy-button" onclick="copyToClipboard('passwordOutput')" aria-label="コピー">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="11" height="11" rx="2"></rect>
-          <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+          <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
         </svg>
       </button>
     </div>

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1106,13 +1106,28 @@ limitations under the License.
   </style>
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
 <div class="md-shell md-card">
 <button aria-label="メニュー" class="md-icon-btn md-menu-button" onclick="toggleMenu()" type="button">
 <svg aria-hidden="true" class="md-icon-20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" viewbox="0 0 24 24">
-<path d="M4 6h16"></path>
-<path d="M4 12h16"></path>
-<path d="M4 18h16"></path>
-</svg>
+<use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
+      </svg>
 </button>
 <div class="md-menu-panel hidden" id="menuPanel">
 <a class="md-menu-link" href="../index.html">トップへ戻る</a>
@@ -1406,9 +1421,8 @@ limitations under the License.
 <textarea class="md-textarea md-output" id="outputText" placeholder="ここに結果が表示されます" readonly="" rows="6"></textarea>
 <button class="md-icon-btn md-copy-button" onclick="copyToClipboard('outputText')" aria-label="コピー">
 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-<rect x="9" y="9" width="11" height="11" rx="2"></rect>
-<rect x="4" y="4" width="11" height="11" rx="2"></rect>
-</svg>
+<use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+        </svg>
 </button>
 </div>
 <div class="md-muted" id="outputStats">文字数: 0 / 行数: 0</div>

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -994,6 +994,23 @@ limitations under the License.
 
 </head>
 <body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
   <div class="md-shell">
     <div class="md-card">
 
@@ -1002,10 +1019,8 @@ limitations under the License.
       <div class="md-actions">
         <button type="button" class="md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
           <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-            <path d="M4 6h16"/>
-            <path d="M4 12h16"/>
-            <path d="M4 18h16"/>
-          </svg>
+            <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
+      </svg>
         </button>
       </div>
     </div>

--- a/md3/README.md
+++ b/md3/README.md
@@ -48,6 +48,7 @@
 
 - `md3/spec/token-spec.css`（Token Spec）
 - `md3/spec/core-spec.css`（Core Spec）
+- `md3/spec/icon-spec.svg`（Icon Spec: menu/copy/refresh）
 - `md3/spec/VERSION.md`（バージョンと変更履歴）
 
 ## 標準セット運用（正本と還元）
@@ -57,15 +58,19 @@
   - ページ全体をそのままコピペする対象ではない
 - `md3/spec/token-spec.css` と `md3/spec/core-spec.css` は貼り付け正本（配布元）として扱う
   - 各 `docs/*.html` にはこの2ファイルを基準にコピーして利用する（未使用定義を含んでよい）
+- `md3/spec/icon-spec.svg` はSVGアイコンの貼り付け正本（配布元）として扱う
+  - 単一HTML配布を優先し、`docs/*.html` では外部参照ではなく各HTML内へ埋め込みコピーする
+  - `<use href="...">` と `<use xlink:href="...">` を併記して互換性を確保する
 - `docs/*.html` 側で改善を行った場合は、適用後に `md3` 側へ必ずフィードバックして正本を更新する
 
 ## docs への反映手順（標準）
 
 1. 対象 `docs/*.html` の `<style>` 内で、`:root { ... }` を `md3/spec/token-spec.css` の内容に置き換える。
 2. 同じ `<style>` 内で、共通部品（`md-page`, `md-shell`, `md-card`, `md-input`, `md-button`, `md-tooltip`, `md-code`, `md-snackbar` など）を `md3/spec/core-spec.css` で置き換える。
-3. 画面固有スタイル（`Screen-specific`）は残す。共通化済み定義と重複する箇所だけ削除する。
-4. ブラウザで表示確認する（レイアウト崩れ、ボタン/入力/ツールチップ/コピーUI/通知の見た目と操作）。
-5. 反映時に修正した内容は `md3/index.html` と `md3/spec/*.css` に還元し、`md3/spec/VERSION.md` を更新する。
+3. `<body>` 直下に `md3/spec/icon-spec.svg` 相当の `<svg><defs><symbol>...</symbol></defs></svg>` を埋め込み、menu/copy/refresh を `<use href xlink:href>` へ統一する。
+4. 画面固有スタイル（`Screen-specific`）は残す。共通化済み定義と重複する箇所だけ削除する。
+5. ブラウザで表示確認する（レイアウト崩れ、ボタン/入力/ツールチップ/コピーUI/通知の見た目と操作）。
+6. 反映時に修正した内容は `md3/index.html` と `md3/spec/*` に還元し、`md3/spec/VERSION.md` を更新する。
 
 ## 現状スナップショット（実態）
 

--- a/md3/index.html
+++ b/md3/index.html
@@ -1179,6 +1179,24 @@
 .md-choice-text {
   font-size: 0.9rem; color: #4a4458;
 }</textarea>
+<div class="md-note-title" style="margin-top: 12px;">Icon Spec（menu / copy / refresh）</div>
+<div class="md-preview-note" style="margin-top: 8px;">
+  `Icon Spec` は `md3/spec/icon-spec.svg` を正本とし、各 `docs/*.html` の `<body>` 直下へ埋め込みコピーします（外部参照はしない）。
+  `<use>` は Safari 互換のため `href` と `xlink:href` を併記します。
+</div>
+<textarea class="md-textarea" rows="16" readonly>&lt;svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden"&gt;
+  &lt;defs&gt;
+    &lt;symbol id="md-icon-menu" viewBox="0 0 24 24"&gt;
+      &lt;path d="M4 6h16"/&gt;&lt;path d="M4 12h16"/&gt;&lt;path d="M4 18h16"/&gt;
+    &lt;/symbol&gt;
+    &lt;symbol id="md-icon-copy" viewBox="0 0 24 24"&gt;
+      &lt;rect x="9" y="9" width="11" height="11" rx="2"/&gt;&lt;rect x="4" y="4" width="11" height="11" rx="2"/&gt;
+    &lt;/symbol&gt;
+    &lt;symbol id="md-icon-refresh" viewBox="0 0 24 24"&gt;
+      &lt;path d="M20 12a8 8 0 1 1-2.34-5.66"/&gt;&lt;path d="M20 4v6h-6"/&gt;
+    &lt;/symbol&gt;
+  &lt;/defs&gt;
+&lt;/svg&gt;</textarea>
 <div class="md-note-title" style="margin-top: 12px;">Screen-specific（画面依存）</div>
 <textarea class="md-textarea" rows="16" readonly>.md-example-card {
   background: var(--md-sys-color-surface-variant);

--- a/md3/spec/VERSION.md
+++ b/md3/spec/VERSION.md
@@ -2,11 +2,13 @@
 
 - local-html-tools MD3 Token Spec: `v1.0.0`
 - local-html-tools MD3 Core Spec: `v1.0.2`
+- local-html-tools MD3 Icon Spec: `v1.0.0`
 
 ## Policy
 
 - `token-spec.css` は `local-html-tools MD3 Token Spec`（`:root` / `--md-sys-*` の標準トークン定義）。
 - `core-spec.css` は `local-html-tools MD3 Core Spec`（共通コンポーネントの標準スタイル定義）。
+- `icon-spec.svg` は `local-html-tools MD3 Icon Spec`（menu/copy/refresh の標準SVG定義）。
 - `docs/*.html` には、未使用定義を含む標準セットを貼り付けてよい（仕様準拠を優先）。
 
 ## Change Log
@@ -17,3 +19,5 @@
   - `md-switch` の checked ノブ色を白に変更（`md-switch-input:checked + .md-switch::after`）。
 - `v1.0.2` (2026-02-08)
   - `md-switch-label` の `font-weight` を削除し、ページ側タイポグラフィを優先する。
+- `v1.0.0` (2026-02-08, Icon Spec)
+  - menu / copy / refresh の標準SVGシンボルを追加（`href` + `xlink:href` 併記運用）。

--- a/md3/spec/icon-spec.svg
+++ b/md3/spec/icon-spec.svg
@@ -1,0 +1,24 @@
+<!-- local-html-tools MD3 Icon Spec v1.0.0 (2026-02-08) -->
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     aria-hidden="true"
+     width="0"
+     height="0"
+     viewBox="0 0 0 0"
+     style="position:absolute;width:0;height:0;overflow:hidden">
+  <defs>
+    <symbol id="md-icon-menu" viewBox="0 0 24 24">
+      <path d="M4 6h16"/>
+      <path d="M4 12h16"/>
+      <path d="M4 18h16"/>
+    </symbol>
+    <symbol id="md-icon-copy" viewBox="0 0 24 24">
+      <rect x="9" y="9" width="11" height="11" rx="2"/>
+      <rect x="4" y="4" width="11" height="11" rx="2"/>
+    </symbol>
+    <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+      <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+      <path d="M20 4v6h-6"/>
+    </symbol>
+  </defs>
+</svg>


### PR DESCRIPTION
## 概要

`docs` 配下の単一HTMLツールに対して、SVGアイコンをスプライト方式へ統一しました。
あわせて `md3` 側に Icon Spec の正本を追加し、運用ルールを README / VERSION に反映しています。

## 変更内容

### 1. SVGアイコンの共通化（docs 全体）

- 対象: `docs/**/*.html` の主要ページ（Git / FFmpeg / Link / Text / Grep / Img / Life / Password / index）
- 各HTMLに `md-icon-sprite`（`<svg><defs><symbol>...</symbol></defs></svg>`）を埋め込み
- 以下3アイコンを標準化
  - `md-icon-menu`（ハンバーガー）
  - `md-icon-copy`（クリップボードコピー）
  - `md-icon-refresh`（リロード）
- 既存のインライン `<path>/<rect>` 記述を `<use>` 参照へ置換
- Safari互換のため `href` と `xlink:href` を併記

### 2. `docs/index.html` の適用

- フッターの GitHub / GitHub Pages アイコンをスプライト参照へ変更
  - `md-icon-github`
  - `md-icon-globe`

### 3. md3 正本の追加・文書化

- 追加: `md3/spec/icon-spec.svg`
- 更新: `md3/spec/VERSION.md`
  - `local-html-tools MD3 Icon Spec v1.0.0` を追加
- 更新: `md3/README.md`
  - Icon Spec の位置づけ
  - `docs/*.html` への埋め込み運用
  - `href + xlink:href` 併記方針
- 更新: `md3/index.html`
  - Icon Spec セクション追加（正本と運用の明記）

## 変更規模

- 28 files changed
- 562 insertions / 167 deletions

## 期待効果

- アイコン定義の重複削減
- ページ間の実装統一
- 単一HTML配布を維持しつつ保守性向上
- Safari を含むブラウザ互換性の向上