### PR TITLE
Music変換の安定化: MusicXML⇄ABCの移調/調号処理改善とABCパーサ拡張（tie・broken rhythm・M:C・x休…

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ URL加工系ツールです。
 楽譜変換系ツールです。
 
 - **musicxml-to-svg.html**: MusicXMLから楽譜SVGを生成し、SVGを保存します。
-- **abc-to-musicxml.html**: ABC記法をMusicXMLへ変換し、MusicXMLを保存します。
 - **musicxml-to-abc.html**: MusicXMLをABC記法へ変換し、ABCを保存します。
+- **abc-to-musicxml.html**: ABC記法をMusicXMLへ変換し、MusicXMLを保存します。
 - **musicxml-to-midi.html**: MusicXMLをMIDIへ変換し、.midを保存します。
 
 ## text

--- a/docs/index.html
+++ b/docs/index.html
@@ -1140,15 +1140,6 @@
           </div>
           <p class="md-card-desc">MusicXMLからMIDIを生成し、.midとして保存できます。</p>
         </a>
-        <a href="music/abc-to-musicxml.html" class="md-link-card">
-          <div class="md-card-head">
-            <h3 class="md-card-title">
-              <span aria-hidden="true" class="md-icon-inline">🎵</span>ABC → MusicXML 変換
-            </h3>
-            <span class="md-card-arrow">→</span>
-          </div>
-          <p class="md-card-desc">ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。</p>
-        </a>
         <a href="music/musicxml-to-abc.html" class="md-link-card">
           <div class="md-card-head">
             <h3 class="md-card-title">
@@ -1157,6 +1148,15 @@
             <span class="md-card-arrow">→</span>
           </div>
           <p class="md-card-desc">MusicXMLからABC記法を生成し、ABCとして保存できます。</p>
+        </a>
+        <a href="music/abc-to-musicxml.html" class="md-link-card">
+          <div class="md-card-head">
+            <h3 class="md-card-title">
+              <span aria-hidden="true" class="md-icon-inline">🎵</span>ABC → MusicXML 変換
+            </h3>
+            <span class="md-card-arrow">→</span>
+          </div>
+          <p class="md-card-desc">ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。</p>
         </a>
       </div>
       </section>

--- a/docs/music/abc-to-musicxml-src.html
+++ b/docs/music/abc-to-musicxml-src.html
@@ -140,6 +140,12 @@ C D E F | G A B c |</textarea>
               <label class="md-label" for="defaultComposerInput">既定作曲者</label>
               <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
             </div>
+            <div class="md-grid-full">
+              <label class="md-check-option" for="inferTransposeFromPartNameCheckbox">
+                <input id="inferTransposeFromPartNameCheckbox" type="checkbox" checked />
+                <span>パート名の "in A / in Bb" から移調を推定する</span>
+              </label>
+            </div>
           </div>
         </details>
 

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -162,6 +162,18 @@ limitations under the License.
       margin-top: 0.8rem;
     }
 
+    .md-grid-full {
+      grid-column: 1 / -1;
+    }
+
+    .md-check-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
     .md-disclosure {
       margin-bottom: 0.8rem;
       border: 1px solid #e5e0ec;
@@ -536,6 +548,12 @@ C D E F | G A B c |</textarea>
             <div>
               <label class="md-label" for="defaultComposerInput">既定作曲者</label>
               <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
+            </div>
+            <div class="md-grid-full">
+              <label class="md-check-option" for="inferTransposeFromPartNameCheckbox">
+                <input id="inferTransposeFromPartNameCheckbox" type="checkbox" checked />
+                <span>パート名の "in A / in Bb" から移調を推定する</span>
+              </label>
             </div>
           </div>
         </details>
@@ -1273,6 +1291,22 @@ const MusicXmlWriterCommon = (() => {
           if (!note.isRest && note.accidentalText) {
             lines.push('        <accidental>' + note.accidentalText + '</accidental>');
           }
+          if (!note.isRest && note.tieStart) {
+            lines.push("        <tie type=\"start\"/>");
+          }
+          if (!note.isRest && note.tieStop) {
+            lines.push("        <tie type=\"stop\"/>");
+          }
+          if (!note.isRest && (note.tieStart || note.tieStop)) {
+            lines.push("        <notations>");
+            if (note.tieStart) {
+              lines.push("          <tied type=\"start\"/>");
+            }
+            if (note.tieStop) {
+              lines.push("          <tied type=\"stop\"/>");
+            }
+            lines.push("        </notations>");
+          }
           lines.push('      </note>');
         }
 
@@ -1353,6 +1387,7 @@ const abcInput = document.getElementById("abcInput");
     const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
+    const inferTransposeFromPartNameCheckbox = document.getElementById("inferTransposeFromPartNameCheckbox");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
     const playSineBtn = document.getElementById("playSineBtn");
@@ -1385,6 +1420,10 @@ const abcInput = document.getElementById("abcInput");
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
+    inferTransposeFromPartNameCheckbox.addEventListener("change", () => {
+      persistSettings();
+      convertAbc();
+    });
     document.addEventListener("click", handleDocumentClick);
 
     applyInputMode();
@@ -1438,7 +1477,8 @@ const abcInput = document.getElementById("abcInput");
       try {
         const result = parseAbc(source, {
           defaultTitle: defaultTitleInput.value.trim() || "Untitled",
-          defaultComposer: defaultComposerInput.value.trim() || "Unknown"
+          defaultComposer: defaultComposerInput.value.trim() || "Unknown",
+          inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
         });
 
         const xml = musicXmlWriterCommon.buildScorePartwiseXml(result);
@@ -1551,6 +1591,7 @@ const abcInput = document.getElementById("abcInput");
       const meter = parseMeter(headers.M || "4/4", warnings);
       const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
       const keyInfo = parseKey(headers.K || "C", warnings);
+      const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
       const measuresByVoice = {};
       let noteCount = 0;
 
@@ -1564,6 +1605,10 @@ const abcInput = document.getElementById("abcInput");
       for (const entry of bodyEntries) {
         const measures = ensureVoice(entry.voiceId);
         let currentMeasure = measures[measures.length - 1];
+        let measureAccidentals = {};
+        let lastNote = null;
+        let pendingTieToNext = false;
+        let pendingRhythmScale = null;
         let idx = 0;
         const text = entry.text;
 
@@ -1575,16 +1620,54 @@ const abcInput = document.getElementById("abcInput");
             continue;
           }
 
+          if (ch === ">" || ch === "<") {
+            if (!lastNote || lastNote.isRest) {
+              warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+              idx += 1;
+              continue;
+            }
+            const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
+            pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
+            lastNote.duration = Math.max(1, Math.round(lastNote.duration * (lastScale.num / lastScale.den)));
+            lastNote.type = typeFromDuration(lastNote.duration, 960);
+            idx += 1;
+            continue;
+          }
+
           if (ch === "|") {
             if (currentMeasure.length > 0 || measures.length === 0) {
               currentMeasure = [];
               measures.push(currentMeasure);
             }
+            measureAccidentals = {};
+            lastNote = null;
             idx += 1;
             continue;
           }
 
-          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === "\"" || ch === ":") {
+          if (ch === "-") {
+            if (lastNote && !lastNote.isRest) {
+              lastNote.tieStart = true;
+              pendingTieToNext = true;
+            } else {
+              warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+            }
+            idx += 1;
+            continue;
+          }
+
+          if (ch === "\"" ) {
+            const endQuote = text.indexOf("\"", idx + 1);
+            if (endQuote >= 0) {
+              idx = endQuote + 1;
+            } else {
+              idx = text.length;
+            }
+            warnings.push("line " + entry.lineNo + ': インライン文字列(\"...\")はスキップしました。');
+            continue;
+          }
+
+          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === ":") {
             warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
             idx += 1;
             continue;
@@ -1597,7 +1680,7 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const pitchChar = text[idx];
-          if (!pitchChar || !/[A-Ga-gzZ]/.test(pitchChar)) {
+          if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
             throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
           }
           idx += 1;
@@ -1616,15 +1699,49 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const len = parseLengthToken(lengthToken, entry.lineNo);
-          const absoluteLength = multiplyFractions(unitLength, len);
+          let absoluteLength = multiplyFractions(unitLength, len);
+          if (pendingRhythmScale) {
+            absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+            pendingRhythmScale = null;
+          }
+
+          if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
+            const rhythmChar = text[idx];
+            idx += 1;
+            if (rhythmChar === ">") {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
+              pendingRhythmScale = { num: 1, den: 2 };
+            } else {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
+              pendingRhythmScale = { num: 3, den: 2 };
+            }
+          }
+
           const dur = durationInDivisions(absoluteLength, 960);
           if (dur <= 0) {
             throw new Error("line " + entry.lineNo + ": 長さが不正です");
           }
 
-          const note = buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, dur, entry.lineNo);
+          const note = buildNoteData(
+            pitchChar,
+            accidental,
+            octaveShift,
+            absoluteLength,
+            dur,
+            entry.lineNo,
+            keySignatureAccidentals,
+            measureAccidentals
+          );
+          if (pendingTieToNext && !note.isRest) {
+            note.tieStop = true;
+            pendingTieToNext = false;
+          } else if (note.isRest && pendingTieToNext) {
+            warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+            pendingTieToNext = false;
+          }
           note.voice = entry.voiceId;
           currentMeasure.push(note);
+          lastNote = note;
           noteCount += 1;
         }
       }
@@ -1646,7 +1763,7 @@ const abcInput = document.getElementById("abcInput");
         return {
           partId: "P" + String(index + 1),
           partName,
-          transpose: inferTransposeFromPartName(partName),
+          transpose: settings.inferTransposeFromPartName ? inferTransposeFromPartName(partName) : null,
           voiceId,
           measures: measuresByVoice[voiceId] || [[]]
         };
