### PR TITLE
fix(midi-to-musicxml): 休符ノートにも voice を出力して互換性エラーを解消

### DIFF
--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -1510,7 +1510,8 @@ function buildRestToken(durationTick, ppqn) {
   return {
     isRest: true,
     duration,
-    type: durationToType(duration)
+    type: durationToType(duration),
+    voice: "1"
   };
 }
 

--- a/docs/music/src/midi-to-musicxml/js/main.js
+++ b/docs/music/src/midi-to-musicxml/js/main.js
@@ -751,7 +751,8 @@ function buildRestToken(durationTick, ppqn) {
   return {
     isRest: true,
     duration,
-    type: durationToType(duration)
+    type: durationToType(duration),
+    voice: "1"
   };
 }
 

--- a/docs/music/src/midi-to-musicxml/ts/main.ts
+++ b/docs/music/src/midi-to-musicxml/ts/main.ts
@@ -751,7 +751,8 @@ function buildRestToken(durationTick, ppqn) {
   return {
     isRest: true,
     duration,
-    type: durationToType(duration)
+    type: durationToType(duration),
+    voice: "1"
   };
 }
 


### PR DESCRIPTION
## 概要

`MIDI -> MusicXML` 変換で生成した MusicXML を別ツールで読み込む際、`voice` 不足エラーが発生する問題を修正しました。

## 変更内容

- `docs/music/src/midi-to-musicxml/ts/main.ts`
  - `buildRestToken(...)` の戻り値に `voice: "1"` を追加
  - これにより、休符ノートにも `<voice>` が出力されるように修正

- 生成物更新
  - `docs/music/src/midi-to-musicxml/js/main.js`
  - `docs/music/midi-to-musicxml.html`

## 背景

従来は音符には `voice` が付与されていた一方で、休符には `voice` が付与されていませんでした。 そのため、`voice` の整合性を厳密に検証するツールで読み込みエラーになるケースがありました。

## 期待される効果

- 生成された MusicXML において、音符・休符ともに `voice` が揃う
- 他ツール連携時の `voice` 不足エラーを回避