### PR TITLE
feat: git-pseudo-squash / file-rename-cmdline-gen に「設定をクリア」を追加

### DIFF
--- a/docs/git/git-pseudo-squash-spec.md
+++ b/docs/git/git-pseudo-squash-spec.md
@@ -242,4 +242,9 @@ PowerShellモードでも `useCurrentBranch = true` 時のリネーム行は POS
 
 ### 3.8 クリア仕様
 1. 既存「基点ブランチ履歴クリア」は現状どおり基点履歴のみ対象
-2. UI設定クリアは別機能として分離（必要なら「表示設定リセット」を追加）
+2. UI設定クリアは別機能として分離し、「設定をクリア」ボタンで実行する
+3. 確認ダイアログ文言は次を使用する  
+`ローカルに保存されているこのツールの設定をクリアします。よろしいですか？`
+4. 「設定をクリア」は `gitPseudoSquash.ui.*` キーを削除し、`gitPseudoSquash.squashBaseBranch` は既定値 `devel` に戻す
+5. 基点ブランチ履歴キー（`gitPseudoSquash.squashBaseBranchHistory`）も削除し、autocomplete履歴を初期化する
+6. 実行後はUIを既定値へ戻し、候補を再描画して全コマンドを再生成する

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -599,6 +599,25 @@ limitations under the License.
       background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline);
     }
 
+    .md-button--compact {
+      padding: 0.38rem 0.75rem;
+      font-size: 0.82rem;
+      font-weight: 500;
+      line-height: 1.2;
+    }
+
+    .md-button--with-icon {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .md-inline-action {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.2rem;
+    }
+
     .md-button--secondary {
       background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px;
     }
@@ -1239,6 +1258,20 @@ limitations under the License.
             </span>
           </span>
         </label>
+        <span class="md-inline-action">
+          <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon" onclick="clearUiPreferences()" title="設定をクリア" aria-label="設定をクリア">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-trash" xlink:href="#md-icon-trash"></use>
+            </svg>
+            <span>設定をクリア</span>
+          </button>
+          <span class="md-tooltip-group">
+            <span class="md-info-chip">
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>
+            </span>
+            <span class="md-tooltip-content md-tooltip md-tooltip--rich">ローカルに保存されているこのツールの設定をクリアします。</span>
+          </span>
+        </span>
       </div>
       <div id="baseRemoteRow" class="md-form-grid md-form-grid-2">
         <div class="md-form-row">
@@ -1966,6 +1999,52 @@ limitations under the License.
         element.addEventListener("input", persist);
         element.addEventListener("change", persist);
       });
