### PR TITLE
Music系ツールのUX改善とMusicXML→MIDIの内蔵シンセ再生対応

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1116,6 +1116,51 @@
       </div>
       </section>
 
+      <section class="md-section-card">
+      <h2 class="md-section-title">
+        <span aria-hidden="true" class="md-icon-inline">🎼</span>Music
+      </h3>
+      <p class="md-section-subtitle">楽譜データの変換</p>
+      <div class="md-grid md-grid-3 md-section">
+        <a href="music/musicxml-to-svg.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎼</span>MusicXML → SVG 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">MusicXMLから楽譜SVGを生成し、SVGとして保存できます。</p>
+        </a>
+        <a href="music/abc-to-musicxml.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎵</span>ABC → MusicXML 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。</p>
+        </a>
+        <a href="music/musicxml-to-abc.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎶</span>MusicXML → ABC 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">MusicXMLからABC記法を生成し、ABCとして保存できます。</p>
+        </a>
+        <a href="music/musicxml-to-midi.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🥁</span>MusicXML → MIDI 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">MusicXMLからMIDIを生成し、.midとして保存できます。</p>
+        </a>
+      </div>
+      </section>
+
 
 
 
@@ -1325,55 +1370,6 @@
         </a>
       </div>
       </section>
-
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🎼</span>Music
-      </h3>
-      <p class="md-section-subtitle">楽譜データの変換</p>
-      <div class="md-grid md-grid-3 md-section">
-        <a href="music/musicxml-to-svg.html" class="md-link-card">
-          <div class="md-card-head">
-            <h3 class="md-card-title">
-              <span aria-hidden="true" class="md-icon-inline">🎼</span>MusicXML → SVG 変換
-            </h3>
-            <span class="md-card-arrow">→</span>
-          </div>
-          <p class="md-card-desc">MusicXMLから楽譜SVGを生成し、SVGとして保存できます。</p>
-        </a>
-        <a href="music/abc-to-musicxml.html" class="md-link-card">
-          <div class="md-card-head">
-            <h3 class="md-card-title">
-              <span aria-hidden="true" class="md-icon-inline">🎵</span>ABC → MusicXML 変換
-            </h3>
-            <span class="md-card-arrow">→</span>
-          </div>
-          <p class="md-card-desc">ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。</p>
-        </a>
-        <a href="music/musicxml-to-abc.html" class="md-link-card">
-          <div class="md-card-head">
-            <h3 class="md-card-title">
-              <span aria-hidden="true" class="md-icon-inline">🎶</span>MusicXML → ABC 変換
-            </h3>
-            <span class="md-card-arrow">→</span>
-          </div>
-          <p class="md-card-desc">MusicXMLからABC記法を生成し、ABCとして保存できます。</p>
-        </a>
-        <a href="music/musicxml-to-midi.html" class="md-link-card">
-          <div class="md-card-head">
-            <h3 class="md-card-title">
-              <span aria-hidden="true" class="md-icon-inline">🥁</span>MusicXML → MIDI 変換
-            </h3>
-            <span class="md-card-arrow">→</span>
-          </div>
-          <p class="md-card-desc">MusicXMLからMIDIを生成し、.midとして保存できます。</p>
-        </a>
-      </div>
-      </section>
-
-
-
-
 
 
       <section class="md-section-card">

--- a/docs/music/abc-to-musicxml-src.html
+++ b/docs/music/abc-to-musicxml-src.html
@@ -89,7 +89,18 @@ K:C
 C D E F | G A B c |</textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" hidden />
       </section>
 
       <section class="md-section">

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -437,7 +437,18 @@ K:C
 C D E F | G A B c |</textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" hidden />
       </section>
 
       <section class="md-section">
