### PR TITLE
Mermaid SVGのXML正規化対応と git-pseudo-squash 出力欄への右下コピーボタン追加

### DIFF
--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -2644,9 +2644,9 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
         });
 
         const result = await mermaid.render(renderId, source);
-        lastSvg = result.svg;
-        svgPreview.innerHTML = result.svg;
-        svgText.textContent = result.svg;
+        lastSvg = normalizeSvgForXml(result.svg);
+        svgPreview.innerHTML = lastSvg;
+        svgText.textContent = lastSvg;
 
         downloadSvgBtn.disabled = false;
         showToast("SVGを生成しました。");
@@ -2684,6 +2684,28 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
       }).catch((error) => {
         setError("コピーに失敗しました: " + (error && error.message ? error.message : String(error)));
       });
+    }
+
+    function normalizeSvgForXml(svgText) {
+      if (!svgText) {
+        return "";
+      }
+
+      // Mermaid can emit HTML-style <br> inside foreignObject labels.
+      // Convert them to XML-safe self-closing tags for standalone SVG consumers.
+      const candidate = svgText
+        .replace(/<br\s*>/gi, "<br/>")
+        .replace(/<br([^/>]*)><\/br>/gi, "<br$1/>");
+
+      try {
+        const parsed = new DOMParser().parseFromString(candidate, "image/svg+xml");
+        if (parsed.querySelector("parsererror")) {
+          return candidate;
+        }
+        return new XMLSerializer().serializeToString(parsed.documentElement);
+      } catch (error) {
+        return candidate;
+      }
     }
 
     function setError(message, lineNumber) {

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -237,6 +237,9 @@ limitations under the License.
       color: #1f1b2d;
       min-height: 2.5rem;
     }
+    .md-code--dual-copy {
+      padding-bottom: 2.5rem;
+    }
 
     .md-copy-button {
       position: absolute;
@@ -248,6 +251,11 @@ limitations under the License.
       background: #f7f2fa;
       border: none;
       cursor: pointer;
+    }
+    .md-copy-button--bottom-right {
+      top: auto;
+      right: 0.5rem;
+      bottom: 0.5rem;
     }
 
     .md-snackbar {
@@ -935,7 +943,9 @@ limitations under the License.
       border: 1px solid #e5e0ec;
       color: #1f1b2d;
     }
+    .md-code--dual-copy { padding-bottom: 2.5rem; }
     .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
+    .md-copy-button--bottom-right { top: auto; right: 0.5rem; bottom: 0.5rem; }
 
     .md-icon-20 { width: 20px; height: 20px; }
 
@@ -1429,8 +1439,13 @@ limitations under the License.
     </div>
 
     <div class="md-code-block">
-      <code id="rebaseCmd" class="md-code"></code>
+      <code id="rebaseCmd" class="md-code md-code--dual-copy"></code>
       <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('rebaseCmd')">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+          </svg>
+      </button>
+      <button class="md-copy-button md-copy-button--bottom-right md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('rebaseCmd')" aria-label="コピー（右下）">
         <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
             <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
           </svg>


### PR DESCRIPTION
### 概要
1. `docs/diagram/mermaid-to-svg.html`
- Mermaidレンダリング結果をそのまま保持するのではなく、`normalizeSvgForXml()` で正規化してから `lastSvg` / プレビュー / 出力テキストに反映。
- `foreignObject` 内に含まれる HTML 形式の `<br>` を XML安全な `<br/>` へ変換。
- `DOMParser("image/svg+xml")` と `XMLSerializer` による再シリアライズを追加し、単体SVGとして扱いやすく改善。
- パース失敗時はフォールバックで候補文字列を返し、既存動作を壊さないように対応。

2. `docs/git/git-pseudo-squash.html`
- `rebaseCmd` のコードブロックに右下コピーボタンを追加。
- 2つ目ボタン追加に伴い、表示重なりを防ぐため `md-code--dual-copy`（下余白確保）を追加。
- 右下固定用スタイル `md-copy-button--bottom-right` を追加。

### 目的
- Mermaid出力SVGがXMLとして不正になるケース（例: `<br>`）を防ぐ。
- 出力コマンド欄のコピー操作性を改善する（右下からもコピー可能にする）。

### 影響範囲
- Mermaid to SVG のレンダリング後のSVG文字列処理。
- git-pseudo-squash の `rebaseCmd` 表示ブロックのUI。

### 確認観点
- Mermaidで改行入りラベル（`<br/>` 含む）を生成して、保存・コピーしたSVGが利用先で読み込めること。
- `rebaseCmd` ブロックで右上・右下どちらのコピーアイコンでも同じ内容がコピーされること。
- コードブロック内でボタンが内容と重ならないこと。