### PR TITLE
feat(music): MIDI→MusicXML 変換ツールを追加し、音域ベースのレーン/記号割り当てに対応

### DIFF
--- a/docs/music/BUILD_PROCESS.md
+++ b/docs/music/BUILD_PROCESS.md
@@ -5,6 +5,7 @@
 ## 対象（現行）
 
 - `musicxml-to-midi`
+- `midi-to-musicxml`
 - `musicxml-to-abc`
 - `abc-to-musicxml`
 - `musicxml-to-svg`
@@ -17,6 +18,14 @@
 - `docs/music/src/musicxml-to-midi/ts/main.ts`
 - `docs/music/src/musicxml-to-midi/js/midi-writer.js`（ライブラリ同梱）
 - `docs/music/src/musicxml-to-midi/js/main.js`（TS変換後）
+
+## ファイル構成（midi-to-musicxml）
+
+- `docs/music/midi-to-musicxml-src.html`: 開発用テンプレート（手編集対象）
+- `docs/music/midi-to-musicxml.html`: 配布用生成物（手編集しない）
+- `docs/music/src/midi-to-musicxml/css/app.css`
+- `docs/music/src/midi-to-musicxml/ts/main.ts`
+- `docs/music/src/midi-to-musicxml/js/main.js`（TS変換後）
 
 ## ファイル構成（musicxml-to-abc / abc-to-musicxml）
 

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -1253,6 +1253,7 @@ const MusicXmlWriterCommon = (() => {
 
         lines.push('    <measure number="' + measureNo + '">');
         if (measureIndex === 0) {
+          const clef = normalizeClef(part.clef);
           lines.push('      <attributes>');
           lines.push('        <divisions>960</divisions>');
           lines.push('        <key><fifths>' + meta.keyInfo.fifths + '</fifths></key>');
@@ -1266,7 +1267,7 @@ const MusicXmlWriterCommon = (() => {
             }
             lines.push("        </transpose>");
           }
-          lines.push('        <clef><sign>G</sign><line>2</line></clef>');
+          lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
         }
 
@@ -1346,6 +1347,18 @@ const MusicXmlWriterCommon = (() => {
       chromatic,
       octaveChange: Number.isFinite(octaveChange) ? octaveChange : 0
     };
+  }
+
+  function normalizeClef(rawClef) {
+    if (!rawClef || typeof rawClef !== "object") {
+      return { sign: "G", line: 2 };
+    }
+    const sign = String(rawClef.sign || "G").trim().toUpperCase();
+    const line = Number.parseInt(rawClef.line, 10);
+    if ((sign !== "G" && sign !== "F" && sign !== "C") || !Number.isFinite(line) || line <= 0) {
+      return { sign: "G", line: 2 };
+    }
+    return { sign, line };
   }
 
   return {

--- a/docs/music/midi-to-musicxml-src.html
+++ b/docs/music/midi-to-musicxml-src.html
@@ -1,0 +1,181 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MIDI → MusicXML 変換</title>
+    <link rel="stylesheet" href="src/midi-to-musicxml/css/app.css" />
+</head>
+<body>
+  <svg aria-hidden="true" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 7h16" />
+        <path d="M4 12h16" />
+        <path d="M4 17h16" />
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2" />
+        <rect x="4" y="4" width="11" height="11" rx="2" />
+      </symbol>
+    </defs>
+  </svg>
+
+  <main class="md-shell">
+    <section class="md-card">
+      <button type="button" class="md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
+        </svg>
+      </button>
+      <div id="menuPanel" class="md-menu-panel md-hidden">
+        <a href="../index.html" class="md-menu-link">トップへ戻る</a>
+      </div>
+
+      <h1 class="md-headline">
+        <span aria-hidden="true" class="md-headline__icon">🎹</span>
+        <span>MIDI → MusicXML 変換</span>
+        <span class="md-tooltip-group">
+          <span class="md-info-chip" tabindex="0" aria-label="このツールの説明">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
+              <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
+              <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
+              <circle cx="12" cy="7.5" r="1" fill="#ffffff"></circle>
+            </svg>
+          </span>
+          <span class="md-tooltip-content md-tooltip">MIDIをMusicXMLに変換します。MVPとしてノート列中心に変換し、拍子・テンポは取得できる範囲で反映します。</span>
+        </span>
+      </h1>
+
+      <section class="md-section">
+        <div class="md-title-info-row">
+          <h2 class="md-section-title">MIDI入力</h2>
+        </div>
+
+        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
+          <label class="md-radio-option">
+            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
+            <span>ファイル読込</span>
+          </label>
+          <label class="md-radio-option">
+            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
+            <span>16進ソース入力</span>
+          </label>
+        </div>
+
+        <div id="fileInputBlock">
+          <div class="md-actions">
+            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+              <span>ファイルを選択</span>
+            </button>
+            <span id="fileNameText">未選択</span>
+          </div>
+          <input id="fileInput" class="md-file" type="file" accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream" hidden />
+        </div>
+
+        <div id="sourceInputBlock" class="md-hidden">
+          <textarea id="hexInput" class="md-textarea md-textarea--compact" spellcheck="false" placeholder="4D546864000000060001000201E04D54726B... (16進)"></textarea>
+        </div>
+      </section>
+
+      <section class="md-section">
+        <div class="md-title-info-row">
+          <h2 class="md-section-title">変換設定</h2>
+        </div>
+
+        <details class="md-disclosure">
+          <summary class="md-disclosure-summary">詳細設定（既定タイトル / 既定作曲者 / 量子化 / 時間スケール）</summary>
+          <div class="md-grid md-grid--defaults">
+            <div>
+              <label class="md-label" for="defaultTitleInput">既定タイトル</label>
+              <input id="defaultTitleInput" class="md-input" type="text" value="Untitled" />
+            </div>
+            <div>
+              <label class="md-label" for="defaultComposerInput">既定作曲者</label>
+              <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
+            </div>
+            <div>
+              <label class="md-label" for="quantizeSelect">量子化単位</label>
+              <select id="quantizeSelect" class="md-input">
+                <option value="1/8">1/8</option>
+                <option value="1/16" selected>1/16</option>
+                <option value="1/32">1/32</option>
+              </select>
+            </div>
+            <div>
+              <label class="md-label" for="timeScaleSelect">時間スケール</label>
+              <select id="timeScaleSelect" class="md-input">
+                <option value="0.5">0.5x (半分)</option>
+                <option value="1" selected>1.0x (そのまま)</option>
+                <option value="2">2.0x (2倍)</option>
+              </select>
+            </div>
+          </div>
+        </details>
+
+        <div class="md-grid">
+          <div>
+            <label class="md-label" for="defaultTempoInput">既定テンポ (BPM)</label>
+            <input id="defaultTempoInput" class="md-input" type="number" min="20" max="300" step="1" value="120" />
+          </div>
+          <div>
+            <label class="md-label" for="defaultBeatsInput">既定拍子（分子）</label>
+            <input id="defaultBeatsInput" class="md-input" type="number" min="1" max="12" step="1" value="4" />
+          </div>
+          <div>
+            <label class="md-label" for="defaultBeatTypeInput">既定拍子（分母）</label>
+            <input id="defaultBeatTypeInput" class="md-input" type="number" min="1" max="16" step="1" value="4" />
+          </div>
+        </div>
+
+        <div class="md-actions">
+          <button id="convertBtn" class="md-button md-button--primary" type="button">
+            <span>変換</span>
+          </button>
+          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>
+            <span>MusicXML保存</span>
+          </button>
+          <button id="copyBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+            </svg>
+            <span>コピー</span>
+          </button>
+        </div>
+        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <p id="warningText" class="md-warning md-hidden"></p>
+      </section>
+
+      <section class="md-section">
+        <h2 class="md-section-title">簡易プレビュー</h2>
+        <div id="previewText" class="md-preview">未変換</div>
+      </section>
+
+      <section class="md-section">
+        <h2 class="md-section-title">MusicXML出力</h2>
+        <code id="xmlOutput" class="md-code"></code>
+      </section>
+    </section>
+  </main>
+
+  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+
+    <script src="src/common/js/musicxml-writer-common.js"></script>
+    <script src="src/midi-to-musicxml/js/main.js"></script>
+</body>
+</html>

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -1,0 +1,1668 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MIDI → MusicXML 変換</title>
+    
+  <style>
+:root {
+      --md-danger: #b3261e;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-tertiary-container: #f3e8fd;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Yu Gothic UI", "Hiragino Sans", sans-serif;
+      background: var(--md-sys-color-background);
+      color: var(--md-sys-color-on-surface);
+    }
+
+    .md-shell {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      position: relative;
+    }
+
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin: 0 0 1rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+
+    .md-headline__icon {
+      margin-right: 0.4rem;
+    }
+
+    .md-section {
+      margin-top: 1.2rem;
+    }
+
+    .md-section-title {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .md-title-info-row {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      margin-bottom: 0.35rem;
+    }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.54rem;
+      font-weight: 600;
+      background: #eceaf1;
+      color: #49454f;
+    }
+
+    .md-textarea,
+    .md-input,
+    .md-file {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      box-sizing: border-box;
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-textarea {
+      min-height: 15rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      line-height: 1.5;
+    }
+
+    .md-textarea--compact {
+      min-height: 8rem;
+    }
+
+    .md-textarea:focus,
+    .md-input:focus,
+    .md-file:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.8rem;
+    }
+
+    .md-radio-group {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+
+    .md-radio-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
+    .md-grid--defaults {
+      margin-top: 0.8rem;
+    }
+
+    .md-disclosure {
+      margin-bottom: 0.8rem;
+      border: 1px solid #e5e0ec;
+      border-radius: 12px;
+      background: #faf8fc;
+      padding: 0.7rem 0.85rem;
+    }
+
+    .md-disclosure-summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: #3d2e5a;
+      list-style: none;
+    }
+
+    .md-disclosure-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .md-disclosure-summary::before {
+      content: "▸";
+      display: inline-block;
+      margin-right: 0.35rem;
+      transition: transform 120ms ease;
+    }
+
+    .md-disclosure[open] .md-disclosure-summary::before {
+      transform: rotate(90deg);
+    }
+
+    @media (min-width: 720px) {
+      .md-grid {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+    }
+
+    .md-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      margin-top: 0.8rem;
+    }
+
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background 150ms ease;
+      white-space: nowrap;
+    }
+
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+
+    .md-button--primary:hover {
+      background: #4f00c9;
+    }
+
+    .md-button--secondary {
+      background: #e8f5f3;
+      color: #15443e;
+      box-shadow: 0 2px 6px rgba(3, 218, 198, 0.25);
+    }
+
+    .md-button:disabled {
+      background: #e6e1ee;
+      color: #9a94a7;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .md-preview {
+      border: 1px solid #e5e0ec;
+      border-radius: 12px;
+      padding: 0.75rem;
+      background: var(--md-sys-color-tertiary-container);
+      font-size: 0.9rem;
+      color: #3d2e5a;
+      white-space: pre-wrap;
+    }
+
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      min-height: 8rem;
+    }
+
+    .md-error {
+      margin-top: 0.7rem;
+      color: var(--md-danger);
+      font-size: 0.92rem;
+      white-space: pre-wrap;
+    }
+
+    .md-warning {
+      margin-top: 0.7rem;
+      color: #8a4f00;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+      background: #fff3e0;
+      border: 1px solid #ffcc80;
+      border-radius: 10px;
+      padding: 0.6rem 0.7rem;
+    }
+
+    .md-snackbar {
+      position: fixed;
+      left: 50%;
+      bottom: 1.2rem;
+      transform: translateX(-50%);
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.65rem 0.95rem;
+      border-radius: 999px;
+      font-size: 0.86rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+      z-index: 120;
+    }
+
+    .md-visible {
+      opacity: 1;
+    }
+
+    .md-hidden {
+      display: none;
+    }
+
+    .md-menu-button {
+      position: absolute;
+      top: 14px;
+      right: 14px;
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      background: #f0edf5;
+      border: none;
+      cursor: pointer;
+    }
+
+    .md-menu-panel {
+      position: absolute;
+      top: 58px;
+      right: 14px;
+      background: #ffffff;
+      border: 1px solid #ddd5ea;
+      border-radius: 10px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+      min-width: 160px;
+      z-index: 100;
+    }
+
+    .md-menu-link {
+      display: block;
+      padding: 0.7rem 0.9rem;
+      color: #342f3e;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    .md-menu-link:hover {
+      background: #f6f1fb;
+    }
+
+    .md-tooltip-group {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+    }
+
+    .md-info-icon {
+      width: 18px;
+      height: 18px;
+    }
+
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+
+    .md-tooltip-group:hover .md-tooltip-content,
+    .md-tooltip-group:focus-within .md-tooltip-content {
+      opacity: 1;
+    }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+  </style>
+</head>
+<body>
+  <svg aria-hidden="true" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 7h16" />
+        <path d="M4 12h16" />
+        <path d="M4 17h16" />
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2" />
+        <rect x="4" y="4" width="11" height="11" rx="2" />
+      </symbol>
+    </defs>
+  </svg>
+
+  <main class="md-shell">
+    <section class="md-card">
+      <button type="button" class="md-menu-button" aria-label="メニュー" onclick="toggleMenu()">
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
+        </svg>
+      </button>
+      <div id="menuPanel" class="md-menu-panel md-hidden">
+        <a href="../index.html" class="md-menu-link">トップへ戻る</a>
+      </div>
+
+      <h1 class="md-headline">
+        <span aria-hidden="true" class="md-headline__icon">🎹</span>
+        <span>MIDI → MusicXML 変換</span>
+        <span class="md-tooltip-group">
+          <span class="md-info-chip" tabindex="0" aria-label="このツールの説明">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none">
+              <circle cx="12" cy="12" r="9" fill="#cbbcf0"></circle>
+              <rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"></rect>
+              <circle cx="12" cy="7.5" r="1" fill="#ffffff"></circle>
+            </svg>
+          </span>
+          <span class="md-tooltip-content md-tooltip">MIDIをMusicXMLに変換します。MVPとしてノート列中心に変換し、拍子・テンポは取得できる範囲で反映します。</span>
+        </span>
+      </h1>
+
+      <section class="md-section">
+        <div class="md-title-info-row">
+          <h2 class="md-section-title">MIDI入力</h2>
+        </div>
+
+        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
+          <label class="md-radio-option">
+            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
+            <span>ファイル読込</span>
+          </label>
+          <label class="md-radio-option">
+            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
+            <span>16進ソース入力</span>
+          </label>
+        </div>
+
+        <div id="fileInputBlock">
+          <div class="md-actions">
+            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
+              <span>ファイルを選択</span>
+            </button>
+            <span id="fileNameText">未選択</span>
+          </div>
+          <input id="fileInput" class="md-file" type="file" accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream" hidden />
+        </div>
+
+        <div id="sourceInputBlock" class="md-hidden">
+          <textarea id="hexInput" class="md-textarea md-textarea--compact" spellcheck="false" placeholder="4D546864000000060001000201E04D54726B... (16進)"></textarea>
+        </div>
+      </section>
+
+      <section class="md-section">
+        <div class="md-title-info-row">
+          <h2 class="md-section-title">変換設定</h2>
+        </div>
+
+        <details class="md-disclosure">
+          <summary class="md-disclosure-summary">詳細設定（既定タイトル / 既定作曲者 / 量子化 / 時間スケール）</summary>
+          <div class="md-grid md-grid--defaults">
+            <div>
+              <label class="md-label" for="defaultTitleInput">既定タイトル</label>
+              <input id="defaultTitleInput" class="md-input" type="text" value="Untitled" />
+            </div>
+            <div>
+              <label class="md-label" for="defaultComposerInput">既定作曲者</label>
+              <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
+            </div>
+            <div>
+              <label class="md-label" for="quantizeSelect">量子化単位</label>
+              <select id="quantizeSelect" class="md-input">
+                <option value="1/8">1/8</option>
+                <option value="1/16" selected>1/16</option>
+                <option value="1/32">1/32</option>
+              </select>
+            </div>
+            <div>
+              <label class="md-label" for="timeScaleSelect">時間スケール</label>
+              <select id="timeScaleSelect" class="md-input">
+                <option value="0.5">0.5x (半分)</option>
+                <option value="1" selected>1.0x (そのまま)</option>
+                <option value="2">2.0x (2倍)</option>
+              </select>
+            </div>
+          </div>
+        </details>
+
+        <div class="md-grid">
+          <div>
+            <label class="md-label" for="defaultTempoInput">既定テンポ (BPM)</label>
+            <input id="defaultTempoInput" class="md-input" type="number" min="20" max="300" step="1" value="120" />
+          </div>
+          <div>
+            <label class="md-label" for="defaultBeatsInput">既定拍子（分子）</label>
+            <input id="defaultBeatsInput" class="md-input" type="number" min="1" max="12" step="1" value="4" />
+          </div>
+          <div>
+            <label class="md-label" for="defaultBeatTypeInput">既定拍子（分母）</label>
+            <input id="defaultBeatTypeInput" class="md-input" type="number" min="1" max="16" step="1" value="4" />
+          </div>
+        </div>
+
+        <div class="md-actions">
+          <button id="convertBtn" class="md-button md-button--primary" type="button">
+            <span>変換</span>
+          </button>
+          <button id="downloadBtn" class="md-button md-button--secondary" type="button" disabled>
+            <span>MusicXML保存</span>
+          </button>
+          <button id="copyBtn" class="md-button md-button--secondary" type="button" disabled>
+            <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
+              <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+            </svg>
+            <span>コピー</span>
+          </button>
+        </div>
+        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <p id="warningText" class="md-warning md-hidden"></p>
+      </section>
+
+      <section class="md-section">
+        <h2 class="md-section-title">簡易プレビュー</h2>
+        <div id="previewText" class="md-preview">未変換</div>
+      </section>
+
+      <section class="md-section">
+        <h2 class="md-section-title">MusicXML出力</h2>
+        <code id="xmlOutput" class="md-code"></code>
+      </section>
+    </section>
+  </main>
+
+  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+
+    
+    
+  <script>
+const MusicXmlWriterCommon = (() => {
+  function escapeXml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+  }
+
+  function buildScorePartwiseXml(parsed) {
+    const lines = [];
+    const meta = parsed.meta;
+    const parts = Array.isArray(parsed.parts) && parsed.parts.length > 0
+      ? parsed.parts
+      : [{
+        partId: "P1",
+        partName: "Music",
+        measures: parsed.measures || [[]]
+      }];
+
+    lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+    lines.push('<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN"');
+    lines.push('  "http://www.musicxml.org/dtds/partwise.dtd">');
+    lines.push('<score-partwise version="3.1">');
+    lines.push('  <work><work-title>' + escapeXml(meta.title) + '</work-title></work>');
+    lines.push('  <identification><creator type="composer">' + escapeXml(meta.composer) + '</creator></identification>');
+    lines.push('  <part-list>');
+    for (const part of parts) {
+      const partId = part.partId || "P1";
+      const partName = part.partName || "Music";
+      lines.push('    <score-part id="' + escapeXml(partId) + '"><part-name>' + escapeXml(partName) + '</part-name></score-part>');
+    }
+    lines.push('  </part-list>');
+    for (const part of parts) {
+      const partId = part.partId || "P1";
+      const measures = Array.isArray(part.measures) && part.measures.length > 0 ? part.measures : [[]];
+      lines.push('  <part id="' + escapeXml(partId) + '">');
+
+      for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
+        const measureNo = measureIndex + 1;
+        const notes = measures[measureIndex];
+
+        lines.push('    <measure number="' + measureNo + '">');
+        if (measureIndex === 0) {
+          const clef = normalizeClef(part.clef);
+          lines.push('      <attributes>');
+          lines.push('        <divisions>960</divisions>');
+          lines.push('        <key><fifths>' + meta.keyInfo.fifths + '</fifths></key>');
+          lines.push('        <time><beats>' + meta.meter.beats + '</beats><beat-type>' + meta.meter.beatType + '</beat-type></time>');
+          const transpose = normalizeTranspose(part.transpose);
+          if (transpose) {
+            lines.push("        <transpose>");
+            lines.push("          <chromatic>" + transpose.chromatic + "</chromatic>");
+            if (Number.isFinite(transpose.octaveChange) && transpose.octaveChange !== 0) {
+              lines.push("          <octave-change>" + transpose.octaveChange + "</octave-change>");
+            }
+            lines.push("        </transpose>");
+          }
+          lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
+          lines.push('      </attributes>');
+        }
+
+        for (const note of notes) {
+          lines.push('      <note>');
+          if (note.chord) {
+            lines.push("        <chord/>");
+          }
+          if (note.isRest) {
+            lines.push('        <rest/>');
+          } else {
+            lines.push('        <pitch>');
+            lines.push('          <step>' + note.step + '</step>');
+            if (note.alter !== null) {
+              lines.push('          <alter>' + note.alter + '</alter>');
+            }
+            lines.push('          <octave>' + note.octave + '</octave>');
+            lines.push('        </pitch>');
+          }
+
+          lines.push('        <duration>' + note.duration + '</duration>');
+          lines.push('        <type>' + note.type + '</type>');
+          if (note.voice) {
+            lines.push('        <voice>' + escapeXml(note.voice) + '</voice>');
+          }
+          if (!note.isRest && note.accidentalText) {
+            lines.push('        <accidental>' + note.accidentalText + '</accidental>');
+          }
+          if (!note.isRest && note.tieStart) {
+            lines.push("        <tie type=\"start\"/>");
+          }
+          if (!note.isRest && note.tieStop) {
+            lines.push("        <tie type=\"stop\"/>");
+          }
+          if (!note.isRest && (note.tieStart || note.tieStop)) {
+            lines.push("        <notations>");
+            if (note.tieStart) {
+              lines.push("          <tied type=\"start\"/>");
+            }
+            if (note.tieStop) {
+              lines.push("          <tied type=\"stop\"/>");
+            }
+            lines.push("        </notations>");
+          }
+          lines.push('      </note>');
+        }
+
+        lines.push('    </measure>');
+      }
+
+      lines.push('  </part>');
+    }
+    lines.push('</score-partwise>');
+    return lines.join("\n");
+  }
+
+  function normalizeTranspose(rawTranspose) {
+    if (rawTranspose === null || typeof rawTranspose === "undefined") {
+      return null;
+    }
+    if (Number.isFinite(rawTranspose)) {
+      const chromaticOnly = Number(rawTranspose);
+      if (chromaticOnly === 0) {
+        return null;
+      }
+      return { chromatic: chromaticOnly, octaveChange: 0 };
+    }
+    if (typeof rawTranspose !== "object") {
+      return null;
+    }
+    const chromatic = Number(rawTranspose.chromatic);
+    const octaveChange = Number(rawTranspose.octaveChange || 0);
+    if (!Number.isFinite(chromatic) || chromatic === 0) {
+      return null;
+    }
+    return {
+      chromatic,
+      octaveChange: Number.isFinite(octaveChange) ? octaveChange : 0
+    };
+  }
+
+  function normalizeClef(rawClef) {
+    if (!rawClef || typeof rawClef !== "object") {
+      return { sign: "G", line: 2 };
+    }
+    const sign = String(rawClef.sign || "G").trim().toUpperCase();
+    const line = Number.parseInt(rawClef.line, 10);
+    if ((sign !== "G" && sign !== "F" && sign !== "C") || !Number.isFinite(line) || line <= 0) {
+      return { sign: "G", line: 2 };
+    }
+    return { sign, line };
+  }
+
+  return {
+    escapeXml,
+    buildScorePartwiseXml
+  };
+})();
+
+if (typeof window !== "undefined") {
+  window["MusicXmlWriterCommon"] = MusicXmlWriterCommon;
+}
+  </script>
+
+  <script>
+const musicXmlWriterCommon = window["MusicXmlWriterCommon"] || (typeof MusicXmlWriterCommon !== "undefined" ? MusicXmlWriterCommon : null);
+if (!musicXmlWriterCommon) {
+  throw new Error("MusicXmlWriterCommon is not loaded.");
+}
+
+const fileInput = document.getElementById("fileInput");
+const fileSelectBtn = document.getElementById("fileSelectBtn");
+const fileNameText = document.getElementById("fileNameText");
+const inputModeSourceRadio = document.getElementById("inputModeSource");
+const inputModeFileRadio = document.getElementById("inputModeFile");
+const sourceInputBlock = document.getElementById("sourceInputBlock");
+const fileInputBlock = document.getElementById("fileInputBlock");
+const hexInput = document.getElementById("hexInput");
+const defaultTitleInput = document.getElementById("defaultTitleInput");
+const defaultComposerInput = document.getElementById("defaultComposerInput");
+const defaultTempoInput = document.getElementById("defaultTempoInput");
+const defaultBeatsInput = document.getElementById("defaultBeatsInput");
+const defaultBeatTypeInput = document.getElementById("defaultBeatTypeInput");
+const quantizeSelect = document.getElementById("quantizeSelect");
+const timeScaleSelect = document.getElementById("timeScaleSelect");
+const convertBtn = document.getElementById("convertBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const previewText = document.getElementById("previewText");
+const xmlOutput = document.getElementById("xmlOutput");
+const errorText = document.getElementById("errorText");
+const warningText = document.getElementById("warningText");
+const toast = document.getElementById("toast");
+const menuPanel = document.getElementById("menuPanel");
+
+const SETTINGS_KEY = "midi-to-musicxml-settings";
+const MAX_POLYPHONY_LANES = 16;
+const TREBLE_BASS_SPLIT_NOTE = 60;
+const TREBLE_CLEF = { sign: "G", line: 2, label: "Treble" };
+const BASS_CLEF = { sign: "F", line: 4, label: "Bass" };
+
+let loadedMidiBytes = null;
+let loadedMidiName = "";
+let lastXmlText = "";
+
+restoreSettings();
+
+fileInput.addEventListener("change", onFileChange);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+inputModeSourceRadio.addEventListener("change", applyInputMode);
+inputModeFileRadio.addEventListener("change", applyInputMode);
+defaultTitleInput.addEventListener("change", persistSettings);
+defaultComposerInput.addEventListener("change", persistSettings);
+defaultTempoInput.addEventListener("change", persistSettings);
+defaultBeatsInput.addEventListener("change", persistSettings);
+defaultBeatTypeInput.addEventListener("change", persistSettings);
+quantizeSelect.addEventListener("change", persistSettings);
+timeScaleSelect.addEventListener("change", persistSettings);
+convertBtn.addEventListener("click", convertMidi);
+downloadBtn.addEventListener("click", downloadMusicXml);
+copyBtn.addEventListener("click", copyMusicXml);
+document.addEventListener("click", handleDocumentClick);
+
+applyInputMode();
+
+function onFileChange(event) {
+  const file = event.target.files && event.target.files[0];
+  if (!file) {
+    loadedMidiBytes = null;
+    loadedMidiName = "";
+    updateFileName("");
+    return;
+  }
+
+  inputModeFileRadio.checked = true;
+  applyInputMode();
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    const result = reader.result;
+    if (!(result instanceof ArrayBuffer)) {
+      setError("MIDIファイルの読み込みに失敗しました。");
+      return;
+    }
+    loadedMidiBytes = new Uint8Array(result);
+    loadedMidiName = file.name;
+    updateFileName(file.name);
+    showToast("MIDIを読み込みました。");
+  };
+  reader.onerror = () => {
+    setError("MIDIファイルの読み込みに失敗しました。");
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+function updateFileName(name) {
+  fileNameText.textContent = name || "未選択";
+}
+
+function applyInputMode() {
+  const sourceMode = inputModeSourceRadio.checked;
+  sourceInputBlock.classList.toggle("md-hidden", !sourceMode);
+  fileInputBlock.classList.toggle("md-hidden", sourceMode);
+}
+
+function convertMidi() {
+  clearError();
+  clearWarning();
+
+  try {
+    const midiBytes = getInputMidiBytes();
+    if (!midiBytes || midiBytes.length === 0) {
+      throw new Error("MIDI入力が空です。");
+    }
+
+    const settings = {
+      defaultTitle: (defaultTitleInput.value || "").trim() || "Untitled",
+      defaultComposer: (defaultComposerInput.value || "").trim() || "Unknown",
+      defaultTempo: clampNumber(defaultTempoInput.value, 120, 20, 300),
+      defaultBeats: clampNumber(defaultBeatsInput.value, 4, 1, 12),
+      defaultBeatType: clampNumber(defaultBeatTypeInput.value, 4, 1, 16),
+      quantize: quantizeSelect.value || "1/16",
+      timeScale: clampFloat(timeScaleSelect.value, 1, 0.1, 8)
+    };
+
+    const parsedMidi = parseMidiFile(midiBytes);
+    const conversion = convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedMidiName);
+    const xml = musicXmlWriterCommon.buildScorePartwiseXml(conversion.parsedForXml);
+
+    lastXmlText = xml;
+    xmlOutput.textContent = xml;
+    downloadBtn.disabled = false;
+    copyBtn.disabled = false;
+
+    const previewLines = [
+      "title: " + conversion.summary.title,
+      "composer: " + conversion.summary.composer,
+      "format: " + parsedMidi.format,
+      "tracks: " + parsedMidi.trackCount,
+      "parts: " + conversion.summary.parts,
+      "ppqn: " + parsedMidi.ppqn,
+      "tempo: " + conversion.summary.tempo,
+      "meter: " + conversion.summary.meter,
+      "time scale: " + settings.timeScale + "x",
+      "notes: " + conversion.summary.notes,
+      "rests: " + conversion.summary.rests,
+      "measures: " + conversion.summary.measures
+    ];
+    previewText.textContent = previewLines.join("\n");
+
+    if (conversion.warnings.length > 0) {
+      warningText.textContent = "警告:\n" + conversion.warnings.join("\n");
+      warningText.classList.remove("md-hidden");
+    }
+
+    showToast("MusicXMLを生成しました。");
+  } catch (error) {
+    resetOutput();
+    const message = error && error.message ? error.message : String(error);
+    setError("変換に失敗しました: " + message);
+  }
+}
+
+function getInputMidiBytes() {
+  if (inputModeSourceRadio.checked) {
+    const source = (hexInput.value || "").trim();
+    if (!source) {
+      return null;
+    }
+    return parseHexString(source);
+  }
+  return loadedMidiBytes;
+}
+
+function parseHexString(text) {
+  const cleaned = text.replace(/[^0-9a-fA-F]/g, "");
+  if (cleaned.length === 0) {
+    return null;
+  }
+  if (cleaned.length % 2 !== 0) {
+    throw new Error("16進ソースの桁数が不正です。");
+  }
+  const out = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function parseMidiFile(bytes) {
+  const reader = createReader(bytes);
+  const chunkId = readAscii(reader, 4);
+  if (chunkId !== "MThd") {
+    throw new Error("MIDIヘッダ (MThd) が見つかりません。");
+  }
+
+  const headerLength = readU32(reader);
+  if (headerLength < 6) {
+    throw new Error("MIDIヘッダ長が不正です。");
+  }
+
+  const format = readU16(reader);
+  const trackCount = readU16(reader);
+  const division = readU16(reader);
+  if ((division & 0x8000) !== 0) {
+    throw new Error("SMPTE形式のdivisionには未対応です。");
+  }
+  const ppqn = division;
+
+  if (headerLength > 6) {
+    reader.offset += headerLength - 6;
+  }
+
+  const trackParses = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const warnings = [];
+
+  for (let trackIndex = 0; trackIndex < trackCount; trackIndex += 1) {
+    const id = readAscii(reader, 4);
+    if (id !== "MTrk") {
+      throw new Error("MTrkチャンクが見つかりません。track=" + (trackIndex + 1));
+    }
+    const length = readU32(reader);
+    const trackEnd = reader.offset + length;
+    if (trackEnd > bytes.length) {
+      throw new Error("MTrkチャンク長が不正です。track=" + (trackIndex + 1));
+    }
+    const parsedTrack = parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings);
+    trackParses.push(parsedTrack);
+    for (const ev of parsedTrack.tempoEvents) {
+      tempoEvents.push(ev);
+    }
+    for (const ev of parsedTrack.meterEvents) {
+      meterEvents.push(ev);
+    }
+    reader.offset = trackEnd;
+  }
+
+  const earliestTempo = findEarliestEvent(tempoEvents);
+  const earliestMeter = findEarliestEvent(meterEvents);
+
+  return {
+    format,
+    trackCount,
+    ppqn,
+    tracks: trackParses,
+    tempoBpm: earliestTempo ? Math.max(20, Math.round(60000000 / earliestTempo.mpqn)) : null,
+    meter: earliestMeter ? { beats: earliestMeter.beats, beatType: earliestMeter.beatType } : null,
+    warnings
+  };
+}
+
+function parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings) {
+  let tick = 0;
+  let runningStatus = 0;
+  const notes = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const activeNotes = new Map();
+
+  let trackName = "";
+  let program = null;
+
+  while (reader.offset < trackEnd) {
+    tick += readVarLen(reader);
+
+    if (reader.offset >= trackEnd) {
+      break;
+    }
+
+    let status = readU8(reader);
+    if (status < 0x80) {
+      if (!runningStatus) {
+        throw new Error("ランニングステータスが不正です。track=" + (trackIndex + 1));
+      }
+      reader.offset -= 1;
+      status = runningStatus;
+    } else {
+      runningStatus = status;
+    }
+
+    if (status === 0xff) {
+      const metaType = readU8(reader);
+      const metaLen = readVarLen(reader);
+      const metaStart = reader.offset;
+      const metaEnd = metaStart + metaLen;
+      if (metaEnd > trackEnd) {
+        throw new Error("メタイベント長が不正です。track=" + (trackIndex + 1));
+      }
+
+      if (metaType === 0x03) {
+        trackName = utf8Decode(bytes.slice(metaStart, metaEnd));
+      } else if (metaType === 0x51 && metaLen === 3) {
+        const mpqn = (bytes[metaStart] << 16) | (bytes[metaStart + 1] << 8) | bytes[metaStart + 2];
+        if (mpqn > 0) {
+          tempoEvents.push({ tick, mpqn });
+        }
+      } else if (metaType === 0x58 && metaLen >= 2) {
+        const beats = bytes[metaStart];
+        const beatType = 1 << bytes[metaStart + 1];
+        if (beats > 0 && beatType > 0) {
+          meterEvents.push({ tick, beats, beatType });
+        }
+      }
+
+      reader.offset = metaEnd;
+      continue;
+    }
+
+    if (status === 0xf0 || status === 0xf7) {
+      const syxLen = readVarLen(reader);
+      reader.offset += syxLen;
+      if (reader.offset > trackEnd) {
+        throw new Error("SysEx長が不正です。track=" + (trackIndex + 1));
+      }
+      continue;
+    }
+
+    const high = status >> 4;
+    const channel = status & 0x0f;
+
+    if (high === 0x8 || high === 0x9 || high === 0xa || high === 0xb || high === 0xe) {
+      const data1 = readU8(reader);
+      const data2 = readU8(reader);
+      if (high === 0x9 && data2 > 0) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key) || [];
+        stack.push({ tick, velocity: data2 });
+        activeNotes.set(key, stack);
+      } else if (high === 0x8 || (high === 0x9 && data2 === 0)) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key);
+        if (!stack || stack.length === 0) {
+          warnings.push("track " + (trackIndex + 1) + ": NoteOffに対応するNoteOnがありません。note=" + data1);
+        } else {
+          const start = stack.pop();
+          const duration = Math.max(1, tick - start.tick);
+          notes.push({
+            trackIndex,
+            channel,
+            noteNumber: data1,
+            startTick: start.tick,
+            durationTick: duration,
+            velocity: start.velocity
+          });
+        }
+      }
+      continue;
+    }
+
+    if (high === 0xc || high === 0xd) {
+      const data = readU8(reader);
+      if (high === 0xc && program === null) {
+        program = data;
+      }
+      continue;
+    }
+
+    throw new Error("未対応のMIDIイベントです。status=0x" + status.toString(16));
+  }
+
+  if (activeNotes.size > 0) {
+    warnings.push("track " + (trackIndex + 1) + ": 終端でクローズされないノートがあります。");
+  }
+
+  notes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    return a.noteNumber - b.noteNumber;
+  });
+
+  return {
+    trackIndex,
+    trackName,
+    program,
+    notes,
+    tempoEvents,
+    meterEvents
+  };
+}
+
+function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
+  const warnings = parsedMidi.warnings.slice();
+
+  const title = deriveTitle(parsedMidi, settings.defaultTitle, loadedName);
+  const composer = settings.defaultComposer;
+  const tempo = parsedMidi.tempoBpm || settings.defaultTempo;
+  const meter = parsedMidi.meter || {
+    beats: settings.defaultBeats,
+    beatType: settings.defaultBeatType
+  };
+  const quantizeTicks = resolveQuantizeTicks(settings.quantize, parsedMidi.ppqn);
+
+  const tracksWithNotes = parsedMidi.tracks.filter((track) => track.notes.length > 0);
+  if (tracksWithNotes.length === 0) {
+    throw new Error("ノートイベントが見つかりませんでした。");
+  }
+
+  const parts = [];
+  let totalNotes = 0;
+  let totalRests = 0;
+  let totalMeasures = 0;
+  let partSerial = 1;
+
+  for (let i = 0; i < tracksWithNotes.length; i += 1) {
+    const track = tracksWithNotes[i];
+    const basePartName = track.trackName || "Track " + String(track.trackIndex + 1);
+    const clefLanes = splitTrackNotesIntoClefLanes(track.notes, quantizeTicks, settings.timeScale, track.trackIndex, warnings);
+    for (let laneIndex = 0; laneIndex < clefLanes.length; laneIndex += 1) {
+      const lane = clefLanes[laneIndex];
+      if (!lane || !lane.notes || lane.notes.length === 0) {
+        continue;
+      }
+      const partBuild = buildMeasuresFromMonophonicTrack(lane.notes, parsedMidi.ppqn, meter);
+      totalNotes += partBuild.noteCount;
+      totalRests += partBuild.restCount;
+      totalMeasures = Math.max(totalMeasures, partBuild.measures.length);
+      const laneNameSuffix = " " + lane.clef.label + " L" + String(lane.serialInClef);
+      parts.push({
+        partId: "P" + String(partSerial),
+        partName: clefLanes.length === 1 ? basePartName : (basePartName + laneNameSuffix),
+        clef: {
+          sign: lane.clef.sign,
+          line: lane.clef.line
+        },
+        measures: partBuild.measures
+      });
+      partSerial += 1;
+    }
+  }
+
+  const parsedForXml = {
+    meta: {
+      title,
+      composer,
+      keyInfo: { fifths: 0 },
+      meter,
+      tempo
+    },
+    parts
+  };
+
+  return {
+    parsedForXml,
+    warnings,
+    summary: {
+      title,
+      composer,
+      parts: parts.length,
+      tempo,
+      meter: meter.beats + "/" + meter.beatType,
+      notes: totalNotes,
+      rests: totalRests,
+      measures: totalMeasures
+    }
+  };
+}
+
+function splitTrackNotesIntoClefLanes(notes, quantizeTicks, timeScale, trackIndex, warnings) {
+  const laneLimitPerClef = Math.max(1, Math.floor(MAX_POLYPHONY_LANES / 2));
+  const trebleLanes = createLanePool(laneLimitPerClef, TREBLE_CLEF);
+  const bassLanes = createLanePool(laneLimitPerClef, BASS_CLEF);
+  const quantizedNotes = notes.map((note) => {
+    const scaledStart = Math.max(0, Math.round(note.startTick * timeScale));
+    const scaledDuration = Math.max(1, Math.round(note.durationTick * timeScale));
+    const startTick = quantizeTick(scaledStart, quantizeTicks);
+    const durationTick = Math.max(1, quantizeTick(scaledDuration, quantizeTicks));
+    return {
+      trackIndex: note.trackIndex,
+      noteNumber: note.noteNumber,
+      startTick,
+      durationTick
+    };
+  });
+
+  quantizedNotes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    if (a.noteNumber !== b.noteNumber) {
+      return b.noteNumber - a.noteNumber;
+    }
+    return b.durationTick - a.durationTick;
+  });
+
+  for (const note of quantizedNotes) {
+    const primaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? trebleLanes : bassLanes;
+    const secondaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? bassLanes : trebleLanes;
+    let lane = pickBestLane(primaryPool, note.startTick);
+    if (!lane) {
+      lane = pickBestLane(secondaryPool, note.startTick);
+    }
+
+    if (!lane) {
+      warnings.push(
+        "track " +
+        (trackIndex + 1) +
+        ": 同時発音が" +
+        MAX_POLYPHONY_LANES +
+        "を超えたため一部ノートをスキップしました。"
+      );
+      continue;
+    }
+
+    lane.notes.push(note);
+    lane.endTick = note.startTick + note.durationTick;
+  }
+
+  return [...trebleLanes, ...bassLanes].filter((lane) => lane.notes.length > 0);
+}
+
+function createLanePool(size, clef) {
+  return Array.from({ length: size }, (_unused, index) => ({
+    notes: [],
+    endTick: -1,
+    serialInClef: index + 1,
+    clef
+  }));
+}
+
+function pickBestLane(pool, startTick) {
+  let best = null;
+  let bestGap = Number.POSITIVE_INFINITY;
+  for (const lane of pool) {
+    if (lane.endTick > startTick) {
+      continue;
+    }
+    const gap = startTick - lane.endTick;
+    if (gap < bestGap) {
+      best = lane;
+      bestGap = gap;
+    }
+  }
+  return best;
+}
+
+function buildMeasuresFromMonophonicTrack(notes, ppqn, meter) {
+  const ticksPerMeasure = Math.max(1, Math.round((ppqn * 4 * meter.beats) / meter.beatType));
+  const measures = [[]];
+  let cursor = 0;
+  let noteCount = 0;
+  let restCount = 0;
+
+  for (const note of notes) {
+    let start = note.startTick;
+    const duration = Math.max(1, note.durationTick);
+
+    if (start < cursor) {
+      start = cursor;
+    }
+
+    if (start > cursor) {
+      const inserted = pushDurationToken(measures, cursor, start - cursor, ticksPerMeasure, ppqn, null);
+      restCount += inserted;
+      cursor = start;
+    }
+
+    const insertedNotes = pushDurationToken(measures, cursor, duration, ticksPerMeasure, ppqn, note.noteNumber);
+    noteCount += insertedNotes;
+    cursor += duration;
+  }
+
+  while (measures.length > 1 && measures[measures.length - 1].length === 0) {
+    measures.pop();
+  }
+
+  return {
+    measures,
+    noteCount,
+    restCount
+  };
+}
+
+function pushDurationToken(measures, startTick, durationTick, ticksPerMeasure, ppqn, midiNoteNumber) {
+  let remaining = durationTick;
+  let tick = startTick;
+  let inserted = 0;
+
+  while (remaining > 0) {
+    const measureIndex = Math.floor(tick / ticksPerMeasure);
+    while (measures.length <= measureIndex) {
+      measures.push([]);
+    }
+
+    const tickInMeasure = tick % ticksPerMeasure;
+    const freeInMeasure = ticksPerMeasure - tickInMeasure;
+    const chunk = Math.max(1, Math.min(remaining, freeInMeasure));
+
+    if (midiNoteNumber === null) {
+      measures[measureIndex].push(buildRestToken(chunk, ppqn));
+    } else {
+      measures[measureIndex].push(buildNoteToken(midiNoteNumber, chunk, ppqn));
+    }
+
+    inserted += 1;
+    tick += chunk;
+    remaining -= chunk;
+  }
+
+  return inserted;
+}
+
+function buildRestToken(durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  return {
+    isRest: true,
+    duration,
+    type: durationToType(duration)
+  };
+}
+
+function buildNoteToken(midiNoteNumber, durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  const pitch = midiNumberToPitch(midiNoteNumber);
+  return {
+    isRest: false,
+    step: pitch.step,
+    alter: pitch.alter,
+    octave: pitch.octave,
+    duration,
+    type: durationToType(duration),
+    voice: "1"
+  };
+}
+
+function midiTicksToMusicXmlDuration(ticks, ppqn) {
+  return Math.max(1, Math.round((ticks * 960) / ppqn));
+}
+
+function durationToType(duration) {
+  const table = [
+    { duration: 3840, type: "whole" },
+    { duration: 1920, type: "half" },
+    { duration: 960, type: "quarter" },
+    { duration: 480, type: "eighth" },
+    { duration: 240, type: "16th" },
+    { duration: 120, type: "32nd" },
+    { duration: 60, type: "64th" }
+  ];
+
+  let best = table[0];
+  let minDiff = Math.abs(duration - best.duration);
+  for (const entry of table) {
+    const diff = Math.abs(duration - entry.duration);
+    if (diff < minDiff) {
+      minDiff = diff;
+      best = entry;
+    }
+  }
+  return best.type;
+}
+
+function midiNumberToPitch(midiNumber) {
+  const normalized = Math.max(0, Math.min(127, midiNumber));
+  const semitone = normalized % 12;
+  const octave = Math.floor(normalized / 12) - 1;
+  const map = [
+    { step: "C", alter: null },
+    { step: "C", alter: 1 },
+    { step: "D", alter: null },
+    { step: "D", alter: 1 },
+    { step: "E", alter: null },
+    { step: "F", alter: null },
+    { step: "F", alter: 1 },
+    { step: "G", alter: null },
+    { step: "G", alter: 1 },
+    { step: "A", alter: null },
+    { step: "A", alter: 1 },
+    { step: "B", alter: null }
+  ];
+  const found = map[semitone] || map[0];
+  return {
+    step: found.step,
+    alter: found.alter,
+    octave
+  };
+}
+
+function deriveTitle(parsedMidi, fallbackTitle, loadedName) {
+  for (const track of parsedMidi.tracks) {
+    if (track.trackName && track.trackName.trim()) {
+      return track.trackName.trim();
+    }
+  }
+  if (loadedName) {
+    const dot = loadedName.lastIndexOf(".");
+    if (dot > 0) {
+      return loadedName.slice(0, dot);
+    }
+    return loadedName;
+  }
+  return fallbackTitle;
+}
+
+function findEarliestEvent(events) {
+  if (!events || events.length === 0) {
+    return null;
+  }
+  let earliest = events[0];
+  for (const event of events) {
+    if (event.tick < earliest.tick) {
+      earliest = event;
+    }
+  }
+  return earliest;
+}
+
+function resolveQuantizeTicks(quantizeValue, ppqn) {
+  if (quantizeValue === "1/8") {
+    return Math.max(1, Math.round(ppqn / 2));
+  }
+  if (quantizeValue === "1/32") {
+    return Math.max(1, Math.round(ppqn / 8));
+  }
+  return Math.max(1, Math.round(ppqn / 4));
+}
+
+function quantizeTick(value, quantum) {
+  return Math.max(0, Math.round(value / quantum) * quantum);
+}
+
+function createReader(bytes) {
+  return {
+    bytes,
+    offset: 0
+  };
+}
+
+function readAscii(reader, length) {
+  ensureReadable(reader, length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += String.fromCharCode(reader.bytes[reader.offset + i]);
+  }
+  reader.offset += length;
+  return out;
+}
+
+function readU8(reader) {
+  ensureReadable(reader, 1);
+  const value = reader.bytes[reader.offset];
+  reader.offset += 1;
+  return value;
+}
+
+function readU16(reader) {
+  ensureReadable(reader, 2);
+  const value = (reader.bytes[reader.offset] << 8) | reader.bytes[reader.offset + 1];
+  reader.offset += 2;
+  return value;
+}
+
+function readU32(reader) {
+  ensureReadable(reader, 4);
+  const value =
+    (reader.bytes[reader.offset] * 16777216) +
+    (reader.bytes[reader.offset + 1] << 16) +
+    (reader.bytes[reader.offset + 2] << 8) +
+    reader.bytes[reader.offset + 3];
+  reader.offset += 4;
+  return value;
+}
+
+function readVarLen(reader) {
+  let value = 0;
+  let count = 0;
+  while (true) {
+    const byte = readU8(reader);
+    value = (value << 7) | (byte & 0x7f);
+    count += 1;
+    if ((byte & 0x80) === 0) {
+      return value;
+    }
+    if (count > 4) {
+      throw new Error("可変長値が不正です。");
+    }
+  }
+}
+
+function ensureReadable(reader, length) {
+  if (reader.offset + length > reader.bytes.length) {
+    throw new Error("MIDIデータの末尾を超えて読み込みました。");
+  }
+}
+
+function utf8Decode(bytes) {
+  try {
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(bytes);
+  } catch (_error) {
+    let out = "";
+    for (let i = 0; i < bytes.length; i += 1) {
+      out += String.fromCharCode(bytes[i]);
+    }
+    return out;
+  }
+}
+
+function clampNumber(value, fallback, min, max) {
+  const num = Number.parseInt(value, 10);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function clampFloat(value, fallback, min, max) {
+  const num = Number.parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function resetOutput() {
+  lastXmlText = "";
+  xmlOutput.textContent = "";
+  previewText.textContent = "未変換";
+  downloadBtn.disabled = true;
+  copyBtn.disabled = true;
+}
+
+function setError(message) {
+  errorText.textContent = message;
+  errorText.classList.remove("md-hidden");
+}
+
+function clearError() {
+  errorText.textContent = "";
+  errorText.classList.add("md-hidden");
+}
+
+function clearWarning() {
+  warningText.textContent = "";
+  warningText.classList.add("md-hidden");
+}
+
+function persistSettings() {
+  try {
+    const payload = {
+      defaultTitle: defaultTitleInput.value,
+      defaultComposer: defaultComposerInput.value,
+      defaultTempo: defaultTempoInput.value,
+      defaultBeats: defaultBeatsInput.value,
+      defaultBeatType: defaultBeatTypeInput.value,
+      quantize: quantizeSelect.value,
+      timeScale: timeScaleSelect.value
+    };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
+  } catch (_error) {
+  }
+}
+
+function restoreSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed.defaultTitle) {
+      defaultTitleInput.value = String(parsed.defaultTitle);
+    }
+    if (parsed.defaultComposer) {
+      defaultComposerInput.value = String(parsed.defaultComposer);
+    }
+    if (parsed.defaultTempo) {
+      defaultTempoInput.value = String(parsed.defaultTempo);
+    }
+    if (parsed.defaultBeats) {
+      defaultBeatsInput.value = String(parsed.defaultBeats);
+    }
+    if (parsed.defaultBeatType) {
+      defaultBeatTypeInput.value = String(parsed.defaultBeatType);
+    }
+    if (parsed.quantize) {
+      quantizeSelect.value = String(parsed.quantize);
+    }
+    if (parsed.timeScale) {
+      timeScaleSelect.value = String(parsed.timeScale);
+    }
+  } catch (_error) {
+  }
+}
+
+function downloadMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  const blob = new Blob([lastXmlText], { type: "application/xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "score.musicxml";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  showToast("MusicXMLを保存しました。");
+}
+
+async function copyMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(lastXmlText);
+    showToast("MusicXMLをコピーしました。");
+  } catch (_error) {
+    showToast("コピーに失敗しました。");
+  }
+}
+
+let toastTimer = 0;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.remove("md-hidden");
+  toast.classList.add("md-visible");
+  if (toastTimer) {
+    clearTimeout(toastTimer);
+  }
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("md-visible");
+    toast.classList.add("md-hidden");
+  }, 1600);
+}
+
+window["toggleMenu"] = function toggleMenu() {
+  menuPanel.classList.toggle("md-hidden");
+};
+
+function handleDocumentClick(event) {
+  if (menuPanel.classList.contains("md-hidden")) {
+    return;
+  }
+
+  const target = event.target;
+  if (!target) {
+    return;
+  }
+
+  const menuButton = target.closest ? target.closest(".md-menu-button") : null;
+  const panel = target.closest ? target.closest("#menuPanel") : null;
+  if (!menuButton && !panel) {
+    menuPanel.classList.add("md-hidden");
+  }
+}
+  </script>
+</body>
+</html>

