### PR TITLE
fix: `git-pseudo-squash` の設定変更時に3種コマンドを即時再生成する

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -1475,6 +1475,7 @@ limitations under the License.
         // 編集は常に可能にする（現在のブランチ使用時も入力は保持）
         workBranch.classList.remove("md-disabled");
       }
+      regenerateAllCommands();
     }
 
     function updateBaseScope() {
@@ -1510,10 +1511,17 @@ limitations under the License.
       if (squashRemoteLabel && lockOrigin) {
         squashRemoteLabel.classList.toggle("md-hidden", lockOrigin.checked);
       }
+      regenerateAllCommands();
     }
 
     function toggleOriginLock() {
       updateBaseScope();
+    }
+
+    function regenerateAllCommands() {
+      generateCreateBranchCommand({ silent: true });
+      generateRebaseCommand({ silent: true });
+      generatePlannedDiffCommand({ silent: true });
     }
 
     function setDefaultWorkBranch() {
@@ -1527,7 +1535,7 @@ limitations under the License.
       const min = now.getMinutes();
       const timeStr = convertTimeToThreeChars(hh, min);
       input.value = `tiga${mm}${dd}${timeStr}`;
-      generateCreateBranchCommand({ silent: true });
+      regenerateAllCommands();
     }
 
     function updateWorkBranchWithCurrentTime() {
@@ -1541,7 +1549,7 @@ limitations under the License.
       const min = now.getMinutes();
       const timeStr = convertTimeToThreeChars(hh, min);
       input.value = `tiga${mm}${dd}${timeStr}`;
-      generateCreateBranchCommand({ silent: true });
+      regenerateAllCommands();
     }
 
     function generateRebaseCommand(options = {}) {
@@ -1696,7 +1704,7 @@ limitations under the License.
     }
 
     function setupCreateBranchAutoUpdate() {
-      const ids = ["squashBaseBranch", "workBranch", "squashBaseScope", "baseRemote", "squashRemote", "shellEnvPowerShell"];
+      const ids = ["squashBaseBranch", "workBranch", "squashBaseScope", "baseRemote", "squashRemote", "shellEnvPowerShell", "lockOrigin"];
       const handler = () => generateCreateBranchCommand({ silent: true });
       ids.forEach((id) => {
         const element = document.getElementById(id);
@@ -1708,7 +1716,7 @@ limitations under the License.
 
     function setupRebaseAutoUpdate() {
       const inputIds = ["squashBaseBranch", "workBranch", "squashBaseScope", "baseRemote", "squashRemote", "commitMessage"];
-      const changeIds = ["useCurrentBranch", "optPush", "shellEnvPowerShell"];
+      const changeIds = ["useCurrentBranch", "optPush", "shellEnvPowerShell", "lockOrigin"];
       const handler = () => {
         generateRebaseCommand({ silent: true });
         generatePlannedDiffCommand({ silent: true });


### PR DESCRIPTION
## 概要
`docs/git/git-pseudo-squash.html` で、設定を途中で戻して変更した場合にコマンド表示が古いまま残るケースを修正しました。 UI入力変更に対して、`作業開始` / `squash` / `planned diff` の3種コマンドを一貫して再生成します。

## 変更内容
- `regenerateAllCommands()` を追加
  - `generateCreateBranchCommand`
  - `generateRebaseCommand`
  - `generatePlannedDiffCommand` をまとめて実行
- 次の操作で全コマンド再生成するよう変更
  - `toggleCurrentBranch()`
  - `updateBaseScope()`
  - `setDefaultWorkBranch()`
  - `updateWorkBranchWithCurrentTime()`
- イベント購読対象を追加
  - `setupCreateBranchAutoUpdate()` に `lockOrigin` を追加
  - `setupRebaseAutoUpdate()` の `changeIds` に `lockOrigin` を追加

## 期待される効果
- 「リモート + origin と作業」ON/OFF切替後に「基点の参照先」を変更しても、表示コマンドが即時に正しい内容へ更新される
- 時刻更新ボタンで作業ブランチを更新した際も、`create` のみでなく `rebase/planned diff` まで同期される

## 影響範囲
- 対象: `docs/git/git-pseudo-squash.html` のフロントエンドロジック
- 仕様変更なし（コマンド生成ルール自体は不変）