### PR TITLE
feat(text): file-rename-cmdline-gen の入力永続化追加と UI 文言・一覧反映

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1043,7 +1043,7 @@
           <span aria-hidden="true" class="md-icon-inline">🗂️</span>
           <span>local-html-tools</span>
         </div>
-        <div class="md-app-meta">更新日: 2026-02-08</div>
+        <div class="md-app-meta">更新日: 2026-02-09</div>
       </div>
     </header>
 
@@ -1349,6 +1349,15 @@
             <span class="md-card-arrow">→</span>
           </div>
           <p class="md-card-desc">テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。</p>
+        </a>
+        <a href="text/file-rename-cmdline-gen.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🏷️</span>ファイル名連番リネーム
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。</p>
         </a>
       </div>
       </section>

--- a/docs/text/file-rename-cmdline-gen-spec.md
+++ b/docs/text/file-rename-cmdline-gen-spec.md
@@ -158,6 +158,36 @@ mv 'スクリーンショット-2024-01-15-123457.png' 'MyTest_002.png'
 - 説明は `?` ツールチップに集約。
 - コード表示は `md-code-block` + `md-copy-button`。
 
+## localStorage 永続化仕様
+
+以下の入力値を `localStorage` に保存し、次回アクセス時に復元する。
+
+- `shellEnvPowerShell`（PowerShell スイッチ）
+- `extensionFilter`（拡張子）
+- `filenamePattern`（名前パターン）
+- `prefixInput`（プレフィックス）
+- `startNoInput`（開始番号）
+- `digitsInput`（桁数）
+
+キー:
+
+- `fileRenameCmdlineGen.ui.shellEnvPowerShell`
+- `fileRenameCmdlineGen.ui.extensionFilter`
+- `fileRenameCmdlineGen.ui.filenamePattern`
+- `fileRenameCmdlineGen.ui.prefix`
+- `fileRenameCmdlineGen.ui.startNo`
+- `fileRenameCmdlineGen.ui.digits`
+
+保存タイミング:
+
+- 対象項目の `input/change` イベントで保存。
+- `localStorage` 例外は握りつぶして継続。
+
+復元タイミング:
+
+- 初期化時に読み込み、復元後にコマンド再生成を実行。
+- `startNoInput` は `1` 以上の整数のみ復元。
+
 ## 想定 JavaScript 関数
 
 - `regenerateAll()` - すべての出力再生成
@@ -168,4 +198,3 @@ mv 'スクリーンショット-2024-01-15-123457.png' 'MyTest_002.png'
 - `quoteShell(value, shellEnv)` - シェル別クォート処理
 - `copyToClipboard(elementId)` - コピー
 - `showToast(message)` - トースト
-

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -302,6 +302,8 @@ limitations under the License.
       font-size: 0.8125rem;
       font-weight: 400;
       line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       border: 1px solid rgba(255, 255, 255, 0.08);
     }
@@ -543,7 +545,7 @@ limitations under the License.
       <span>ファイル名連番リネームコマンドジェネレータ</span>
       <span class="md-tooltip-group">
         <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-        <span class="md-tooltip-content md-tooltip">ファイル名リストから連番リネームコマンドを生成します。PowerShellまたはbashで実行できるコマンドを出力します。</span>
+        <span class="md-tooltip-content md-tooltip">ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。</span>
       </span>
     </h1>
 
@@ -736,6 +738,37 @@ limitations under the License.
   </div>
 
   <script>
+    const UI_SHELL_ENV_POWERSHELL_STORAGE_KEY = "fileRenameCmdlineGen.ui.shellEnvPowerShell";
+    const UI_EXTENSION_FILTER_STORAGE_KEY = "fileRenameCmdlineGen.ui.extensionFilter";
+    const UI_FILENAME_PATTERN_STORAGE_KEY = "fileRenameCmdlineGen.ui.filenamePattern";
+    const UI_PREFIX_STORAGE_KEY = "fileRenameCmdlineGen.ui.prefix";
+    const UI_START_NO_STORAGE_KEY = "fileRenameCmdlineGen.ui.startNo";
+    const UI_DIGITS_STORAGE_KEY = "fileRenameCmdlineGen.ui.digits";
+
+    function getStoredString(key) {
+      try {
+        const value = localStorage.getItem(key);
+        return value == null ? null : value;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function getStoredBoolean(key) {
+      const raw = getStoredString(key);
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return null;
+    }
+
+    function setStoredValue(key, value) {
+      try {
+        localStorage.setItem(key, String(value));
+      } catch (error) {
+        // localStorage が使えない環境でも動作継続
+      }
+    }
+
     function toggleMenu() {
       const panel = document.getElementById("menuPanel");
       if (!panel) return;
@@ -944,7 +977,92 @@ limitations under the License.
       });
     }
 
