### PR TITLE
git-pseudo-squash: 基点ブランチ履歴の永続化と入力UIの重なり解消

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -780,20 +780,22 @@ limitations under the License.
     }
 
     .md-input-wrap {
-      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
       flex: 1 1 16rem;
       min-width: 12rem;
     }
 
     .md-input-wrap .md-input {
-      padding-right: 3rem;
+      flex: 1 1 auto;
+      min-width: 0;
+      padding-right: 0.75rem;
     }
 
     .md-input-action {
-      position: absolute;
-      top: 50%;
-      right: -0.5rem;
-      transform: translateY(-50%);
+      position: static;
+      flex: 0 0 auto;
       box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
     }
 
@@ -1011,16 +1013,20 @@ limitations under the License.
     .md-switch-label .md-info-chip { margin-left: 0; }
 
     .md-input-wrap {
-      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
       flex: 1 1 16rem;
       min-width: 12rem;
     }
-    .md-input-wrap .md-input { padding-right: 3rem; }
+    .md-input-wrap .md-input {
+      flex: 1 1 auto;
+      min-width: 0;
+      padding-right: 0.75rem;
+    }
     .md-input-action {
-      position: absolute;
-      top: 50%;
-      right: -0.5rem;
-      transform: translateY(-50%);
+      position: static;
+      flex: 0 0 auto;
       box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
     }
 
@@ -1109,6 +1115,13 @@ limitations under the License.
         <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
         <path d="M20 4v6h-6"/>
       </symbol>
+      <symbol id="md-icon-trash" viewBox="0 0 24 24">
+        <path d="M4 7h16"/>
+        <path d="M10 11v6"/>
+        <path d="M14 11v6"/>
+        <path d="M6 7l1 12h10l1-12"/>
+        <path d="M9 7V5h6v2"/>
+      </symbol>
     </defs>
   </svg>
   <div class="md-surface-card md-card">
@@ -1149,6 +1162,11 @@ limitations under the License.
             <span>：</span>
           </label>
           <input type="text" id="squashBaseBranch" list="baseBranchSuggestions" placeholder="例: devel" class="md-input md-field--dropdown" value="devel">
+          <button type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="clearBaseBranchHistory()" title="基点ブランチ履歴をクリア" aria-label="基点ブランチ履歴をクリア">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <use href="#md-icon-trash" xlink:href="#md-icon-trash"></use>
+            </svg>
+          </button>
           <datalist id="baseBranchSuggestions">
             <option value="main"></option>
             <option value="master"></option>
@@ -1820,9 +1838,128 @@ limitations under the License.
       });
     }
 