--- a/docs/music/src/common/js/musicxml-writer-common.js
+++ b/docs/music/src/common/js/musicxml-writer-common.js
@@ -43,6 +43,7 @@ const MusicXmlWriterCommon = (() => {
 
         lines.push('    <measure number="' + measureNo + '">');
         if (measureIndex === 0) {
+          const clef = normalizeClef(part.clef);
           lines.push('      <attributes>');
           lines.push('        <divisions>960</divisions>');
           lines.push('        <key><fifths>' + meta.keyInfo.fifths + '</fifths></key>');
@@ -56,7 +57,7 @@ const MusicXmlWriterCommon = (() => {
             }
             lines.push("        </transpose>");
           }
-          lines.push('        <clef><sign>G</sign><line>2</line></clef>');
+          lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
         }
 
@@ -136,6 +137,18 @@ const MusicXmlWriterCommon = (() => {
       chromatic,
       octaveChange: Number.isFinite(octaveChange) ? octaveChange : 0
     };
+  }
+
+  function normalizeClef(rawClef) {
+    if (!rawClef || typeof rawClef !== "object") {
+      return { sign: "G", line: 2 };
+    }
+    const sign = String(rawClef.sign || "G").trim().toUpperCase();
+    const line = Number.parseInt(rawClef.line, 10);
+    if ((sign !== "G" && sign !== "F" && sign !== "C") || !Number.isFinite(line) || line <= 0) {
+      return { sign: "G", line: 2 };
+    }
+    return { sign, line };
   }
 
   return {

--- a/docs/music/src/common/ts/musicxml-writer-common.ts
+++ b/docs/music/src/common/ts/musicxml-writer-common.ts
@@ -43,6 +43,7 @@ const MusicXmlWriterCommon = (() => {
 
         lines.push('    <measure number="' + measureNo + '">');
         if (measureIndex === 0) {
+          const clef = normalizeClef(part.clef);
           lines.push('      <attributes>');
           lines.push('        <divisions>960</divisions>');
           lines.push('        <key><fifths>' + meta.keyInfo.fifths + '</fifths></key>');
@@ -56,7 +57,7 @@ const MusicXmlWriterCommon = (() => {
             }
             lines.push("        </transpose>");
           }
-          lines.push('        <clef><sign>G</sign><line>2</line></clef>');
+          lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
         }
 
@@ -136,6 +137,18 @@ const MusicXmlWriterCommon = (() => {
       chromatic,
       octaveChange: Number.isFinite(octaveChange) ? octaveChange : 0
     };
+  }
+
+  function normalizeClef(rawClef) {
+    if (!rawClef || typeof rawClef !== "object") {
+      return { sign: "G", line: 2 };
+    }
+    const sign = String(rawClef.sign || "G").trim().toUpperCase();
+    const line = Number.parseInt(rawClef.line, 10);
+    if ((sign !== "G" && sign !== "F" && sign !== "C") || !Number.isFinite(line) || line <= 0) {
+      return { sign: "G", line: 2 };
+    }
+    return { sign, line };
   }
 
   return {

--- a/docs/music/src/midi-to-musicxml/css/app.css
+++ b/docs/music/src/midi-to-musicxml/css/app.css
@@ -1,0 +1,374 @@
+:root {
+      --md-danger: #b3261e;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-tertiary-container: #f3e8fd;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Yu Gothic UI", "Hiragino Sans", sans-serif;
+      background: var(--md-sys-color-background);
+      color: var(--md-sys-color-on-surface);
+    }
+
+    .md-shell {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+      padding: 24px;
+      position: relative;
+    }
+
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin: 0 0 1rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+
+    .md-headline__icon {
+      margin-right: 0.4rem;
+    }
+
+    .md-section {
+      margin-top: 1.2rem;
+    }
+
+    .md-section-title {
+      font-size: 1.1rem;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .md-title-info-row {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.1rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      margin-bottom: 0.35rem;
+    }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.54rem;
+      font-weight: 600;
+      background: #eceaf1;
+      color: #49454f;
+    }
+
+    .md-textarea,
+    .md-input,
+    .md-file {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      box-sizing: border-box;
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-textarea {
+      min-height: 15rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      line-height: 1.5;
+    }
+
+    .md-textarea--compact {
+      min-height: 8rem;
+    }
+
+    .md-textarea:focus,
+    .md-input:focus,
+    .md-file:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.8rem;
+    }
+
+    .md-radio-group {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.8rem;
+    }
+
+    .md-radio-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
+    .md-grid--defaults {
+      margin-top: 0.8rem;
+    }
+
+    .md-disclosure {
+      margin-bottom: 0.8rem;
+      border: 1px solid #e5e0ec;
+      border-radius: 12px;
+      background: #faf8fc;
+      padding: 0.7rem 0.85rem;
+    }
+
+    .md-disclosure-summary {
+      cursor: pointer;
+      font-weight: 600;
+      color: #3d2e5a;
+      list-style: none;
+    }
+
+    .md-disclosure-summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .md-disclosure-summary::before {
+      content: "▸";
+      display: inline-block;
+      margin-right: 0.35rem;
+      transition: transform 120ms ease;
+    }
+
+    .md-disclosure[open] .md-disclosure-summary::before {
+      transform: rotate(90deg);
+    }
+
+    @media (min-width: 720px) {
+      .md-grid {
+        grid-template-columns: 1fr 1fr 1fr;
+      }
+    }
+
+    .md-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      margin-top: 0.8rem;
+    }
+
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background 150ms ease;
+      white-space: nowrap;
+    }
+
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+
+    .md-button--primary:hover {
+      background: #4f00c9;
+    }
+
+    .md-button--secondary {
+      background: #e8f5f3;
+      color: #15443e;
+      box-shadow: 0 2px 6px rgba(3, 218, 198, 0.25);
+    }
+
+    .md-button:disabled {
+      background: #e6e1ee;
+      color: #9a94a7;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .md-preview {
+      border: 1px solid #e5e0ec;
+      border-radius: 12px;
+      padding: 0.75rem;
+      background: var(--md-sys-color-tertiary-container);
+      font-size: 0.9rem;
+      color: #3d2e5a;
+      white-space: pre-wrap;
+    }
+
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      min-height: 8rem;
+    }
+
+    .md-error {
+      margin-top: 0.7rem;
+      color: var(--md-danger);
+      font-size: 0.92rem;
+      white-space: pre-wrap;
+    }
+
+    .md-warning {
+      margin-top: 0.7rem;
+      color: #8a4f00;
+      font-size: 0.9rem;
+      white-space: pre-wrap;
+      background: #fff3e0;
+      border: 1px solid #ffcc80;
+      border-radius: 10px;
+      padding: 0.6rem 0.7rem;
+    }
+
+    .md-snackbar {
+      position: fixed;
+      left: 50%;
+      bottom: 1.2rem;
+      transform: translateX(-50%);
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.65rem 0.95rem;
+      border-radius: 999px;
+      font-size: 0.86rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+      z-index: 120;
+    }
+
+    .md-visible {
+      opacity: 1;
+    }
+
+    .md-hidden {
+      display: none;
+    }
+
+    .md-menu-button {
+      position: absolute;
+      top: 14px;
+      right: 14px;
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      background: #f0edf5;
+      border: none;
+      cursor: pointer;
+    }
+
+    .md-menu-panel {
+      position: absolute;
+      top: 58px;
+      right: 14px;
+      background: #ffffff;
+      border: 1px solid #ddd5ea;
+      border-radius: 10px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+      min-width: 160px;
+      z-index: 100;
+    }
+
+    .md-menu-link {
+      display: block;
+      padding: 0.7rem 0.9rem;
+      color: #342f3e;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    .md-menu-link:hover {
+      background: #f6f1fb;
+    }
+
+    .md-tooltip-group {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+    }
+
+    .md-info-icon {
+      width: 18px;
+      height: 18px;
+    }
+
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+
+    .md-tooltip-group:hover .md-tooltip-content,
+    .md-tooltip-group:focus-within .md-tooltip-content {
+      opacity: 1;
+    }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }

--- a/docs/music/src/midi-to-musicxml/js/main.js
+++ b/docs/music/src/midi-to-musicxml/js/main.js
@@ -1,0 +1,944 @@
+const musicXmlWriterCommon = window["MusicXmlWriterCommon"] || (typeof MusicXmlWriterCommon !== "undefined" ? MusicXmlWriterCommon : null);
+if (!musicXmlWriterCommon) {
+  throw new Error("MusicXmlWriterCommon is not loaded.");
+}
+
+const fileInput = document.getElementById("fileInput");
+const fileSelectBtn = document.getElementById("fileSelectBtn");
+const fileNameText = document.getElementById("fileNameText");
+const inputModeSourceRadio = document.getElementById("inputModeSource");
+const inputModeFileRadio = document.getElementById("inputModeFile");
+const sourceInputBlock = document.getElementById("sourceInputBlock");
+const fileInputBlock = document.getElementById("fileInputBlock");
+const hexInput = document.getElementById("hexInput");
+const defaultTitleInput = document.getElementById("defaultTitleInput");
+const defaultComposerInput = document.getElementById("defaultComposerInput");
+const defaultTempoInput = document.getElementById("defaultTempoInput");
+const defaultBeatsInput = document.getElementById("defaultBeatsInput");
+const defaultBeatTypeInput = document.getElementById("defaultBeatTypeInput");
+const quantizeSelect = document.getElementById("quantizeSelect");
+const timeScaleSelect = document.getElementById("timeScaleSelect");
+const convertBtn = document.getElementById("convertBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const previewText = document.getElementById("previewText");
+const xmlOutput = document.getElementById("xmlOutput");
+const errorText = document.getElementById("errorText");
+const warningText = document.getElementById("warningText");
+const toast = document.getElementById("toast");
+const menuPanel = document.getElementById("menuPanel");
+
+const SETTINGS_KEY = "midi-to-musicxml-settings";
+const MAX_POLYPHONY_LANES = 16;
+const TREBLE_BASS_SPLIT_NOTE = 60;
+const TREBLE_CLEF = { sign: "G", line: 2, label: "Treble" };
+const BASS_CLEF = { sign: "F", line: 4, label: "Bass" };
+
+let loadedMidiBytes = null;
+let loadedMidiName = "";
+let lastXmlText = "";
+
+restoreSettings();
+
+fileInput.addEventListener("change", onFileChange);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+inputModeSourceRadio.addEventListener("change", applyInputMode);
+inputModeFileRadio.addEventListener("change", applyInputMode);
+defaultTitleInput.addEventListener("change", persistSettings);
+defaultComposerInput.addEventListener("change", persistSettings);
+defaultTempoInput.addEventListener("change", persistSettings);
+defaultBeatsInput.addEventListener("change", persistSettings);
+defaultBeatTypeInput.addEventListener("change", persistSettings);
+quantizeSelect.addEventListener("change", persistSettings);
+timeScaleSelect.addEventListener("change", persistSettings);
+convertBtn.addEventListener("click", convertMidi);
+downloadBtn.addEventListener("click", downloadMusicXml);
+copyBtn.addEventListener("click", copyMusicXml);
+document.addEventListener("click", handleDocumentClick);
+
+applyInputMode();
+
+function onFileChange(event) {
+  const file = event.target.files && event.target.files[0];
+  if (!file) {
+    loadedMidiBytes = null;
+    loadedMidiName = "";
+    updateFileName("");
+    return;
+  }
+
+  inputModeFileRadio.checked = true;
+  applyInputMode();
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    const result = reader.result;
+    if (!(result instanceof ArrayBuffer)) {
+      setError("MIDIファイルの読み込みに失敗しました。");
+      return;
+    }
+    loadedMidiBytes = new Uint8Array(result);
+    loadedMidiName = file.name;
+    updateFileName(file.name);
+    showToast("MIDIを読み込みました。");
+  };
+  reader.onerror = () => {
+    setError("MIDIファイルの読み込みに失敗しました。");
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+function updateFileName(name) {
+  fileNameText.textContent = name || "未選択";
+}
+
+function applyInputMode() {
+  const sourceMode = inputModeSourceRadio.checked;
+  sourceInputBlock.classList.toggle("md-hidden", !sourceMode);
+  fileInputBlock.classList.toggle("md-hidden", sourceMode);
+}
+
+function convertMidi() {
+  clearError();
+  clearWarning();
+
+  try {
+    const midiBytes = getInputMidiBytes();
+    if (!midiBytes || midiBytes.length === 0) {
+      throw new Error("MIDI入力が空です。");
+    }
+
+    const settings = {
+      defaultTitle: (defaultTitleInput.value || "").trim() || "Untitled",
+      defaultComposer: (defaultComposerInput.value || "").trim() || "Unknown",
+      defaultTempo: clampNumber(defaultTempoInput.value, 120, 20, 300),
+      defaultBeats: clampNumber(defaultBeatsInput.value, 4, 1, 12),
+      defaultBeatType: clampNumber(defaultBeatTypeInput.value, 4, 1, 16),
+      quantize: quantizeSelect.value || "1/16",
+      timeScale: clampFloat(timeScaleSelect.value, 1, 0.1, 8)
+    };
+
+    const parsedMidi = parseMidiFile(midiBytes);
+    const conversion = convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedMidiName);
+    const xml = musicXmlWriterCommon.buildScorePartwiseXml(conversion.parsedForXml);
+
+    lastXmlText = xml;
+    xmlOutput.textContent = xml;
+    downloadBtn.disabled = false;
+    copyBtn.disabled = false;
+
+    const previewLines = [
+      "title: " + conversion.summary.title,
+      "composer: " + conversion.summary.composer,
+      "format: " + parsedMidi.format,
+      "tracks: " + parsedMidi.trackCount,
+      "parts: " + conversion.summary.parts,
+      "ppqn: " + parsedMidi.ppqn,
+      "tempo: " + conversion.summary.tempo,
+      "meter: " + conversion.summary.meter,
+      "time scale: " + settings.timeScale + "x",
+      "notes: " + conversion.summary.notes,
+      "rests: " + conversion.summary.rests,
+      "measures: " + conversion.summary.measures
+    ];
+    previewText.textContent = previewLines.join("\n");
+
+    if (conversion.warnings.length > 0) {
+      warningText.textContent = "警告:\n" + conversion.warnings.join("\n");
+      warningText.classList.remove("md-hidden");
+    }
+
+    showToast("MusicXMLを生成しました。");
+  } catch (error) {
+    resetOutput();
+    const message = error && error.message ? error.message : String(error);
+    setError("変換に失敗しました: " + message);
+  }
+}
+
+function getInputMidiBytes() {
+  if (inputModeSourceRadio.checked) {
+    const source = (hexInput.value || "").trim();
+    if (!source) {
+      return null;
+    }
+    return parseHexString(source);
+  }
+  return loadedMidiBytes;
+}
+
+function parseHexString(text) {
+  const cleaned = text.replace(/[^0-9a-fA-F]/g, "");
+  if (cleaned.length === 0) {
+    return null;
+  }
+  if (cleaned.length % 2 !== 0) {
+    throw new Error("16進ソースの桁数が不正です。");
+  }
+  const out = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function parseMidiFile(bytes) {
+  const reader = createReader(bytes);
+  const chunkId = readAscii(reader, 4);
+  if (chunkId !== "MThd") {
+    throw new Error("MIDIヘッダ (MThd) が見つかりません。");
+  }
+
+  const headerLength = readU32(reader);
+  if (headerLength < 6) {
+    throw new Error("MIDIヘッダ長が不正です。");
+  }
+
+  const format = readU16(reader);
+  const trackCount = readU16(reader);
+  const division = readU16(reader);
+  if ((division & 0x8000) !== 0) {
+    throw new Error("SMPTE形式のdivisionには未対応です。");
+  }
+  const ppqn = division;
+
+  if (headerLength > 6) {
+    reader.offset += headerLength - 6;
+  }
+
+  const trackParses = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const warnings = [];
+
+  for (let trackIndex = 0; trackIndex < trackCount; trackIndex += 1) {
+    const id = readAscii(reader, 4);
+    if (id !== "MTrk") {
+      throw new Error("MTrkチャンクが見つかりません。track=" + (trackIndex + 1));
+    }
+    const length = readU32(reader);
+    const trackEnd = reader.offset + length;
+    if (trackEnd > bytes.length) {
+      throw new Error("MTrkチャンク長が不正です。track=" + (trackIndex + 1));
+    }
+    const parsedTrack = parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings);
+    trackParses.push(parsedTrack);
+    for (const ev of parsedTrack.tempoEvents) {
+      tempoEvents.push(ev);
+    }
+    for (const ev of parsedTrack.meterEvents) {
+      meterEvents.push(ev);
+    }
+    reader.offset = trackEnd;
+  }
+
+  const earliestTempo = findEarliestEvent(tempoEvents);
+  const earliestMeter = findEarliestEvent(meterEvents);
+
+  return {
+    format,
+    trackCount,
+    ppqn,
+    tracks: trackParses,
+    tempoBpm: earliestTempo ? Math.max(20, Math.round(60000000 / earliestTempo.mpqn)) : null,
+    meter: earliestMeter ? { beats: earliestMeter.beats, beatType: earliestMeter.beatType } : null,
+    warnings
+  };
+}
+
+function parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings) {
+  let tick = 0;
+  let runningStatus = 0;
+  const notes = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const activeNotes = new Map();
+
+  let trackName = "";
+  let program = null;
+
+  while (reader.offset < trackEnd) {
+    tick += readVarLen(reader);
+
+    if (reader.offset >= trackEnd) {
+      break;
+    }
+
+    let status = readU8(reader);
+    if (status < 0x80) {
+      if (!runningStatus) {
+        throw new Error("ランニングステータスが不正です。track=" + (trackIndex + 1));
+      }
+      reader.offset -= 1;
+      status = runningStatus;
+    } else {
+      runningStatus = status;
+    }
+
+    if (status === 0xff) {
+      const metaType = readU8(reader);
+      const metaLen = readVarLen(reader);
+      const metaStart = reader.offset;
+      const metaEnd = metaStart + metaLen;
+      if (metaEnd > trackEnd) {
+        throw new Error("メタイベント長が不正です。track=" + (trackIndex + 1));
+      }
+
+      if (metaType === 0x03) {
+        trackName = utf8Decode(bytes.slice(metaStart, metaEnd));
+      } else if (metaType === 0x51 && metaLen === 3) {
+        const mpqn = (bytes[metaStart] << 16) | (bytes[metaStart + 1] << 8) | bytes[metaStart + 2];
+        if (mpqn > 0) {
+          tempoEvents.push({ tick, mpqn });
+        }
+      } else if (metaType === 0x58 && metaLen >= 2) {
+        const beats = bytes[metaStart];
+        const beatType = 1 << bytes[metaStart + 1];
+        if (beats > 0 && beatType > 0) {
+          meterEvents.push({ tick, beats, beatType });
+        }
+      }
+
+      reader.offset = metaEnd;
+      continue;
+    }
+
+    if (status === 0xf0 || status === 0xf7) {
+      const syxLen = readVarLen(reader);
+      reader.offset += syxLen;
+      if (reader.offset > trackEnd) {
+        throw new Error("SysEx長が不正です。track=" + (trackIndex + 1));
+      }
+      continue;
+    }
+
+    const high = status >> 4;
+    const channel = status & 0x0f;
+
+    if (high === 0x8 || high === 0x9 || high === 0xa || high === 0xb || high === 0xe) {
+      const data1 = readU8(reader);
+      const data2 = readU8(reader);
+      if (high === 0x9 && data2 > 0) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key) || [];
+        stack.push({ tick, velocity: data2 });
+        activeNotes.set(key, stack);
+      } else if (high === 0x8 || (high === 0x9 && data2 === 0)) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key);
+        if (!stack || stack.length === 0) {
+          warnings.push("track " + (trackIndex + 1) + ": NoteOffに対応するNoteOnがありません。note=" + data1);
+        } else {
+          const start = stack.pop();
+          const duration = Math.max(1, tick - start.tick);
+          notes.push({
+            trackIndex,
+            channel,
+            noteNumber: data1,
+            startTick: start.tick,
+            durationTick: duration,
+            velocity: start.velocity
+          });
+        }
+      }
+      continue;
+    }
+
+    if (high === 0xc || high === 0xd) {
+      const data = readU8(reader);
+      if (high === 0xc && program === null) {
+        program = data;
+      }
+      continue;
+    }
+
+    throw new Error("未対応のMIDIイベントです。status=0x" + status.toString(16));
+  }
+
+  if (activeNotes.size > 0) {
+    warnings.push("track " + (trackIndex + 1) + ": 終端でクローズされないノートがあります。");
+  }
+
+  notes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    return a.noteNumber - b.noteNumber;
+  });
+
+  return {
+    trackIndex,
+    trackName,
+    program,
+    notes,
+    tempoEvents,
+    meterEvents
+  };
+}
+
+function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
+  const warnings = parsedMidi.warnings.slice();
+
+  const title = deriveTitle(parsedMidi, settings.defaultTitle, loadedName);
+  const composer = settings.defaultComposer;
+  const tempo = parsedMidi.tempoBpm || settings.defaultTempo;
+  const meter = parsedMidi.meter || {
+    beats: settings.defaultBeats,
+    beatType: settings.defaultBeatType
+  };
+  const quantizeTicks = resolveQuantizeTicks(settings.quantize, parsedMidi.ppqn);
+
+  const tracksWithNotes = parsedMidi.tracks.filter((track) => track.notes.length > 0);
+  if (tracksWithNotes.length === 0) {
+    throw new Error("ノートイベントが見つかりませんでした。");
+  }
+
+  const parts = [];
+  let totalNotes = 0;
+  let totalRests = 0;
+  let totalMeasures = 0;
+  let partSerial = 1;
+
+  for (let i = 0; i < tracksWithNotes.length; i += 1) {
+    const track = tracksWithNotes[i];
+    const basePartName = track.trackName || "Track " + String(track.trackIndex + 1);
+    const clefLanes = splitTrackNotesIntoClefLanes(track.notes, quantizeTicks, settings.timeScale, track.trackIndex, warnings);
+    for (let laneIndex = 0; laneIndex < clefLanes.length; laneIndex += 1) {
+      const lane = clefLanes[laneIndex];
+      if (!lane || !lane.notes || lane.notes.length === 0) {
+        continue;
+      }
+      const partBuild = buildMeasuresFromMonophonicTrack(lane.notes, parsedMidi.ppqn, meter);
+      totalNotes += partBuild.noteCount;
+      totalRests += partBuild.restCount;
+      totalMeasures = Math.max(totalMeasures, partBuild.measures.length);
+      const laneNameSuffix = " " + lane.clef.label + " L" + String(lane.serialInClef);
+      parts.push({
+        partId: "P" + String(partSerial),
+        partName: clefLanes.length === 1 ? basePartName : (basePartName + laneNameSuffix),
+        clef: {
+          sign: lane.clef.sign,
+          line: lane.clef.line
+        },
+        measures: partBuild.measures
+      });
+      partSerial += 1;
+    }
+  }
+
+  const parsedForXml = {
+    meta: {
+      title,
+      composer,
+      keyInfo: { fifths: 0 },
+      meter,
+      tempo
+    },
+    parts
+  };
+
+  return {
+    parsedForXml,
+    warnings,
+    summary: {
+      title,
+      composer,
+      parts: parts.length,
+      tempo,
+      meter: meter.beats + "/" + meter.beatType,
+      notes: totalNotes,
+      rests: totalRests,
+      measures: totalMeasures
+    }
+  };
+}
+
+function splitTrackNotesIntoClefLanes(notes, quantizeTicks, timeScale, trackIndex, warnings) {
+  const laneLimitPerClef = Math.max(1, Math.floor(MAX_POLYPHONY_LANES / 2));
+  const trebleLanes = createLanePool(laneLimitPerClef, TREBLE_CLEF);
+  const bassLanes = createLanePool(laneLimitPerClef, BASS_CLEF);
+  const quantizedNotes = notes.map((note) => {
+    const scaledStart = Math.max(0, Math.round(note.startTick * timeScale));
+    const scaledDuration = Math.max(1, Math.round(note.durationTick * timeScale));
+    const startTick = quantizeTick(scaledStart, quantizeTicks);
+    const durationTick = Math.max(1, quantizeTick(scaledDuration, quantizeTicks));
+    return {
+      trackIndex: note.trackIndex,
+      noteNumber: note.noteNumber,
+      startTick,
+      durationTick
+    };
+  });
+
+  quantizedNotes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    if (a.noteNumber !== b.noteNumber) {
+      return b.noteNumber - a.noteNumber;
+    }
+    return b.durationTick - a.durationTick;
+  });
+
+  for (const note of quantizedNotes) {
+    const primaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? trebleLanes : bassLanes;
+    const secondaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? bassLanes : trebleLanes;
+    let lane = pickBestLane(primaryPool, note.startTick);
+    if (!lane) {
+      lane = pickBestLane(secondaryPool, note.startTick);
+    }
+
+    if (!lane) {
+      warnings.push(
+        "track " +
+        (trackIndex + 1) +
+        ": 同時発音が" +
+        MAX_POLYPHONY_LANES +
+        "を超えたため一部ノートをスキップしました。"
+      );
+      continue;
+    }
+
+    lane.notes.push(note);
+    lane.endTick = note.startTick + note.durationTick;
+  }
+
+  return [...trebleLanes, ...bassLanes].filter((lane) => lane.notes.length > 0);
+}
+
+function createLanePool(size, clef) {
+  return Array.from({ length: size }, (_unused, index) => ({
+    notes: [],
+    endTick: -1,
+    serialInClef: index + 1,
+    clef
+  }));
+}
+
+function pickBestLane(pool, startTick) {
+  let best = null;
+  let bestGap = Number.POSITIVE_INFINITY;
+  for (const lane of pool) {
+    if (lane.endTick > startTick) {
+      continue;
+    }
+    const gap = startTick - lane.endTick;
+    if (gap < bestGap) {
+      best = lane;
+      bestGap = gap;
+    }
+  }
+  return best;
+}
+
+function buildMeasuresFromMonophonicTrack(notes, ppqn, meter) {
+  const ticksPerMeasure = Math.max(1, Math.round((ppqn * 4 * meter.beats) / meter.beatType));
+  const measures = [[]];
+  let cursor = 0;
+  let noteCount = 0;
+  let restCount = 0;
+
+  for (const note of notes) {
+    let start = note.startTick;
+    const duration = Math.max(1, note.durationTick);
+
+    if (start < cursor) {
+      start = cursor;
+    }
+
+    if (start > cursor) {
+      const inserted = pushDurationToken(measures, cursor, start - cursor, ticksPerMeasure, ppqn, null);
+      restCount += inserted;
+      cursor = start;
+    }
+
+    const insertedNotes = pushDurationToken(measures, cursor, duration, ticksPerMeasure, ppqn, note.noteNumber);
+    noteCount += insertedNotes;
+    cursor += duration;
+  }
+
+  while (measures.length > 1 && measures[measures.length - 1].length === 0) {
+    measures.pop();
+  }
+
+  return {
+    measures,
+    noteCount,
+    restCount
+  };
+}
+
+function pushDurationToken(measures, startTick, durationTick, ticksPerMeasure, ppqn, midiNoteNumber) {
+  let remaining = durationTick;
+  let tick = startTick;
+  let inserted = 0;
+
+  while (remaining > 0) {
+    const measureIndex = Math.floor(tick / ticksPerMeasure);
+    while (measures.length <= measureIndex) {
+      measures.push([]);
+    }
+
+    const tickInMeasure = tick % ticksPerMeasure;
+    const freeInMeasure = ticksPerMeasure - tickInMeasure;
+    const chunk = Math.max(1, Math.min(remaining, freeInMeasure));
+
+    if (midiNoteNumber === null) {
+      measures[measureIndex].push(buildRestToken(chunk, ppqn));
+    } else {
+      measures[measureIndex].push(buildNoteToken(midiNoteNumber, chunk, ppqn));
+    }
+
+    inserted += 1;
+    tick += chunk;
+    remaining -= chunk;
+  }
+
+  return inserted;
+}
+
+function buildRestToken(durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  return {
+    isRest: true,
+    duration,
+    type: durationToType(duration)
+  };
+}
+
+function buildNoteToken(midiNoteNumber, durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  const pitch = midiNumberToPitch(midiNoteNumber);
+  return {
+    isRest: false,
+    step: pitch.step,
+    alter: pitch.alter,
+    octave: pitch.octave,
+    duration,
+    type: durationToType(duration),
+    voice: "1"
+  };
+}
+
+function midiTicksToMusicXmlDuration(ticks, ppqn) {
+  return Math.max(1, Math.round((ticks * 960) / ppqn));
+}
+
+function durationToType(duration) {
+  const table = [
+    { duration: 3840, type: "whole" },
+    { duration: 1920, type: "half" },
+    { duration: 960, type: "quarter" },
+    { duration: 480, type: "eighth" },
+    { duration: 240, type: "16th" },
+    { duration: 120, type: "32nd" },
+    { duration: 60, type: "64th" }
+  ];
+
+  let best = table[0];
+  let minDiff = Math.abs(duration - best.duration);
+  for (const entry of table) {
+    const diff = Math.abs(duration - entry.duration);
+    if (diff < minDiff) {
+      minDiff = diff;
+      best = entry;
+    }
+  }
+  return best.type;
+}
+
+function midiNumberToPitch(midiNumber) {
+  const normalized = Math.max(0, Math.min(127, midiNumber));
+  const semitone = normalized % 12;
+  const octave = Math.floor(normalized / 12) - 1;
+  const map = [
+    { step: "C", alter: null },
+    { step: "C", alter: 1 },
+    { step: "D", alter: null },
+    { step: "D", alter: 1 },
+    { step: "E", alter: null },
+    { step: "F", alter: null },
+    { step: "F", alter: 1 },
+    { step: "G", alter: null },
+    { step: "G", alter: 1 },
+    { step: "A", alter: null },
+    { step: "A", alter: 1 },
+    { step: "B", alter: null }
+  ];
+  const found = map[semitone] || map[0];
+  return {
+    step: found.step,
+    alter: found.alter,
+    octave
+  };
+}
+
+function deriveTitle(parsedMidi, fallbackTitle, loadedName) {
+  for (const track of parsedMidi.tracks) {
+    if (track.trackName && track.trackName.trim()) {
+      return track.trackName.trim();
+    }
+  }
+  if (loadedName) {
+    const dot = loadedName.lastIndexOf(".");
+    if (dot > 0) {
+      return loadedName.slice(0, dot);
+    }
+    return loadedName;
+  }
+  return fallbackTitle;
+}
+
+function findEarliestEvent(events) {
+  if (!events || events.length === 0) {
+    return null;
+  }
+  let earliest = events[0];
+  for (const event of events) {
+    if (event.tick < earliest.tick) {
+      earliest = event;
+    }
+  }
+  return earliest;
+}
+
+function resolveQuantizeTicks(quantizeValue, ppqn) {
+  if (quantizeValue === "1/8") {
+    return Math.max(1, Math.round(ppqn / 2));
+  }
+  if (quantizeValue === "1/32") {
+    return Math.max(1, Math.round(ppqn / 8));
+  }
+  return Math.max(1, Math.round(ppqn / 4));
+}
+
+function quantizeTick(value, quantum) {
+  return Math.max(0, Math.round(value / quantum) * quantum);
+}
+
+function createReader(bytes) {
+  return {
+    bytes,
+    offset: 0
+  };
+}
+
+function readAscii(reader, length) {
+  ensureReadable(reader, length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += String.fromCharCode(reader.bytes[reader.offset + i]);
+  }
+  reader.offset += length;
+  return out;
+}
+
+function readU8(reader) {
+  ensureReadable(reader, 1);
+  const value = reader.bytes[reader.offset];
+  reader.offset += 1;
+  return value;
+}
+
+function readU16(reader) {
+  ensureReadable(reader, 2);
+  const value = (reader.bytes[reader.offset] << 8) | reader.bytes[reader.offset + 1];
+  reader.offset += 2;
+  return value;
+}
+
+function readU32(reader) {
+  ensureReadable(reader, 4);
+  const value =
+    (reader.bytes[reader.offset] * 16777216) +
+    (reader.bytes[reader.offset + 1] << 16) +
+    (reader.bytes[reader.offset + 2] << 8) +
+    reader.bytes[reader.offset + 3];
+  reader.offset += 4;
+  return value;
+}
+
+function readVarLen(reader) {
+  let value = 0;
+  let count = 0;
+  while (true) {
+    const byte = readU8(reader);
+    value = (value << 7) | (byte & 0x7f);
+    count += 1;
+    if ((byte & 0x80) === 0) {
+      return value;
+    }
+    if (count > 4) {
+      throw new Error("可変長値が不正です。");
+    }
+  }
+}
+
+function ensureReadable(reader, length) {
+  if (reader.offset + length > reader.bytes.length) {
+    throw new Error("MIDIデータの末尾を超えて読み込みました。");
+  }
+}
+
+function utf8Decode(bytes) {
+  try {
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(bytes);
+  } catch (_error) {
+    let out = "";
+    for (let i = 0; i < bytes.length; i += 1) {
+      out += String.fromCharCode(bytes[i]);
+    }
+    return out;
+  }
+}
+
+function clampNumber(value, fallback, min, max) {
+  const num = Number.parseInt(value, 10);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function clampFloat(value, fallback, min, max) {
+  const num = Number.parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function resetOutput() {
+  lastXmlText = "";
+  xmlOutput.textContent = "";
+  previewText.textContent = "未変換";
+  downloadBtn.disabled = true;
+  copyBtn.disabled = true;
+}
+
+function setError(message) {
+  errorText.textContent = message;
+  errorText.classList.remove("md-hidden");
+}
+
+function clearError() {
+  errorText.textContent = "";
+  errorText.classList.add("md-hidden");
+}
+
+function clearWarning() {
+  warningText.textContent = "";
+  warningText.classList.add("md-hidden");
+}
+
+function persistSettings() {
+  try {
+    const payload = {
+      defaultTitle: defaultTitleInput.value,
+      defaultComposer: defaultComposerInput.value,
+      defaultTempo: defaultTempoInput.value,
+      defaultBeats: defaultBeatsInput.value,
+      defaultBeatType: defaultBeatTypeInput.value,
+      quantize: quantizeSelect.value,
+      timeScale: timeScaleSelect.value
+    };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
+  } catch (_error) {
+  }
+}
+
+function restoreSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed.defaultTitle) {
+      defaultTitleInput.value = String(parsed.defaultTitle);
+    }
+    if (parsed.defaultComposer) {
+      defaultComposerInput.value = String(parsed.defaultComposer);
+    }
+    if (parsed.defaultTempo) {
+      defaultTempoInput.value = String(parsed.defaultTempo);
+    }
+    if (parsed.defaultBeats) {
+      defaultBeatsInput.value = String(parsed.defaultBeats);
+    }
+    if (parsed.defaultBeatType) {
+      defaultBeatTypeInput.value = String(parsed.defaultBeatType);
+    }
+    if (parsed.quantize) {
+      quantizeSelect.value = String(parsed.quantize);
+    }
+    if (parsed.timeScale) {
+      timeScaleSelect.value = String(parsed.timeScale);
+    }
+  } catch (_error) {
+  }
+}
+
+function downloadMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  const blob = new Blob([lastXmlText], { type: "application/xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "score.musicxml";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  showToast("MusicXMLを保存しました。");
+}
+
+async function copyMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(lastXmlText);
+    showToast("MusicXMLをコピーしました。");
+  } catch (_error) {
+    showToast("コピーに失敗しました。");
+  }
+}
+
+let toastTimer = 0;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.remove("md-hidden");
+  toast.classList.add("md-visible");
+  if (toastTimer) {
+    clearTimeout(toastTimer);
+  }
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("md-visible");
+    toast.classList.add("md-hidden");
+  }, 1600);
+}
+
+window["toggleMenu"] = function toggleMenu() {
+  menuPanel.classList.toggle("md-hidden");
+};
+
+function handleDocumentClick(event) {
+  if (menuPanel.classList.contains("md-hidden")) {
+    return;
+  }
+
+  const target = event.target;
+  if (!target) {
+    return;
+  }
+
+  const menuButton = target.closest ? target.closest(".md-menu-button") : null;
+  const panel = target.closest ? target.closest("#menuPanel") : null;
+  if (!menuButton && !panel) {
+    menuPanel.classList.add("md-hidden");
+  }
+}

