### PR TITLE
Mermaid→SVGツールをSVG専用に整理し、Markdownフェンス入力を自動正規化

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ URL加工系ツールです。
 
 図表系ツールです。
 
-- **mermaid-to-svg.html**: Mermaid記法からSVGを生成し、SVG/PNGを保存します。
+- **mermaid-to-svg.html**: Mermaid記法からSVGを生成し、SVGを保存します。
 
 ## text
 

--- a/docs/diagram/mermaid-to-svg-spec.md
+++ b/docs/diagram/mermaid-to-svg-spec.md
@@ -2,7 +2,7 @@
 
 ## 目的
 
-Mermaid記法を入力し、ブラウザ上でSVGを生成する。生成したSVGはテキストコピーとファイル保存を可能にする。加えてSVGからPNGへの変換保存を提供する。
+Mermaid記法を入力し、ブラウザ上でSVGを生成する。生成したSVGはテキストコピーとファイル保存を可能にする。
 
 ## 入力
 
@@ -15,22 +15,19 @@ Mermaid記法を入力し、ブラウザ上でSVGを生成する。生成したS
 - SVGテキスト
 - ダウンロード:
   - `mermaid-diagram.svg`
-  - `mermaid-diagram.png`
 
 ## エラーハンドリング
 
 - 入力空欄時はエラーメッセージを表示し、処理を中断する
 - Mermaidレンダリング失敗時はエラーメッセージを表示する
-- PNG変換失敗時はエラーメッセージを表示する
 
 ## UI方針
 
 - `md3/spec/token-spec.css` と `md3/spec/core-spec.css` の設計を踏襲
 - 説明はタイトル右の `i` ツールチップに集約
-- ユーザー操作は `レンダリング` / `SVG保存` / `PNG保存` / `コピー` を明示
+- ユーザー操作は `レンダリング` / `SVG保存` / `コピー` を明示
 - 成功時はトーストで短く通知
 
 ## 実装メモ
 
-- Mermaid本体は `docs/diagram/mermaid.min.js` をローカル参照して利用する
-- PNGは `canvas` へ描画して `toBlob("image/png")` で生成する
+- Mermaid本体は `docs/diagram/mermaid.min.js` を同梱して利用する

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -449,7 +449,7 @@ limitations under the License.
               <circle cx="12" cy="7.5" r="1" fill="#ffffff"></circle>
             </svg>
           </span>
-          <span class="md-tooltip-content md-tooltip">Mermaidは、UML関連図（クラス図・シーケンス図など）やフローチャートをテキスト記法で記述し、図として可視化できる仕組みです。このツールはその記法からSVGを生成し、必要に応じてPNGとして保存できます。</span>
+          <span class="md-tooltip-content md-tooltip">Mermaidは、UML関連図（クラス図・シーケンス図など）やフローチャートをテキスト記法で記述し、図として可視化できる仕組みです。このツールはその記法からSVGを生成して保存できます。</span>
         </span>
       </h1>
 
@@ -485,7 +485,6 @@ limitations under the License.
   A[Start] --> B{Need SVG?}
   B -->|Yes| C[Render Mermaid]
   C --> D[Download SVG]
-  C --> E[Download PNG]
   B -->|No| F[Edit source]</textarea>
         </div>
 
@@ -533,7 +532,6 @@ limitations under the License.
         </div>
         <div class="md-actions">
           <button id="downloadSvgBtn" class="md-button md-button--secondary" type="button" disabled>SVG保存</button>
-          <button id="downloadPngBtn" class="md-button md-button--secondary" type="button" disabled>PNG保存</button>
         </div>
       </section>
 
@@ -2605,7 +2603,6 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
     const svgText = document.getElementById("svgText");
     const errorText = document.getElementById("errorText");
     const downloadSvgBtn = document.getElementById("downloadSvgBtn");
-    const downloadPngBtn = document.getElementById("downloadPngBtn");
     const copySvgBtn = document.getElementById("copySvgBtn");
     const toast = document.getElementById("toast");
     const menuPanel = document.getElementById("menuPanel");
@@ -2624,13 +2621,12 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
 
     renderBtn.addEventListener("click", renderMermaid);
     downloadSvgBtn.addEventListener("click", downloadSvg);