+    const BASE_BRANCH_STORAGE_KEY = "gitPseudoSquash.squashBaseBranch";
+    const BASE_BRANCH_HISTORY_STORAGE_KEY = "gitPseudoSquash.squashBaseBranchHistory";
+    const BASE_BRANCH_HISTORY_MAX = 12;
+    let baseBranchDefaultSuggestions = [];
+
+    function uniqueBranchNames(values) {
+      const seen = new Set();
+      const uniqueValues = [];
+      values.forEach((value) => {
+        if (!value || seen.has(value)) return;
+        seen.add(value);
+        uniqueValues.push(value);
+      });
+      return uniqueValues;
+    }
+
+    function getStoredBaseBranchHistory() {
+      try {
+        const raw = localStorage.getItem(BASE_BRANCH_HISTORY_STORAGE_KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) return [];
+        const normalized = parsed
+          .map((value) => (typeof value === "string" ? value.trim() : ""))
+          .filter((value) => value.length > 0);
+        return uniqueBranchNames(normalized).slice(0, BASE_BRANCH_HISTORY_MAX);
+      } catch (_) {
+        return [];
+      }
+    }
+
+    function saveBaseBranchHistory(values) {
+      try {
+        localStorage.setItem(BASE_BRANCH_HISTORY_STORAGE_KEY, JSON.stringify(values));
+      } catch (_) {
+        // localStorage が使えない環境では保存機能を無効化
+      }
+    }
+
+    function renderBaseBranchSuggestions() {
+      const datalist = document.getElementById("baseBranchSuggestions");
+      if (!datalist) return;
+      const history = getStoredBaseBranchHistory();
+      const merged = uniqueBranchNames([...history, ...baseBranchDefaultSuggestions]);
+      datalist.textContent = "";
+      merged.forEach((branch) => {
+        const option = document.createElement("option");
+        option.value = branch;
+        datalist.appendChild(option);
+      });
+    }
+
+    function setupBaseBranchSuggestions() {
+      const datalist = document.getElementById("baseBranchSuggestions");
+      if (!datalist) return;
+      baseBranchDefaultSuggestions = uniqueBranchNames(
+        Array.from(datalist.querySelectorAll("option"))
+          .map((option) => option.value.trim())
+          .filter((value) => value.length > 0)
+      );
+      renderBaseBranchSuggestions();
+    }
+
+    function rememberBaseBranch(value) {
+      const branch = value.trim();
+      if (!branch) return;
+      try {
+        localStorage.setItem(BASE_BRANCH_STORAGE_KEY, branch);
+      } catch (_) {
+        // localStorage が使えない環境では保存機能を無効化
+      }
+      const history = getStoredBaseBranchHistory();
+      const next = [branch, ...history.filter((entry) => entry !== branch)].slice(0, BASE_BRANCH_HISTORY_MAX);
+      saveBaseBranchHistory(next);
+      renderBaseBranchSuggestions();
+    }
+
+    function loadPersistedBaseBranch() {
+      const input = document.getElementById("squashBaseBranch");
+      if (!input) return;
+      try {
+        const stored = localStorage.getItem(BASE_BRANCH_STORAGE_KEY);
+        const history = getStoredBaseBranchHistory();
+        const restored = stored && stored.trim() ? stored.trim() : (history[0] || "");
+        if (restored) {
+          input.value = restored;
+          if (!history.includes(restored)) {
+            saveBaseBranchHistory([restored, ...history].slice(0, BASE_BRANCH_HISTORY_MAX));
+          }
+        }
+      } catch (_) {
+        // localStorage が使えない環境では保存機能を無効化
+      }
+      renderBaseBranchSuggestions();
+    }
+
+    function setupBaseBranchPersistence() {
+      const input = document.getElementById("squashBaseBranch");
+      if (!input) return;
+      const persist = () => {
+        rememberBaseBranch(input.value);
+      };
+      input.addEventListener("change", persist);
+    }
+
+    function clearBaseBranchHistory() {
+      try {
+        localStorage.removeItem(BASE_BRANCH_HISTORY_STORAGE_KEY);
+        localStorage.removeItem(BASE_BRANCH_STORAGE_KEY);
+        renderBaseBranchSuggestions();
+        showToast("基点ブランチ履歴をクリアしました");
+      } catch (_) {
+        showToast("履歴のクリアに失敗しました");
+      }
+    }
+
+    setupBaseBranchSuggestions();
+    loadPersistedBaseBranch();
     updateBaseScope();
     toggleCurrentBranch();
     setDefaultWorkBranch();
+    setupBaseBranchPersistence();
     setupCreateBranchAutoUpdate();
     generateCreateBranchCommand({ silent: true });
     setupRebaseAutoUpdate();


### PR DESCRIPTION
## 概要
`docs/git/git-pseudo-squash.html` の基点ブランチ入力まわりを改善しました。 過去入力の再利用性を上げつつ、入力欄と操作アイコンの視認性を改善しています。

## 変更内容
- 基点ブランチの永続化を追加
  - `localStorage` に直近の基点ブランチを保存・復元
  - 保存キー:
    - `gitPseudoSquash.squashBaseBranch`
    - `gitPseudoSquash.squashBaseBranchHistory`
- 基点ブランチ候補の履歴機能を追加
  - 履歴を最大12件保持
  - 重複排除し、最近利用した候補を先頭表示（MRU）
  - 既存のデフォルト候補とマージして `datalist` に表示
- 履歴クリア機能を追加
  - 基点ブランチ行にクリアボタンを追加
  - `trash` アイコンをスプライトへ追加し、アイコンボタン化
  - 履歴と直近値を同時に削除
- 入力UIの重なりを解消
  - 作業ブランチ入力の更新アイコンを絶対配置から通常フローへ変更
  - `.md-input-wrap` を `flex` 化し、入力欄とアイコンが重ならないレイアウトに調整

## 影響範囲
- 対象ファイル: `docs/git/git-pseudo-squash.html`
- 既存コマンド生成ロジック（create/squash/push/diff）には変更なし

## 確認観点
- 基点ブランチを変更してフォーカスアウト後、再読み込みで値が復元される
- 基点ブランチ候補に履歴が先頭表示される
- 履歴クリアで履歴候補と前回値復元がリセットされる
- 作業ブランチ欄で更新アイコンが入力欄に重ならない