--- a/docs/music/src/midi-to-musicxml/ts/main.ts
+++ b/docs/music/src/midi-to-musicxml/ts/main.ts
@@ -1,0 +1,944 @@
+const musicXmlWriterCommon = window["MusicXmlWriterCommon"] || (typeof MusicXmlWriterCommon !== "undefined" ? MusicXmlWriterCommon : null);
+if (!musicXmlWriterCommon) {
+  throw new Error("MusicXmlWriterCommon is not loaded.");
+}
+
+const fileInput = document.getElementById("fileInput");
+const fileSelectBtn = document.getElementById("fileSelectBtn");
+const fileNameText = document.getElementById("fileNameText");
+const inputModeSourceRadio = document.getElementById("inputModeSource");
+const inputModeFileRadio = document.getElementById("inputModeFile");
+const sourceInputBlock = document.getElementById("sourceInputBlock");
+const fileInputBlock = document.getElementById("fileInputBlock");
+const hexInput = document.getElementById("hexInput");
+const defaultTitleInput = document.getElementById("defaultTitleInput");
+const defaultComposerInput = document.getElementById("defaultComposerInput");
+const defaultTempoInput = document.getElementById("defaultTempoInput");
+const defaultBeatsInput = document.getElementById("defaultBeatsInput");
+const defaultBeatTypeInput = document.getElementById("defaultBeatTypeInput");
+const quantizeSelect = document.getElementById("quantizeSelect");
+const timeScaleSelect = document.getElementById("timeScaleSelect");
+const convertBtn = document.getElementById("convertBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const copyBtn = document.getElementById("copyBtn");
+const previewText = document.getElementById("previewText");
+const xmlOutput = document.getElementById("xmlOutput");
+const errorText = document.getElementById("errorText");
+const warningText = document.getElementById("warningText");
+const toast = document.getElementById("toast");
+const menuPanel = document.getElementById("menuPanel");
+
+const SETTINGS_KEY = "midi-to-musicxml-settings";
+const MAX_POLYPHONY_LANES = 16;
+const TREBLE_BASS_SPLIT_NOTE = 60;
+const TREBLE_CLEF = { sign: "G", line: 2, label: "Treble" };
+const BASS_CLEF = { sign: "F", line: 4, label: "Bass" };
+
+let loadedMidiBytes = null;
+let loadedMidiName = "";
+let lastXmlText = "";
+
+restoreSettings();
+
+fileInput.addEventListener("change", onFileChange);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+inputModeSourceRadio.addEventListener("change", applyInputMode);
+inputModeFileRadio.addEventListener("change", applyInputMode);
+defaultTitleInput.addEventListener("change", persistSettings);
+defaultComposerInput.addEventListener("change", persistSettings);
+defaultTempoInput.addEventListener("change", persistSettings);
+defaultBeatsInput.addEventListener("change", persistSettings);
+defaultBeatTypeInput.addEventListener("change", persistSettings);
+quantizeSelect.addEventListener("change", persistSettings);
+timeScaleSelect.addEventListener("change", persistSettings);
+convertBtn.addEventListener("click", convertMidi);
+downloadBtn.addEventListener("click", downloadMusicXml);
+copyBtn.addEventListener("click", copyMusicXml);
+document.addEventListener("click", handleDocumentClick);
+
+applyInputMode();
+
+function onFileChange(event) {
+  const file = event.target.files && event.target.files[0];
+  if (!file) {
+    loadedMidiBytes = null;
+    loadedMidiName = "";
+    updateFileName("");
+    return;
+  }
+
+  inputModeFileRadio.checked = true;
+  applyInputMode();
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    const result = reader.result;
+    if (!(result instanceof ArrayBuffer)) {
+      setError("MIDIファイルの読み込みに失敗しました。");
+      return;
+    }
+    loadedMidiBytes = new Uint8Array(result);
+    loadedMidiName = file.name;
+    updateFileName(file.name);
+    showToast("MIDIを読み込みました。");
+  };
+  reader.onerror = () => {
+    setError("MIDIファイルの読み込みに失敗しました。");
+  };
+  reader.readAsArrayBuffer(file);
+}
+
+function updateFileName(name) {
+  fileNameText.textContent = name || "未選択";
+}
+
+function applyInputMode() {
+  const sourceMode = inputModeSourceRadio.checked;
+  sourceInputBlock.classList.toggle("md-hidden", !sourceMode);
+  fileInputBlock.classList.toggle("md-hidden", sourceMode);
+}
+
+function convertMidi() {
+  clearError();
+  clearWarning();
+
+  try {
+    const midiBytes = getInputMidiBytes();
+    if (!midiBytes || midiBytes.length === 0) {
+      throw new Error("MIDI入力が空です。");
+    }
+
+    const settings = {
+      defaultTitle: (defaultTitleInput.value || "").trim() || "Untitled",
+      defaultComposer: (defaultComposerInput.value || "").trim() || "Unknown",
+      defaultTempo: clampNumber(defaultTempoInput.value, 120, 20, 300),
+      defaultBeats: clampNumber(defaultBeatsInput.value, 4, 1, 12),
+      defaultBeatType: clampNumber(defaultBeatTypeInput.value, 4, 1, 16),
+      quantize: quantizeSelect.value || "1/16",
+      timeScale: clampFloat(timeScaleSelect.value, 1, 0.1, 8)
+    };
+
+    const parsedMidi = parseMidiFile(midiBytes);
+    const conversion = convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedMidiName);
+    const xml = musicXmlWriterCommon.buildScorePartwiseXml(conversion.parsedForXml);
+
+    lastXmlText = xml;
+    xmlOutput.textContent = xml;
+    downloadBtn.disabled = false;
+    copyBtn.disabled = false;
+
+    const previewLines = [
+      "title: " + conversion.summary.title,
+      "composer: " + conversion.summary.composer,
+      "format: " + parsedMidi.format,
+      "tracks: " + parsedMidi.trackCount,
+      "parts: " + conversion.summary.parts,
+      "ppqn: " + parsedMidi.ppqn,
+      "tempo: " + conversion.summary.tempo,
+      "meter: " + conversion.summary.meter,
+      "time scale: " + settings.timeScale + "x",
+      "notes: " + conversion.summary.notes,
+      "rests: " + conversion.summary.rests,
+      "measures: " + conversion.summary.measures
+    ];
+    previewText.textContent = previewLines.join("\n");
+
+    if (conversion.warnings.length > 0) {
+      warningText.textContent = "警告:\n" + conversion.warnings.join("\n");
+      warningText.classList.remove("md-hidden");
+    }
+
+    showToast("MusicXMLを生成しました。");
+  } catch (error) {
+    resetOutput();
+    const message = error && error.message ? error.message : String(error);
+    setError("変換に失敗しました: " + message);
+  }
+}
+
+function getInputMidiBytes() {
+  if (inputModeSourceRadio.checked) {
+    const source = (hexInput.value || "").trim();
+    if (!source) {
+      return null;
+    }
+    return parseHexString(source);
+  }
+  return loadedMidiBytes;
+}
+
+function parseHexString(text) {
+  const cleaned = text.replace(/[^0-9a-fA-F]/g, "");
+  if (cleaned.length === 0) {
+    return null;
+  }
+  if (cleaned.length % 2 !== 0) {
+    throw new Error("16進ソースの桁数が不正です。");
+  }
+  const out = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function parseMidiFile(bytes) {
+  const reader = createReader(bytes);
+  const chunkId = readAscii(reader, 4);
+  if (chunkId !== "MThd") {
+    throw new Error("MIDIヘッダ (MThd) が見つかりません。");
+  }
+
+  const headerLength = readU32(reader);
+  if (headerLength < 6) {
+    throw new Error("MIDIヘッダ長が不正です。");
+  }
+
+  const format = readU16(reader);
+  const trackCount = readU16(reader);
+  const division = readU16(reader);
+  if ((division & 0x8000) !== 0) {
+    throw new Error("SMPTE形式のdivisionには未対応です。");
+  }
+  const ppqn = division;
+
+  if (headerLength > 6) {
+    reader.offset += headerLength - 6;
+  }
+
+  const trackParses = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const warnings = [];
+
+  for (let trackIndex = 0; trackIndex < trackCount; trackIndex += 1) {
+    const id = readAscii(reader, 4);
+    if (id !== "MTrk") {
+      throw new Error("MTrkチャンクが見つかりません。track=" + (trackIndex + 1));
+    }
+    const length = readU32(reader);
+    const trackEnd = reader.offset + length;
+    if (trackEnd > bytes.length) {
+      throw new Error("MTrkチャンク長が不正です。track=" + (trackIndex + 1));
+    }
+    const parsedTrack = parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings);
+    trackParses.push(parsedTrack);
+    for (const ev of parsedTrack.tempoEvents) {
+      tempoEvents.push(ev);
+    }
+    for (const ev of parsedTrack.meterEvents) {
+      meterEvents.push(ev);
+    }
+    reader.offset = trackEnd;
+  }
+
+  const earliestTempo = findEarliestEvent(tempoEvents);
+  const earliestMeter = findEarliestEvent(meterEvents);
+
+  return {
+    format,
+    trackCount,
+    ppqn,
+    tracks: trackParses,
+    tempoBpm: earliestTempo ? Math.max(20, Math.round(60000000 / earliestTempo.mpqn)) : null,
+    meter: earliestMeter ? { beats: earliestMeter.beats, beatType: earliestMeter.beatType } : null,
+    warnings
+  };
+}
+
+function parseTrackEvents(bytes, reader, trackEnd, trackIndex, warnings) {
+  let tick = 0;
+  let runningStatus = 0;
+  const notes = [];
+  const tempoEvents = [];
+  const meterEvents = [];
+  const activeNotes = new Map();
+
+  let trackName = "";
+  let program = null;
+
+  while (reader.offset < trackEnd) {
+    tick += readVarLen(reader);
+
+    if (reader.offset >= trackEnd) {
+      break;
+    }
+
+    let status = readU8(reader);
+    if (status < 0x80) {
+      if (!runningStatus) {
+        throw new Error("ランニングステータスが不正です。track=" + (trackIndex + 1));
+      }
+      reader.offset -= 1;
+      status = runningStatus;
+    } else {
+      runningStatus = status;
+    }
+
+    if (status === 0xff) {
+      const metaType = readU8(reader);
+      const metaLen = readVarLen(reader);
+      const metaStart = reader.offset;
+      const metaEnd = metaStart + metaLen;
+      if (metaEnd > trackEnd) {
+        throw new Error("メタイベント長が不正です。track=" + (trackIndex + 1));
+      }
+
+      if (metaType === 0x03) {
+        trackName = utf8Decode(bytes.slice(metaStart, metaEnd));
+      } else if (metaType === 0x51 && metaLen === 3) {
+        const mpqn = (bytes[metaStart] << 16) | (bytes[metaStart + 1] << 8) | bytes[metaStart + 2];
+        if (mpqn > 0) {
+          tempoEvents.push({ tick, mpqn });
+        }
+      } else if (metaType === 0x58 && metaLen >= 2) {
+        const beats = bytes[metaStart];
+        const beatType = 1 << bytes[metaStart + 1];
+        if (beats > 0 && beatType > 0) {
+          meterEvents.push({ tick, beats, beatType });
+        }
+      }
+
+      reader.offset = metaEnd;
+      continue;
+    }
+
+    if (status === 0xf0 || status === 0xf7) {
+      const syxLen = readVarLen(reader);
+      reader.offset += syxLen;
+      if (reader.offset > trackEnd) {
+        throw new Error("SysEx長が不正です。track=" + (trackIndex + 1));
+      }
+      continue;
+    }
+
+    const high = status >> 4;
+    const channel = status & 0x0f;
+
+    if (high === 0x8 || high === 0x9 || high === 0xa || high === 0xb || high === 0xe) {
+      const data1 = readU8(reader);
+      const data2 = readU8(reader);
+      if (high === 0x9 && data2 > 0) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key) || [];
+        stack.push({ tick, velocity: data2 });
+        activeNotes.set(key, stack);
+      } else if (high === 0x8 || (high === 0x9 && data2 === 0)) {
+        const key = channel + ":" + data1;
+        const stack = activeNotes.get(key);
+        if (!stack || stack.length === 0) {
+          warnings.push("track " + (trackIndex + 1) + ": NoteOffに対応するNoteOnがありません。note=" + data1);
+        } else {
+          const start = stack.pop();
+          const duration = Math.max(1, tick - start.tick);
+          notes.push({
+            trackIndex,
+            channel,
+            noteNumber: data1,
+            startTick: start.tick,
+            durationTick: duration,
+            velocity: start.velocity
+          });
+        }
+      }
+      continue;
+    }
+
+    if (high === 0xc || high === 0xd) {
+      const data = readU8(reader);
+      if (high === 0xc && program === null) {
+        program = data;
+      }
+      continue;
+    }
+
+    throw new Error("未対応のMIDIイベントです。status=0x" + status.toString(16));
+  }
+
+  if (activeNotes.size > 0) {
+    warnings.push("track " + (trackIndex + 1) + ": 終端でクローズされないノートがあります。");
+  }
+
+  notes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    return a.noteNumber - b.noteNumber;
+  });
+
+  return {
+    trackIndex,
+    trackName,
+    program,
+    notes,
+    tempoEvents,
+    meterEvents
+  };
+}
+
+function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
+  const warnings = parsedMidi.warnings.slice();
+
+  const title = deriveTitle(parsedMidi, settings.defaultTitle, loadedName);
+  const composer = settings.defaultComposer;
+  const tempo = parsedMidi.tempoBpm || settings.defaultTempo;
+  const meter = parsedMidi.meter || {
+    beats: settings.defaultBeats,
+    beatType: settings.defaultBeatType
+  };
+  const quantizeTicks = resolveQuantizeTicks(settings.quantize, parsedMidi.ppqn);
+
+  const tracksWithNotes = parsedMidi.tracks.filter((track) => track.notes.length > 0);
+  if (tracksWithNotes.length === 0) {
+    throw new Error("ノートイベントが見つかりませんでした。");
+  }
+
+  const parts = [];
+  let totalNotes = 0;
+  let totalRests = 0;
+  let totalMeasures = 0;
+  let partSerial = 1;
+
+  for (let i = 0; i < tracksWithNotes.length; i += 1) {
+    const track = tracksWithNotes[i];
+    const basePartName = track.trackName || "Track " + String(track.trackIndex + 1);
+    const clefLanes = splitTrackNotesIntoClefLanes(track.notes, quantizeTicks, settings.timeScale, track.trackIndex, warnings);
+    for (let laneIndex = 0; laneIndex < clefLanes.length; laneIndex += 1) {
+      const lane = clefLanes[laneIndex];
+      if (!lane || !lane.notes || lane.notes.length === 0) {
+        continue;
+      }
+      const partBuild = buildMeasuresFromMonophonicTrack(lane.notes, parsedMidi.ppqn, meter);
+      totalNotes += partBuild.noteCount;
+      totalRests += partBuild.restCount;
+      totalMeasures = Math.max(totalMeasures, partBuild.measures.length);
+      const laneNameSuffix = " " + lane.clef.label + " L" + String(lane.serialInClef);
+      parts.push({
+        partId: "P" + String(partSerial),
+        partName: clefLanes.length === 1 ? basePartName : (basePartName + laneNameSuffix),
+        clef: {
+          sign: lane.clef.sign,
+          line: lane.clef.line
+        },
+        measures: partBuild.measures
+      });
+      partSerial += 1;
+    }
+  }
+
+  const parsedForXml = {
+    meta: {
+      title,
+      composer,
+      keyInfo: { fifths: 0 },
+      meter,
+      tempo
+    },
+    parts
+  };
+
+  return {
+    parsedForXml,
+    warnings,
+    summary: {
+      title,
+      composer,
+      parts: parts.length,
+      tempo,
+      meter: meter.beats + "/" + meter.beatType,
+      notes: totalNotes,
+      rests: totalRests,
+      measures: totalMeasures
+    }
+  };
+}
+
+function splitTrackNotesIntoClefLanes(notes, quantizeTicks, timeScale, trackIndex, warnings) {
+  const laneLimitPerClef = Math.max(1, Math.floor(MAX_POLYPHONY_LANES / 2));
+  const trebleLanes = createLanePool(laneLimitPerClef, TREBLE_CLEF);
+  const bassLanes = createLanePool(laneLimitPerClef, BASS_CLEF);
+  const quantizedNotes = notes.map((note) => {
+    const scaledStart = Math.max(0, Math.round(note.startTick * timeScale));
+    const scaledDuration = Math.max(1, Math.round(note.durationTick * timeScale));
+    const startTick = quantizeTick(scaledStart, quantizeTicks);
+    const durationTick = Math.max(1, quantizeTick(scaledDuration, quantizeTicks));
+    return {
+      trackIndex: note.trackIndex,
+      noteNumber: note.noteNumber,
+      startTick,
+      durationTick
+    };
+  });
+
+  quantizedNotes.sort((a, b) => {
+    if (a.startTick !== b.startTick) {
+      return a.startTick - b.startTick;
+    }
+    if (a.noteNumber !== b.noteNumber) {
+      return b.noteNumber - a.noteNumber;
+    }
+    return b.durationTick - a.durationTick;
+  });
+
+  for (const note of quantizedNotes) {
+    const primaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? trebleLanes : bassLanes;
+    const secondaryPool = note.noteNumber >= TREBLE_BASS_SPLIT_NOTE ? bassLanes : trebleLanes;
+    let lane = pickBestLane(primaryPool, note.startTick);
+    if (!lane) {
+      lane = pickBestLane(secondaryPool, note.startTick);
+    }
+
+    if (!lane) {
+      warnings.push(
+        "track " +
+        (trackIndex + 1) +
+        ": 同時発音が" +
+        MAX_POLYPHONY_LANES +
+        "を超えたため一部ノートをスキップしました。"
+      );
+      continue;
+    }
+
+    lane.notes.push(note);
+    lane.endTick = note.startTick + note.durationTick;
+  }
+
+  return [...trebleLanes, ...bassLanes].filter((lane) => lane.notes.length > 0);
+}
+
+function createLanePool(size, clef) {
+  return Array.from({ length: size }, (_unused, index) => ({
+    notes: [],
+    endTick: -1,
+    serialInClef: index + 1,
+    clef
+  }));
+}
+
+function pickBestLane(pool, startTick) {
+  let best = null;
+  let bestGap = Number.POSITIVE_INFINITY;
+  for (const lane of pool) {
+    if (lane.endTick > startTick) {
+      continue;
+    }
+    const gap = startTick - lane.endTick;
+    if (gap < bestGap) {
+      best = lane;
+      bestGap = gap;
+    }
+  }
+  return best;
+}
+
+function buildMeasuresFromMonophonicTrack(notes, ppqn, meter) {
+  const ticksPerMeasure = Math.max(1, Math.round((ppqn * 4 * meter.beats) / meter.beatType));
+  const measures = [[]];
+  let cursor = 0;
+  let noteCount = 0;
+  let restCount = 0;
+
+  for (const note of notes) {
+    let start = note.startTick;
+    const duration = Math.max(1, note.durationTick);
+
+    if (start < cursor) {
+      start = cursor;
+    }
+
+    if (start > cursor) {
+      const inserted = pushDurationToken(measures, cursor, start - cursor, ticksPerMeasure, ppqn, null);
+      restCount += inserted;
+      cursor = start;
+    }
+
+    const insertedNotes = pushDurationToken(measures, cursor, duration, ticksPerMeasure, ppqn, note.noteNumber);
+    noteCount += insertedNotes;
+    cursor += duration;
+  }
+
+  while (measures.length > 1 && measures[measures.length - 1].length === 0) {
+    measures.pop();
+  }
+
+  return {
+    measures,
+    noteCount,
+    restCount
+  };
+}
+
+function pushDurationToken(measures, startTick, durationTick, ticksPerMeasure, ppqn, midiNoteNumber) {
+  let remaining = durationTick;
+  let tick = startTick;
+  let inserted = 0;
+
+  while (remaining > 0) {
+    const measureIndex = Math.floor(tick / ticksPerMeasure);
+    while (measures.length <= measureIndex) {
+      measures.push([]);
+    }
+
+    const tickInMeasure = tick % ticksPerMeasure;
+    const freeInMeasure = ticksPerMeasure - tickInMeasure;
+    const chunk = Math.max(1, Math.min(remaining, freeInMeasure));
+
+    if (midiNoteNumber === null) {
+      measures[measureIndex].push(buildRestToken(chunk, ppqn));
+    } else {
+      measures[measureIndex].push(buildNoteToken(midiNoteNumber, chunk, ppqn));
+    }
+
+    inserted += 1;
+    tick += chunk;
+    remaining -= chunk;
+  }
+
+  return inserted;
+}
+
+function buildRestToken(durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  return {
+    isRest: true,
+    duration,
+    type: durationToType(duration)
+  };
+}
+
+function buildNoteToken(midiNoteNumber, durationTick, ppqn) {
+  const duration = midiTicksToMusicXmlDuration(durationTick, ppqn);
+  const pitch = midiNumberToPitch(midiNoteNumber);
+  return {
+    isRest: false,
+    step: pitch.step,
+    alter: pitch.alter,
+    octave: pitch.octave,
+    duration,
+    type: durationToType(duration),
+    voice: "1"
+  };
+}
+
+function midiTicksToMusicXmlDuration(ticks, ppqn) {
+  return Math.max(1, Math.round((ticks * 960) / ppqn));
+}
+
+function durationToType(duration) {
+  const table = [
+    { duration: 3840, type: "whole" },
+    { duration: 1920, type: "half" },
+    { duration: 960, type: "quarter" },
+    { duration: 480, type: "eighth" },
+    { duration: 240, type: "16th" },
+    { duration: 120, type: "32nd" },
+    { duration: 60, type: "64th" }
+  ];
+
+  let best = table[0];
+  let minDiff = Math.abs(duration - best.duration);
+  for (const entry of table) {
+    const diff = Math.abs(duration - entry.duration);
+    if (diff < minDiff) {
+      minDiff = diff;
+      best = entry;
+    }
+  }
+  return best.type;
+}
+
+function midiNumberToPitch(midiNumber) {
+  const normalized = Math.max(0, Math.min(127, midiNumber));
+  const semitone = normalized % 12;
+  const octave = Math.floor(normalized / 12) - 1;
+  const map = [
+    { step: "C", alter: null },
+    { step: "C", alter: 1 },
+    { step: "D", alter: null },
+    { step: "D", alter: 1 },
+    { step: "E", alter: null },
+    { step: "F", alter: null },
+    { step: "F", alter: 1 },
+    { step: "G", alter: null },
+    { step: "G", alter: 1 },
+    { step: "A", alter: null },
+    { step: "A", alter: 1 },
+    { step: "B", alter: null }
+  ];
+  const found = map[semitone] || map[0];
+  return {
+    step: found.step,
+    alter: found.alter,
+    octave
+  };
+}
+
+function deriveTitle(parsedMidi, fallbackTitle, loadedName) {
+  for (const track of parsedMidi.tracks) {
+    if (track.trackName && track.trackName.trim()) {
+      return track.trackName.trim();
+    }
+  }
+  if (loadedName) {
+    const dot = loadedName.lastIndexOf(".");
+    if (dot > 0) {
+      return loadedName.slice(0, dot);
+    }
+    return loadedName;
+  }
+  return fallbackTitle;
+}
+
+function findEarliestEvent(events) {
+  if (!events || events.length === 0) {
+    return null;
+  }
+  let earliest = events[0];
+  for (const event of events) {
+    if (event.tick < earliest.tick) {
+      earliest = event;
+    }
+  }
+  return earliest;
+}
+
+function resolveQuantizeTicks(quantizeValue, ppqn) {
+  if (quantizeValue === "1/8") {
+    return Math.max(1, Math.round(ppqn / 2));
+  }
+  if (quantizeValue === "1/32") {
+    return Math.max(1, Math.round(ppqn / 8));
+  }
+  return Math.max(1, Math.round(ppqn / 4));
+}
+
+function quantizeTick(value, quantum) {
+  return Math.max(0, Math.round(value / quantum) * quantum);
+}
+
+function createReader(bytes) {
+  return {
+    bytes,
+    offset: 0
+  };
+}
+
+function readAscii(reader, length) {
+  ensureReadable(reader, length);
+  let out = "";
+  for (let i = 0; i < length; i += 1) {
+    out += String.fromCharCode(reader.bytes[reader.offset + i]);
+  }
+  reader.offset += length;
+  return out;
+}
+
+function readU8(reader) {
+  ensureReadable(reader, 1);
+  const value = reader.bytes[reader.offset];
+  reader.offset += 1;
+  return value;
+}
+
+function readU16(reader) {
+  ensureReadable(reader, 2);
+  const value = (reader.bytes[reader.offset] << 8) | reader.bytes[reader.offset + 1];
+  reader.offset += 2;
+  return value;
+}
+
+function readU32(reader) {
+  ensureReadable(reader, 4);
+  const value =
+    (reader.bytes[reader.offset] * 16777216) +
+    (reader.bytes[reader.offset + 1] << 16) +
+    (reader.bytes[reader.offset + 2] << 8) +
+    reader.bytes[reader.offset + 3];
+  reader.offset += 4;
+  return value;
+}
+
+function readVarLen(reader) {
+  let value = 0;
+  let count = 0;
+  while (true) {
+    const byte = readU8(reader);
+    value = (value << 7) | (byte & 0x7f);
+    count += 1;
+    if ((byte & 0x80) === 0) {
+      return value;
+    }
+    if (count > 4) {
+      throw new Error("可変長値が不正です。");
+    }
+  }
+}
+
+function ensureReadable(reader, length) {
+  if (reader.offset + length > reader.bytes.length) {
+    throw new Error("MIDIデータの末尾を超えて読み込みました。");
+  }
+}
+
+function utf8Decode(bytes) {
+  try {
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(bytes);
+  } catch (_error) {
+    let out = "";
+    for (let i = 0; i < bytes.length; i += 1) {
+      out += String.fromCharCode(bytes[i]);
+    }
+    return out;
+  }
+}
+
+function clampNumber(value, fallback, min, max) {
+  const num = Number.parseInt(value, 10);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function clampFloat(value, fallback, min, max) {
+  const num = Number.parseFloat(value);
+  if (!Number.isFinite(num)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, num));
+}
+
+function resetOutput() {
+  lastXmlText = "";
+  xmlOutput.textContent = "";
+  previewText.textContent = "未変換";
+  downloadBtn.disabled = true;
+  copyBtn.disabled = true;
+}
+
+function setError(message) {
+  errorText.textContent = message;
+  errorText.classList.remove("md-hidden");
+}
+
+function clearError() {
+  errorText.textContent = "";
+  errorText.classList.add("md-hidden");
+}
+
+function clearWarning() {
+  warningText.textContent = "";
+  warningText.classList.add("md-hidden");
+}
+
+function persistSettings() {
+  try {
+    const payload = {
+      defaultTitle: defaultTitleInput.value,
+      defaultComposer: defaultComposerInput.value,
+      defaultTempo: defaultTempoInput.value,
+      defaultBeats: defaultBeatsInput.value,
+      defaultBeatType: defaultBeatTypeInput.value,
+      quantize: quantizeSelect.value,
+      timeScale: timeScaleSelect.value
+    };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
+  } catch (_error) {
+  }
+}
+
+function restoreSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed.defaultTitle) {
+      defaultTitleInput.value = String(parsed.defaultTitle);
+    }
+    if (parsed.defaultComposer) {
+      defaultComposerInput.value = String(parsed.defaultComposer);
+    }
+    if (parsed.defaultTempo) {
+      defaultTempoInput.value = String(parsed.defaultTempo);
+    }
+    if (parsed.defaultBeats) {
+      defaultBeatsInput.value = String(parsed.defaultBeats);
+    }
+    if (parsed.defaultBeatType) {
+      defaultBeatTypeInput.value = String(parsed.defaultBeatType);
+    }
+    if (parsed.quantize) {
+      quantizeSelect.value = String(parsed.quantize);
+    }
+    if (parsed.timeScale) {
+      timeScaleSelect.value = String(parsed.timeScale);
+    }
+  } catch (_error) {
+  }
+}
+
+function downloadMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  const blob = new Blob([lastXmlText], { type: "application/xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "score.musicxml";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  showToast("MusicXMLを保存しました。");
+}
+
+async function copyMusicXml() {
+  if (!lastXmlText) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(lastXmlText);
+    showToast("MusicXMLをコピーしました。");
+  } catch (_error) {
+    showToast("コピーに失敗しました。");
+  }
+}
+
+let toastTimer = 0;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.remove("md-hidden");
+  toast.classList.add("md-visible");
+  if (toastTimer) {
+    clearTimeout(toastTimer);
+  }
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("md-visible");
+    toast.classList.add("md-hidden");
+  }, 1600);
+}
+
+window["toggleMenu"] = function toggleMenu() {
+  menuPanel.classList.toggle("md-hidden");
+};
+
+function handleDocumentClick(event) {
+  if (menuPanel.classList.contains("md-hidden")) {
+    return;
+  }
+
+  const target = event.target;
+  if (!target) {
+    return;
+  }
+
+  const menuButton = target.closest ? target.closest(".md-menu-button") : null;
+  const panel = target.closest ? target.closest("#menuPanel") : null;
+  if (!menuButton && !panel) {
+    menuPanel.classList.add("md-hidden");
+  }
+}