+    function loadPersistedInputs() {
+      const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+      const extensionFilter = document.getElementById("extensionFilter");
+      const filenamePattern = document.getElementById("filenamePattern");
+      const prefixInput = document.getElementById("prefixInput");
+      const startNoInput = document.getElementById("startNoInput");
+      const digitsInput = document.getElementById("digitsInput");
+
+      const shellEnvValue = getStoredBoolean(UI_SHELL_ENV_POWERSHELL_STORAGE_KEY);
+      const extensionValue = getStoredString(UI_EXTENSION_FILTER_STORAGE_KEY);
+      const filenamePatternValue = getStoredString(UI_FILENAME_PATTERN_STORAGE_KEY);
+      const prefixValue = getStoredString(UI_PREFIX_STORAGE_KEY);
+      const startNoValue = getStoredString(UI_START_NO_STORAGE_KEY);
+      const digitsValue = getStoredString(UI_DIGITS_STORAGE_KEY);
+
+      if (shellEnvPowerShell && shellEnvValue !== null) {
+        shellEnvPowerShell.checked = shellEnvValue;
+      }
+      if (extensionFilter && extensionValue !== null) {
+        extensionFilter.value = extensionValue;
+      }
+      if (filenamePattern && filenamePatternValue !== null) {
+        filenamePattern.value = filenamePatternValue;
+      }
+      if (prefixInput && prefixValue !== null) {
+        prefixInput.value = prefixValue;
+      }
+      if (startNoInput && startNoValue !== null) {
+        const parsed = Number(startNoValue);
+        if (Number.isInteger(parsed) && parsed >= 1) {
+          startNoInput.value = String(parsed);
+        }
+      }
+      if (digitsInput && digitsValue && digitsInput.querySelector(`option[value="${digitsValue}"]`)) {
+        digitsInput.value = digitsValue;
+      }
+    }
+
+    function savePersistedInputs() {
+      const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+      const extensionFilter = document.getElementById("extensionFilter");
+      const filenamePattern = document.getElementById("filenamePattern");
+      const prefixInput = document.getElementById("prefixInput");
+      const startNoInput = document.getElementById("startNoInput");
+      const digitsInput = document.getElementById("digitsInput");
+
+      if (shellEnvPowerShell) {
+        setStoredValue(UI_SHELL_ENV_POWERSHELL_STORAGE_KEY, shellEnvPowerShell.checked);
+      }
+      if (extensionFilter) {
+        setStoredValue(UI_EXTENSION_FILTER_STORAGE_KEY, extensionFilter.value);
+      }
+      if (filenamePattern) {
+        setStoredValue(UI_FILENAME_PATTERN_STORAGE_KEY, filenamePattern.value);
+      }
+      if (prefixInput) {
+        setStoredValue(UI_PREFIX_STORAGE_KEY, prefixInput.value);
+      }
+      if (startNoInput) {
+        setStoredValue(UI_START_NO_STORAGE_KEY, startNoInput.value);
+      }
+      if (digitsInput) {
+        setStoredValue(UI_DIGITS_STORAGE_KEY, digitsInput.value);
+      }
+    }
+
+    function setupInputPersistence() {
+      const ids = [
+        "shellEnvPowerShell",
+        "extensionFilter",
+        "filenamePattern",
+        "prefixInput",
+        "startNoInput",
+        "digitsInput"
+      ];
+      ids.forEach((id) => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("input", savePersistedInputs);
+        element.addEventListener("change", savePersistedInputs);
+      });
+    }
+
+    loadPersistedInputs();
     setupAutoUpdate();
+    setupInputPersistence();
     regenerateAll();
   </script>
 </body>


### PR DESCRIPTION
## 概要

`docs/text/file-rename-cmdline-gen.html` に対して、使い勝手と表示品質の改善を行いました。 あわせてトップ一覧 (`docs/index.html`) と仕様書 (`docs/text/file-rename-cmdline-gen-spec.md`) を更新しています。

## 変更内容

### 1. 入力値の localStorage 永続化を追加
対象項目:
- PowerShell 環境 (`shellEnvPowerShell`)
- 拡張子 (`extensionFilter`)
- 名前パターン (`filenamePattern`)
- プレフィックス (`prefixInput`)
- 開始番号 (`startNoInput`)
- 桁数 (`digitsInput`)

追加仕様:
- 初期化時に保存値を復元
- `input/change` で保存
- `startNoInput` は `1` 以上の整数のみ復元
- `localStorage` 例外時は処理継続

### 2. ツールチップ崩れの修正
`docs/text/file-rename-cmdline-gen.html` の `.md-tooltip` に以下を追加し、長文の見切れを防止:
- `white-space: normal;`
- `overflow-wrap: anywhere;`

### 3. タイトル横 `i` の説明文を更新
以下へ統一:
- `ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。`

### 4. トップ一覧への反映
`docs/index.html` のテキストカテゴリに
- `text/file-rename-cmdline-gen.html` を追加し、カード説明を上記 `i` 説明文と同一内容へ更新。
更新日も `2026-02-09` に更新。

### 5. 仕様書更新
`docs/text/file-rename-cmdline-gen-spec.md` に localStorage 永続化仕様を追記。

## 変更ファイル

- `docs/text/file-rename-cmdline-gen.html`
- `docs/text/file-rename-cmdline-gen-spec.md`
- `docs/index.html`

## 確認ポイント

- 各対象入力を変更後、ページ再読み込みで値が復元されること
- ツールチップ長文が折り返され、見切れないこと
- `docs/index.html` から「ファイル名連番リネーム」へ遷移できること