-    downloadPngBtn.addEventListener("click", downloadPng);
     copySvgBtn.addEventListener("click", copySvg);
     themeSelect.addEventListener("change", persistThemeSelection);
     document.addEventListener("click", handleDocumentClick);
 
     async function renderMermaid() {
-      const source = mermaidInput.value.trim();
+      const source = normalizeMermaidSource(mermaidInput.value);
       if (!source) {
         setError("Mermaid記法を入力してください。");
         return;
@@ -2653,14 +2649,12 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
         svgText.textContent = result.svg;
 
         downloadSvgBtn.disabled = false;
-        downloadPngBtn.disabled = false;
         showToast("SVGを生成しました。");
       } catch (error) {
         lastSvg = "";
         svgPreview.innerHTML = "";
         svgText.textContent = "";
         downloadSvgBtn.disabled = true;
-        downloadPngBtn.disabled = true;
         const errorMessage = error && error.message ? error.message : String(error);
         const errorLine = extractMermaidErrorLine(errorMessage);
         setError("レンダリングに失敗しました: " + errorMessage, errorLine);
@@ -2677,22 +2671,6 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
       const blob = new Blob([lastSvg], { type: "image/svg+xml;charset=utf-8" });
       downloadBlob(blob, "mermaid-diagram.svg");
       showToast("SVGを保存しました。");
-    }
-
-    async function downloadPng() {
-      if (!lastSvg) {
-        setError("先にSVGを生成してください。");
-        return;
-      }
-
-      clearError();
-      try {
-        const pngBlob = await svgToPngBlob(lastSvg, 2);
-        downloadBlob(pngBlob, "mermaid-diagram.png");
-        showToast("PNGを保存しました。");
-      } catch (error) {
-        setError("PNG変換に失敗しました: " + (error && error.message ? error.message : String(error)));
-      }
     }
 
     function copySvg() {
@@ -2761,6 +2739,35 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
       localStorage.setItem(THEME_STORAGE_KEY, themeSelect.value);
     }
 
+    function normalizeMermaidSource(rawText) {
+      if (!rawText) {
+        return "";
+      }
+
+      const lines = rawText.split("\n");
+      let first = 0;
+      let last = lines.length - 1;
+
+      while (first <= last && lines[first].trim() === "") {
+        first++;
+      }
+      while (last >= first && lines[last].trim() === "") {
+        last--;
+      }
+      if (first > last) {
+        return "";
+      }
+
+      const firstLine = lines[first].trim();
+      const lastLine = lines[last].trim();
+      const hasCodeFencePair = /^```(?:[^\s`]*)?\s*$/i.test(firstLine) && /^```\s*$/.test(lastLine);
+      if (hasCodeFencePair) {
+        return lines.slice(first + 1, last).join("\n").trim();
+      }
+
+      return lines.slice(first, last + 1).join("\n").trim();
+    }
+
     function extractMermaidErrorLine(message) {
       if (!message) {
         return null;
@@ -2816,44 +2823,6 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
       link.click();
       link.remove();
       setTimeout(() => URL.revokeObjectURL(url), 1000);
-    }
-
-    async function svgToPngBlob(svgTextValue, scale) {
-      const svgBlob = new Blob([svgTextValue], { type: "image/svg+xml;charset=utf-8" });
-      const svgUrl = URL.createObjectURL(svgBlob);
-
-      try {
-        const image = await loadImage(svgUrl);
-        const width = Math.max(1, Math.ceil(image.naturalWidth * scale));
-        const height = Math.max(1, Math.ceil(image.naturalHeight * scale));
-
-        const canvas = document.createElement("canvas");
-        canvas.width = width;
-        canvas.height = height;
-
-        const ctx = canvas.getContext("2d");
-        if (!ctx) {
-          throw new Error("canvas context の取得に失敗しました。");
-        }
-
-        ctx.drawImage(image, 0, 0, width, height);
-        const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
-        if (!blob) {
-          throw new Error("PNG化に失敗しました。");
-        }
-        return blob;
-      } finally {
-        URL.revokeObjectURL(svgUrl);
-      }
-    }
-
-    function loadImage(url) {
-      return new Promise((resolve, reject) => {
-        const image = new Image();
-        image.onload = () => resolve(image);
-        image.onerror = () => reject(new Error("SVGの読み込みに失敗しました。"));
-        image.src = url;
-      });
     }
 
     renderMermaid();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1312,7 +1312,7 @@
             </h3>
             <span class="md-card-arrow">→</span>
           </div>
-          <p class="md-card-desc">Mermaid記法からSVGを生成し、SVG/PNGとして保存できます。</p>
+          <p class="md-card-desc">Mermaid記法からSVGを生成し、SVGとして保存できます。</p>
         </a>
       </div>
       </section>


### PR DESCRIPTION
## 概要
`docs/diagram/mermaid-to-svg.html` の機能と文言を見直し、PNG出力を廃止してSVG専用ツールとして整理しました。 あわせて、コピー元都合で含まれるコードフェンス（``` / ```キーワード）をレンダリング前に自動除去する正規化処理を追加しました。

## 変更点
- `docs/diagram/mermaid-to-svg.html`
  - PNG保存ボタンを削除
  - PNG変換処理（`downloadPng`, `svgToPngBlob`, `loadImage`）を削除
  - ツール説明文を「SVG保存」に統一
  - サンプル図から `Download PNG` ノードを削除
  - 入力正規化 `normalizeMermaidSource()` を追加
    - 先頭・末尾の空行を除去
    - 先頭が ```` ``` ```` または ```` ```任意キーワード ````、末尾が ```` ``` ```` の場合にフェンスを除去
  - `renderMermaid()` は `trim()` ではなく正規化関数を利用
- `docs/diagram/mermaid-to-svg-spec.md`
  - PNG関連記述を削除し、SVG専用仕様へ更新
- `README.md`
  - ツール説明を `SVG/PNG` から `SVG` へ更新
- `docs/index.html`
  - Diagramカード説明を `SVG/PNG` から `SVG` へ更新

## 影響
- PNG出力機能は利用不可になります（SVG出力のみ）
- Markdownコードブロック付き入力の貼り付け互換性が向上します
- 既存のSVGレンダリング、コピー、保存、テーマ保持、エラー行フォーカスには影響ありません