### PR TITLE
musicxml-to-svg に横スクロール長尺SVGモードを追加し、改ページ制御を切り替え可能にする

### DIFF
--- a/docs/music/musicxml-to-svg-src.html
+++ b/docs/music/musicxml-to-svg-src.html
@@ -154,7 +154,14 @@ limitations under the License.
           </div>
           <div>
             <label class="md-label" for="pageWidthInput">pageWidth</label>
-            <input id="pageWidthInput" class="md-input" type="number" min="400" max="5000" step="10" value="1600" />
+            <input id="pageWidthInput" class="md-input" type="number" min="400" max="50000" step="10" value="1600" />
+          </div>
+          <div>
+            <label class="md-label" for="longLineModeInput">右方向に広げる（横スクロール）</label>
+            <label class="md-radio-option">
+              <input id="longLineModeInput" type="checkbox" />
+              <span>改ページを抑えて右に長いSVGを生成</span>
+            </label>
           </div>
           <div>
             <label class="md-label" for="marginTopInput">pageMarginTop</label>

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -220,6 +220,11 @@ limitations under the License.
       display: block;
     }
 
+    .md-preview-stage--long-line svg {
+      max-width: none;
+      width: auto;
+    }
+
     .md-pager {
       margin-top: 0.7rem;
       display: flex;
@@ -529,7 +534,14 @@ limitations under the License.
           </div>
           <div>
             <label class="md-label" for="pageWidthInput">pageWidth</label>
-            <input id="pageWidthInput" class="md-input" type="number" min="400" max="5000" step="10" value="1600" />
+            <input id="pageWidthInput" class="md-input" type="number" min="400" max="50000" step="10" value="1600" />
+          </div>
+          <div>
+            <label class="md-label" for="longLineModeInput">右方向に広げる（横スクロール）</label>
+            <label class="md-radio-option">
+              <input id="longLineModeInput" type="checkbox" />
+              <span>改ページを抑えて右に長いSVGを生成</span>
+            </label>
           </div>
           <div>
             <label class="md-label" for="marginTopInput">pageMarginTop</label>
@@ -1503,6 +1515,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
+    const longLineModeInput = document.getElementById("longLineModeInput");
     const marginTopInput = document.getElementById("marginTopInput");
     const marginBottomInput = document.getElementById("marginBottomInput");
     const marginLeftInput = document.getElementById("marginLeftInput");
@@ -1524,6 +1537,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     const STORAGE_KEY = "diagram-musicxml-render-options";
     const MIDI_TICKS_PER_QUARTER = 128;
+    const LONG_LINE_PAGE_WIDTH = 200000;
 
     let lastSvg = "";
     let lastSynthSchedule = null;
@@ -1560,8 +1574,13 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     ].forEach((input) => {
       input.addEventListener("change", persistOptions);
     });
+    longLineModeInput.addEventListener("change", () => {
+      applyLongLineModeUiState();
+      persistOptions();
+    });
 
     applyInputMode();
+    applyLongLineModeUiState();
     initVerovioToolkit();
 
     function initVerovioToolkit() {
@@ -1626,6 +1645,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("MusicXMLを入力してください。");
         return;
       }
+      const renderSource = isLongLineModeEnabled() ? removeMusicXmlForcedBreaks(source) : source;
 
       clearError();
       renderBtn.disabled = true;