+    }
+
+    function clearUiPreferences() {
+      const confirmed = confirm("ローカルに保存されているこのツールの設定をクリアします。よろしいですか？");
+      if (!confirmed) return;
+
+      try {
+        localStorage.removeItem(UI_SHELL_ENV_POWERSHELL_STORAGE_KEY);
+        localStorage.removeItem(UI_LOCK_ORIGIN_STORAGE_KEY);
+        localStorage.removeItem(UI_SQUASH_BASE_SCOPE_STORAGE_KEY);
+        localStorage.removeItem(UI_BASE_REMOTE_STORAGE_KEY);
+        localStorage.removeItem(UI_SQUASH_REMOTE_STORAGE_KEY);
+        localStorage.removeItem(UI_USE_CURRENT_BRANCH_STORAGE_KEY);
+        localStorage.removeItem(BASE_BRANCH_HISTORY_STORAGE_KEY);
+        localStorage.setItem(BASE_BRANCH_STORAGE_KEY, "devel");
+      } catch (_) {
+        showToast("設定のクリアに失敗しました");
+        return;
+      }
+
+      const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+      const lockOrigin = document.getElementById("lockOrigin");
+      const squashBaseScope = document.getElementById("squashBaseScope");
+      const baseRemote = document.getElementById("baseRemote");
+      const squashRemote = document.getElementById("squashRemote");
+      const useCurrentBranch = document.getElementById("useCurrentBranch");
+      const squashBaseBranch = document.getElementById("squashBaseBranch");
+      const workBranch = document.getElementById("workBranch");
+      const commitMessage = document.getElementById("commitMessage");
+
+      if (shellEnvPowerShell) shellEnvPowerShell.checked = false;
+      if (lockOrigin) lockOrigin.checked = true;
+      if (squashBaseScope) squashBaseScope.value = "remote";
+      if (baseRemote) baseRemote.value = "origin";
+      if (squashRemote) squashRemote.value = "origin";
+      if (useCurrentBranch) useCurrentBranch.checked = true;
+      if (squashBaseBranch) squashBaseBranch.value = "devel";
+      if (workBranch) workBranch.value = "";
+      if (commitMessage) commitMessage.value = "";
+      setDefaultWorkBranch();
+      renderBaseBranchSuggestions();
+
+      updateBaseScope();
+      toggleCurrentBranch();
+      regenerateAllCommands();
+      showToast("設定をクリアしました");
     }
 
     function uniqueBranchNames(values) {

--- a/docs/text/file-rename-cmdline-gen-spec.md
+++ b/docs/text/file-rename-cmdline-gen-spec.md
@@ -188,6 +188,25 @@ mv 'スクリーンショット-2024-01-15-123457.png' 'MyTest_002.png'
 - 初期化時に読み込み、復元後にコマンド再生成を実行。
 - `startNoInput` は `1` 以上の整数のみ復元。
 
+### 設定クリア仕様
+
+- 「設定をクリア」ボタンで以下キーを削除する
+  - `fileRenameCmdlineGen.ui.shellEnvPowerShell`
+  - `fileRenameCmdlineGen.ui.extensionFilter`
+  - `fileRenameCmdlineGen.ui.filenamePattern`
+  - `fileRenameCmdlineGen.ui.prefix`
+  - `fileRenameCmdlineGen.ui.startNo`
+  - `fileRenameCmdlineGen.ui.digits`
+- 確認ダイアログ文言:
+  - `ローカルに保存されているこのツールの設定をクリアします。よろしいですか？`
+- クリア後は以下既定値で UI を更新し、再生成する
+  - `shellEnvPowerShell = false`
+  - `extensionFilter = "png"`
+  - `filenamePattern = "スクリーンショット*"`
+  - `prefixInput = "MyImage_"`
+  - `startNoInput = 1`
+  - `digitsInput = 3`
+
 ## 想定 JavaScript 関数
 
 - `regenerateAll()` - すべての出力再生成

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -254,6 +254,42 @@ limitations under the License.
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     }
 
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+
+    .md-button--surface {
+      background: var(--md-sys-color-surface-variant);
+      color: var(--md-sys-color-on-surface);
+      border: 1px solid var(--md-sys-color-outline);
+    }
+
+    .md-button--compact {
+      padding: 0.38rem 0.75rem;
+      font-size: 0.82rem;
+      font-weight: 500;
+      line-height: 1.2;
+    }
+
+    .md-button--with-icon {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .md-inline-action {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.2rem;
+    }
+
     .md-icon-btn:hover {
       background: #e6e1ee;
     }
@@ -527,6 +563,13 @@ limitations under the License.
         <rect x="9" y="9" width="11" height="11" rx="2"/>
         <rect x="4" y="4" width="11" height="11" rx="2"/>
       </symbol>
+      <symbol id="md-icon-trash" viewBox="0 0 24 24">
+        <path d="M4 7h16"/>
+        <path d="M10 11v6"/>
+        <path d="M14 11v6"/>
+        <path d="M6 7l1 12h10l1-12"/>
+        <path d="M9 7V5h6v2"/>
+      </symbol>
     </defs>
   </svg>
 
@@ -559,6 +602,20 @@ limitations under the License.
           <span class="md-tooltip-content md-tooltip">Windows PowerShell用のコマンドを出力するかどうかを切り替えます。スイッチがオフの場合はmacOS/Linuxのbash/zsh向けのコマンドを出力します。ご利用の環境に従って切り替えてください。</span>
         </span>
       </label>
+      <span class="md-inline-action">
+        <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon" onclick="clearUiPreferences()" title="設定をクリア" aria-label="設定をクリア">
+          <svg viewBox="0 0 24 24" class="md-info-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <use href="#md-icon-trash" xlink:href="#md-icon-trash"></use>
+          </svg>
+          <span>設定をクリア</span>
+        </button>
+        <span class="md-tooltip-group">
+          <span class="md-info-chip">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>
+          </span>
+          <span class="md-tooltip-content md-tooltip">ローカルに保存されているこのツールの設定をクリアします。</span>
+        </span>
+      </span>
     </div>
 
     <section class="md-section">
@@ -1058,6 +1115,40 @@ limitations under the License.
         element.addEventListener("input", savePersistedInputs);
         element.addEventListener("change", savePersistedInputs);
       });
