### PR TITLE
fix: `git-branch-diff` のツールチップ欠けを修正し、初期設定と説明文を改善

### DIFF
--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -955,6 +955,14 @@ limitations under the License.
     .md-tooltip--wide { width: 24rem; max-width: 90vw; }
     .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
 
+    /* Switch rows are often near the right edge; anchor tooltip to the right to avoid clipping. */
+    .md-switch-label .md-tooltip-content {
+      left: auto;
+      right: 0;
+      transform: none;
+      max-width: calc(100vw - 2rem);
+    }
+
     .md-icon-btn {
       width: 40px;
       height: 40px;
@@ -981,6 +989,8 @@ limitations under the License.
       font-size: 0.8125rem;
       font-weight: 400;
       line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       letter-spacing: 0.01em;
     }
@@ -1109,14 +1119,15 @@ limitations under the License.
             <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
             <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               比較の基準にするブランチです。差分の「片側」として使われます。
-              例: main / devel
+              例: main / devel。
+              ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。
             </span>
           </span>
           <span>：</span>
         </label>
         <input type="text" id="branchA" placeholder="例: main" class="md-input">
         <label class="md-switch-label">
-          <input type="checkbox" id="scopeA" class="md-switch-input" checked onchange="updateRemoteState()">
+          <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
           リモートとして扱う
         </label>
@@ -1130,14 +1141,15 @@ limitations under the License.
             <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
             <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--narrow">
               比較対象のブランチです。2つのブランチ差分を表示します。
-              例: feature123 / release
+              例: devel / feature123
+              ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。
             </span>
           </span>
           <span>：</span>
         </label>
         <input type="text" id="branchB" placeholder="例: devel" class="md-input">
         <label class="md-switch-label">
-          <input type="checkbox" id="scopeB" class="md-switch-input" checked onchange="updateRemoteState()">
+          <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
           リモートとして扱う
         </label>


### PR DESCRIPTION
## 概要
`docs/git/git-branch-diff.html` において、スイッチ周辺でツールチップ文言が欠ける問題を修正し、あわせて初期設定と入力説明を見直しました。

## 変更内容
- ツールチップ表示崩れ対策（CSS）
  - `.md-switch-label .md-tooltip-content` を右寄せアンカーに変更
  - 画面幅に収まるよう `max-width: calc(100vw - 2rem)` を設定
  - `.md-tooltip` に `white-space: normal` / `overflow-wrap: anywhere` を追加して折り返しを有効化
- 初期値の見直し
  - `scopeA` / `scopeB`（リモートとして扱う）をデフォルトOFFに変更
- ツールチップ文言の改善
  - 基準ブランチ・比較ブランチ両方に「ローカル時はコミットID（SHA）指定可能」を追記
  - 例示文を調整（`main / devel。`、`devel / feature123`）

## 期待される効果
- 右端付近の `(i)` ツールチップでも文言が欠けにくくなる
- ブランチ指定の入力意図（ブランチ名 + SHA）が伝わりやすくなる
- 初期状態がローカル比較寄りとなり、SHA指定運用にも自然に入れる

## 影響範囲
- 対象: `docs/git/git-branch-diff.html`
- UI文言・スタイル・初期状態の変更のみ（コマンド生成ロジックの本質変更なし）