### PR TITLE
Amazon URL抽出のASIN判定を強化し、入力URLに応じて dp/gp 出力を切り替え

### DIFF
--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1057,6 +1057,8 @@ limitations under the License.
         <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
         <span class="md-tooltip-content md-tooltip">
           例: https://www.amazon.co.jp/.../dp/B0XXXXXXX<br>
+          例: https://www.amazon.co.jp/gp/product/B0XXXXXXX/<br>
+          例: https://www.amazon.co.jp/gp/offer-listing/B0XXXXXXX/<br>
           ASIN（10文字）だけでもOK
         </span>
       </span>
@@ -1090,28 +1092,82 @@ limitations under the License.
         return trimmed.toUpperCase();
       }
 
-      const dpMatch = trimmed.match(/\/dp\/([A-Z0-9]{10})/i);
-      if (dpMatch) return dpMatch[1].toUpperCase();
+      const directPatterns = [
+        /\/dp\/([A-Z0-9]{10})(?=[/?&#]|$)/i,
+        /\/gp\/product\/([A-Z0-9]{10})(?=[/?&#]|$)/i,
+        /\/gp\/aw\/d\/([A-Z0-9]{10})(?=[/?&#]|$)/i,
+        /\/gp\/offer-listing\/([A-Z0-9]{10})(?=[/?&#]|$)/i
+      ];
+      for (const pattern of directPatterns) {
+        const match = trimmed.match(pattern);
+        if (match) return match[1].toUpperCase();
+      }
 
-      const gpMatch = trimmed.match(/\/gp\/product\/([A-Z0-9]{10})/i);
-      if (gpMatch) return gpMatch[1].toUpperCase();
+      const queryPatterns = [
+        /[?&]asin=([A-Z0-9]{10})(?=[&#]|$)/i,
+        /[?&]ASIN=([A-Z0-9]{10})(?=[&#]|$)/i,
+        /[?&]pd_rd_i=([A-Z0-9]{10})(?=[&#]|$)/i
+      ];
+      for (const pattern of queryPatterns) {
+        const match = trimmed.match(pattern);
+        if (match) return match[1].toUpperCase();
+      }
 
-      const asinParam = trimmed.match(/[?&]asin=([A-Z0-9]{10})/i);
-      if (asinParam) return asinParam[1].toUpperCase();
+      // URL構文として読める場合は pathname / query を優先して抽出する
+      try {
+        const url = new URL(trimmed);
+        const path = decodeURIComponent(url.pathname || "");
+        for (const pattern of directPatterns) {
+          const match = path.match(pattern);
+          if (match) return match[1].toUpperCase();
+        }
+        const params = url.searchParams;
+        const keys = ["asin", "ASIN", "pd_rd_i"];
+        for (const key of keys) {
+          const value = params.get(key);
+          if (value && /^[A-Z0-9]{10}$/i.test(value)) {
+            return value.toUpperCase();
+          }
+        }
+      } catch (_) {
+        // URLとして解釈できない入力は下のフォールバックへ進む
+      }
+
+      // 最後のフォールバック: Amazon系URL内に露出したASINを拾う
+      const genericAmazonAsin = trimmed.match(/amazon\.[^/\s]+\/[^?\s#]*?([A-Z0-9]{10})(?=[/?&#]|$)/i);
+      if (genericAmazonAsin) return genericAmazonAsin[1].toUpperCase();
 
       return "";
+    }
+
+    function detectAmazonPathStyle(input) {
+      const trimmed = (input || "").trim();
+      if (!trimmed) return "dp";
+      if (/\/dp\/[A-Z0-9]{10}(?=[/?&#]|$)/i.test(trimmed)) {
+        return "dp";
+      }
+      if (/\/gp\/(product|aw\/d|offer-listing)\/[A-Z0-9]{10}(?=[/?&#]|$)/i.test(trimmed) || /\/gp\//i.test(trimmed)) {
+        return "gp";
+      }
+      return "dp";
     }
 
     function generateDpPath() {
       const input = document.getElementById("amazonUrl").value;
       const asin = extractAsin(input);
+      const pathStyle = detectAmazonPathStyle(input);
 
       if (!asin) {
+        document.getElementById("dpPath").textContent = "";
         alert("URLまたはASIN（10文字）を入力してください。");
         return;
       }
 
-      document.getElementById("dpPath").textContent = `https://www.amazon.co.jp/dp/${asin}`;
+      if (pathStyle === "gp") {
+        document.getElementById("dpPath").textContent = `https://www.amazon.co.jp/gp/product/${asin}/`;
+      } else {
+        document.getElementById("dpPath").textContent = `https://www.amazon.co.jp/dp/${asin}`;
+      }
     }
 
     function copyToClipboard(id) {


### PR DESCRIPTION
### 概要
`docs/link/amazon-dp-extract.html` の ASIN 抽出ロジックを拡張し、Amazon URL のバリエーション対応を強化しました。 あわせて、入力URLの系統（`/dp/` or `/gp/`）に合わせて出力形式を切り替えるように変更しています。

### 変更内容
- ヘルプ文言に対応URL例を追加
  - `gp/product` 形式
  - `gp/offer-listing` 形式
- ASIN抽出ロジックを強化
  - パス形式対応:
    - `/dp/<ASIN>`
    - `/gp/product/<ASIN>`
    - `/gp/aw/d/<ASIN>`
    - `/gp/offer-listing/<ASIN>`
  - クエリ形式対応:
    - `asin=<ASIN>`
    - `ASIN=<ASIN>`
    - `pd_rd_i=<ASIN>`
  - `URL` オブジェクトを使った pathname / searchParams 解析を追加
  - Amazon URL向けのフォールバック抽出を追加
- 出力形式の選択ロジックを追加
  - `/dp/` 入力時: `https://www.amazon.co.jp/dp/<ASIN>`
  - `/gp/` 系入力時: `https://www.amazon.co.jp/gp/product/<ASIN>/`
  - 判別不能時: `dp` を既定
- 抽出失敗時の表示を明確化
  - 既存の出力欄を空にしてからアラート表示

### 影響範囲
- `docs/link/amazon-dp-extract.html` のみ

### 確認観点
- `https://www.amazon.co.jp/dp/B0FDF93THJ` 入力で `dp` 形式が出力される
- `https://www.amazon.co.jp/gp/product/B0FDF93THJ/` 入力で `gp/product` 形式が出力される
- `https://www.amazon.co.jp/gp/offer-listing/B0FDF93THJ/` 入力で `gp/product` 形式が出力される
- `ASIN` 単体入力（例: `B0FDF93THJ`）で `dp` 形式が出力される