+    }
+
+    function clearUiPreferences() {
+      const confirmed = confirm("ローカルに保存されているこのツールの設定をクリアします。よろしいですか？");
+      if (!confirmed) return;
+
+      try {
+        localStorage.removeItem(UI_SHELL_ENV_POWERSHELL_STORAGE_KEY);
+        localStorage.removeItem(UI_EXTENSION_FILTER_STORAGE_KEY);
+        localStorage.removeItem(UI_FILENAME_PATTERN_STORAGE_KEY);
+        localStorage.removeItem(UI_PREFIX_STORAGE_KEY);
+        localStorage.removeItem(UI_START_NO_STORAGE_KEY);
+        localStorage.removeItem(UI_DIGITS_STORAGE_KEY);
+      } catch (error) {
+        showToast("設定のクリアに失敗しました");
+        return;
+      }
+
+      const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+      const extensionFilter = document.getElementById("extensionFilter");
+      const filenamePattern = document.getElementById("filenamePattern");
+      const prefixInput = document.getElementById("prefixInput");
+      const startNoInput = document.getElementById("startNoInput");
+      const digitsInput = document.getElementById("digitsInput");
+
+      if (shellEnvPowerShell) shellEnvPowerShell.checked = false;
+      if (extensionFilter) extensionFilter.value = "png";
+      if (filenamePattern) filenamePattern.value = "スクリーンショット*";
+      if (prefixInput) prefixInput.value = "MyImage_";
+      if (startNoInput) startNoInput.value = "1";
+      if (digitsInput) digitsInput.value = "3";
+
+      regenerateAll();
+      showToast("設定をクリアしました");
     }
 
     loadPersistedInputs();


### PR DESCRIPTION
## 概要

`git-pseudo-squash` と `file-rename-cmdline-gen` に、ローカル保存設定を初期化する「設定をクリア」機能を追加しました。 ボタン配置、確認ダイアログ、初期値復帰、再生成までを実装し、仕様書も更新しています。

## 変更内容

### 1. `docs/git/git-pseudo-squash.html`
- `PowerShell`/`lockOrigin` 行に `設定をクリア` ボタンを追加
  - trash アイコン付き
  - ボタン外側に `i` ツールチップを配置
- `clearUiPreferences()` を追加
  - 確認文言: `ローカルに保存されているこのツールの設定をクリアします。よろしいですか？`
  - 削除対象:
    - `gitPseudoSquash.ui.*` 一式
    - `gitPseudoSquash.squashBaseBranchHistory`
  - `gitPseudoSquash.squashBaseBranch` は `devel` に再設定
  - UIを既定値へ復帰
    - `shellEnvPowerShell=false`
    - `lockOrigin=true`
    - `squashBaseScope=remote`
    - `baseRemote=origin`
    - `squashRemote=origin`
    - `useCurrentBranch=true`
    - `squashBaseBranch=devel`
    - `workBranch=""`（`setDefaultWorkBranch()` で再生成）
    - `commitMessage=""`
  - `renderBaseBranchSuggestions()` 実行で候補再描画
  - `regenerateAllCommands()` 実行、トースト表示

### 2. `docs/text/file-rename-cmdline-gen.html`
- `PowerShell環境` 行に `設定をクリア` ボタンを追加
  - trash アイコン付き
  - ボタン外側に `i` ツールチップを配置
- `clearUiPreferences()` を追加
  - 同じ確認文言を使用
  - 削除対象:
    - `fileRenameCmdlineGen.ui.*` 一式
  - UIを既定値へ復帰
    - `shellEnvPowerShell=false`
    - `extensionFilter=png`
    - `filenamePattern=スクリーンショット*`
    - `prefixInput=MyImage_`
    - `startNoInput=1`
    - `digitsInput=3`
  - `regenerateAll()` 実行、トースト表示

### 3. 仕様書更新
- `docs/git/git-pseudo-squash-spec.md`
  - クリア仕様（ボタン、確認文言、削除キー、復帰動作）を追記
- `docs/text/file-rename-cmdline-gen-spec.md`
  - 設定クリア仕様を新規追記

## 変更ファイル

- `docs/git/git-pseudo-squash.html`
- `docs/git/git-pseudo-squash-spec.md`
- `docs/text/file-rename-cmdline-gen.html`
- `docs