@@ -523,6 +534,8 @@ C D E F | G A B c |</textarea>
   <script>
 const abcInput = document.getElementById("abcInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const convertBtn = document.getElementById("convertBtn");
@@ -545,6 +558,7 @@ const abcInput = document.getElementById("abcInput");
     downloadBtn.addEventListener("click", downloadMusicXml);
     copyBtn.addEventListener("click", copyMusicXml);
     fileInput.addEventListener("change", loadAbcFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
@@ -554,8 +568,10 @@ const abcInput = document.getElementById("abcInput");
     function loadAbcFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         abcInput.value = String(reader.result || "");
@@ -565,6 +581,10 @@ const abcInput = document.getElementById("abcInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertAbc() {

--- a/docs/music/musicxml-to-abc-src.html
+++ b/docs/music/musicxml-to-abc-src.html
@@ -104,7 +104,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -454,7 +454,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">
@@ -548,6 +559,8 @@ limitations under the License.
   <script>
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultLengthSelect = document.getElementById("defaultLengthSelect");
@@ -571,6 +584,7 @@ const xmlInput = document.getElementById("xmlInput");
     downloadBtn.addEventListener("click", downloadAbc);
     copyBtn.addEventListener("click", copyAbc);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultLengthSelect.addEventListener("change", persistSettings);
@@ -581,8 +595,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -592,6 +608,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {

--- a/docs/music/musicxml-to-midi-src.html
+++ b/docs/music/musicxml-to-midi-src.html
@@ -100,7 +100,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              <path d="M12 10v6" />
+              <path d="M9.5 13.5 12 16l2.5-2.5" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">
@@ -139,11 +150,46 @@ limitations under the License.
               <option value="fm_piano_2">FM Piano 2 (Electric Piano 2)</option>
             </select>
           </div>
+          <div>
+            <label class="md-label" for="synthWaveformSelect">内蔵シンセ波形</label>
+            <select id="synthWaveformSelect" class="md-input">
+              <option value="sine">sine (やわらかい音)</option>
+              <option value="square">square (明るく硬い音)</option>
+              <option value="triangle">triangle (中間の音)</option>
+            </select>
+          </div>
         </div>
 
         <div class="md-actions">
-          <button id="convertBtn" class="md-button md-button--primary" type="button">変換</button>
-          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>MIDI保存</button>
+          <button id="convertBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M5 7h10" />
+              <path d="M11 3l4 4-4 4" />
+              <path d="M19 17H9" />
+              <path d="M13 13l-4 4 4 4" />
+            </svg>
+            <span>変換</span>
+          </button>
+          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 4v9" />
+              <path d="M8 10l4 4 4-4" />
+              <path d="M5 18h14" />
+            </svg>
+            <span>MIDI保存</span>
+          </button>
+          <button id="playBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+            <span>再生</span>
+          </button>
+          <button id="stopBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align:middle;margin-right:0.35rem">
+              <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
+            </svg>
+            <span>停止</span>
+          </button>
         </div>
         <p id="errorText" class="md-error md-hidden" role="alert"></p>
         <p id="warningText" class="md-warning md-hidden"></p>

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -423,7 +423,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              <path d="M12 10v6" />
+              <path d="M9.5 13.5 12 16l2.5-2.5" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">
@@ -462,11 +473,46 @@ limitations under the License.
               <option value="fm_piano_2">FM Piano 2 (Electric Piano 2)</option>
             </select>
           </div>
+          <div>
+            <label class="md-label" for="synthWaveformSelect">内蔵シンセ波形</label>
+            <select id="synthWaveformSelect" class="md-input">
+              <option value="sine">sine (やわらかい音)</option>
+              <option value="square">square (明るく硬い音)</option>
+              <option value="triangle">triangle (中間の音)</option>
+            </select>
+          </div>
         </div>
 
         <div class="md-actions">
-          <button id="convertBtn" class="md-button md-button--primary" type="button">変換</button>
-          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>MIDI保存</button>
+          <button id="convertBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M5 7h10" />
+              <path d="M11 3l4 4-4 4" />
+              <path d="M19 17H9" />
+              <path d="M13 13l-4 4 4 4" />
+            </svg>
+            <span>変換</span>
+          </button>
+          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 4v9" />
+              <path d="M8 10l4 4 4-4" />
+              <path d="M5 18h14" />
+            </svg>
+            <span>MIDI保存</span>
+          </button>
+          <button id="playBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+            <span>再生</span>
+          </button>
+          <button id="stopBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" style="vertical-align:middle;margin-right:0.35rem">
+              <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
+            </svg>
+            <span>停止</span>
+          </button>
         </div>
         <p id="errorText" class="md-error md-hidden" role="alert"></p>
         <p id="warningText" class="md-warning md-hidden"></p>
@@ -2385,12 +2431,17 @@ window.MidiWriter = main;
   <script>
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultTempoInput = document.getElementById("defaultTempoInput");
     const instrumentOverrideSelect = document.getElementById("instrumentOverrideSelect");
+    const synthWaveformSelect = document.getElementById("synthWaveformSelect");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
+    const playBtn = document.getElementById("playBtn");
+    const stopBtn = document.getElementById("stopBtn");
     const previewText = document.getElementById("previewText");
     const logOutput = document.getElementById("logOutput");
     const errorText = document.getElementById("errorText");
@@ -2402,16 +2453,24 @@ const xmlInput = document.getElementById("xmlInput");
     const MIDI_TICKS_PER_QUARTER = 128;
 
     let lastMidiBytes = null;
+    let lastSynthSchedule = null;
+    let audioContext = null;
+    let activeSynthNodes = [];
+    let synthStopTimer = null;
 
     restoreSettings();
 
     convertBtn.addEventListener("click", convertMusicXml);
     downloadBtn.addEventListener("click", downloadMidi);
+    playBtn.addEventListener("click", playMidi);
+    stopBtn.addEventListener("click", stopMidi);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultTempoInput.addEventListener("change", persistSettings);
     instrumentOverrideSelect.addEventListener("change", persistSettings);
+    synthWaveformSelect.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
 
     convertMusicXml();
@@ -2419,8 +2478,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -2430,6 +2491,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {
@@ -2496,13 +2561,17 @@ const xmlInput = document.getElementById("xmlInput");
         const writer = new MidiWriter.Writer(tracks);
         const built = writer.buildFile();
         lastMidiBytes = built instanceof Uint8Array ? built : Uint8Array.from(built || []);
+        lastSynthSchedule = buildSynthSchedule(result.meta.tempo, voiceIds, result.voiceTracksById, instrumentOverride);
 
         downloadBtn.disabled = lastMidiBytes.length === 0;
+        playBtn.disabled = !lastSynthSchedule || lastSynthSchedule.events.length === 0;
+        stopBtn.disabled = true;
         previewText.textContent = [
           "title: " + result.meta.title,
           "composer: " + result.meta.composer,
           "tempo: " + result.meta.tempo,
           "instrument override: " + instrumentOverrideLabel(instrumentOverride),
+          "synth waveform: " + normalizeWaveform(synthWaveformSelect.value),
           "meter: " + result.meta.meter.beats + "/" + result.meta.meter.beatType,
           "parts: " + result.meta.partCount,
           "voices: " + result.meta.voiceCount,
@@ -2705,6 +2774,7 @@ const xmlInput = document.getElementById("xmlInput");
                 const soundingPitch = midiNumberToMidiWriterPitch(soundingMidi);
                 voiceTracksById[trackId].events.push({
                   pitch: soundingPitch,
+                  midiNumber: soundingMidi,
                   ticks: event.ticks,
                   start: timelineTick + cursorTick
                 });
@@ -3054,11 +3124,48 @@ const xmlInput = document.getElementById("xmlInput");
       return Math.max(0, Math.min(127, Math.round(program)));
     }
 
+    function buildSynthSchedule(tempo, voiceIds, voiceTracksById, instrumentOverride) {
+      const events = [];
+      for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
+        const voiceId = voiceIds[trackIndex];
+        const voiceTrack = voiceTracksById[voiceId];
+        if (!voiceTrack || !Array.isArray(voiceTrack.events)) {
+          continue;
+        }
+        const channel = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
+        for (const event of voiceTrack.events) {
+          if (!event || !Number.isFinite(event.midiNumber) || !Number.isFinite(event.start) || !Number.isFinite(event.ticks)) {
+            continue;
+          }
+          events.push({
+            midiNumber: Math.max(0, Math.min(127, Math.round(event.midiNumber))),
+            start: Math.max(0, Math.round(event.start)),
+            ticks: Math.max(1, Math.round(event.ticks)),
+            channel
+          });
+        }
+      }
+      events.sort((a, b) => {
+        if (a.start !== b.start) {
+          return a.start - b.start;
+        }
+        return a.midiNumber - b.midiNumber;
+      });
+      return {
+        tempo: clampTempo(tempo),
+        events
+      };
+    }
+
     function resetOutput() {
+      stopMidi(false);
       lastMidiBytes = null;
+      lastSynthSchedule = null;
       previewText.textContent = "未変換";
       logOutput.textContent = "未変換";
       downloadBtn.disabled = true;
+      playBtn.disabled = true;
+      stopBtn.disabled = true;
     }
 
     function downloadMidi() {
@@ -3069,6 +3176,126 @@ const xmlInput = document.getElementById("xmlInput");
       const blob = new Blob([lastMidiBytes], { type: "audio/midi" });
       downloadBlob(blob, "score.mid");
       showToast("MIDIを保存しました。");
+    }
+
+    function playMidi() {
+      if (!lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        setError("先に変換してください。");
+        return;
+      }
+      const AudioContextCtor =
+        window.AudioContext ||
+        (window).webkitAudioContext;
+      if (!AudioContextCtor) {
+        setError("このブラウザはWebAudioに対応していません。");
+        return;
+      }
+
+      if (!audioContext) {
+        audioContext = new AudioContextCtor();
+      }
+
+      stopMidi(false);
+
+      audioContext.resume().then(() => {
+        startSynthPlayback();
+        clearError();
+        stopBtn.disabled = false;
+        showToast("内蔵シンセ再生を開始しました。");
+      }).catch((error) => {
+        stopBtn.disabled = true;
+        setError("内蔵シンセ再生に失敗しました: " + (error && error.message ? error.message : String(error)));
+      });
+    }
+
+    function startSynthPlayback() {
+      if (!audioContext || !lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        return;
+      }
+      const waveform = normalizeWaveform(synthWaveformSelect.value);
+      const secPerTick = 60 / (lastSynthSchedule.tempo * MIDI_TICKS_PER_QUARTER);
+      const baseTime = audioContext.currentTime + 0.04;
+      let latestEndTime = baseTime;
+
+      for (const event of lastSynthSchedule.events) {
+        const startAt = baseTime + (event.start * secPerTick);
+        const bodyDuration = Math.max(0.04, event.ticks * secPerTick);
+        const attack = 0.005;
+        const release = 0.03;
+        const endAt = startAt + bodyDuration;
+
+        const oscillator = audioContext.createOscillator();
+        oscillator.type = waveform;
+        oscillator.frequency.setValueAtTime(midiNumberToFrequency(event.midiNumber), startAt);
+
+        const gainNode = audioContext.createGain();
+        const gainLevel = event.channel === 10 ? 0.06 : 0.1;
+        gainNode.gain.setValueAtTime(0.0001, startAt);
+        gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        gainNode.gain.setValueAtTime(gainLevel, endAt);
+        gainNode.gain.linearRampToValueAtTime(0.0001, endAt + release);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.start(startAt);
+        oscillator.stop(endAt + release + 0.01);
+
+        oscillator.onended = () => {
+          try {
+            oscillator.disconnect();
+            gainNode.disconnect();
+          } catch (_error) {
+            // ignore cleanup failure
+          }
+        };
+        activeSynthNodes.push({ oscillator, gainNode });
+        latestEndTime = Math.max(latestEndTime, endAt + release + 0.02);
+      }
+
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+      }
+      const waitMs = Math.max(0, Math.ceil((latestEndTime - audioContext.currentTime) * 1000));
+      synthStopTimer = setTimeout(() => {
+        activeSynthNodes = [];
+        stopBtn.disabled = true;
+      }, waitMs);
+    }
+
+    function stopMidi(showMessage = true) {
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+        synthStopTimer = null;
+      }
+      for (const node of activeSynthNodes) {
+        try {
+          node.oscillator.stop();
+        } catch (_error) {
+          // ignore already-stopped nodes
+        }
+        try {
+          node.oscillator.disconnect();
+          node.gainNode.disconnect();
+        } catch (_error) {
+          // ignore disconnect error
+        }
+      }
+      activeSynthNodes = [];
+      stopBtn.disabled = true;
+      if (showMessage) {
+        showToast("内蔵シンセ再生を停止しました。");
+      }
+    }
+
+    function normalizeWaveform(value) {
+      if (value === "square" || value === "triangle") {
+        return value;
+      }
+      return "sine";
+    }
+
+    function midiNumberToFrequency(midiNumber) {
+      return 440 * Math.pow(2, (midiNumber - 69) / 12);
     }
 
     function setError(message) {
@@ -3127,7 +3354,8 @@ const xmlInput = document.getElementById("xmlInput");
         defaultTitle: defaultTitleInput.value,
         defaultComposer: defaultComposerInput.value,
         defaultTempo: defaultTempoInput.value,
-        instrumentOverride: instrumentOverrideSelect.value
+        instrumentOverride: instrumentOverrideSelect.value,
+        synthWaveform: synthWaveformSelect.value
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
@@ -3151,6 +3379,9 @@ const xmlInput = document.getElementById("xmlInput");
           }
           if (typeof data.instrumentOverride === "string") {
             instrumentOverrideSelect.value = data.instrumentOverride;
+          }
+          if (typeof data.synthWaveform === "string") {
+            synthWaveformSelect.value = normalizeWaveform(data.synthWaveform);
           }
         }
       } catch (_error) {

--- a/docs/music/musicxml-to-svg-src.html
+++ b/docs/music/musicxml-to-svg-src.html
@@ -107,7 +107,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -467,7 +467,18 @@ limitations under the License.
 </score-partwise></textarea>
 
         <label class="md-label" for="fileInput">ファイル読込</label>
-        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" />
+        <div class="md-actions">
+          <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <path d="M12 16V4" />
+              <path d="M8 8l4-4 4 4" />
+              <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            </svg>
+            <span>ファイルを選択</span>
+          </button>
+          <span id="fileNameText">未選択</span>
+        </div>
+        <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
       </section>
 
       <section class="md-section">
@@ -1031,6 +1042,8 @@ https://github.com/nodeca/pako/blob/main/LICENSE
   <script>
 const musicxmlInput = document.getElementById("musicxmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
     const marginTopInput = document.getElementById("marginTopInput");
@@ -1068,6 +1081,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     nextPageBtn.addEventListener("click", showNextPage);
     copySvgBtn.addEventListener("click", copySvg);
     fileInput.addEventListener("change", loadMusicXMLFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     document.addEventListener("click", handleDocumentClick);
 
     [
@@ -1116,8 +1130,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     function loadMusicXMLFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         musicxmlInput.value = String(reader.result || "");
@@ -1127,6 +1143,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function renderMusicXML() {

--- a/docs/music/src/abc-to-musicxml/js/main.js
+++ b/docs/music/src/abc-to-musicxml/js/main.js
@@ -1,5 +1,7 @@
 const abcInput = document.getElementById("abcInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const convertBtn = document.getElementById("convertBtn");
@@ -22,6 +24,7 @@ const abcInput = document.getElementById("abcInput");
     downloadBtn.addEventListener("click", downloadMusicXml);
     copyBtn.addEventListener("click", copyMusicXml);
     fileInput.addEventListener("change", loadAbcFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
@@ -31,8 +34,10 @@ const abcInput = document.getElementById("abcInput");
     function loadAbcFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         abcInput.value = String(reader.result || "");
@@ -42,6 +47,10 @@ const abcInput = document.getElementById("abcInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertAbc() {

--- a/docs/music/src/abc-to-musicxml/ts/main.ts
+++ b/docs/music/src/abc-to-musicxml/ts/main.ts
@@ -1,5 +1,7 @@
 const abcInput = document.getElementById("abcInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const convertBtn = document.getElementById("convertBtn");
@@ -22,6 +24,7 @@ const abcInput = document.getElementById("abcInput");
     downloadBtn.addEventListener("click", downloadMusicXml);
     copyBtn.addEventListener("click", copyMusicXml);
     fileInput.addEventListener("change", loadAbcFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
@@ -31,8 +34,10 @@ const abcInput = document.getElementById("abcInput");
     function loadAbcFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         abcInput.value = String(reader.result || "");
@@ -42,6 +47,10 @@ const abcInput = document.getElementById("abcInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertAbc() {

--- a/docs/music/src/musicxml-to-abc/js/main.js
+++ b/docs/music/src/musicxml-to-abc/js/main.js
@@ -1,5 +1,7 @@
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultLengthSelect = document.getElementById("defaultLengthSelect");
@@ -23,6 +25,7 @@ const xmlInput = document.getElementById("xmlInput");
     downloadBtn.addEventListener("click", downloadAbc);
     copyBtn.addEventListener("click", copyAbc);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultLengthSelect.addEventListener("change", persistSettings);
@@ -33,8 +36,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -44,6 +49,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {

--- a/docs/music/src/musicxml-to-abc/ts/main.ts
+++ b/docs/music/src/musicxml-to-abc/ts/main.ts
@@ -1,5 +1,7 @@
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultLengthSelect = document.getElementById("defaultLengthSelect");
@@ -23,6 +25,7 @@ const xmlInput = document.getElementById("xmlInput");
     downloadBtn.addEventListener("click", downloadAbc);
     copyBtn.addEventListener("click", copyAbc);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultLengthSelect.addEventListener("change", persistSettings);
@@ -33,8 +36,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -44,6 +49,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {

--- a/docs/music/src/musicxml-to-midi/js/main.js
+++ b/docs/music/src/musicxml-to-midi/js/main.js
@@ -1,11 +1,16 @@
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultTempoInput = document.getElementById("defaultTempoInput");
     const instrumentOverrideSelect = document.getElementById("instrumentOverrideSelect");
+    const synthWaveformSelect = document.getElementById("synthWaveformSelect");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
+    const playBtn = document.getElementById("playBtn");
+    const stopBtn = document.getElementById("stopBtn");
     const previewText = document.getElementById("previewText");
     const logOutput = document.getElementById("logOutput");
     const errorText = document.getElementById("errorText");
@@ -17,16 +22,24 @@ const xmlInput = document.getElementById("xmlInput");
     const MIDI_TICKS_PER_QUARTER = 128;
 
     let lastMidiBytes = null;
+    let lastSynthSchedule = null;
+    let audioContext = null;
+    let activeSynthNodes = [];
+    let synthStopTimer = null;
 
     restoreSettings();
 
     convertBtn.addEventListener("click", convertMusicXml);
     downloadBtn.addEventListener("click", downloadMidi);
+    playBtn.addEventListener("click", playMidi);
+    stopBtn.addEventListener("click", stopMidi);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultTempoInput.addEventListener("change", persistSettings);
     instrumentOverrideSelect.addEventListener("change", persistSettings);
+    synthWaveformSelect.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
 
     convertMusicXml();
@@ -34,8 +47,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -45,6 +60,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {
@@ -111,13 +130,17 @@ const xmlInput = document.getElementById("xmlInput");
         const writer = new MidiWriter.Writer(tracks);
         const built = writer.buildFile();
         lastMidiBytes = built instanceof Uint8Array ? built : Uint8Array.from(built || []);
+        lastSynthSchedule = buildSynthSchedule(result.meta.tempo, voiceIds, result.voiceTracksById, instrumentOverride);
 
         downloadBtn.disabled = lastMidiBytes.length === 0;
+        playBtn.disabled = !lastSynthSchedule || lastSynthSchedule.events.length === 0;
+        stopBtn.disabled = true;
         previewText.textContent = [
           "title: " + result.meta.title,
           "composer: " + result.meta.composer,
           "tempo: " + result.meta.tempo,
           "instrument override: " + instrumentOverrideLabel(instrumentOverride),
+          "synth waveform: " + normalizeWaveform(synthWaveformSelect.value),
           "meter: " + result.meta.meter.beats + "/" + result.meta.meter.beatType,
           "parts: " + result.meta.partCount,
           "voices: " + result.meta.voiceCount,
@@ -320,6 +343,7 @@ const xmlInput = document.getElementById("xmlInput");
                 const soundingPitch = midiNumberToMidiWriterPitch(soundingMidi);
                 voiceTracksById[trackId].events.push({
                   pitch: soundingPitch,
+                  midiNumber: soundingMidi,
                   ticks: event.ticks,
                   start: timelineTick + cursorTick
                 });
@@ -669,11 +693,48 @@ const xmlInput = document.getElementById("xmlInput");
       return Math.max(0, Math.min(127, Math.round(program)));
     }
 
+    function buildSynthSchedule(tempo, voiceIds, voiceTracksById, instrumentOverride) {
+      const events = [];
+      for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
+        const voiceId = voiceIds[trackIndex];
+        const voiceTrack = voiceTracksById[voiceId];
+        if (!voiceTrack || !Array.isArray(voiceTrack.events)) {
+          continue;
+        }
+        const channel = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
+        for (const event of voiceTrack.events) {
+          if (!event || !Number.isFinite(event.midiNumber) || !Number.isFinite(event.start) || !Number.isFinite(event.ticks)) {
+            continue;
+          }
+          events.push({
+            midiNumber: Math.max(0, Math.min(127, Math.round(event.midiNumber))),
+            start: Math.max(0, Math.round(event.start)),
+            ticks: Math.max(1, Math.round(event.ticks)),
+            channel
+          });
+        }
+      }
+      events.sort((a, b) => {
+        if (a.start !== b.start) {
+          return a.start - b.start;
+        }
+        return a.midiNumber - b.midiNumber;
+      });
+      return {
+        tempo: clampTempo(tempo),
+        events
+      };
+    }
+
     function resetOutput() {
+      stopMidi(false);
       lastMidiBytes = null;
+      lastSynthSchedule = null;
       previewText.textContent = "未変換";
       logOutput.textContent = "未変換";
       downloadBtn.disabled = true;
+      playBtn.disabled = true;
+      stopBtn.disabled = true;
     }
 
     function downloadMidi() {
@@ -684,6 +745,126 @@ const xmlInput = document.getElementById("xmlInput");
       const blob = new Blob([lastMidiBytes], { type: "audio/midi" });
       downloadBlob(blob, "score.mid");
       showToast("MIDIを保存しました。");
+    }
+
+    function playMidi() {
+      if (!lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        setError("先に変換してください。");
+        return;
+      }
+      const AudioContextCtor =
+        window.AudioContext ||
+        (window).webkitAudioContext;
+      if (!AudioContextCtor) {
+        setError("このブラウザはWebAudioに対応していません。");
+        return;
+      }
+
+      if (!audioContext) {
+        audioContext = new AudioContextCtor();
+      }
+
+      stopMidi(false);
+
+      audioContext.resume().then(() => {
+        startSynthPlayback();
+        clearError();
+        stopBtn.disabled = false;
+        showToast("内蔵シンセ再生を開始しました。");
+      }).catch((error) => {
+        stopBtn.disabled = true;
+        setError("内蔵シンセ再生に失敗しました: " + (error && error.message ? error.message : String(error)));
+      });
+    }
+
+    function startSynthPlayback() {
+      if (!audioContext || !lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        return;
+      }
+      const waveform = normalizeWaveform(synthWaveformSelect.value);
+      const secPerTick = 60 / (lastSynthSchedule.tempo * MIDI_TICKS_PER_QUARTER);
+      const baseTime = audioContext.currentTime + 0.04;
+      let latestEndTime = baseTime;
+
+      for (const event of lastSynthSchedule.events) {
+        const startAt = baseTime + (event.start * secPerTick);
+        const bodyDuration = Math.max(0.04, event.ticks * secPerTick);
+        const attack = 0.005;
+        const release = 0.03;
+        const endAt = startAt + bodyDuration;
+
+        const oscillator = audioContext.createOscillator();
+        oscillator.type = waveform;
+        oscillator.frequency.setValueAtTime(midiNumberToFrequency(event.midiNumber), startAt);
+
+        const gainNode = audioContext.createGain();
+        const gainLevel = event.channel === 10 ? 0.06 : 0.1;
+        gainNode.gain.setValueAtTime(0.0001, startAt);
+        gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        gainNode.gain.setValueAtTime(gainLevel, endAt);
+        gainNode.gain.linearRampToValueAtTime(0.0001, endAt + release);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.start(startAt);
+        oscillator.stop(endAt + release + 0.01);
+
+        oscillator.onended = () => {
+          try {
+            oscillator.disconnect();
+            gainNode.disconnect();
+          } catch (_error) {
+            // ignore cleanup failure
+          }
+        };
+        activeSynthNodes.push({ oscillator, gainNode });
+        latestEndTime = Math.max(latestEndTime, endAt + release + 0.02);
+      }
+
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+      }
+      const waitMs = Math.max(0, Math.ceil((latestEndTime - audioContext.currentTime) * 1000));
+      synthStopTimer = setTimeout(() => {
+        activeSynthNodes = [];
+        stopBtn.disabled = true;
+      }, waitMs);
+    }
+
+    function stopMidi(showMessage = true) {
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+        synthStopTimer = null;
+      }
+      for (const node of activeSynthNodes) {
+        try {
+          node.oscillator.stop();
+        } catch (_error) {
+          // ignore already-stopped nodes
+        }
+        try {
+          node.oscillator.disconnect();
+          node.gainNode.disconnect();
+        } catch (_error) {
+          // ignore disconnect error
+        }
+      }
+      activeSynthNodes = [];
+      stopBtn.disabled = true;
+      if (showMessage) {
+        showToast("内蔵シンセ再生を停止しました。");
+      }
+    }
+
+    function normalizeWaveform(value) {
+      if (value === "square" || value === "triangle") {
+        return value;
+      }
+      return "sine";
+    }
+
+    function midiNumberToFrequency(midiNumber) {
+      return 440 * Math.pow(2, (midiNumber - 69) / 12);
     }
 
     function setError(message) {
@@ -742,7 +923,8 @@ const xmlInput = document.getElementById("xmlInput");
         defaultTitle: defaultTitleInput.value,
         defaultComposer: defaultComposerInput.value,
         defaultTempo: defaultTempoInput.value,
-        instrumentOverride: instrumentOverrideSelect.value
+        instrumentOverride: instrumentOverrideSelect.value,
+        synthWaveform: synthWaveformSelect.value
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
@@ -766,6 +948,9 @@ const xmlInput = document.getElementById("xmlInput");
           }
           if (typeof data.instrumentOverride === "string") {
             instrumentOverrideSelect.value = data.instrumentOverride;
+          }
+          if (typeof data.synthWaveform === "string") {
+            synthWaveformSelect.value = normalizeWaveform(data.synthWaveform);
           }
         }
       } catch (_error) {

--- a/docs/music/src/musicxml-to-midi/ts/main.ts
+++ b/docs/music/src/musicxml-to-midi/ts/main.ts
@@ -1,11 +1,16 @@
 const xmlInput = document.getElementById("xmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
     const defaultTempoInput = document.getElementById("defaultTempoInput");
     const instrumentOverrideSelect = document.getElementById("instrumentOverrideSelect");
+    const synthWaveformSelect = document.getElementById("synthWaveformSelect");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
+    const playBtn = document.getElementById("playBtn");
+    const stopBtn = document.getElementById("stopBtn");
     const previewText = document.getElementById("previewText");
     const logOutput = document.getElementById("logOutput");
     const errorText = document.getElementById("errorText");
@@ -17,16 +22,24 @@ const xmlInput = document.getElementById("xmlInput");
     const MIDI_TICKS_PER_QUARTER = 128;
 
     let lastMidiBytes = null;
+    let lastSynthSchedule = null;
+    let audioContext = null;
+    let activeSynthNodes = [];
+    let synthStopTimer = null;
 
     restoreSettings();
 
     convertBtn.addEventListener("click", convertMusicXml);
     downloadBtn.addEventListener("click", downloadMidi);
+    playBtn.addEventListener("click", playMidi);
+    stopBtn.addEventListener("click", stopMidi);
     fileInput.addEventListener("change", loadXmlFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
     defaultTempoInput.addEventListener("change", persistSettings);
     instrumentOverrideSelect.addEventListener("change", persistSettings);
+    synthWaveformSelect.addEventListener("change", persistSettings);
     document.addEventListener("click", handleDocumentClick);
 
     convertMusicXml();
@@ -34,8 +47,10 @@ const xmlInput = document.getElementById("xmlInput");
     function loadXmlFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         xmlInput.value = String(reader.result || "");
@@ -45,6 +60,10 @@ const xmlInput = document.getElementById("xmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function convertMusicXml() {
@@ -111,13 +130,17 @@ const xmlInput = document.getElementById("xmlInput");
         const writer = new MidiWriter.Writer(tracks);
         const built = writer.buildFile();
         lastMidiBytes = built instanceof Uint8Array ? built : Uint8Array.from(built || []);
+        lastSynthSchedule = buildSynthSchedule(result.meta.tempo, voiceIds, result.voiceTracksById, instrumentOverride);
 
         downloadBtn.disabled = lastMidiBytes.length === 0;
+        playBtn.disabled = !lastSynthSchedule || lastSynthSchedule.events.length === 0;
+        stopBtn.disabled = true;
         previewText.textContent = [
           "title: " + result.meta.title,
           "composer: " + result.meta.composer,
           "tempo: " + result.meta.tempo,
           "instrument override: " + instrumentOverrideLabel(instrumentOverride),
+          "synth waveform: " + normalizeWaveform(synthWaveformSelect.value),
           "meter: " + result.meta.meter.beats + "/" + result.meta.meter.beatType,
           "parts: " + result.meta.partCount,
           "voices: " + result.meta.voiceCount,
@@ -320,6 +343,7 @@ const xmlInput = document.getElementById("xmlInput");
                 const soundingPitch = midiNumberToMidiWriterPitch(soundingMidi);
                 voiceTracksById[trackId].events.push({
                   pitch: soundingPitch,
+                  midiNumber: soundingMidi,
                   ticks: event.ticks,
                   start: timelineTick + cursorTick
                 });
@@ -669,11 +693,48 @@ const xmlInput = document.getElementById("xmlInput");
       return Math.max(0, Math.min(127, Math.round(program)));
     }
 
+    function buildSynthSchedule(tempo, voiceIds, voiceTracksById, instrumentOverride) {
+      const events = [];
+      for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
+        const voiceId = voiceIds[trackIndex];
+        const voiceTrack = voiceTracksById[voiceId];
+        if (!voiceTrack || !Array.isArray(voiceTrack.events)) {
+          continue;
+        }
+        const channel = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
+        for (const event of voiceTrack.events) {
+          if (!event || !Number.isFinite(event.midiNumber) || !Number.isFinite(event.start) || !Number.isFinite(event.ticks)) {
+            continue;
+          }
+          events.push({
+            midiNumber: Math.max(0, Math.min(127, Math.round(event.midiNumber))),
+            start: Math.max(0, Math.round(event.start)),
+            ticks: Math.max(1, Math.round(event.ticks)),
+            channel
+          });
+        }
+      }
+      events.sort((a, b) => {
+        if (a.start !== b.start) {
+          return a.start - b.start;
+        }
+        return a.midiNumber - b.midiNumber;
+      });
+      return {
+        tempo: clampTempo(tempo),
+        events
+      };
+    }
+
     function resetOutput() {
+      stopMidi(false);
       lastMidiBytes = null;
+      lastSynthSchedule = null;
       previewText.textContent = "未変換";
       logOutput.textContent = "未変換";
       downloadBtn.disabled = true;
+      playBtn.disabled = true;
+      stopBtn.disabled = true;
     }
 
     function downloadMidi() {
@@ -684,6 +745,126 @@ const xmlInput = document.getElementById("xmlInput");
       const blob = new Blob([lastMidiBytes], { type: "audio/midi" });
       downloadBlob(blob, "score.mid");
       showToast("MIDIを保存しました。");
+    }
+
+    function playMidi() {
+      if (!lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        setError("先に変換してください。");
+        return;
+      }
+      const AudioContextCtor =
+        window.AudioContext ||
+        (window).webkitAudioContext;
+      if (!AudioContextCtor) {
+        setError("このブラウザはWebAudioに対応していません。");
+        return;
+      }
+
+      if (!audioContext) {
+        audioContext = new AudioContextCtor();
+      }
+
+      stopMidi(false);
+
+      audioContext.resume().then(() => {
+        startSynthPlayback();
+        clearError();
+        stopBtn.disabled = false;
+        showToast("内蔵シンセ再生を開始しました。");
+      }).catch((error) => {
+        stopBtn.disabled = true;
+        setError("内蔵シンセ再生に失敗しました: " + (error && error.message ? error.message : String(error)));
+      });
+    }
+
+    function startSynthPlayback() {
+      if (!audioContext || !lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+        return;
+      }
+      const waveform = normalizeWaveform(synthWaveformSelect.value);
+      const secPerTick = 60 / (lastSynthSchedule.tempo * MIDI_TICKS_PER_QUARTER);
+      const baseTime = audioContext.currentTime + 0.04;
+      let latestEndTime = baseTime;
+
+      for (const event of lastSynthSchedule.events) {
+        const startAt = baseTime + (event.start * secPerTick);
+        const bodyDuration = Math.max(0.04, event.ticks * secPerTick);
+        const attack = 0.005;
+        const release = 0.03;
+        const endAt = startAt + bodyDuration;
+
+        const oscillator = audioContext.createOscillator();
+        oscillator.type = waveform;
+        oscillator.frequency.setValueAtTime(midiNumberToFrequency(event.midiNumber), startAt);
+
+        const gainNode = audioContext.createGain();
+        const gainLevel = event.channel === 10 ? 0.06 : 0.1;
+        gainNode.gain.setValueAtTime(0.0001, startAt);
+        gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+        gainNode.gain.setValueAtTime(gainLevel, endAt);
+        gainNode.gain.linearRampToValueAtTime(0.0001, endAt + release);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.start(startAt);
+        oscillator.stop(endAt + release + 0.01);
+
+        oscillator.onended = () => {
+          try {
+            oscillator.disconnect();
+            gainNode.disconnect();
+          } catch (_error) {
+            // ignore cleanup failure
+          }
+        };
+        activeSynthNodes.push({ oscillator, gainNode });
+        latestEndTime = Math.max(latestEndTime, endAt + release + 0.02);
+      }
+
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+      }
+      const waitMs = Math.max(0, Math.ceil((latestEndTime - audioContext.currentTime) * 1000));
+      synthStopTimer = setTimeout(() => {
+        activeSynthNodes = [];
+        stopBtn.disabled = true;
+      }, waitMs);
+    }
+
+    function stopMidi(showMessage = true) {
+      if (synthStopTimer) {
+        clearTimeout(synthStopTimer);
+        synthStopTimer = null;
+      }
+      for (const node of activeSynthNodes) {
+        try {
+          node.oscillator.stop();
+        } catch (_error) {
+          // ignore already-stopped nodes
+        }
+        try {
+          node.oscillator.disconnect();
+          node.gainNode.disconnect();
+        } catch (_error) {
+          // ignore disconnect error
+        }
+      }
+      activeSynthNodes = [];
+      stopBtn.disabled = true;
+      if (showMessage) {
+        showToast("内蔵シンセ再生を停止しました。");
+      }
+    }
+
+    function normalizeWaveform(value) {
+      if (value === "square" || value === "triangle") {
+        return value;
+      }
+      return "sine";
+    }
+
+    function midiNumberToFrequency(midiNumber) {
+      return 440 * Math.pow(2, (midiNumber - 69) / 12);
     }
 
     function setError(message) {
@@ -742,7 +923,8 @@ const xmlInput = document.getElementById("xmlInput");
         defaultTitle: defaultTitleInput.value,
         defaultComposer: defaultComposerInput.value,
         defaultTempo: defaultTempoInput.value,
-        instrumentOverride: instrumentOverrideSelect.value
+        instrumentOverride: instrumentOverrideSelect.value,
+        synthWaveform: synthWaveformSelect.value
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
@@ -766,6 +948,9 @@ const xmlInput = document.getElementById("xmlInput");
           }
           if (typeof data.instrumentOverride === "string") {
             instrumentOverrideSelect.value = data.instrumentOverride;
+          }
+          if (typeof data.synthWaveform === "string") {
+            synthWaveformSelect.value = normalizeWaveform(data.synthWaveform);
           }
         }
       } catch (_error) {

--- a/docs/music/src/musicxml-to-svg/js/main.js
+++ b/docs/music/src/musicxml-to-svg/js/main.js
@@ -1,5 +1,7 @@
 const musicxmlInput = document.getElementById("musicxmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
     const marginTopInput = document.getElementById("marginTopInput");
@@ -37,6 +39,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     nextPageBtn.addEventListener("click", showNextPage);
     copySvgBtn.addEventListener("click", copySvg);
     fileInput.addEventListener("change", loadMusicXMLFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     document.addEventListener("click", handleDocumentClick);
 
     [
@@ -85,8 +88,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     function loadMusicXMLFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         musicxmlInput.value = String(reader.result || "");
@@ -96,6 +101,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function renderMusicXML() {

--- a/docs/music/src/musicxml-to-svg/ts/main.ts
+++ b/docs/music/src/musicxml-to-svg/ts/main.ts
@@ -1,5 +1,7 @@
 const musicxmlInput = document.getElementById("musicxmlInput");
     const fileInput = document.getElementById("fileInput");
+    const fileSelectBtn = document.getElementById("fileSelectBtn");
+    const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
     const marginTopInput = document.getElementById("marginTopInput");
@@ -37,6 +39,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     nextPageBtn.addEventListener("click", showNextPage);
     copySvgBtn.addEventListener("click", copySvg);
     fileInput.addEventListener("change", loadMusicXMLFile);
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
     document.addEventListener("click", handleDocumentClick);
 
     [
@@ -85,8 +88,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     function loadMusicXMLFile(event) {
       const file = event.target.files && event.target.files[0];
       if (!file) {
+        updateFileName("");
         return;
       }
+      updateFileName(file.name);
       const reader = new FileReader();
       reader.onload = () => {
         musicxmlInput.value = String(reader.result || "");
@@ -96,6 +101,10 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("ファイルの読み込みに失敗しました。");
       };
       reader.readAsText(file, "utf-8");
+    }
+
+    function updateFileName(name) {
+      fileNameText.textContent = name || "未選択";
     }
 
     function renderMusicXML() {


### PR DESCRIPTION
## 概要

Musicディレクトリの各ツールを中心に、UI/操作性の改善と `MusicXML → MIDI` の再生機能強化を行いました。 あわせてトップページのカテゴリ並び順を見直し、`Music` セクションを `Git` の直後に移動しました。

## 主な変更

### 1. `MusicXML → MIDI` の再生方式を強化
- `audio/midi` 依存の再生から、WebAudioベースの内蔵シンセ再生へ変更
- 再生/停止ボタンを追加し、ブラウザ内での再生制御を実装
- 波形選択（`sine` / `square` / `triangle`）を追加
- 再生用にイベントスケジュールを生成し、音高（MIDIノート）をもとに発音
- `localStorage` に波形設定を保存・復元

対象:
- `docs/music/src/musicxml-to-midi/ts/main.ts`
- `docs/music/src/musicxml-to-midi/js/main.js`
- `docs/music/musicxml-to-midi-src.html`
- `docs/music/musicxml-to-midi.html`

### 2. Music系ツールのファイル入力UX改善
- `<input type="file">` 直表示から、`ファイルを選択` ボタン + 選択ファイル名表示へ変更
- ファイル未選択時は `未選択` を表示

対象:
- `docs/music/src/abc-to-musicxml/ts/main.ts`
- `docs/music/src/musicxml-to-abc/ts/main.ts`
- `docs/music/src/musicxml-to-svg/ts/main.ts`
- 各対応 `js` / `*-src.html` / 生成 `*.html`

### 3. ボタンの視認性向上（SVGアイコン追加）
`MusicXML → MIDI` 画面の主要操作ボタンにSVGアイコンを追加
- ファイル選択（folder_open系）
- 変換
- MIDI保存
- 再生
- 停止

対象:
- `docs/music/musicxml-to-midi-src.html`
- `docs/music/musicxml-to-midi.html`

### 4. トップページのカテゴリ順見直し
- `docs/index.html` のセクション順を変更し、`Music` を `Git` の次へ移動

## 変更ファイル数 / 差分規模

- 17 files changed
- 856 insertions, 66 deletions

## 動作確認

- `npm run build:music` 実行済み
- `docs/music/*.html` 生成更新済み

## 補足

- `typecheck:music` はローカル環境で `tsc` 未導入のため未実行