@@ -1768,7 +1885,14 @@ const abcInput = document.getElementById("abcInput");
     }
 
     function parseMeter(raw, warnings) {
-      const m = raw.match(/^(\d+)\/(\d+)$/);
+      const normalized = String(raw || "").trim();
+      if (normalized === "C") {
+        return { beats: 4, beatType: 4 };
+      }
+      if (normalized === "C|") {
+        return { beats: 2, beatType: 2 };
+      }
+      const m = normalized.match(/^(\d+)\/(\d+)$/);
       if (!m) {
         warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
         return { beats: 4, beatType: 4 };
@@ -1805,8 +1929,17 @@ const abcInput = document.getElementById("abcInput");
       return abcCommon.parseAbcLengthToken(token, lineNo);
     }
 
-    function buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, duration, lineNo) {
-      const isRest = /[zZ]/.test(pitchChar);
+    function buildNoteData(
+      pitchChar,
+      accidental,
+      octaveShift,
+      absoluteLength,
+      duration,
+      lineNo,
+      keySignatureAccidentals,
+      measureAccidentals
+    ) {
+      const isRest = /[zZxX]/.test(pitchChar);
       if (isRest) {
         return {
           isRest: true,
@@ -1836,12 +1969,23 @@ const abcInput = document.getElementById("abcInput");
       if (accidental === "^") {
         alter = 1;
         accidentalText = "sharp";
+        measureAccidentals[step] = 1;
       } else if (accidental === "_") {
         alter = -1;
         accidentalText = "flat";
+        measureAccidentals[step] = -1;
       } else if (accidental === "=") {
         alter = 0;
         accidentalText = "natural";
+        measureAccidentals[step] = 0;
+      } else {
+        let resolvedAlter = 0;
+        if (Object.prototype.hasOwnProperty.call(measureAccidentals, step)) {
+          resolvedAlter = measureAccidentals[step];
+        } else if (Object.prototype.hasOwnProperty.call(keySignatureAccidentals, step)) {
+          resolvedAlter = keySignatureAccidentals[step];
+        }
+        alter = resolvedAlter === 0 ? null : resolvedAlter;
       }
 
       return {
@@ -1853,6 +1997,23 @@ const abcInput = document.getElementById("abcInput");
         duration,
         type: typeFromFraction(absoluteLength)
       };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
 
@@ -1878,6 +2039,26 @@ const abcInput = document.getElementById("abcInput");
 
     function durationInDivisions(wholeFraction, divisionsPerQuarter) {
       return Math.round((wholeFraction.num / wholeFraction.den) * 4 * divisionsPerQuarter);
+    }
+
+    function typeFromDuration(duration, divisionsPerQuarter) {
+      const whole = Number(duration) / (4 * divisionsPerQuarter);
+      if (whole >= 1) {
+        return "whole";
+      }
+      if (whole >= 0.5) {
+        return "half";
+      }
+      if (whole >= 0.25) {
+        return "quarter";
+      }
+      if (whole >= 0.125) {
+        return "eighth";
+      }
+      if (whole >= 0.0625) {
+        return "16th";
+      }
+      return "32nd";
     }
 
     function multiplyFractions(a, b) {
@@ -2052,12 +2233,14 @@ const abcInput = document.getElementById("abcInput");
     function persistSettings() {
       const payload = {
         defaultTitle: defaultTitleInput.value,
-        defaultComposer: defaultComposerInput.value
+        defaultComposer: defaultComposerInput.value,
+        inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
 
     function restoreSettings() {
+      inferTransposeFromPartNameCheckbox.checked = true;
       const raw = localStorage.getItem(SETTINGS_KEY);
       if (!raw) {
         return;
@@ -2071,9 +2254,13 @@ const abcInput = document.getElementById("abcInput");
           if (typeof data.defaultComposer === "string") {
             defaultComposerInput.value = data.defaultComposer;
           }
+          if (typeof data.inferTransposeFromPartName === "boolean") {
+            inferTransposeFromPartNameCheckbox.checked = data.inferTransposeFromPartName;
+          }
         }
       } catch (_error) {
         // ignore broken localStorage
+        inferTransposeFromPartNameCheckbox.checked = true;
       }
     }
   </script>

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -164,6 +164,18 @@ limitations under the License.
       margin-top: 0.8rem;
     }
 
+    .md-grid-full {
+      grid-column: 1 / -1;
+    }
+
+    .md-check-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
     .md-disclosure {
       margin-bottom: 0.8rem;
       border: 1px solid #e5e0ec;
@@ -1372,6 +1384,7 @@ const xmlInput = document.getElementById("xmlInput");
       let divisions = 1;
       let meter = { beats: 4, beatType: 4 };
       let key = "C";
+      let keyFifths = 0;
       let noteCount = 0;
       const voices = [];
 
@@ -1384,7 +1397,12 @@ const xmlInput = document.getElementById("xmlInput");
         const part = partNodes[partIndex];
         const partId = part.getAttribute("id") || ("P" + String(partIndex + 1));
         const voiceId = "V" + String(partIndex + 1);
-        const partName = partNameById[partId] || partId;
+        const originalPartName = partNameById[partId] || partId;
+        let partName = originalPartName;
+        let currentTransposeSemitones = 0;
+        let currentWrittenFifths = 0;
+        let currentWrittenMode = "major";
+        let partTransposeApplied = false;
         const measures = [];
 
         const measureNodes = Array.from(part.children).filter((node) => node.nodeType === 1 && node.nodeName === "measure");
@@ -1405,6 +1423,22 @@ const xmlInput = document.getElementById("xmlInput");
               }
             }
 
+            let shouldRecalculateKey = false;
+            const transposeNode = attrNode.querySelector(":scope > transpose");
+            if (transposeNode) {
+              const chromaticText = getChildText(transposeNode, "chromatic");
+              const octaveChangeText = getChildText(transposeNode, "octave-change");
+              const chromatic = chromaticText ? Number.parseInt(chromaticText, 10) : 0;
+              const octaveChange = octaveChangeText ? Number.parseInt(octaveChangeText, 10) : 0;
+              currentTransposeSemitones =
+                (Number.isFinite(chromatic) ? chromatic : 0) +
+                ((Number.isFinite(octaveChange) ? octaveChange : 0) * 12);
+              if (currentTransposeSemitones !== 0) {
+                partTransposeApplied = true;
+              }
+              shouldRecalculateKey = true;
+            }
+
             const beatsText = getChildText(attrNode.querySelector("time"), "beats");
             const beatTypeText = getChildText(attrNode.querySelector("time"), "beat-type");
             if (beatsText && beatTypeText) {
@@ -1420,17 +1454,35 @@ const xmlInput = document.getElementById("xmlInput");
             if (fifthsText !== "") {
               const fifthsVal = Number.parseInt(fifthsText, 10);
               if (Number.isFinite(fifthsVal)) {
-                key = keyFromFifths(fifthsVal, modeText);
+                currentWrittenFifths = fifthsVal;
+                currentWrittenMode = modeText;
+                shouldRecalculateKey = true;
               }
+            }
+
+            if (shouldRecalculateKey) {
+              const transposed = transposeKeyFromFifthsMode(currentWrittenFifths, currentWrittenMode, currentTransposeSemitones);
+              key = transposed.keyText;
+              keyFifths = transposed.fifths;
             }
           }
 
           const tokens = [];
+          const measureAccidentals = {};
 
           for (const child of Array.from(measureNode.children)) {
             const name = child.nodeName;
             if (name === "note") {
-              const noteToken = noteToAbc(child, divisions, settings.defaultLength, warnings, measureNo);
+              const noteToken = noteToAbc(
+                child,
+                divisions,
+                settings.defaultLength,
+                warnings,
+                measureNo,
+                currentTransposeSemitones,
+                keyFifths,
+                measureAccidentals
+              );
               if (noteToken.skipped) {
                 if (noteToken.reason === "chord" && !warnedChord) {
                   warnings.push("和音（<chord/>）は先頭音のみ扱います。");
@@ -1467,7 +1519,7 @@ const xmlInput = document.getElementById("xmlInput");
 
         voices.push({
           id: voiceId,
-          name: partName,
+          name: normalizePartNameForAbc(partName, partTransposeApplied),
           measures
         });
       }
@@ -1515,7 +1567,7 @@ const xmlInput = document.getElementById("xmlInput");
       };
     }
 
-    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo) {
+    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo, transposeSemitones, keyFifths, measureAccidentals) {
       if (noteNode.querySelector(":scope > grace")) {
         warnings.push("measure " + measureNo + ": grace note はスキップしました。");
         return { skipped: true, reason: "grace" };
@@ -1561,24 +1613,215 @@ const xmlInput = document.getElementById("xmlInput");
 
       const alterText = getChildText(noteNode.querySelector(":scope > pitch"), "alter");
       const alter = alterText === "" ? 0 : Number.parseInt(alterText, 10);
-      const accidental = abcCommon.accidentalFromAlter(Number.isFinite(alter) ? alter : 0);
+      const baseAlter = Number.isFinite(alter) ? alter : 0;
+      const midiNumber = stepAlterOctaveToMidiNumber(step, baseAlter, octave) + (Number.isFinite(transposeSemitones) ? transposeSemitones : 0);
+      if (midiNumber < 0 || midiNumber > 127) {
+        warnings.push("measure " + measureNo + ": 移調後に音域外となる note をスキップしました。");
+        return { skipped: true, reason: "transpose-range" };
+      }
+      const transposed = midiNumberToStepAlterOctave(midiNumber, keyFifths < 0);
+      const outStep = transposed.step;
+      const outOctave = transposed.octave;
+      const outAlter = transposed.alter;
+
+      const keySignature = keySignatureAlterByStep(keyFifths);
+      const measureDefaultAlter = Object.prototype.hasOwnProperty.call(measureAccidentals, outStep)
+        ? measureAccidentals[outStep]
+        : (Object.prototype.hasOwnProperty.call(keySignature, outStep) ? keySignature[outStep] : 0);
+
+      let accidental = "";
+      if (outAlter !== measureDefaultAlter) {
+        accidental = outAlter === 0 ? "=" : abcCommon.accidentalFromAlter(outAlter);
+      }
+      measureAccidentals[outStep] = outAlter;
+      const pitchText = abcCommon.abcPitchFromStepOctave(outStep, outOctave);
 
       if (noteNode.querySelector(":scope > tie") || noteNode.querySelector(":scope > notations > tied")) {
         return {
           skipped: false,
           reason: "tie",
-          token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+          token: accidental + pitchText + lengthToken
         };
       }
 
       return {
         skipped: false,
-        token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+        token: accidental + pitchText + lengthToken
       };
     }
 
     function keyFromFifths(fifths, mode) {
       return abcCommon.keyFromFifthsMode(fifths, mode);
+    }
+
+    function transposeKeyFromFifthsMode(fifths, mode, transposeSemitones) {
+      const normalizedMode = normalizeModeName(mode);
+      const modeOffset = modeDegreeOffset(normalizedMode);
+      const tonicPc = mod12((fifths * 7) + modeOffset);
+      const transposedPc = mod12(tonicPc + transposeSemitones);
+      const preferFlats = fifths < 0;
+      const keyText = abcKeyFromPitchClassMode(transposedPc, normalizedMode, preferFlats);
+      return {
+        keyText,
+        fifths: fifthsFromPitchClassMode(transposedPc, normalizedMode)
+      };
+    }
+
+    function normalizeModeName(mode) {
+      const normalized = String(mode || "major").trim().toLowerCase();
+      if (normalized === "minor") {
+        return "aeolian";
+      }
+      if (normalized === "major") {
+        return "ionian";
+      }
+      return normalized;
+    }
+
+    function modeDegreeOffset(mode) {
+      switch (mode) {
+        case "ionian":
+          return 0;
+        case "dorian":
+          return 2;
+        case "phrygian":
+          return 4;
+        case "lydian":
+          return 5;
+        case "mixolydian":
+          return 7;
+        case "aeolian":
+          return 9;
+        case "locrian":
+          return 11;
+        default:
+          return 0;
+      }
+    }
+
+    function modeSuffix(mode) {
+      switch (mode) {
+        case "aeolian":
+          return "m";
+        case "dorian":
+          return "dor";
+        case "phrygian":
+          return "phr";
+        case "lydian":
+          return "lyd";
+        case "mixolydian":
+          return "mix";
+        case "locrian":
+          return "loc";
+        case "ionian":
+        default:
+          return "";
+      }
+    }
+
+    function abcKeyFromPitchClassMode(pitchClass, mode, preferFlats) {
+      const namesSharp = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+      const namesFlat = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+      const tonic = (preferFlats ? namesFlat : namesSharp)[mod12(pitchClass)];
+      return tonic + modeSuffix(mode);
+    }
+
+    function fifthsFromPitchClassMode(pitchClass, mode) {
+      const offset = modeDegreeOffset(mode);
+      let best = 0;
+      let bestAbs = Number.POSITIVE_INFINITY;
+      for (let f = -7; f <= 7; f += 1) {
+        if (mod12((f * 7) + offset) !== mod12(pitchClass)) {
+          continue;
+        }
+        const abs = Math.abs(f);
+        if (abs < bestAbs) {
+          bestAbs = abs;
+          best = f;
+        }
+      }
+      return Number.isFinite(bestAbs) ? best : 0;
+    }
+
+    function mod12(value) {
+      const m = Number(value) % 12;
+      return m < 0 ? m + 12 : m;
+    }
+
+    function stepAlterOctaveToMidiNumber(step, alter, octave) {
+      const base = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11
+      };
+      const s = String(step || "").toUpperCase();
+      if (!Object.prototype.hasOwnProperty.call(base, s)) {
+        return 60;
+      }
+      const semitone = base[s] + alter;
+      return (octave + 1) * 12 + semitone;
+    }
+
+    function midiNumberToStepAlterOctave(midiNumber, preferFlats) {
+      const normalized = Math.round(midiNumber);
+      const octave = Math.floor(normalized / 12) - 1;
+      const pitchClass = mod12(normalized);
+      const sharpMap = [
+        { step: "C", alter: 0 },
+        { step: "C", alter: 1 },
+        { step: "D", alter: 0 },
+        { step: "D", alter: 1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "F", alter: 1 },
+        { step: "G", alter: 0 },
+        { step: "G", alter: 1 },
+        { step: "A", alter: 0 },
+        { step: "A", alter: 1 },
+        { step: "B", alter: 0 }
+      ];
+      const flatMap = [
+        { step: "C", alter: 0 },
+        { step: "D", alter: -1 },
+        { step: "D", alter: 0 },
+        { step: "E", alter: -1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "G", alter: -1 },
+        { step: "G", alter: 0 },
+        { step: "A", alter: -1 },
+        { step: "A", alter: 0 },
+        { step: "B", alter: -1 },
+        { step: "B", alter: 0 }
+      ];
+      const mapping = preferFlats ? flatMap : sharpMap;
+      const pitch = mapping[pitchClass];
+      return {
+        step: pitch.step,
+        alter: pitch.alter,
+        octave
+      };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
     function getChildText(parent, tagName) {
@@ -1599,6 +1842,17 @@ const xmlInput = document.getElementById("xmlInput");
 
     function escapeAbcText(text) {
       return String(text || "").replace(/"/g, "'");
+    }
+
+    function normalizePartNameForAbc(partName, transposeApplied) {
+      const name = String(partName || "").trim();
+      if (!transposeApplied || !name) {
+        return name;
+      }
+      return name
+        .replace(/\s+in\s+[A-Ga-g](?:[#b]|♯|♭)?\b/g, "")
+        .replace(/\s{2,}/g, " ")
+        .trim();
     }
 
     function buildPartNameMap(root) {

--- a/docs/music/src/abc-to-musicxml/css/app.css
+++ b/docs/music/src/abc-to-musicxml/css/app.css
@@ -139,6 +139,18 @@
       margin-top: 0.8rem;
     }
 
+    .md-grid-full {
+      grid-column: 1 / -1;
+    }
+
+    .md-check-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
     .md-disclosure {
       margin-bottom: 0.8rem;
       border: 1px solid #e5e0ec;

--- a/docs/music/src/abc-to-musicxml/js/main.js
+++ b/docs/music/src/abc-to-musicxml/js/main.js
@@ -29,6 +29,7 @@ const abcInput = document.getElementById("abcInput");
     const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
+    const inferTransposeFromPartNameCheckbox = document.getElementById("inferTransposeFromPartNameCheckbox");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
     const playSineBtn = document.getElementById("playSineBtn");
@@ -61,6 +62,10 @@ const abcInput = document.getElementById("abcInput");
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
+    inferTransposeFromPartNameCheckbox.addEventListener("change", () => {
+      persistSettings();
+      convertAbc();
+    });
     document.addEventListener("click", handleDocumentClick);
 
     applyInputMode();
@@ -114,7 +119,8 @@ const abcInput = document.getElementById("abcInput");
       try {
         const result = parseAbc(source, {
           defaultTitle: defaultTitleInput.value.trim() || "Untitled",
-          defaultComposer: defaultComposerInput.value.trim() || "Unknown"
+          defaultComposer: defaultComposerInput.value.trim() || "Unknown",
+          inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
         });
 
         const xml = musicXmlWriterCommon.buildScorePartwiseXml(result);
@@ -227,6 +233,7 @@ const abcInput = document.getElementById("abcInput");
       const meter = parseMeter(headers.M || "4/4", warnings);
       const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
       const keyInfo = parseKey(headers.K || "C", warnings);
+      const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
       const measuresByVoice = {};
       let noteCount = 0;
 
@@ -240,6 +247,10 @@ const abcInput = document.getElementById("abcInput");
       for (const entry of bodyEntries) {
         const measures = ensureVoice(entry.voiceId);
         let currentMeasure = measures[measures.length - 1];
+        let measureAccidentals = {};
+        let lastNote = null;
+        let pendingTieToNext = false;
+        let pendingRhythmScale = null;
         let idx = 0;
         const text = entry.text;
 
@@ -251,16 +262,54 @@ const abcInput = document.getElementById("abcInput");
             continue;
           }
 
+          if (ch === ">" || ch === "<") {
+            if (!lastNote || lastNote.isRest) {
+              warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+              idx += 1;
+              continue;
+            }
+            const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
+            pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
+            lastNote.duration = Math.max(1, Math.round(lastNote.duration * (lastScale.num / lastScale.den)));
+            lastNote.type = typeFromDuration(lastNote.duration, 960);
+            idx += 1;
+            continue;
+          }
+
           if (ch === "|") {
             if (currentMeasure.length > 0 || measures.length === 0) {
               currentMeasure = [];
               measures.push(currentMeasure);
             }
+            measureAccidentals = {};
+            lastNote = null;
             idx += 1;
             continue;
           }
 
-          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === "\"" || ch === ":") {
+          if (ch === "-") {
+            if (lastNote && !lastNote.isRest) {
+              lastNote.tieStart = true;
+              pendingTieToNext = true;
+            } else {
+              warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+            }
+            idx += 1;
+            continue;
+          }
+
+          if (ch === "\"" ) {
+            const endQuote = text.indexOf("\"", idx + 1);
+            if (endQuote >= 0) {
+              idx = endQuote + 1;
+            } else {
+              idx = text.length;
+            }
+            warnings.push("line " + entry.lineNo + ': インライン文字列(\"...\")はスキップしました。');
+            continue;
+          }
+
+          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === ":") {
             warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
             idx += 1;
             continue;
@@ -273,7 +322,7 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const pitchChar = text[idx];
-          if (!pitchChar || !/[A-Ga-gzZ]/.test(pitchChar)) {
+          if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
             throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
           }
           idx += 1;
@@ -292,15 +341,49 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const len = parseLengthToken(lengthToken, entry.lineNo);
-          const absoluteLength = multiplyFractions(unitLength, len);
+          let absoluteLength = multiplyFractions(unitLength, len);
+          if (pendingRhythmScale) {
+            absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+            pendingRhythmScale = null;
+          }
+
+          if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
+            const rhythmChar = text[idx];
+            idx += 1;
+            if (rhythmChar === ">") {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
+              pendingRhythmScale = { num: 1, den: 2 };
+            } else {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
+              pendingRhythmScale = { num: 3, den: 2 };
+            }
+          }
+
           const dur = durationInDivisions(absoluteLength, 960);
           if (dur <= 0) {
             throw new Error("line " + entry.lineNo + ": 長さが不正です");
           }
 
-          const note = buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, dur, entry.lineNo);
+          const note = buildNoteData(
+            pitchChar,
+            accidental,
+            octaveShift,
+            absoluteLength,
+            dur,
+            entry.lineNo,
+            keySignatureAccidentals,
+            measureAccidentals
+          );
+          if (pendingTieToNext && !note.isRest) {
+            note.tieStop = true;
+            pendingTieToNext = false;
+          } else if (note.isRest && pendingTieToNext) {
+            warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+            pendingTieToNext = false;
+          }
           note.voice = entry.voiceId;
           currentMeasure.push(note);
+          lastNote = note;
           noteCount += 1;
         }
       }
@@ -322,7 +405,7 @@ const abcInput = document.getElementById("abcInput");
         return {
           partId: "P" + String(index + 1),
           partName,
-          transpose: inferTransposeFromPartName(partName),
+          transpose: settings.inferTransposeFromPartName ? inferTransposeFromPartName(partName) : null,
           voiceId,
           measures: measuresByVoice[voiceId] || [[]]
         };
@@ -444,7 +527,14 @@ const abcInput = document.getElementById("abcInput");
     }
 
     function parseMeter(raw, warnings) {
-      const m = raw.match(/^(\d+)\/(\d+)$/);
+      const normalized = String(raw || "").trim();
+      if (normalized === "C") {
+        return { beats: 4, beatType: 4 };
+      }
+      if (normalized === "C|") {
+        return { beats: 2, beatType: 2 };
+      }
+      const m = normalized.match(/^(\d+)\/(\d+)$/);
       if (!m) {
         warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
         return { beats: 4, beatType: 4 };
@@ -481,8 +571,17 @@ const abcInput = document.getElementById("abcInput");
       return abcCommon.parseAbcLengthToken(token, lineNo);
     }
 
-    function buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, duration, lineNo) {
-      const isRest = /[zZ]/.test(pitchChar);
+    function buildNoteData(
+      pitchChar,
+      accidental,
+      octaveShift,
+      absoluteLength,
+      duration,
+      lineNo,
+      keySignatureAccidentals,
+      measureAccidentals
+    ) {
+      const isRest = /[zZxX]/.test(pitchChar);
       if (isRest) {
         return {
           isRest: true,
@@ -512,12 +611,23 @@ const abcInput = document.getElementById("abcInput");
       if (accidental === "^") {
         alter = 1;
         accidentalText = "sharp";
+        measureAccidentals[step] = 1;
       } else if (accidental === "_") {
         alter = -1;
         accidentalText = "flat";
+        measureAccidentals[step] = -1;
       } else if (accidental === "=") {
         alter = 0;
         accidentalText = "natural";
+        measureAccidentals[step] = 0;
+      } else {
+        let resolvedAlter = 0;
+        if (Object.prototype.hasOwnProperty.call(measureAccidentals, step)) {
+          resolvedAlter = measureAccidentals[step];
+        } else if (Object.prototype.hasOwnProperty.call(keySignatureAccidentals, step)) {
+          resolvedAlter = keySignatureAccidentals[step];
+        }
+        alter = resolvedAlter === 0 ? null : resolvedAlter;
       }
 
       return {
@@ -529,6 +639,23 @@ const abcInput = document.getElementById("abcInput");
         duration,
         type: typeFromFraction(absoluteLength)
       };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
 
@@ -554,6 +681,26 @@ const abcInput = document.getElementById("abcInput");
 
     function durationInDivisions(wholeFraction, divisionsPerQuarter) {
       return Math.round((wholeFraction.num / wholeFraction.den) * 4 * divisionsPerQuarter);
+    }
+
+    function typeFromDuration(duration, divisionsPerQuarter) {
+      const whole = Number(duration) / (4 * divisionsPerQuarter);
+      if (whole >= 1) {
+        return "whole";
+      }
+      if (whole >= 0.5) {
+        return "half";
+      }
+      if (whole >= 0.25) {
+        return "quarter";
+      }
+      if (whole >= 0.125) {
+        return "eighth";
+      }
+      if (whole >= 0.0625) {
+        return "16th";
+      }
+      return "32nd";
     }
 
     function multiplyFractions(a, b) {
@@ -728,12 +875,14 @@ const abcInput = document.getElementById("abcInput");
     function persistSettings() {
       const payload = {
         defaultTitle: defaultTitleInput.value,
-        defaultComposer: defaultComposerInput.value
+        defaultComposer: defaultComposerInput.value,
+        inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
 
     function restoreSettings() {
+      inferTransposeFromPartNameCheckbox.checked = true;
       const raw = localStorage.getItem(SETTINGS_KEY);
       if (!raw) {
         return;
@@ -747,8 +896,12 @@ const abcInput = document.getElementById("abcInput");
           if (typeof data.defaultComposer === "string") {
             defaultComposerInput.value = data.defaultComposer;
           }
+          if (typeof data.inferTransposeFromPartName === "boolean") {
+            inferTransposeFromPartNameCheckbox.checked = data.inferTransposeFromPartName;
+          }
         }
       } catch (_error) {
         // ignore broken localStorage
+        inferTransposeFromPartNameCheckbox.checked = true;
       }
     }

--- a/docs/music/src/abc-to-musicxml/ts/main.ts
+++ b/docs/music/src/abc-to-musicxml/ts/main.ts
@@ -29,6 +29,7 @@ const abcInput = document.getElementById("abcInput");
     const fileNameText = document.getElementById("fileNameText");
     const defaultTitleInput = document.getElementById("defaultTitleInput");
     const defaultComposerInput = document.getElementById("defaultComposerInput");
+    const inferTransposeFromPartNameCheckbox = document.getElementById("inferTransposeFromPartNameCheckbox");
     const convertBtn = document.getElementById("convertBtn");
     const downloadBtn = document.getElementById("downloadBtn");
     const playSineBtn = document.getElementById("playSineBtn");
@@ -61,6 +62,10 @@ const abcInput = document.getElementById("abcInput");
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
     defaultComposerInput.addEventListener("change", persistSettings);
+    inferTransposeFromPartNameCheckbox.addEventListener("change", () => {
+      persistSettings();
+      convertAbc();
+    });
     document.addEventListener("click", handleDocumentClick);
 
     applyInputMode();
@@ -114,7 +119,8 @@ const abcInput = document.getElementById("abcInput");
       try {
         const result = parseAbc(source, {
           defaultTitle: defaultTitleInput.value.trim() || "Untitled",
-          defaultComposer: defaultComposerInput.value.trim() || "Unknown"
+          defaultComposer: defaultComposerInput.value.trim() || "Unknown",
+          inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
         });
 
         const xml = musicXmlWriterCommon.buildScorePartwiseXml(result);
@@ -227,6 +233,7 @@ const abcInput = document.getElementById("abcInput");
       const meter = parseMeter(headers.M || "4/4", warnings);
       const unitLength = parseFraction(headers.L || "1/8", "L", warnings);
       const keyInfo = parseKey(headers.K || "C", warnings);
+      const keySignatureAccidentals = keySignatureAlterByStep(keyInfo.fifths);
       const measuresByVoice = {};
       let noteCount = 0;
 
@@ -240,6 +247,10 @@ const abcInput = document.getElementById("abcInput");
       for (const entry of bodyEntries) {
         const measures = ensureVoice(entry.voiceId);
         let currentMeasure = measures[measures.length - 1];
+        let measureAccidentals = {};
+        let lastNote = null;
+        let pendingTieToNext = false;
+        let pendingRhythmScale = null;
         let idx = 0;
         const text = entry.text;
 
@@ -251,16 +262,54 @@ const abcInput = document.getElementById("abcInput");
             continue;
           }
 
+          if (ch === ">" || ch === "<") {
+            if (!lastNote || lastNote.isRest) {
+              warnings.push("line " + entry.lineNo + ": broken rhythm(" + ch + ") の前にノートがないためスキップしました。");
+              idx += 1;
+              continue;
+            }
+            const lastScale = ch === ">" ? { num: 3, den: 2 } : { num: 1, den: 2 };
+            pendingRhythmScale = ch === ">" ? { num: 1, den: 2 } : { num: 3, den: 2 };
+            lastNote.duration = Math.max(1, Math.round(lastNote.duration * (lastScale.num / lastScale.den)));
+            lastNote.type = typeFromDuration(lastNote.duration, 960);
+            idx += 1;
+            continue;
+          }
+
           if (ch === "|") {
             if (currentMeasure.length > 0 || measures.length === 0) {
               currentMeasure = [];
               measures.push(currentMeasure);
             }
+            measureAccidentals = {};
+            lastNote = null;
             idx += 1;
             continue;
           }
 
-          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === "\"" || ch === ":") {
+          if (ch === "-") {
+            if (lastNote && !lastNote.isRest) {
+              lastNote.tieStart = true;
+              pendingTieToNext = true;
+            } else {
+              warnings.push("line " + entry.lineNo + ": tie(-) の前にノートがないためスキップしました。");
+            }
+            idx += 1;
+            continue;
+          }
+
+          if (ch === "\"" ) {
+            const endQuote = text.indexOf("\"", idx + 1);
+            if (endQuote >= 0) {
+              idx = endQuote + 1;
+            } else {
+              idx = text.length;
+            }
+            warnings.push("line " + entry.lineNo + ': インライン文字列(\"...\")はスキップしました。');
+            continue;
+          }
+
+          if (ch === "[" || ch === "]" || ch === "(" || ch === ")" || ch === "{" || ch === "}" || ch === ":") {
             warnings.push("line " + entry.lineNo + ": 非対応記法をスキップしました: " + ch);
             idx += 1;
             continue;
@@ -273,7 +322,7 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const pitchChar = text[idx];
-          if (!pitchChar || !/[A-Ga-gzZ]/.test(pitchChar)) {
+          if (!pitchChar || !/[A-Ga-gzZxX]/.test(pitchChar)) {
             throw new Error("line " + entry.lineNo + ": ノート/休符の解釈に失敗しました: " + text.slice(idx, idx + 12));
           }
           idx += 1;
@@ -292,15 +341,49 @@ const abcInput = document.getElementById("abcInput");
           }
 
           const len = parseLengthToken(lengthToken, entry.lineNo);
-          const absoluteLength = multiplyFractions(unitLength, len);
+          let absoluteLength = multiplyFractions(unitLength, len);
+          if (pendingRhythmScale) {
+            absoluteLength = multiplyFractions(absoluteLength, pendingRhythmScale);
+            pendingRhythmScale = null;
+          }
+
+          if (idx < text.length && (text[idx] === ">" || text[idx] === "<")) {
+            const rhythmChar = text[idx];
+            idx += 1;
+            if (rhythmChar === ">") {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 3, den: 2 });
+              pendingRhythmScale = { num: 1, den: 2 };
+            } else {
+              absoluteLength = multiplyFractions(absoluteLength, { num: 1, den: 2 });
+              pendingRhythmScale = { num: 3, den: 2 };
+            }
+          }
+
           const dur = durationInDivisions(absoluteLength, 960);
           if (dur <= 0) {
             throw new Error("line " + entry.lineNo + ": 長さが不正です");
           }
 
-          const note = buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, dur, entry.lineNo);
+          const note = buildNoteData(
+            pitchChar,
+            accidental,
+            octaveShift,
+            absoluteLength,
+            dur,
+            entry.lineNo,
+            keySignatureAccidentals,
+            measureAccidentals
+          );
+          if (pendingTieToNext && !note.isRest) {
+            note.tieStop = true;
+            pendingTieToNext = false;
+          } else if (note.isRest && pendingTieToNext) {
+            warnings.push("line " + entry.lineNo + ": tie(-) の後ろが休符のため tie を解除しました。");
+            pendingTieToNext = false;
+          }
           note.voice = entry.voiceId;
           currentMeasure.push(note);
+          lastNote = note;
           noteCount += 1;
         }
       }
@@ -322,7 +405,7 @@ const abcInput = document.getElementById("abcInput");
         return {
           partId: "P" + String(index + 1),
           partName,
-          transpose: inferTransposeFromPartName(partName),
+          transpose: settings.inferTransposeFromPartName ? inferTransposeFromPartName(partName) : null,
           voiceId,
           measures: measuresByVoice[voiceId] || [[]]
         };
@@ -444,7 +527,14 @@ const abcInput = document.getElementById("abcInput");
     }
 
     function parseMeter(raw, warnings) {
-      const m = raw.match(/^(\d+)\/(\d+)$/);
+      const normalized = String(raw || "").trim();
+      if (normalized === "C") {
+        return { beats: 4, beatType: 4 };
+      }
+      if (normalized === "C|") {
+        return { beats: 2, beatType: 2 };
+      }
+      const m = normalized.match(/^(\d+)\/(\d+)$/);
       if (!m) {
         warnings.push("拍子 M: の形式が不正なため 4/4 を使用しました: " + raw);
         return { beats: 4, beatType: 4 };
@@ -481,8 +571,17 @@ const abcInput = document.getElementById("abcInput");
       return abcCommon.parseAbcLengthToken(token, lineNo);
     }
 
-    function buildNoteData(pitchChar, accidental, octaveShift, absoluteLength, duration, lineNo) {
-      const isRest = /[zZ]/.test(pitchChar);
+    function buildNoteData(
+      pitchChar,
+      accidental,
+      octaveShift,
+      absoluteLength,
+      duration,
+      lineNo,
+      keySignatureAccidentals,
+      measureAccidentals
+    ) {
+      const isRest = /[zZxX]/.test(pitchChar);
       if (isRest) {
         return {
           isRest: true,
@@ -512,12 +611,23 @@ const abcInput = document.getElementById("abcInput");
       if (accidental === "^") {
         alter = 1;
         accidentalText = "sharp";
+        measureAccidentals[step] = 1;
       } else if (accidental === "_") {
         alter = -1;
         accidentalText = "flat";
+        measureAccidentals[step] = -1;
       } else if (accidental === "=") {
         alter = 0;
         accidentalText = "natural";
+        measureAccidentals[step] = 0;
+      } else {
+        let resolvedAlter = 0;
+        if (Object.prototype.hasOwnProperty.call(measureAccidentals, step)) {
+          resolvedAlter = measureAccidentals[step];
+        } else if (Object.prototype.hasOwnProperty.call(keySignatureAccidentals, step)) {
+          resolvedAlter = keySignatureAccidentals[step];
+        }
+        alter = resolvedAlter === 0 ? null : resolvedAlter;
       }
 
       return {
@@ -529,6 +639,23 @@ const abcInput = document.getElementById("abcInput");
         duration,
         type: typeFromFraction(absoluteLength)
       };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
 
@@ -554,6 +681,26 @@ const abcInput = document.getElementById("abcInput");
 
     function durationInDivisions(wholeFraction, divisionsPerQuarter) {
       return Math.round((wholeFraction.num / wholeFraction.den) * 4 * divisionsPerQuarter);
+    }
+
+    function typeFromDuration(duration, divisionsPerQuarter) {
+      const whole = Number(duration) / (4 * divisionsPerQuarter);
+      if (whole >= 1) {
+        return "whole";
+      }
+      if (whole >= 0.5) {
+        return "half";
+      }
+      if (whole >= 0.25) {
+        return "quarter";
+      }
+      if (whole >= 0.125) {
+        return "eighth";
+      }
+      if (whole >= 0.0625) {
+        return "16th";
+      }
+      return "32nd";
     }
 
     function multiplyFractions(a, b) {
@@ -728,12 +875,14 @@ const abcInput = document.getElementById("abcInput");
     function persistSettings() {
       const payload = {
         defaultTitle: defaultTitleInput.value,
-        defaultComposer: defaultComposerInput.value
+        defaultComposer: defaultComposerInput.value,
+        inferTransposeFromPartName: !!inferTransposeFromPartNameCheckbox.checked
       };
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
     }
 
     function restoreSettings() {
+      inferTransposeFromPartNameCheckbox.checked = true;
       const raw = localStorage.getItem(SETTINGS_KEY);
       if (!raw) {
         return;
@@ -747,8 +896,12 @@ const abcInput = document.getElementById("abcInput");
           if (typeof data.defaultComposer === "string") {
             defaultComposerInput.value = data.defaultComposer;
           }
+          if (typeof data.inferTransposeFromPartName === "boolean") {
+            inferTransposeFromPartNameCheckbox.checked = data.inferTransposeFromPartName;
+          }
         }
       } catch (_error) {
         // ignore broken localStorage
+        inferTransposeFromPartNameCheckbox.checked = true;
       }
     }

--- a/docs/music/src/common/js/musicxml-writer-common.js
+++ b/docs/music/src/common/js/musicxml-writer-common.js
@@ -82,6 +82,22 @@ const MusicXmlWriterCommon = (() => {
           if (!note.isRest && note.accidentalText) {
             lines.push('        <accidental>' + note.accidentalText + '</accidental>');
           }
+          if (!note.isRest && note.tieStart) {
+            lines.push("        <tie type=\"start\"/>");
+          }
+          if (!note.isRest && note.tieStop) {
+            lines.push("        <tie type=\"stop\"/>");
+          }
+          if (!note.isRest && (note.tieStart || note.tieStop)) {
+            lines.push("        <notations>");
+            if (note.tieStart) {
+              lines.push("          <tied type=\"start\"/>");
+            }
+            if (note.tieStop) {
+              lines.push("          <tied type=\"stop\"/>");
+            }
+            lines.push("        </notations>");
+          }
           lines.push('      </note>');
         }
 

--- a/docs/music/src/common/ts/musicxml-writer-common.ts
+++ b/docs/music/src/common/ts/musicxml-writer-common.ts
@@ -82,6 +82,22 @@ const MusicXmlWriterCommon = (() => {
           if (!note.isRest && note.accidentalText) {
             lines.push('        <accidental>' + note.accidentalText + '</accidental>');
           }
+          if (!note.isRest && note.tieStart) {
+            lines.push("        <tie type=\"start\"/>");
+          }
+          if (!note.isRest && note.tieStop) {
+            lines.push("        <tie type=\"stop\"/>");
+          }
+          if (!note.isRest && (note.tieStart || note.tieStop)) {
+            lines.push("        <notations>");
+            if (note.tieStart) {
+              lines.push("          <tied type=\"start\"/>");
+            }
+            if (note.tieStop) {
+              lines.push("          <tied type=\"stop\"/>");
+            }
+            lines.push("        </notations>");
+          }
           lines.push('      </note>');
         }
 

--- a/docs/music/src/musicxml-to-abc/css/app.css
+++ b/docs/music/src/musicxml-to-abc/css/app.css
@@ -141,6 +141,18 @@
       margin-top: 0.8rem;
     }
 
+    .md-grid-full {
+      grid-column: 1 / -1;
+    }
+
+    .md-check-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
     .md-disclosure {
       margin-bottom: 0.8rem;
       border: 1px solid #e5e0ec;

--- a/docs/music/src/musicxml-to-abc/js/main.js
+++ b/docs/music/src/musicxml-to-abc/js/main.js
@@ -157,6 +157,7 @@ const xmlInput = document.getElementById("xmlInput");
       let divisions = 1;
       let meter = { beats: 4, beatType: 4 };
       let key = "C";
+      let keyFifths = 0;
       let noteCount = 0;
       const voices = [];
 
@@ -169,7 +170,12 @@ const xmlInput = document.getElementById("xmlInput");
         const part = partNodes[partIndex];
         const partId = part.getAttribute("id") || ("P" + String(partIndex + 1));
         const voiceId = "V" + String(partIndex + 1);
-        const partName = partNameById[partId] || partId;
+        const originalPartName = partNameById[partId] || partId;
+        let partName = originalPartName;
+        let currentTransposeSemitones = 0;
+        let currentWrittenFifths = 0;
+        let currentWrittenMode = "major";
+        let partTransposeApplied = false;
         const measures = [];
 
         const measureNodes = Array.from(part.children).filter((node) => node.nodeType === 1 && node.nodeName === "measure");
@@ -190,6 +196,22 @@ const xmlInput = document.getElementById("xmlInput");
               }
             }
 
+            let shouldRecalculateKey = false;
+            const transposeNode = attrNode.querySelector(":scope > transpose");
+            if (transposeNode) {
+              const chromaticText = getChildText(transposeNode, "chromatic");
+              const octaveChangeText = getChildText(transposeNode, "octave-change");
+              const chromatic = chromaticText ? Number.parseInt(chromaticText, 10) : 0;
+              const octaveChange = octaveChangeText ? Number.parseInt(octaveChangeText, 10) : 0;
+              currentTransposeSemitones =
+                (Number.isFinite(chromatic) ? chromatic : 0) +
+                ((Number.isFinite(octaveChange) ? octaveChange : 0) * 12);
+              if (currentTransposeSemitones !== 0) {
+                partTransposeApplied = true;
+              }
+              shouldRecalculateKey = true;
+            }
+
             const beatsText = getChildText(attrNode.querySelector("time"), "beats");
             const beatTypeText = getChildText(attrNode.querySelector("time"), "beat-type");
             if (beatsText && beatTypeText) {
@@ -205,17 +227,35 @@ const xmlInput = document.getElementById("xmlInput");
             if (fifthsText !== "") {
               const fifthsVal = Number.parseInt(fifthsText, 10);
               if (Number.isFinite(fifthsVal)) {
-                key = keyFromFifths(fifthsVal, modeText);
+                currentWrittenFifths = fifthsVal;
+                currentWrittenMode = modeText;
+                shouldRecalculateKey = true;
               }
+            }
+
+            if (shouldRecalculateKey) {
+              const transposed = transposeKeyFromFifthsMode(currentWrittenFifths, currentWrittenMode, currentTransposeSemitones);
+              key = transposed.keyText;
+              keyFifths = transposed.fifths;
             }
           }
 
           const tokens = [];
+          const measureAccidentals = {};
 
           for (const child of Array.from(measureNode.children)) {
             const name = child.nodeName;
             if (name === "note") {
-              const noteToken = noteToAbc(child, divisions, settings.defaultLength, warnings, measureNo);
+              const noteToken = noteToAbc(
+                child,
+                divisions,
+                settings.defaultLength,
+                warnings,
+                measureNo,
+                currentTransposeSemitones,
+                keyFifths,
+                measureAccidentals
+              );
               if (noteToken.skipped) {
                 if (noteToken.reason === "chord" && !warnedChord) {
                   warnings.push("和音（<chord/>）は先頭音のみ扱います。");
@@ -252,7 +292,7 @@ const xmlInput = document.getElementById("xmlInput");
 
         voices.push({
           id: voiceId,
-          name: partName,
+          name: normalizePartNameForAbc(partName, partTransposeApplied),
           measures
         });
       }
@@ -300,7 +340,7 @@ const xmlInput = document.getElementById("xmlInput");
       };
     }
 
-    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo) {
+    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo, transposeSemitones, keyFifths, measureAccidentals) {
       if (noteNode.querySelector(":scope > grace")) {
         warnings.push("measure " + measureNo + ": grace note はスキップしました。");
         return { skipped: true, reason: "grace" };
@@ -346,24 +386,215 @@ const xmlInput = document.getElementById("xmlInput");
 
       const alterText = getChildText(noteNode.querySelector(":scope > pitch"), "alter");
       const alter = alterText === "" ? 0 : Number.parseInt(alterText, 10);
-      const accidental = abcCommon.accidentalFromAlter(Number.isFinite(alter) ? alter : 0);
+      const baseAlter = Number.isFinite(alter) ? alter : 0;
+      const midiNumber = stepAlterOctaveToMidiNumber(step, baseAlter, octave) + (Number.isFinite(transposeSemitones) ? transposeSemitones : 0);
+      if (midiNumber < 0 || midiNumber > 127) {
+        warnings.push("measure " + measureNo + ": 移調後に音域外となる note をスキップしました。");
+        return { skipped: true, reason: "transpose-range" };
+      }
+      const transposed = midiNumberToStepAlterOctave(midiNumber, keyFifths < 0);
+      const outStep = transposed.step;
+      const outOctave = transposed.octave;
+      const outAlter = transposed.alter;
+
+      const keySignature = keySignatureAlterByStep(keyFifths);
+      const measureDefaultAlter = Object.prototype.hasOwnProperty.call(measureAccidentals, outStep)
+        ? measureAccidentals[outStep]
+        : (Object.prototype.hasOwnProperty.call(keySignature, outStep) ? keySignature[outStep] : 0);
+
+      let accidental = "";
+      if (outAlter !== measureDefaultAlter) {
+        accidental = outAlter === 0 ? "=" : abcCommon.accidentalFromAlter(outAlter);
+      }
+      measureAccidentals[outStep] = outAlter;
+      const pitchText = abcCommon.abcPitchFromStepOctave(outStep, outOctave);
 
       if (noteNode.querySelector(":scope > tie") || noteNode.querySelector(":scope > notations > tied")) {
         return {
           skipped: false,
           reason: "tie",
-          token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+          token: accidental + pitchText + lengthToken
         };
       }
 
       return {
         skipped: false,
-        token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+        token: accidental + pitchText + lengthToken
       };
     }
 
     function keyFromFifths(fifths, mode) {
       return abcCommon.keyFromFifthsMode(fifths, mode);
+    }
+
+    function transposeKeyFromFifthsMode(fifths, mode, transposeSemitones) {
+      const normalizedMode = normalizeModeName(mode);
+      const modeOffset = modeDegreeOffset(normalizedMode);
+      const tonicPc = mod12((fifths * 7) + modeOffset);
+      const transposedPc = mod12(tonicPc + transposeSemitones);
+      const preferFlats = fifths < 0;
+      const keyText = abcKeyFromPitchClassMode(transposedPc, normalizedMode, preferFlats);
+      return {
+        keyText,
+        fifths: fifthsFromPitchClassMode(transposedPc, normalizedMode)
+      };
+    }
+
+    function normalizeModeName(mode) {
+      const normalized = String(mode || "major").trim().toLowerCase();
+      if (normalized === "minor") {
+        return "aeolian";
+      }
+      if (normalized === "major") {
+        return "ionian";
+      }
+      return normalized;
+    }
+
+    function modeDegreeOffset(mode) {
+      switch (mode) {
+        case "ionian":
+          return 0;
+        case "dorian":
+          return 2;
+        case "phrygian":
+          return 4;
+        case "lydian":
+          return 5;
+        case "mixolydian":
+          return 7;
+        case "aeolian":
+          return 9;
+        case "locrian":
+          return 11;
+        default:
+          return 0;
+      }
+    }
+
+    function modeSuffix(mode) {
+      switch (mode) {
+        case "aeolian":
+          return "m";
+        case "dorian":
+          return "dor";
+        case "phrygian":
+          return "phr";
+        case "lydian":
+          return "lyd";
+        case "mixolydian":
+          return "mix";
+        case "locrian":
+          return "loc";
+        case "ionian":
+        default:
+          return "";
+      }
+    }
+
+    function abcKeyFromPitchClassMode(pitchClass, mode, preferFlats) {
+      const namesSharp = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+      const namesFlat = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+      const tonic = (preferFlats ? namesFlat : namesSharp)[mod12(pitchClass)];
+      return tonic + modeSuffix(mode);
+    }
+
+    function fifthsFromPitchClassMode(pitchClass, mode) {
+      const offset = modeDegreeOffset(mode);
+      let best = 0;
+      let bestAbs = Number.POSITIVE_INFINITY;
+      for (let f = -7; f <= 7; f += 1) {
+        if (mod12((f * 7) + offset) !== mod12(pitchClass)) {
+          continue;
+        }
+        const abs = Math.abs(f);
+        if (abs < bestAbs) {
+          bestAbs = abs;
+          best = f;
+        }
+      }
+      return Number.isFinite(bestAbs) ? best : 0;
+    }
+
+    function mod12(value) {
+      const m = Number(value) % 12;
+      return m < 0 ? m + 12 : m;
+    }
+
+    function stepAlterOctaveToMidiNumber(step, alter, octave) {
+      const base = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11
+      };
+      const s = String(step || "").toUpperCase();
+      if (!Object.prototype.hasOwnProperty.call(base, s)) {
+        return 60;
+      }
+      const semitone = base[s] + alter;
+      return (octave + 1) * 12 + semitone;
+    }
+
+    function midiNumberToStepAlterOctave(midiNumber, preferFlats) {
+      const normalized = Math.round(midiNumber);
+      const octave = Math.floor(normalized / 12) - 1;
+      const pitchClass = mod12(normalized);
+      const sharpMap = [
+        { step: "C", alter: 0 },
+        { step: "C", alter: 1 },
+        { step: "D", alter: 0 },
+        { step: "D", alter: 1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "F", alter: 1 },
+        { step: "G", alter: 0 },
+        { step: "G", alter: 1 },
+        { step: "A", alter: 0 },
+        { step: "A", alter: 1 },
+        { step: "B", alter: 0 }
+      ];
+      const flatMap = [
+        { step: "C", alter: 0 },
+        { step: "D", alter: -1 },
+        { step: "D", alter: 0 },
+        { step: "E", alter: -1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "G", alter: -1 },
+        { step: "G", alter: 0 },
+        { step: "A", alter: -1 },
+        { step: "A", alter: 0 },
+        { step: "B", alter: -1 },
+        { step: "B", alter: 0 }
+      ];
+      const mapping = preferFlats ? flatMap : sharpMap;
+      const pitch = mapping[pitchClass];
+      return {
+        step: pitch.step,
+        alter: pitch.alter,
+        octave
+      };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
     function getChildText(parent, tagName) {
@@ -384,6 +615,17 @@ const xmlInput = document.getElementById("xmlInput");
 
     function escapeAbcText(text) {
       return String(text || "").replace(/"/g, "'");
+    }
+
+    function normalizePartNameForAbc(partName, transposeApplied) {
+      const name = String(partName || "").trim();
+      if (!transposeApplied || !name) {
+        return name;
+      }
+      return name
+        .replace(/\s+in\s+[A-Ga-g](?:[#b]|♯|♭)?\b/g, "")
+        .replace(/\s{2,}/g, " ")
+        .trim();
     }
 
     function buildPartNameMap(root) {

--- a/docs/music/src/musicxml-to-abc/ts/main.ts
+++ b/docs/music/src/musicxml-to-abc/ts/main.ts
@@ -157,6 +157,7 @@ const xmlInput = document.getElementById("xmlInput");
       let divisions = 1;
       let meter = { beats: 4, beatType: 4 };
       let key = "C";
+      let keyFifths = 0;
       let noteCount = 0;
       const voices = [];
 
@@ -169,7 +170,12 @@ const xmlInput = document.getElementById("xmlInput");
         const part = partNodes[partIndex];
         const partId = part.getAttribute("id") || ("P" + String(partIndex + 1));
         const voiceId = "V" + String(partIndex + 1);
-        const partName = partNameById[partId] || partId;
+        const originalPartName = partNameById[partId] || partId;
+        let partName = originalPartName;
+        let currentTransposeSemitones = 0;
+        let currentWrittenFifths = 0;
+        let currentWrittenMode = "major";
+        let partTransposeApplied = false;
         const measures = [];
 
         const measureNodes = Array.from(part.children).filter((node) => node.nodeType === 1 && node.nodeName === "measure");
@@ -190,6 +196,22 @@ const xmlInput = document.getElementById("xmlInput");
               }
             }
 
+            let shouldRecalculateKey = false;
+            const transposeNode = attrNode.querySelector(":scope > transpose");
+            if (transposeNode) {
+              const chromaticText = getChildText(transposeNode, "chromatic");
+              const octaveChangeText = getChildText(transposeNode, "octave-change");
+              const chromatic = chromaticText ? Number.parseInt(chromaticText, 10) : 0;
+              const octaveChange = octaveChangeText ? Number.parseInt(octaveChangeText, 10) : 0;
+              currentTransposeSemitones =
+                (Number.isFinite(chromatic) ? chromatic : 0) +
+                ((Number.isFinite(octaveChange) ? octaveChange : 0) * 12);
+              if (currentTransposeSemitones !== 0) {
+                partTransposeApplied = true;
+              }
+              shouldRecalculateKey = true;
+            }
+
             const beatsText = getChildText(attrNode.querySelector("time"), "beats");
             const beatTypeText = getChildText(attrNode.querySelector("time"), "beat-type");
             if (beatsText && beatTypeText) {
@@ -205,17 +227,35 @@ const xmlInput = document.getElementById("xmlInput");
             if (fifthsText !== "") {
               const fifthsVal = Number.parseInt(fifthsText, 10);
               if (Number.isFinite(fifthsVal)) {
-                key = keyFromFifths(fifthsVal, modeText);
+                currentWrittenFifths = fifthsVal;
+                currentWrittenMode = modeText;
+                shouldRecalculateKey = true;
               }
+            }
+
+            if (shouldRecalculateKey) {
+              const transposed = transposeKeyFromFifthsMode(currentWrittenFifths, currentWrittenMode, currentTransposeSemitones);
+              key = transposed.keyText;
+              keyFifths = transposed.fifths;
             }
           }
 
           const tokens = [];
+          const measureAccidentals = {};
 
           for (const child of Array.from(measureNode.children)) {
             const name = child.nodeName;
             if (name === "note") {
-              const noteToken = noteToAbc(child, divisions, settings.defaultLength, warnings, measureNo);
+              const noteToken = noteToAbc(
+                child,
+                divisions,
+                settings.defaultLength,
+                warnings,
+                measureNo,
+                currentTransposeSemitones,
+                keyFifths,
+                measureAccidentals
+              );
               if (noteToken.skipped) {
                 if (noteToken.reason === "chord" && !warnedChord) {
                   warnings.push("和音（<chord/>）は先頭音のみ扱います。");
@@ -252,7 +292,7 @@ const xmlInput = document.getElementById("xmlInput");
 
         voices.push({
           id: voiceId,
-          name: partName,
+          name: normalizePartNameForAbc(partName, partTransposeApplied),
           measures
         });
       }
@@ -300,7 +340,7 @@ const xmlInput = document.getElementById("xmlInput");
       };
     }
 
-    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo) {
+    function noteToAbc(noteNode, divisions, defaultLength, warnings, measureNo, transposeSemitones, keyFifths, measureAccidentals) {
       if (noteNode.querySelector(":scope > grace")) {
         warnings.push("measure " + measureNo + ": grace note はスキップしました。");
         return { skipped: true, reason: "grace" };
@@ -346,24 +386,215 @@ const xmlInput = document.getElementById("xmlInput");
 
       const alterText = getChildText(noteNode.querySelector(":scope > pitch"), "alter");
       const alter = alterText === "" ? 0 : Number.parseInt(alterText, 10);
-      const accidental = abcCommon.accidentalFromAlter(Number.isFinite(alter) ? alter : 0);
+      const baseAlter = Number.isFinite(alter) ? alter : 0;
+      const midiNumber = stepAlterOctaveToMidiNumber(step, baseAlter, octave) + (Number.isFinite(transposeSemitones) ? transposeSemitones : 0);
+      if (midiNumber < 0 || midiNumber > 127) {
+        warnings.push("measure " + measureNo + ": 移調後に音域外となる note をスキップしました。");
+        return { skipped: true, reason: "transpose-range" };
+      }
+      const transposed = midiNumberToStepAlterOctave(midiNumber, keyFifths < 0);
+      const outStep = transposed.step;
+      const outOctave = transposed.octave;
+      const outAlter = transposed.alter;
+
+      const keySignature = keySignatureAlterByStep(keyFifths);
+      const measureDefaultAlter = Object.prototype.hasOwnProperty.call(measureAccidentals, outStep)
+        ? measureAccidentals[outStep]
+        : (Object.prototype.hasOwnProperty.call(keySignature, outStep) ? keySignature[outStep] : 0);
+
+      let accidental = "";
+      if (outAlter !== measureDefaultAlter) {
+        accidental = outAlter === 0 ? "=" : abcCommon.accidentalFromAlter(outAlter);
+      }
+      measureAccidentals[outStep] = outAlter;
+      const pitchText = abcCommon.abcPitchFromStepOctave(outStep, outOctave);
 
       if (noteNode.querySelector(":scope > tie") || noteNode.querySelector(":scope > notations > tied")) {
         return {
           skipped: false,
           reason: "tie",
-          token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+          token: accidental + pitchText + lengthToken
         };
       }
 
       return {
         skipped: false,
-        token: accidental + abcCommon.abcPitchFromStepOctave(step, octave) + lengthToken
+        token: accidental + pitchText + lengthToken
       };
     }
 
     function keyFromFifths(fifths, mode) {
       return abcCommon.keyFromFifthsMode(fifths, mode);
+    }
+
+    function transposeKeyFromFifthsMode(fifths, mode, transposeSemitones) {
+      const normalizedMode = normalizeModeName(mode);
+      const modeOffset = modeDegreeOffset(normalizedMode);
+      const tonicPc = mod12((fifths * 7) + modeOffset);
+      const transposedPc = mod12(tonicPc + transposeSemitones);
+      const preferFlats = fifths < 0;
+      const keyText = abcKeyFromPitchClassMode(transposedPc, normalizedMode, preferFlats);
+      return {
+        keyText,
+        fifths: fifthsFromPitchClassMode(transposedPc, normalizedMode)
+      };
+    }
+
+    function normalizeModeName(mode) {
+      const normalized = String(mode || "major").trim().toLowerCase();
+      if (normalized === "minor") {
+        return "aeolian";
+      }
+      if (normalized === "major") {
+        return "ionian";
+      }
+      return normalized;
+    }
+
+    function modeDegreeOffset(mode) {
+      switch (mode) {
+        case "ionian":
+          return 0;
+        case "dorian":
+          return 2;
+        case "phrygian":
+          return 4;
+        case "lydian":
+          return 5;
+        case "mixolydian":
+          return 7;
+        case "aeolian":
+          return 9;
+        case "locrian":
+          return 11;
+        default:
+          return 0;
+      }
+    }
+
+    function modeSuffix(mode) {
+      switch (mode) {
+        case "aeolian":
+          return "m";
+        case "dorian":
+          return "dor";
+        case "phrygian":
+          return "phr";
+        case "lydian":
+          return "lyd";
+        case "mixolydian":
+          return "mix";
+        case "locrian":
+          return "loc";
+        case "ionian":
+        default:
+          return "";
+      }
+    }
+
+    function abcKeyFromPitchClassMode(pitchClass, mode, preferFlats) {
+      const namesSharp = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+      const namesFlat = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+      const tonic = (preferFlats ? namesFlat : namesSharp)[mod12(pitchClass)];
+      return tonic + modeSuffix(mode);
+    }
+
+    function fifthsFromPitchClassMode(pitchClass, mode) {
+      const offset = modeDegreeOffset(mode);
+      let best = 0;
+      let bestAbs = Number.POSITIVE_INFINITY;
+      for (let f = -7; f <= 7; f += 1) {
+        if (mod12((f * 7) + offset) !== mod12(pitchClass)) {
+          continue;
+        }
+        const abs = Math.abs(f);
+        if (abs < bestAbs) {
+          bestAbs = abs;
+          best = f;
+        }
+      }
+      return Number.isFinite(bestAbs) ? best : 0;
+    }
+
+    function mod12(value) {
+      const m = Number(value) % 12;
+      return m < 0 ? m + 12 : m;
+    }
+
+    function stepAlterOctaveToMidiNumber(step, alter, octave) {
+      const base = {
+        C: 0,
+        D: 2,
+        E: 4,
+        F: 5,
+        G: 7,
+        A: 9,
+        B: 11
+      };
+      const s = String(step || "").toUpperCase();
+      if (!Object.prototype.hasOwnProperty.call(base, s)) {
+        return 60;
+      }
+      const semitone = base[s] + alter;
+      return (octave + 1) * 12 + semitone;
+    }
+
+    function midiNumberToStepAlterOctave(midiNumber, preferFlats) {
+      const normalized = Math.round(midiNumber);
+      const octave = Math.floor(normalized / 12) - 1;
+      const pitchClass = mod12(normalized);
+      const sharpMap = [
+        { step: "C", alter: 0 },
+        { step: "C", alter: 1 },
+        { step: "D", alter: 0 },
+        { step: "D", alter: 1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "F", alter: 1 },
+        { step: "G", alter: 0 },
+        { step: "G", alter: 1 },
+        { step: "A", alter: 0 },
+        { step: "A", alter: 1 },
+        { step: "B", alter: 0 }
+      ];
+      const flatMap = [
+        { step: "C", alter: 0 },
+        { step: "D", alter: -1 },
+        { step: "D", alter: 0 },
+        { step: "E", alter: -1 },
+        { step: "E", alter: 0 },
+        { step: "F", alter: 0 },
+        { step: "G", alter: -1 },
+        { step: "G", alter: 0 },
+        { step: "A", alter: -1 },
+        { step: "A", alter: 0 },
+        { step: "B", alter: -1 },
+        { step: "B", alter: 0 }
+      ];
+      const mapping = preferFlats ? flatMap : sharpMap;
+      const pitch = mapping[pitchClass];
+      return {
+        step: pitch.step,
+        alter: pitch.alter,
+        octave
+      };
+    }
+
+    function keySignatureAlterByStep(fifths) {
+      const map = {};
+      const sharpOrder = ["F", "C", "G", "D", "A", "E", "B"];
+      const flatOrder = ["B", "E", "A", "D", "G", "C", "F"];
+      const f = Number.isFinite(fifths) ? Math.max(-7, Math.min(7, Math.trunc(fifths))) : 0;
+      if (f > 0) {
+        for (let i = 0; i < f; i += 1) {
+          map[sharpOrder[i]] = 1;
+        }
+      } else if (f < 0) {
+        for (let i = 0; i < Math.abs(f); i += 1) {
+          map[flatOrder[i]] = -1;
+        }
+      }
+      return map;
     }
 
     function getChildText(parent, tagName) {
@@ -384,6 +615,17 @@ const xmlInput = document.getElementById("xmlInput");
 
     function escapeAbcText(text) {
       return String(text || "").replace(/"/g, "'");
+    }
+
+    function normalizePartNameForAbc(partName, transposeApplied) {
+      const name = String(partName || "").trim();
+      if (!transposeApplied || !name) {
+        return name;
+      }
+      return name
+        .replace(/\s+in\s+[A-Ga-g](?:[#b]|♯|♭)?\b/g, "")
+        .replace(/\s{2,}/g, " ")
+        .trim();
     }
 
     function buildPartNameMap(root) {

--- a/docs/music/tests/abc-to-musicxml-main.test.js
+++ b/docs/music/tests/abc-to-musicxml-main.test.js
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function runScript(relPath) {
+  const code = readFileSync(path.resolve(__dirname, relPath), "utf8");
+  new Function(code)();
+}
+
+function installLocalStorageMock() {
+  const store = new Map();
+  const mock = {
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    }
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: mock,
+    configurable: true
+  });
+}
+
+describe("abc-to-musicxml main", () => {
+  it("can disable transpose inference for in-A source", () => {
+    document.body.innerHTML = `
+      <textarea id="abcInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <input id="inferTransposeFromPartNameCheckbox" type="checkbox" checked />
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="xmlOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const abcInput = document.getElementById("abcInput");
+    abcInput.value = `X:1
+T:Test
+M:4/4
+L:1/4
+K:C
+V:1 name="clarinet in A"
+^G A B c |`;
+
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/musicxml-writer-common.ts");
+    runScript("../src/abc-to-musicxml/ts/main.ts");
+
+    const checkbox = document.getElementById("inferTransposeFromPartNameCheckbox");
+    checkbox.checked = false;
+    document.getElementById("convertBtn").click();
+
+    const xmlOutput = document.getElementById("xmlOutput");
+    const xml1 = xmlOutput.textContent;
+    expect(xml1).not.toContain("<transpose>");
+    expect(xml1).toContain("<step>G</step>");
+    expect(xml1).toContain("<alter>1</alter>");
+
+    abcInput.value = `X:1
+T:Test
+M:4/4
+L:1/4
+K:A
+V:1 name="clarinet in A"
+G A B c |`;
+    document.getElementById("convertBtn").click();
+
+    const xml2 = xmlOutput.textContent;
+    expect(xml2).not.toContain("<transpose>");
+    expect(xml2).toContain("<key><fifths>3</fifths></key>");
+    expect(xml2).toContain("<step>G</step>");
+    expect(xml2).toContain("<alter>1</alter>");
+  });
+
+  it("enables transpose inference by default for in-A part name", () => {
+    document.body.innerHTML = `
+      <textarea id="abcInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <input id="inferTransposeFromPartNameCheckbox" type="checkbox" checked />
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="xmlOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const abcInput = document.getElementById("abcInput");
+    abcInput.value = `X:1
+T:Test
+M:4/4
+L:1/4
+K:A
+V:1 name="clarinet in A"
+C |`;
+
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/musicxml-writer-common.ts");
+    runScript("../src/abc-to-musicxml/ts/main.ts");
+
+    const xml = document.getElementById("xmlOutput").textContent;
+    expect(xml).toContain("<transpose>");
+    expect(xml).toContain("<chromatic>-3</chromatic>");
+  });
+
+  it("infers transpose semitones from part names (in Bb / in F)", () => {
+    document.body.innerHTML = `
+      <textarea id="abcInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <input id="inferTransposeFromPartNameCheckbox" type="checkbox" checked />
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="xmlOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const abcInput = document.getElementById("abcInput");
+    abcInput.value = `X:1
+T:Test
+M:4/4
+L:1/4
+K:C
+%%score (V1) (V2)
+V:V1 name="clarinet in Bb"
+C |
+V:V2 name="horn in F"
+C |`;
+
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/musicxml-writer-common.ts");
+    runScript("../src/abc-to-musicxml/ts/main.ts");
+
+    const xml = document.getElementById("xmlOutput").textContent;
+    expect(xml).toContain("<part-name>clarinet in Bb</part-name>");
+    expect(xml).toContain("<part-name>horn in F</part-name>");
+    expect(xml).toContain("<chromatic>-2</chromatic>");
+    expect(xml).toContain("<chromatic>5</chromatic>");
+  });
+
+  it("supports M:C, tie, broken rhythm, and inline text", () => {
+    document.body.innerHTML = `
+      <textarea id="abcInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <input id="inferTransposeFromPartNameCheckbox" type="checkbox" />
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="xmlOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const abcInput = document.getElementById("abcInput");
+    abcInput.value = `X:1
+T:Q
+M:C
+L:1/8
+K:Bb
+V:1
+D2-|D2 E > F "pizz." G2 |`;
+
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/musicxml-writer-common.ts");
+    runScript("../src/abc-to-musicxml/ts/main.ts");
+
+    const xml = document.getElementById("xmlOutput").textContent;
+    const warning = document.getElementById("warningText").textContent;
+    expect(xml).toContain("<time><beats>4</beats><beat-type>4</beat-type></time>");
+    expect(xml).toContain("<tie type=\"start\"/>");
+    expect(xml).toContain("<tie type=\"stop\"/>");
+    expect(xml).toContain("<duration>720</duration>");
+    expect(xml).toContain("<duration>240</duration>");
+    expect(warning).toContain("インライン文字列");
+  });
+
+  it("accepts x rest tokens", () => {
+    document.body.innerHTML = `
+      <textarea id="abcInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <input id="inferTransposeFromPartNameCheckbox" type="checkbox" />
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="xmlOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const abcInput = document.getElementById("abcInput");
+    abcInput.value = `X:1
+T:R
+M:4/4
+L:1/16
+K:C
+V:1
+x16|x8 z8|`;
+
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/musicxml-writer-common.ts");
+    runScript("../src/abc-to-musicxml/ts/main.ts");
+
+    const xml = document.getElementById("xmlOutput").textContent;
+    expect(xml).toContain("<rest/>");
+    expect(document.getElementById("errorText").textContent).toBe("");
+  });
+});

--- a/docs/music/tests/musicxml-to-abc-main.test.js
+++ b/docs/music/tests/musicxml-to-abc-main.test.js
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function runScript(relPath) {
+  const code = readFileSync(path.resolve(__dirname, relPath), "utf8");
+  new Function(code)();
+}
+
+function installLocalStorageMock() {
+  const store = new Map();
+  const mock = {
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    }
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: mock,
+    configurable: true
+  });
+}
+
+describe("musicxml-to-abc main", () => {
+  it("applies transpose to key and pitch for transposing instruments", () => {
+    document.body.innerHTML = `
+      <textarea id="xmlInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <select id="defaultLengthSelect"><option value="1/4" selected>1/4</option></select>
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="abcOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>clarinet in A</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <transpose><chromatic>-3</chromatic></transpose>
+      </attributes>
+      <note><pitch><step>C</step><octave>4</octave></pitch><duration>960</duration></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/musicxml-to-abc/ts/main.ts");
+
+    const output = document.getElementById("abcOutput").textContent;
+    expect(output).toContain("K:A");
+    expect(output).toContain("A");
+    expect(output).not.toContain("in A");
+  });
+
+  it("applies chromatic plus octave-change to notes", () => {
+    document.body.innerHTML = `
+      <textarea id="xmlInput"></textarea>
+      <input id="fileInput" />
+      <input id="inputModeSource" type="radio" checked />
+      <input id="inputModeFile" type="radio" />
+      <div id="sourceInputBlock"></div>
+      <div id="fileInputBlock"></div>
+      <button id="fileSelectBtn"></button>
+      <span id="fileNameText"></span>
+      <input id="defaultTitleInput" value="Untitled" />
+      <input id="defaultComposerInput" value="Unknown" />
+      <select id="defaultLengthSelect"><option value="1/4" selected>1/4</option></select>
+      <button id="convertBtn"></button>
+      <button id="downloadBtn"></button>
+      <button id="playSineBtn"></button>
+      <button id="copyBtn"></button>
+      <pre id="previewText"></pre>
+      <pre id="abcOutput"></pre>
+      <p id="errorText"></p>
+      <p id="warningText"></p>
+      <div id="toast"></div>
+      <div id="menuPanel"></div>
+    `;
+    installLocalStorageMock();
+
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>test</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>960</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <transpose><chromatic>2</chromatic><octave-change>-1</octave-change></transpose>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch><duration>960</duration></note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+    runScript("../src/common/ts/musicxml-common.ts");
+    runScript("../src/common/ts/musicxml-synth-schedule-common.ts");
+    runScript("../src/common/ts/music-synth-common.ts");
+    runScript("../src/common/ts/abc-common.ts");
+    runScript("../src/musicxml-to-abc/ts/main.ts");
+
+    const output = document.getElementById("abcOutput").textContent;
+    // C5 + (2 - 12) = D4
+    expect(output).toContain("D");
+  });
+});


### PR DESCRIPTION
…符対応）

## Summary

Music系ツールの変換精度と互換性を中心に改善しました。
主に `musicxml-to-abc` / `abc-to-musicxml` の挙動を見直し、移調楽器・調号・ABC記法の実運用ケースに対応しています。

## What Changed

### 1) `MusicXML -> ABC` の移調・調号処理を改善
- `<transpose>`（`chromatic` + `octave-change`）を音高へ反映
- `K:`（調号）を移調後キーへ再計算
- 小節内の臨時記号スコープを考慮したABC出力に改善
- 移調適用済みパートは `V:` 名から `in A` 等の移調表記を正規化（再変換時の二重移調を抑止）

対象:
- `docs/music/src/musicxml-to-abc/ts/main.ts`
- `docs/music/src/musicxml-to-abc/js/main.js`
- `docs/music/musicxml-to-abc.html`

### 2) `ABC -> MusicXML` パーサを拡張
- `M:C` / `M:C|` 対応（4/4, 2/2 解釈）
- タイ `-` 対応（`<tie>` / `<notations><tied>` 出力）
- broken rhythm `>` / `<` 対応（空白あり `A > B` も処理）
- インライン文字列 `"..."` を警告付きスキップ
- `x` / `X` 休符（不可視休符）受理
- 調号 + 小節内臨時記号を音高決定に反映
- パート名からの移調推定スイッチ追加・既定ON運用（`in A` / `in Bb` 等）

対象:
- `docs/music/src/abc-to-musicxml/ts/main.ts`
- `docs/music/src/abc-to-musicxml/js/main.js`
- `docs/music/src/common/ts/musicxml-writer-common.ts`
- `docs/music/src/common/js/musicxml-writer-common.js`
- `docs/music/abc-to-musicxml-src.html`
- `docs/music/abc-to-musicxml.html`
- `docs/music/src/abc-to-musicxml/css/app.css`

### 3) 回帰テストを追加
- `musicxml-to-abc` の統合テスト新規追加
- `abc-to-musicxml` の統合テスト新規追加
  - 移調推定ON/OFF
  - `M:C`
  - tie
  - broken rhythm
  - インライン文字列
  - `x` 休符

対象:
- `docs/music/tests/musicxml-to-abc-main.test.js`（新規）
- `docs/music/tests/abc-to-musicxml-main.test.js`（新規）

### 4) インデックス/READMEの並び整理
- MusicセクションのABC関連リンク順を調整（`MusicXML -> ABC` を先に）

対象:
- `docs/index.html`
- `README.md`

## Why

- 実データで発生していた「移調楽器だけ音がずれる」「一般的ABCが読めない」問題を解消するため
- 変換往復時（MusicXML→ABC→MusicXML）での二重移調や調号解釈崩れを抑制するため
- MVP範囲でも実運用で遭遇しやすいABC記法（`M:C`, tie, `>`, `"..."`, `x`）に対応するため

## Validation

- `vitest` 回帰テストを拡充し、変換主要シナリオをカバー
- 追加後テストは全件通過