--- a/scripts/build-music.mjs
+++ b/scripts/build-music.mjs
@@ -21,6 +21,20 @@ const TARGETS = [
     ]
   },
   {
+    id: "midi-to-musicxml",
+    srcHtml: "docs/music/midi-to-musicxml-src.html",
+    outHtml: "docs/music/midi-to-musicxml.html",
+    cssOrder: ["src/midi-to-musicxml/css/app.css"],
+    jsOrder: [
+      "src/common/js/musicxml-writer-common.js",
+      "src/midi-to-musicxml/js/main.js"
+    ],
+    tsOrder: [
+      "src/common/ts/musicxml-writer-common.ts",
+      "src/midi-to-musicxml/ts/main.ts"
+    ]
+  },
+  {
     id: "musicxml-to-abc",
     srcHtml: "docs/music/musicxml-to-abc-src.html",
     outHtml: "docs/music/musicxml-to-abc.html",


### PR DESCRIPTION
## 概要

`docs/music` に新しく **MIDI → MusicXML 変換**を追加しました。
MIDI読み込み（ファイル/16進入力）から MusicXML 生成・保存までをブラウザで完結できるようにしています。

あわせて、同時発音の崩れを抑えるために、音域ベースの割り当てロジックを実装しました。

## 変更内容

### 1. 新規ツール追加（midi-to-musicxml）
- 追加: `docs/music/midi-to-musicxml-src.html`
- 追加: `docs/music/src/midi-to-musicxml/ts/main.ts`
- 追加: `docs/music/src/midi-to-musicxml/css/app.css`
- 生成: `docs/music/src/midi-to-musicxml/js/main.js`
- 生成: `docs/music/midi-to-musicxml.html`

主な機能:
- `.mid/.midi` ファイル入力、および16進入力
- MIDIヘッダ/トラック解析（ノート、テンポ、拍子）
- MusicXMLへの変換、プレビュー、コピー、保存

### 2. レーン割り当ての改善
- 最大16レーンを使用
- 音域でまずト音/ヘ音に振り分け（`split note = 60`）
- 各側で重なりを回避しながらレーン割り当て
- 同時刻ノートは **高音を先に** 小さい番号レーンへ割り当て

### 3. MusicXML writer の拡張
- 更新: `docs/music/src/common/ts/musicxml-writer-common.ts`
- 生成: `docs/music/src/common/js/musicxml-writer-common.js`
- パートごとの `clef`（G/F/C）指定をサポート
- 未指定時は従来どおり `G2` を使用

### 4. 変換設定の拡張
- `時間スケール`（0.5x / 1.0x / 2.0x）を追加
- 小節長が倍化/半減するMIDIの補正が可能

### 5. ビルド対象とドキュメント更新
- 更新: `scripts/build-music.mjs`
  - `midi-to-musicxml` ターゲットを追加
- 更新: `docs/music/BUILD_PROCESS.md`
  - 新ツールの構成を追記

## 影響範囲

- `docs/music` のビルド生成物に変更あり
  - `docs/music/midi-to-musicxml.html`（新規）
  - `docs/music/abc-to-musicxml.html`（ビルド生成更新）

## 動作確認

- `npm run build:music` 実行
- `docs/music/midi-to-musicxml.html` が生成されることを確認

## 補足

- 本PRはMVP実装です。 複雑なタイ/装飾/発想記号の完全復元は今後の拡張対象です。