### PR TITLE
ABC Compat Parser EBNF を実装準拠に更新（chord/tuplet/単独オクターブ記号）

### DIFF
--- a/docs/music/abc-compat-parser-ebnf.md
+++ b/docs/music/abc-compat-parser-ebnf.md
@@ -6,8 +6,8 @@ ABC 2.1 を土台にしつつ、`abcjs` / `abcm2ps` でよく見かける記法�
 ## Scope
 
 - ヘッダ: `X,T,C,M,L,K,V` と `%%score`
-- ボディ: 音符、休符(`z/x`)、臨時記号、長さ、タイ(`-`)、broken rhythm(`>` `<`)、小節線
-- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ
+- ボディ: 音符、休符(`z/x`)、臨時記号、長さ、タイ(`-`)、broken rhythm(`>` `<`)、小節線、和音、連符
+- 許容拡張: `M:C`, `M:C|`, インライン文字列(`"..."`)のスキップ、単独オクターブ記号(`,`/`'`)の許容
 
 ## EBNF
 
@@ -25,14 +25,20 @@ header_value     = { any_char_except_newline } ;
 
 body             = { body_token | ws } ;
 body_token       = note_or_rest
+                 | chord
+                 | tuplet
                  | barline
                  | tie
                  | broken_rhythm
                  | inline_text
                  | decoration
-                 | ignorable_symbol ;
+                 | ignorable_symbol
+                 | standalone_octave_mark ;
 
 note_or_rest     = accidental? , pitch_or_rest , octave_marks? , length? , broken_rhythm? ;
+chord            = "[" , chord_note , { chord_note } , "]" , length? , broken_rhythm? ;
+chord_note       = accidental? , pitch , octave_marks? , length? ;
+tuplet           = "(" , digit , [ ":" , digit ] , [ ":" , digit ] ;
 accidental       = "=" | "^" , ["^"] | "_" , ["_"] ;
 pitch_or_rest    = pitch | rest ;
 pitch            = "A"|"B"|"C"|"D"|"E"|"F"|"G"
@@ -46,10 +52,11 @@ length           = integer [ "/" , integer ]
 barline          = "|" | ":" ;
 tie              = "-" ;
 broken_rhythm    = ">" | "<" ;
+standalone_octave_mark = "," | "'" ;
 inline_text      = '"' , { any_char_except_quote } , '"' ;
 decoration       = "!" , { any_char_except_bang } , "!"
                  | "+" , { any_char_except_plus } , "+" ;
-ignorable_symbol = "(" | ")" | "[" | "]" | "{" | "}" ;
+ignorable_symbol = ")" | "{" | "}" ;
 
 voice_id         = ( letter | digit | "_" | "." | "-" ) ,
                    { letter | digit | "_" | "." | "-" } ;
@@ -72,8 +79,10 @@ digit            = "0".."9" ;
 - `A > B` のような空白入り broken rhythm を許容。
 - `"D"A` のような和音名/注釈は MusicXML 生成対象外としてスキップ（警告のみ）。
 - `x` 休符を `z` と同様に扱う。
+- chord (`[CEG]`, `[A,,CE]` など) を同時発音として扱う。
+- tuplet (`(3abc`, `(5:4:5abcde` など) を音価スケーリングで扱う。
 - `:|`, `|:`, `||` などの `:` は小節補助記号として無視（構文エラー化しない）。
-- 現時点で chord (`[CEG]`) / tuplet (`(3abc`) は未対応で、警告付きスキップ。
+- 単独の `,` / `'` は互換目的で無視して継続する。
 
 ## Growth Policy
 


### PR DESCRIPTION
### 概要
`docs/music/abc-compat-parser-ebnf.md` を、現行 `AbcCompatParser` の実装内容に合わせて更新しました。 これまで文書上は未対応扱いだった記法（和音・連符など）を、実態に合わせて明記しています。

### 変更内容
- `Scope` を更新
  - ボディ対象に `和音` と `連符` を追加
  - 許容拡張として単独オクターブ記号（`,` / `'`）の許容を追記
- `EBNF` を更新
  - `body_token` に `chord` / `tuplet` / `standalone_octave_mark` を追加
  - `chord`, `chord_note`, `tuplet` のルールを新規追加
  - `ignorable_symbol` から `(`, `[` など実際に解釈対象となる記号を除外
- `Compatibility Notes` を更新
  - chord/tuplet が対応済みであることを明記
  - 単独 `,` / `'` を互換目的で無視継続する挙動を追記
  - 「chord/tuplet 未対応」の古い記述を削除

### 目的
- 実装と仕様文書の不一致を解消
- 今後の parser 拡張時に、文書を正しい参照元として維持しやすくする

### 影響範囲
- ドキュメントのみ（コード挙動の変更なし）
- 対象ファイル: `docs/music/abc-compat-parser-ebnf.md`