@@ -1633,7 +1653,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
       try {
         const options = getRenderOptions();
         toolkit.setOptions(options);
-        toolkit.loadData(source);
+        toolkit.loadData(renderSource);
 
         pageCount = Number(toolkit.getPageCount()) || 0;
         if (pageCount < 1) {
@@ -1647,7 +1667,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         downloadSvgBtn.disabled = false;
         downloadZipBtn.disabled = false;
         try {
-        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(source, {
+        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(renderSource, {
           ticksPerQuarter: MIDI_TICKS_PER_QUARTER
         });
         } catch (_error) {
@@ -1751,14 +1771,22 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function getRenderOptions() {
-      return {
+      const longLineMode = isLongLineModeEnabled();
+      const options = {
         scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
-        pageWidth: sanitizeNumber(pageWidthInput.value, 1600, 400, 5000),
+        pageWidth: longLineMode ? LONG_LINE_PAGE_WIDTH : getPageWidthInputValue(),
         pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
         pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
         pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
-        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500)
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        breaks: longLineMode ? "none" : "auto",
+        adjustPageWidth: longLineMode
       };
+      return options;
+    }
+
+    function getPageWidthInputValue() {
+      return sanitizeNumber(pageWidthInput.value, 1600, 400, 50000);
     }
 
     function sanitizeNumber(rawValue, fallback, min, max) {
@@ -1770,7 +1798,15 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function persistOptions() {
-      const options = getRenderOptions();
+      const options = {
+        scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
+        pageWidth: getPageWidthInputValue(),
+        pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
+        pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
+        pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        longLineMode: isLongLineModeEnabled()
+      };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(options));
     }
 
@@ -1790,9 +1826,23 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setIfFinite(marginBottomInput, options.pageMarginBottom);
         setIfFinite(marginLeftInput, options.pageMarginLeft);
         setIfFinite(marginRightInput, options.pageMarginRight);
+        if (typeof options.longLineMode === "boolean") {
+          longLineModeInput.checked = options.longLineMode;
+        }
+        applyLongLineModeUiState();
       } catch (_error) {
         // Ignore broken localStorage data
       }
+    }
+
+    function isLongLineModeEnabled() {
+      return Boolean(longLineModeInput && longLineModeInput.checked);
+    }
+
+    function applyLongLineModeUiState() {
+      const enabled = isLongLineModeEnabled();
+      pageWidthInput.disabled = enabled;
+      svgPreview.classList.toggle("md-preview-stage--long-line", enabled);
     }
 
     function setIfFinite(input, value) {
@@ -1897,6 +1947,12 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     function normalizeMusicXMLSource(rawText) {
       return musicXmlCommon.normalizeMusicXmlSource(rawText);
+    }
+
+    function removeMusicXmlForcedBreaks(source) {
+      return source
+        .replace(/\s+new-system\s*=\s*"(?:yes|true|1)"/gi, "")
+        .replace(/\s+new-page\s*=\s*"(?:yes|true|1)"/gi, "");
     }
 
     function extractXmlErrorLine(message) {

--- a/docs/music/src/musicxml-to-svg/css/app.css
+++ b/docs/music/src/musicxml-to-svg/css/app.css
@@ -197,6 +197,11 @@
       display: block;
     }
 
+    .md-preview-stage--long-line svg {
+      max-width: none;
+      width: auto;
+    }
+
     .md-pager {
       margin-top: 0.7rem;
       display: flex;

--- a/docs/music/src/musicxml-to-svg/js/main.js
+++ b/docs/music/src/musicxml-to-svg/js/main.js
@@ -20,6 +20,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
+    const longLineModeInput = document.getElementById("longLineModeInput");
     const marginTopInput = document.getElementById("marginTopInput");
     const marginBottomInput = document.getElementById("marginBottomInput");
     const marginLeftInput = document.getElementById("marginLeftInput");
@@ -41,6 +42,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     const STORAGE_KEY = "diagram-musicxml-render-options";
     const MIDI_TICKS_PER_QUARTER = 128;
+    const LONG_LINE_PAGE_WIDTH = 200000;
 
     let lastSvg = "";
     let lastSynthSchedule = null;
@@ -77,8 +79,13 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     ].forEach((input) => {
       input.addEventListener("change", persistOptions);
     });
+    longLineModeInput.addEventListener("change", () => {
+      applyLongLineModeUiState();
+      persistOptions();
+    });
 
     applyInputMode();
+    applyLongLineModeUiState();
     initVerovioToolkit();
 
     function initVerovioToolkit() {
@@ -143,6 +150,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("MusicXMLを入力してください。");
         return;
       }
+      const renderSource = isLongLineModeEnabled() ? removeMusicXmlForcedBreaks(source) : source;
 
       clearError();
       renderBtn.disabled = true;
@@ -150,7 +158,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
       try {
         const options = getRenderOptions();
         toolkit.setOptions(options);
-        toolkit.loadData(source);
+        toolkit.loadData(renderSource);
 
         pageCount = Number(toolkit.getPageCount()) || 0;
         if (pageCount < 1) {
@@ -164,7 +172,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         downloadSvgBtn.disabled = false;
         downloadZipBtn.disabled = false;
         try {
-        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(source, {
+        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(renderSource, {
           ticksPerQuarter: MIDI_TICKS_PER_QUARTER
         });
         } catch (_error) {
@@ -268,14 +276,22 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function getRenderOptions() {
-      return {
+      const longLineMode = isLongLineModeEnabled();
+      const options = {
         scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
-        pageWidth: sanitizeNumber(pageWidthInput.value, 1600, 400, 5000),
+        pageWidth: longLineMode ? LONG_LINE_PAGE_WIDTH : getPageWidthInputValue(),
         pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
         pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
         pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
-        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500)
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        breaks: longLineMode ? "none" : "auto",
+        adjustPageWidth: longLineMode
       };
+      return options;
+    }
+
+    function getPageWidthInputValue() {
+      return sanitizeNumber(pageWidthInput.value, 1600, 400, 50000);
     }
 
     function sanitizeNumber(rawValue, fallback, min, max) {
@@ -287,7 +303,15 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function persistOptions() {
-      const options = getRenderOptions();
+      const options = {
+        scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
+        pageWidth: getPageWidthInputValue(),
+        pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
+        pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
+        pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        longLineMode: isLongLineModeEnabled()
+      };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(options));
     }
 
@@ -307,9 +331,23 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setIfFinite(marginBottomInput, options.pageMarginBottom);
         setIfFinite(marginLeftInput, options.pageMarginLeft);
         setIfFinite(marginRightInput, options.pageMarginRight);
+        if (typeof options.longLineMode === "boolean") {
+          longLineModeInput.checked = options.longLineMode;
+        }
+        applyLongLineModeUiState();
       } catch (_error) {
         // Ignore broken localStorage data
       }
+    }
+
+    function isLongLineModeEnabled() {
+      return Boolean(longLineModeInput && longLineModeInput.checked);
+    }
+
+    function applyLongLineModeUiState() {
+      const enabled = isLongLineModeEnabled();
+      pageWidthInput.disabled = enabled;
+      svgPreview.classList.toggle("md-preview-stage--long-line", enabled);
     }
 
     function setIfFinite(input, value) {
@@ -414,6 +452,12 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     function normalizeMusicXMLSource(rawText) {
       return musicXmlCommon.normalizeMusicXmlSource(rawText);
+    }
+
+    function removeMusicXmlForcedBreaks(source) {
+      return source
+        .replace(/\s+new-system\s*=\s*"(?:yes|true|1)"/gi, "")
+        .replace(/\s+new-page\s*=\s*"(?:yes|true|1)"/gi, "");
     }
 
     function extractXmlErrorLine(message) {

--- a/docs/music/src/musicxml-to-svg/ts/main.ts
+++ b/docs/music/src/musicxml-to-svg/ts/main.ts
@@ -20,6 +20,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     const fileNameText = document.getElementById("fileNameText");
     const scaleInput = document.getElementById("scaleInput");
     const pageWidthInput = document.getElementById("pageWidthInput");
+    const longLineModeInput = document.getElementById("longLineModeInput");
     const marginTopInput = document.getElementById("marginTopInput");
     const marginBottomInput = document.getElementById("marginBottomInput");
     const marginLeftInput = document.getElementById("marginLeftInput");
@@ -41,6 +42,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     const STORAGE_KEY = "diagram-musicxml-render-options";
     const MIDI_TICKS_PER_QUARTER = 128;
+    const LONG_LINE_PAGE_WIDTH = 200000;
 
     let lastSvg = "";
     let lastSynthSchedule = null;
@@ -77,8 +79,13 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     ].forEach((input) => {
       input.addEventListener("change", persistOptions);
     });
+    longLineModeInput.addEventListener("change", () => {
+      applyLongLineModeUiState();
+      persistOptions();
+    });
 
     applyInputMode();
+    applyLongLineModeUiState();
     initVerovioToolkit();
 
     function initVerovioToolkit() {
@@ -143,6 +150,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setError("MusicXMLを入力してください。");
         return;
       }
+      const renderSource = isLongLineModeEnabled() ? removeMusicXmlForcedBreaks(source) : source;
 
       clearError();
       renderBtn.disabled = true;
@@ -150,7 +158,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
       try {
         const options = getRenderOptions();
         toolkit.setOptions(options);
-        toolkit.loadData(source);
+        toolkit.loadData(renderSource);
 
         pageCount = Number(toolkit.getPageCount()) || 0;
         if (pageCount < 1) {
@@ -164,7 +172,7 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         downloadSvgBtn.disabled = false;
         downloadZipBtn.disabled = false;
         try {
-        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(source, {
+        lastSynthSchedule = musicXmlSynthScheduleCommon.buildSynthScheduleFromMusicXml(renderSource, {
           ticksPerQuarter: MIDI_TICKS_PER_QUARTER
         });
         } catch (_error) {
@@ -268,14 +276,22 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function getRenderOptions() {
-      return {
+      const longLineMode = isLongLineModeEnabled();
+      const options = {
         scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
-        pageWidth: sanitizeNumber(pageWidthInput.value, 1600, 400, 5000),
+        pageWidth: longLineMode ? LONG_LINE_PAGE_WIDTH : getPageWidthInputValue(),
         pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
         pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
         pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
-        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500)
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        breaks: longLineMode ? "none" : "auto",
+        adjustPageWidth: longLineMode
       };
+      return options;
+    }
+
+    function getPageWidthInputValue() {
+      return sanitizeNumber(pageWidthInput.value, 1600, 400, 50000);
     }
 
     function sanitizeNumber(rawValue, fallback, min, max) {
@@ -287,7 +303,15 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function persistOptions() {
-      const options = getRenderOptions();
+      const options = {
+        scale: sanitizeNumber(scaleInput.value, 40, 20, 200),
+        pageWidth: getPageWidthInputValue(),
+        pageMarginTop: sanitizeNumber(marginTopInput.value, 40, 0, 500),
+        pageMarginBottom: sanitizeNumber(marginBottomInput.value, 40, 0, 500),
+        pageMarginLeft: sanitizeNumber(marginLeftInput.value, 40, 0, 500),
+        pageMarginRight: sanitizeNumber(marginRightInput.value, 40, 0, 500),
+        longLineMode: isLongLineModeEnabled()
+      };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(options));
     }
 
@@ -307,9 +331,23 @@ const musicxmlInput = document.getElementById("musicxmlInput");
         setIfFinite(marginBottomInput, options.pageMarginBottom);
         setIfFinite(marginLeftInput, options.pageMarginLeft);
         setIfFinite(marginRightInput, options.pageMarginRight);
+        if (typeof options.longLineMode === "boolean") {
+          longLineModeInput.checked = options.longLineMode;
+        }
+        applyLongLineModeUiState();
       } catch (_error) {
         // Ignore broken localStorage data
       }
+    }
+
+    function isLongLineModeEnabled() {
+      return Boolean(longLineModeInput && longLineModeInput.checked);
+    }
+
+    function applyLongLineModeUiState() {
+      const enabled = isLongLineModeEnabled();
+      pageWidthInput.disabled = enabled;
+      svgPreview.classList.toggle("md-preview-stage--long-line", enabled);
     }
 
     function setIfFinite(input, value) {
@@ -414,6 +452,12 @@ const musicxmlInput = document.getElementById("musicxmlInput");
 
     function normalizeMusicXMLSource(rawText) {
       return musicXmlCommon.normalizeMusicXmlSource(rawText);
+    }
+
+    function removeMusicXmlForcedBreaks(source) {
+      return source
+        .replace(/\s+new-system\s*=\s*"(?:yes|true|1)"/gi, "")
+        .replace(/\s+new-page\s*=\s*"(?:yes|true|1)"/gi, "");
     }
 
     function extractXmlErrorLine(message) {


### PR DESCRIPTION
## 概要
`docs/music/musicxml-to-svg` に「改ページを抑えて右に長いSVGを生成」モードを追加しました。 ON時は改ページを抑制して横スクロール前提の長尺SVGを生成し、OFF時は従来どおりの改ページ挙動を維持します。

## 変更内容
- UIに長尺モードのチェックボックスを追加
  - ラベル: `右方向に広げる（横スクロール）`
  - 入力ID: `longLineModeInput`
- `pageWidth` 入力の上限を `5000` → `50000` に拡張
- 長尺モードON時のレンダリングオプションを追加
  - `pageWidth = 200000`
  - `breaks = "none"`
  - `adjustPageWidth = true`
- 長尺モードOFF時の従来挙動を明示
  - `breaks = "auto"`
  - `adjustPageWidth = false`
- MusicXML内の強制改行指定を長尺モードON時のみ無効化
  - `new-system` / `new-page` 属性を除去してから `toolkit.loadData(...)`
- プレビューCSSを調整し、長尺モード時はSVGの `max-width` 制限を解除して横スクロール表示
- `localStorage` 永続化に `longLineMode` を追加（保存/復元）

## 変更ファイル
- `docs/music/musicxml-to-svg-src.html`
- `docs/music/src/musicxml-to-svg/css/app.css`
- `docs/music/src/musicxml-to-svg/ts/main.ts`
- `docs/music/src/musicxml-to-svg/js/main.js`（生成更新）
- `docs/music/musicxml-to-svg.html`（生成更新）

## 期待される効果
- 長い楽譜を1行（または改ページを最小化した形）で右方向に確認しやすくなる
- 既存ユーザーはOFFのまま従来のページ分割表示を継続できる

## 確認観点
- 長尺モードON:
  - 複数小節が横方向へ連続して表示される
  - `pageWidth` 入力が無効化される
- 長尺モードOFF:
  - 従来どおり改ページされる
  - ページャー挙動（前へ/次へ）が維持される
- 再読み込み後も長尺モード設定が復元される