### PR TITLE
feat(music): MIDI→MusicXMLのテンポ変化・強弱・MIDI音色出力に対応し、調性決定の優先順位を改善

### DIFF
--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -1239,12 +1239,33 @@ const MusicXmlWriterCommon = (() => {
     for (const part of parts) {
       const partId = part.partId || "P1";
       const partName = part.partName || "Music";
-      lines.push('    <score-part id="' + escapeXml(partId) + '"><part-name>' + escapeXml(partName) + '</part-name></score-part>');
+      const midiProgram = normalizeMidiProgram(part.midiProgram);
+      const midiChannel = normalizeMidiChannel(part.midiChannel);
+      const scoreInstrumentId = partId + "-I1";
+      lines.push('    <score-part id="' + escapeXml(partId) + '">');
+      lines.push('      <part-name>' + escapeXml(partName) + '</part-name>');
+      if (midiProgram !== null || midiChannel !== null) {
+        lines.push('      <score-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        lines.push('        <instrument-name>' + escapeXml(resolveMidiInstrumentName(partName, midiProgram)) + '</instrument-name>');
+        lines.push('      </score-instrument>');
+        lines.push('      <midi-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        if (midiChannel !== null) {
+          lines.push("        <midi-channel>" + midiChannel + "</midi-channel>");
+        }
+        if (midiProgram !== null) {
+          lines.push("        <midi-program>" + midiProgram + "</midi-program>");
+        }
+        lines.push("      </midi-instrument>");
+      }
+      lines.push("    </score-part>");
     }
     lines.push('  </part-list>');
-    for (const part of parts) {
+    const tempoChangesByMeasure = normalizeTempoChanges(meta.tempoChanges, meta.tempo);
+    for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      const part = parts[partIndex];
       const partId = part.partId || "P1";
       const measures = Array.isArray(part.measures) && part.measures.length > 0 ? part.measures : [[]];
+      const measureDynamics = Array.isArray(part.measureDynamics) ? part.measureDynamics : [];
       lines.push('  <part id="' + escapeXml(partId) + '">');
 
       for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
@@ -1270,6 +1291,30 @@ const MusicXmlWriterCommon = (() => {
           }
           lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
+        }
+        if (partIndex === 0) {
+          const tempoBpm = tempoChangesByMeasure.get(measureNo);
+          if (Number.isFinite(tempoBpm) && tempoBpm > 0) {
+            lines.push('      <direction placement="above">');
+            lines.push("        <direction-type>");
+            lines.push("          <metronome>");
+            lines.push("            <beat-unit>quarter</beat-unit>");
+            lines.push("            <per-minute>" + tempoBpm + "</per-minute>");
+            lines.push("          </metronome>");
+            lines.push("        </direction-type>");
+            lines.push("        <sound tempo=\"" + tempoBpm + "\"/>");
+            lines.push("      </direction>");
+          }
+        }
+        const dynamicMark = normalizeDynamicMark(measureDynamics[measureIndex]);
+        if (dynamicMark) {
+          lines.push('      <direction placement="below">');
+          lines.push("        <direction-type>");
+          lines.push("          <dynamics>");
+          lines.push("            <" + dynamicMark + "/>");
+          lines.push("          </dynamics>");
+          lines.push("        </direction-type>");
+          lines.push("      </direction>");
         }
 
         for (const note of notes) {
@@ -1370,6 +1415,70 @@ const MusicXmlWriterCommon = (() => {
     return "major";
   }
 
+  function normalizeMidiProgram(rawProgram) {
+    const value = Number.parseInt(rawProgram, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 128) {
+      return null;
+    }
+    return value;
+  }
+
+  function normalizeMidiChannel(rawChannel) {
+    const value = Number.parseInt(rawChannel, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 16) {
+      return null;
+    }
+    return value;
+  }
+
+  function resolveMidiInstrumentName(partName, midiProgram) {
+    const normalizedPartName = String(partName || "").trim();
+    if (normalizedPartName) {
+      return normalizedPartName;
+    }
+    if (midiProgram !== null) {
+      return "Program " + midiProgram;
+    }
+    return "Instrument";
+  }
+
+  function normalizeDynamicMark(rawMark) {
+    const mark = String(rawMark || "").trim().toLowerCase();
+    if (mark === "p" || mark === "mp" || mark === "mf" || mark === "f") {
+      return mark;
+    }
+    return null;
+  }
+
+  function normalizeTempoChanges(rawTempoChanges, fallbackTempo) {
+    const tempoByMeasure = new Map();
+    if (Array.isArray(rawTempoChanges)) {
+      for (const change of rawTempoChanges) {
+        if (!change || typeof change !== "object") {
+          continue;
+        }
+        const measure = Number.parseInt(change.measure, 10);
+        const bpm = Number.parseInt(change.bpm, 10);
+        if (!Number.isFinite(measure) || measure <= 0 || !Number.isFinite(bpm) || bpm <= 0) {
+          continue;
+        }
+        tempoByMeasure.set(measure, bpm);
+      }
+    }
+    if (tempoByMeasure.size === 0) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    } else if (!tempoByMeasure.has(1)) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    }
+    return tempoByMeasure;
+  }
+
   return {
     escapeXml,
     buildScorePartwiseXml
@@ -1379,6 +1488,7 @@ const MusicXmlWriterCommon = (() => {
 if (typeof window !== "undefined") {
   window["MusicXmlWriterCommon"] = MusicXmlWriterCommon;
 }
+  </script>
   </script>
 
   <script>

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -864,6 +864,7 @@ if (typeof window !== "undefined") {
   window["MusicXmlWriterCommon"] = MusicXmlWriterCommon;
 }
   </script>
+  </script>
 
   <script>
 const musicXmlWriterCommon = window["MusicXmlWriterCommon"] || (typeof MusicXmlWriterCommon !== "undefined" ? MusicXmlWriterCommon : null);
@@ -1306,9 +1307,22 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
   let totalMeasures = 0;
   let partSerial = 1;
   const estimatedKey = estimateKeyFromTracks(tracksWithNotes);
-  const sourceKey = parsedMidi.keySignature || estimatedKey;
-  const keyFifths = settings.keyFifths === null ? sourceKey.fifths : settings.keyFifths;
-  const keyMode = settings.keyMode === "auto" ? sourceKey.mode : settings.keyMode;
+  const hasMidiKeySignature = !!parsedMidi.keySignature;
+  let keyFifths = 0;
+  let keyMode = "major";
+  let keySource = "estimated";
+
+  if (hasMidiKeySignature) {
+    keyFifths = parsedMidi.keySignature.fifths;
+    keyMode = parsedMidi.keySignature.mode;
+    keySource = "midi-meta";
+  } else {
+    keyFifths = settings.keyFifths === null ? estimatedKey.fifths : settings.keyFifths;
+    keyMode = settings.keyMode === "auto" ? estimatedKey.mode : settings.keyMode;
+    if (settings.keyFifths !== null || settings.keyMode !== "auto") {
+      keySource = "manual-fallback";
+    }
+  }
 
   for (let i = 0; i < tracksWithNotes.length; i += 1) {
     const track = tracksWithNotes[i];
@@ -1364,7 +1378,7 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       tempo,
       keyFifths,
       keyMode,
-      keySource: settings.keyFifths !== null ? "manual" : (parsedMidi.keySignature ? "midi-meta" : "estimated"),
+      keySource,
       meter: meter.beats + "/" + meter.beatType,
       notes: totalNotes,
       rests: totalRests,

--- a/docs/music/src/common/js/musicxml-writer-common.js
+++ b/docs/music/src/common/js/musicxml-writer-common.js
@@ -29,12 +29,33 @@ const MusicXmlWriterCommon = (() => {
     for (const part of parts) {
       const partId = part.partId || "P1";
       const partName = part.partName || "Music";
-      lines.push('    <score-part id="' + escapeXml(partId) + '"><part-name>' + escapeXml(partName) + '</part-name></score-part>');
+      const midiProgram = normalizeMidiProgram(part.midiProgram);
+      const midiChannel = normalizeMidiChannel(part.midiChannel);
+      const scoreInstrumentId = partId + "-I1";
+      lines.push('    <score-part id="' + escapeXml(partId) + '">');
+      lines.push('      <part-name>' + escapeXml(partName) + '</part-name>');
+      if (midiProgram !== null || midiChannel !== null) {
+        lines.push('      <score-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        lines.push('        <instrument-name>' + escapeXml(resolveMidiInstrumentName(partName, midiProgram)) + '</instrument-name>');
+        lines.push('      </score-instrument>');
+        lines.push('      <midi-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        if (midiChannel !== null) {
+          lines.push("        <midi-channel>" + midiChannel + "</midi-channel>");
+        }
+        if (midiProgram !== null) {
+          lines.push("        <midi-program>" + midiProgram + "</midi-program>");
+        }
+        lines.push("      </midi-instrument>");
+      }
+      lines.push("    </score-part>");
     }
     lines.push('  </part-list>');
-    for (const part of parts) {
+    const tempoChangesByMeasure = normalizeTempoChanges(meta.tempoChanges, meta.tempo);
+    for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      const part = parts[partIndex];
       const partId = part.partId || "P1";
       const measures = Array.isArray(part.measures) && part.measures.length > 0 ? part.measures : [[]];
+      const measureDynamics = Array.isArray(part.measureDynamics) ? part.measureDynamics : [];
       lines.push('  <part id="' + escapeXml(partId) + '">');
 
       for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
@@ -60,6 +81,30 @@ const MusicXmlWriterCommon = (() => {
           }
           lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
+        }
+        if (partIndex === 0) {
+          const tempoBpm = tempoChangesByMeasure.get(measureNo);
+          if (Number.isFinite(tempoBpm) && tempoBpm > 0) {
+            lines.push('      <direction placement="above">');
+            lines.push("        <direction-type>");
+            lines.push("          <metronome>");
+            lines.push("            <beat-unit>quarter</beat-unit>");
+            lines.push("            <per-minute>" + tempoBpm + "</per-minute>");
+            lines.push("          </metronome>");
+            lines.push("        </direction-type>");
+            lines.push("        <sound tempo=\"" + tempoBpm + "\"/>");
+            lines.push("      </direction>");
+          }
+        }
+        const dynamicMark = normalizeDynamicMark(measureDynamics[measureIndex]);
+        if (dynamicMark) {
+          lines.push('      <direction placement="below">');
+          lines.push("        <direction-type>");
+          lines.push("          <dynamics>");
+          lines.push("            <" + dynamicMark + "/>");
+          lines.push("          </dynamics>");
+          lines.push("        </direction-type>");
+          lines.push("      </direction>");
         }
 
         for (const note of notes) {
@@ -160,6 +205,70 @@ const MusicXmlWriterCommon = (() => {
     return "major";
   }
 
+  function normalizeMidiProgram(rawProgram) {
+    const value = Number.parseInt(rawProgram, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 128) {
+      return null;
+    }
+    return value;
+  }
+
+  function normalizeMidiChannel(rawChannel) {
+    const value = Number.parseInt(rawChannel, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 16) {
+      return null;
+    }
+    return value;
+  }
+
+  function resolveMidiInstrumentName(partName, midiProgram) {
+    const normalizedPartName = String(partName || "").trim();
+    if (normalizedPartName) {
+      return normalizedPartName;
+    }
+    if (midiProgram !== null) {
+      return "Program " + midiProgram;
+    }
+    return "Instrument";
+  }
+
+  function normalizeDynamicMark(rawMark) {
+    const mark = String(rawMark || "").trim().toLowerCase();
+    if (mark === "p" || mark === "mp" || mark === "mf" || mark === "f") {
+      return mark;
+    }
+    return null;
+  }
+
+  function normalizeTempoChanges(rawTempoChanges, fallbackTempo) {
+    const tempoByMeasure = new Map();
+    if (Array.isArray(rawTempoChanges)) {
+      for (const change of rawTempoChanges) {
+        if (!change || typeof change !== "object") {
+          continue;
+        }
+        const measure = Number.parseInt(change.measure, 10);
+        const bpm = Number.parseInt(change.bpm, 10);
+        if (!Number.isFinite(measure) || measure <= 0 || !Number.isFinite(bpm) || bpm <= 0) {
+          continue;
+        }
+        tempoByMeasure.set(measure, bpm);
+      }
+    }
+    if (tempoByMeasure.size === 0) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    } else if (!tempoByMeasure.has(1)) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    }
+    return tempoByMeasure;
+  }
+
   return {
     escapeXml,
     buildScorePartwiseXml
@@ -169,3 +278,4 @@ const MusicXmlWriterCommon = (() => {
 if (typeof window !== "undefined") {
   window["MusicXmlWriterCommon"] = MusicXmlWriterCommon;
 }
+  </script>

--- a/docs/music/src/common/ts/musicxml-writer-common.ts
+++ b/docs/music/src/common/ts/musicxml-writer-common.ts
@@ -29,12 +29,33 @@ const MusicXmlWriterCommon = (() => {
     for (const part of parts) {
       const partId = part.partId || "P1";
       const partName = part.partName || "Music";
-      lines.push('    <score-part id="' + escapeXml(partId) + '"><part-name>' + escapeXml(partName) + '</part-name></score-part>');
+      const midiProgram = normalizeMidiProgram(part.midiProgram);
+      const midiChannel = normalizeMidiChannel(part.midiChannel);
+      const scoreInstrumentId = partId + "-I1";
+      lines.push('    <score-part id="' + escapeXml(partId) + '">');
+      lines.push('      <part-name>' + escapeXml(partName) + '</part-name>');
+      if (midiProgram !== null || midiChannel !== null) {
+        lines.push('      <score-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        lines.push('        <instrument-name>' + escapeXml(resolveMidiInstrumentName(partName, midiProgram)) + '</instrument-name>');
+        lines.push('      </score-instrument>');
+        lines.push('      <midi-instrument id="' + escapeXml(scoreInstrumentId) + '">');
+        if (midiChannel !== null) {
+          lines.push("        <midi-channel>" + midiChannel + "</midi-channel>");
+        }
+        if (midiProgram !== null) {
+          lines.push("        <midi-program>" + midiProgram + "</midi-program>");
+        }
+        lines.push("      </midi-instrument>");
+      }
+      lines.push("    </score-part>");
     }
     lines.push('  </part-list>');
-    for (const part of parts) {
+    const tempoChangesByMeasure = normalizeTempoChanges(meta.tempoChanges, meta.tempo);
+    for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      const part = parts[partIndex];
       const partId = part.partId || "P1";
       const measures = Array.isArray(part.measures) && part.measures.length > 0 ? part.measures : [[]];
+      const measureDynamics = Array.isArray(part.measureDynamics) ? part.measureDynamics : [];
       lines.push('  <part id="' + escapeXml(partId) + '">');
 
       for (let measureIndex = 0; measureIndex < measures.length; measureIndex += 1) {
@@ -60,6 +81,30 @@ const MusicXmlWriterCommon = (() => {
           }
           lines.push('        <clef><sign>' + clef.sign + '</sign><line>' + clef.line + '</line></clef>');
           lines.push('      </attributes>');
+        }
+        if (partIndex === 0) {
+          const tempoBpm = tempoChangesByMeasure.get(measureNo);
+          if (Number.isFinite(tempoBpm) && tempoBpm > 0) {
+            lines.push('      <direction placement="above">');
+            lines.push("        <direction-type>");
+            lines.push("          <metronome>");
+            lines.push("            <beat-unit>quarter</beat-unit>");
+            lines.push("            <per-minute>" + tempoBpm + "</per-minute>");
+            lines.push("          </metronome>");
+            lines.push("        </direction-type>");
+            lines.push("        <sound tempo=\"" + tempoBpm + "\"/>");
+            lines.push("      </direction>");
+          }
+        }
+        const dynamicMark = normalizeDynamicMark(measureDynamics[measureIndex]);
+        if (dynamicMark) {
+          lines.push('      <direction placement="below">');
+          lines.push("        <direction-type>");
+          lines.push("          <dynamics>");
+          lines.push("            <" + dynamicMark + "/>");
+          lines.push("          </dynamics>");
+          lines.push("        </direction-type>");
+          lines.push("      </direction>");
         }
 
         for (const note of notes) {
@@ -160,6 +205,70 @@ const MusicXmlWriterCommon = (() => {
     return "major";
   }
 
+  function normalizeMidiProgram(rawProgram) {
+    const value = Number.parseInt(rawProgram, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 128) {
+      return null;
+    }
+    return value;
+  }
+
+  function normalizeMidiChannel(rawChannel) {
+    const value = Number.parseInt(rawChannel, 10);
+    if (!Number.isFinite(value) || value < 1 || value > 16) {
+      return null;
+    }
+    return value;
+  }
+
+  function resolveMidiInstrumentName(partName, midiProgram) {
+    const normalizedPartName = String(partName || "").trim();
+    if (normalizedPartName) {
+      return normalizedPartName;
+    }
+    if (midiProgram !== null) {
+      return "Program " + midiProgram;
+    }
+    return "Instrument";
+  }
+
+  function normalizeDynamicMark(rawMark) {
+    const mark = String(rawMark || "").trim().toLowerCase();
+    if (mark === "p" || mark === "mp" || mark === "mf" || mark === "f") {
+      return mark;
+    }
+    return null;
+  }
+
+  function normalizeTempoChanges(rawTempoChanges, fallbackTempo) {
+    const tempoByMeasure = new Map();
+    if (Array.isArray(rawTempoChanges)) {
+      for (const change of rawTempoChanges) {
+        if (!change || typeof change !== "object") {
+          continue;
+        }
+        const measure = Number.parseInt(change.measure, 10);
+        const bpm = Number.parseInt(change.bpm, 10);
+        if (!Number.isFinite(measure) || measure <= 0 || !Number.isFinite(bpm) || bpm <= 0) {
+          continue;
+        }
+        tempoByMeasure.set(measure, bpm);
+      }
+    }
+    if (tempoByMeasure.size === 0) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    } else if (!tempoByMeasure.has(1)) {
+      const fallback = Number.parseInt(fallbackTempo, 10);
+      if (Number.isFinite(fallback) && fallback > 0) {
+        tempoByMeasure.set(1, fallback);
+      }
+    }
+    return tempoByMeasure;
+  }
+
   return {
     escapeXml,
     buildScorePartwiseXml
@@ -169,3 +278,4 @@ const MusicXmlWriterCommon = (() => {
 if (typeof window !== "undefined") {
   window["MusicXmlWriterCommon"] = MusicXmlWriterCommon;
 }
+  </script>

--- a/docs/music/src/midi-to-musicxml/js/main.js
+++ b/docs/music/src/midi-to-musicxml/js/main.js
@@ -248,6 +248,13 @@ function parseMidiFile(bytes) {
   const earliestTempo = findEarliestEvent(tempoEvents);
   const earliestMeter = findEarliestEvent(meterEvents);
   const earliestKeySignature = findEarliestEvent(keySignatureEvents);
+  const allTempoEvents = tempoEvents
+    .slice()
+    .sort((a, b) => a.tick - b.tick)
+    .map((ev) => ({
+      tick: ev.tick,
+      bpm: Math.max(20, Math.round(60000000 / ev.mpqn))
+    }));
 
   return {
     format,
@@ -255,6 +262,7 @@ function parseMidiFile(bytes) {
     ppqn,
     tracks: trackParses,
     tempoBpm: earliestTempo ? Math.max(20, Math.round(60000000 / earliestTempo.mpqn)) : null,
+    tempoEvents: allTempoEvents,
     meter: earliestMeter ? { beats: earliestMeter.beats, beatType: earliestMeter.beatType } : null,
     keySignature: earliestKeySignature ? {
       fifths: earliestKeySignature.fifths,
@@ -417,6 +425,7 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
     beatType: settings.defaultBeatType
   };
   const quantizeTicks = resolveQuantizeTicks(settings.quantize, parsedMidi.ppqn);
+  const tempoChanges = buildTempoChangesByMeasure(parsedMidi, meter);
 
   const tracksWithNotes = parsedMidi.tracks.filter((track) => track.notes.length > 0);
   if (tracksWithNotes.length === 0) {
@@ -429,9 +438,22 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
   let totalMeasures = 0;
   let partSerial = 1;
   const estimatedKey = estimateKeyFromTracks(tracksWithNotes);
-  const sourceKey = parsedMidi.keySignature || estimatedKey;
-  const keyFifths = settings.keyFifths === null ? sourceKey.fifths : settings.keyFifths;
-  const keyMode = settings.keyMode === "auto" ? sourceKey.mode : settings.keyMode;
+  const hasMidiKeySignature = !!parsedMidi.keySignature;
+  let keyFifths = 0;
+  let keyMode = "major";
+  let keySource = "estimated";
+
+  if (hasMidiKeySignature) {
+    keyFifths = parsedMidi.keySignature.fifths;
+    keyMode = parsedMidi.keySignature.mode;
+    keySource = "midi-meta";
+  } else {
+    keyFifths = settings.keyFifths === null ? estimatedKey.fifths : settings.keyFifths;
+    keyMode = settings.keyMode === "auto" ? estimatedKey.mode : settings.keyMode;
+    if (settings.keyFifths !== null || settings.keyMode !== "auto") {
+      keySource = "manual-fallback";
+    }
+  }
 
   for (let i = 0; i < tracksWithNotes.length; i += 1) {
     const track = tracksWithNotes[i];
@@ -447,6 +469,8 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       totalRests += partBuild.restCount;
       totalMeasures = Math.max(totalMeasures, partBuild.measures.length);
       const laneNameSuffix = " " + lane.clef.label + " L" + String(lane.serialInClef);
+      const midiProgram = Number.isFinite(track.program) ? Math.max(1, Math.min(128, Number(track.program) + 1)) : null;
+      const midiChannel = detectPrimaryMidiChannel(lane.notes);
       parts.push({
         partId: "P" + String(partSerial),
         partName: clefLanes.length === 1 ? basePartName : (basePartName + laneNameSuffix),
@@ -454,7 +478,10 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
           sign: lane.clef.sign,
           line: lane.clef.line
         },
-        measures: partBuild.measures
+        measures: partBuild.measures,
+        measureDynamics: partBuild.measureDynamics,
+        midiProgram,
+        midiChannel
       });
       partSerial += 1;
     }
@@ -466,7 +493,8 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       composer,
       keyInfo: { fifths: keyFifths, mode: keyMode },
       meter,
-      tempo
+      tempo,
+      tempoChanges
     },
     parts
   };
@@ -481,13 +509,68 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       tempo,
       keyFifths,
       keyMode,
-      keySource: settings.keyFifths !== null ? "manual" : (parsedMidi.keySignature ? "midi-meta" : "estimated"),
+      keySource,
       meter: meter.beats + "/" + meter.beatType,
       notes: totalNotes,
       rests: totalRests,
       measures: totalMeasures
     }
   };
+}
+
+function buildTempoChangesByMeasure(parsedMidi, meter) {
+  const out = [];
+  if (!parsedMidi || !Array.isArray(parsedMidi.tempoEvents) || parsedMidi.tempoEvents.length === 0) {
+    return out;
+  }
+  const ppqn = Math.max(1, Number(parsedMidi.ppqn) || 1);
+  const beats = Math.max(1, Number(meter && meter.beats) || 4);
+  const beatType = Math.max(1, Number(meter && meter.beatType) || 4);
+  const ticksPerMeasure = Math.max(1, Math.round((ppqn * 4 * beats) / beatType));
+  const byMeasure = new Map();
+  for (const ev of parsedMidi.tempoEvents) {
+    if (!ev || typeof ev !== "object") {
+      continue;
+    }
+    const tick = Math.max(0, Number(ev.tick) || 0);
+    const bpm = Number.parseInt(ev.bpm, 10);
+    if (!Number.isFinite(bpm) || bpm <= 0) {
+      continue;
+    }
+    const measure = Math.floor(tick / ticksPerMeasure) + 1;
+    byMeasure.set(measure, bpm);
+  }
+  const sortedMeasures = Array.from(byMeasure.keys()).sort((a, b) => a - b);
+  for (const measure of sortedMeasures) {
+    out.push({ measure, bpm: byMeasure.get(measure) });
+  }
+  return out;
+}
+
+function detectPrimaryMidiChannel(notes) {
+  if (!Array.isArray(notes) || notes.length === 0) {
+    return null;
+  }
+  const counts = new Array(16).fill(0);
+  for (const note of notes) {
+    const channel = Number(note && note.channel);
+    if (!Number.isFinite(channel) || channel < 0 || channel > 15) {
+      continue;
+    }
+    counts[channel] += 1;
+  }
+  let bestChannel = -1;
+  let bestCount = -1;
+  for (let i = 0; i < counts.length; i += 1) {
+    if (counts[i] > bestCount) {
+      bestCount = counts[i];
+      bestChannel = i;
+    }
+  }
+  if (bestCount <= 0 || bestChannel < 0) {
+    return null;
+  }
+  return bestChannel + 1;
 }
 
 function estimateKeyFromTracks(tracks) {
@@ -581,9 +664,11 @@ function splitTrackNotesIntoClefLanes(notes, quantizeTicks, timeScale, trackInde
     const durationTick = Math.max(1, quantizeTick(scaledDuration, quantizeTicks));
     return {
       trackIndex: note.trackIndex,
+      channel: Number.isFinite(note.channel) ? note.channel : 0,
       noteNumber: note.noteNumber,
       startTick,
-      durationTick
+      durationTick,
+      velocity: Number.isFinite(note.velocity) ? note.velocity : 64
     };
   });
 
@@ -653,6 +738,8 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
   const measures = [[]];
   const measureAccidentalStates = [];
   const keySignatureStepAlter = buildKeySignatureStepAlterMap(keyFifths);
+  const measureVelocitySums = [];
+  const measureVelocityCounts = [];
   let cursor = 0;
   let noteCount = 0;
   let restCount = 0;
@@ -660,6 +747,7 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
   for (const note of notes) {
     let start = note.startTick;
     const duration = Math.max(1, note.durationTick);
+    const originalStart = Math.max(0, note.startTick);
 
     if (start < cursor) {
       start = cursor;
@@ -691,6 +779,10 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
       keySignatureStepAlter
     );
     noteCount += insertedNotes;
+    const measureIndexForDynamic = Math.floor(originalStart / ticksPerMeasure);
+    const velocity = clampMidiVelocity(note.velocity);
+    measureVelocitySums[measureIndexForDynamic] = (measureVelocitySums[measureIndexForDynamic] || 0) + velocity;
+    measureVelocityCounts[measureIndexForDynamic] = (measureVelocityCounts[measureIndexForDynamic] || 0) + 1;
     cursor += duration;
   }
 
@@ -698,11 +790,52 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
     measures.pop();
   }
 
+  const measureDynamics = [];
+  let previousDynamic = null;
+  for (let i = 0; i < measures.length; i += 1) {
+    const count = measureVelocityCounts[i] || 0;
+    if (count <= 0) {
+      measureDynamics.push(null);
+      continue;
+    }
+    const average = (measureVelocitySums[i] || 0) / count;
+    const dynamic = velocityToDynamicMark(average);
+    if (i === 0 || dynamic !== previousDynamic) {
+      measureDynamics.push(dynamic);
+      previousDynamic = dynamic;
+    } else {
+      measureDynamics.push(null);
+    }
+  }
+
   return {
     measures,
     noteCount,
-    restCount
+    restCount,
+    measureDynamics
   };
+}
+
+function clampMidiVelocity(rawVelocity) {
+  const velocity = Number(rawVelocity);
+  if (!Number.isFinite(velocity)) {
+    return 64;
+  }
+  return Math.max(1, Math.min(127, Math.round(velocity)));
+}
+
+function velocityToDynamicMark(rawVelocity) {
+  const velocity = clampMidiVelocity(rawVelocity);
+  if (velocity <= 39) {
+    return "p";
+  }
+  if (velocity <= 69) {
+    return "mp";
+  }
+  if (velocity <= 99) {
+    return "mf";
+  }
+  return "f";
 }
 
 function pushDurationToken(

--- a/docs/music/src/midi-to-musicxml/ts/main.ts
+++ b/docs/music/src/midi-to-musicxml/ts/main.ts
@@ -248,6 +248,13 @@ function parseMidiFile(bytes) {
   const earliestTempo = findEarliestEvent(tempoEvents);
   const earliestMeter = findEarliestEvent(meterEvents);
   const earliestKeySignature = findEarliestEvent(keySignatureEvents);
+  const allTempoEvents = tempoEvents
+    .slice()
+    .sort((a, b) => a.tick - b.tick)
+    .map((ev) => ({
+      tick: ev.tick,
+      bpm: Math.max(20, Math.round(60000000 / ev.mpqn))
+    }));
 
   return {
     format,
@@ -255,6 +262,7 @@ function parseMidiFile(bytes) {
     ppqn,
     tracks: trackParses,
     tempoBpm: earliestTempo ? Math.max(20, Math.round(60000000 / earliestTempo.mpqn)) : null,
+    tempoEvents: allTempoEvents,
     meter: earliestMeter ? { beats: earliestMeter.beats, beatType: earliestMeter.beatType } : null,
     keySignature: earliestKeySignature ? {
       fifths: earliestKeySignature.fifths,
@@ -417,6 +425,7 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
     beatType: settings.defaultBeatType
   };
   const quantizeTicks = resolveQuantizeTicks(settings.quantize, parsedMidi.ppqn);
+  const tempoChanges = buildTempoChangesByMeasure(parsedMidi, meter);
 
   const tracksWithNotes = parsedMidi.tracks.filter((track) => track.notes.length > 0);
   if (tracksWithNotes.length === 0) {
@@ -429,9 +438,22 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
   let totalMeasures = 0;
   let partSerial = 1;
   const estimatedKey = estimateKeyFromTracks(tracksWithNotes);
-  const sourceKey = parsedMidi.keySignature || estimatedKey;
-  const keyFifths = settings.keyFifths === null ? sourceKey.fifths : settings.keyFifths;
-  const keyMode = settings.keyMode === "auto" ? sourceKey.mode : settings.keyMode;
+  const hasMidiKeySignature = !!parsedMidi.keySignature;
+  let keyFifths = 0;
+  let keyMode = "major";
+  let keySource = "estimated";
+
+  if (hasMidiKeySignature) {
+    keyFifths = parsedMidi.keySignature.fifths;
+    keyMode = parsedMidi.keySignature.mode;
+    keySource = "midi-meta";
+  } else {
+    keyFifths = settings.keyFifths === null ? estimatedKey.fifths : settings.keyFifths;
+    keyMode = settings.keyMode === "auto" ? estimatedKey.mode : settings.keyMode;
+    if (settings.keyFifths !== null || settings.keyMode !== "auto") {
+      keySource = "manual-fallback";
+    }
+  }
 
   for (let i = 0; i < tracksWithNotes.length; i += 1) {
     const track = tracksWithNotes[i];
@@ -447,6 +469,8 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       totalRests += partBuild.restCount;
       totalMeasures = Math.max(totalMeasures, partBuild.measures.length);
       const laneNameSuffix = " " + lane.clef.label + " L" + String(lane.serialInClef);
+      const midiProgram = Number.isFinite(track.program) ? Math.max(1, Math.min(128, Number(track.program) + 1)) : null;
+      const midiChannel = detectPrimaryMidiChannel(lane.notes);
       parts.push({
         partId: "P" + String(partSerial),
         partName: clefLanes.length === 1 ? basePartName : (basePartName + laneNameSuffix),
@@ -454,7 +478,10 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
           sign: lane.clef.sign,
           line: lane.clef.line
         },
-        measures: partBuild.measures
+        measures: partBuild.measures,
+        measureDynamics: partBuild.measureDynamics,
+        midiProgram,
+        midiChannel
       });
       partSerial += 1;
     }
@@ -466,7 +493,8 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       composer,
       keyInfo: { fifths: keyFifths, mode: keyMode },
       meter,
-      tempo
+      tempo,
+      tempoChanges
     },
     parts
   };
@@ -481,13 +509,68 @@ function convertParsedMidiToMusicXmlData(parsedMidi, settings, loadedName) {
       tempo,
       keyFifths,
       keyMode,
-      keySource: settings.keyFifths !== null ? "manual" : (parsedMidi.keySignature ? "midi-meta" : "estimated"),
+      keySource,
       meter: meter.beats + "/" + meter.beatType,
       notes: totalNotes,
       rests: totalRests,
       measures: totalMeasures
     }
   };
+}
+
+function buildTempoChangesByMeasure(parsedMidi, meter) {
+  const out = [];
+  if (!parsedMidi || !Array.isArray(parsedMidi.tempoEvents) || parsedMidi.tempoEvents.length === 0) {
+    return out;
+  }
+  const ppqn = Math.max(1, Number(parsedMidi.ppqn) || 1);
+  const beats = Math.max(1, Number(meter && meter.beats) || 4);
+  const beatType = Math.max(1, Number(meter && meter.beatType) || 4);
+  const ticksPerMeasure = Math.max(1, Math.round((ppqn * 4 * beats) / beatType));
+  const byMeasure = new Map();
+  for (const ev of parsedMidi.tempoEvents) {
+    if (!ev || typeof ev !== "object") {
+      continue;
+    }
+    const tick = Math.max(0, Number(ev.tick) || 0);
+    const bpm = Number.parseInt(ev.bpm, 10);
+    if (!Number.isFinite(bpm) || bpm <= 0) {
+      continue;
+    }
+    const measure = Math.floor(tick / ticksPerMeasure) + 1;
+    byMeasure.set(measure, bpm);
+  }
+  const sortedMeasures = Array.from(byMeasure.keys()).sort((a, b) => a - b);
+  for (const measure of sortedMeasures) {
+    out.push({ measure, bpm: byMeasure.get(measure) });
+  }
+  return out;
+}
+
+function detectPrimaryMidiChannel(notes) {
+  if (!Array.isArray(notes) || notes.length === 0) {
+    return null;
+  }
+  const counts = new Array(16).fill(0);
+  for (const note of notes) {
+    const channel = Number(note && note.channel);
+    if (!Number.isFinite(channel) || channel < 0 || channel > 15) {
+      continue;
+    }
+    counts[channel] += 1;
+  }
+  let bestChannel = -1;
+  let bestCount = -1;
+  for (let i = 0; i < counts.length; i += 1) {
+    if (counts[i] > bestCount) {
+      bestCount = counts[i];
+      bestChannel = i;
+    }
+  }
+  if (bestCount <= 0 || bestChannel < 0) {
+    return null;
+  }
+  return bestChannel + 1;
 }
 
 function estimateKeyFromTracks(tracks) {
@@ -581,9 +664,11 @@ function splitTrackNotesIntoClefLanes(notes, quantizeTicks, timeScale, trackInde
     const durationTick = Math.max(1, quantizeTick(scaledDuration, quantizeTicks));
     return {
       trackIndex: note.trackIndex,
+      channel: Number.isFinite(note.channel) ? note.channel : 0,
       noteNumber: note.noteNumber,
       startTick,
-      durationTick
+      durationTick,
+      velocity: Number.isFinite(note.velocity) ? note.velocity : 64
     };
   });
 
@@ -653,6 +738,8 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
   const measures = [[]];
   const measureAccidentalStates = [];
   const keySignatureStepAlter = buildKeySignatureStepAlterMap(keyFifths);
+  const measureVelocitySums = [];
+  const measureVelocityCounts = [];
   let cursor = 0;
   let noteCount = 0;
   let restCount = 0;
@@ -660,6 +747,7 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
   for (const note of notes) {
     let start = note.startTick;
     const duration = Math.max(1, note.durationTick);
+    const originalStart = Math.max(0, note.startTick);
 
     if (start < cursor) {
       start = cursor;
@@ -691,6 +779,10 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
       keySignatureStepAlter
     );
     noteCount += insertedNotes;
+    const measureIndexForDynamic = Math.floor(originalStart / ticksPerMeasure);
+    const velocity = clampMidiVelocity(note.velocity);
+    measureVelocitySums[measureIndexForDynamic] = (measureVelocitySums[measureIndexForDynamic] || 0) + velocity;
+    measureVelocityCounts[measureIndexForDynamic] = (measureVelocityCounts[measureIndexForDynamic] || 0) + 1;
     cursor += duration;
   }
 
@@ -698,11 +790,52 @@ function buildMeasuresFromMonophonicTrack(notes, ppqn, meter, keyFifths) {
     measures.pop();
   }
 
+  const measureDynamics = [];
+  let previousDynamic = null;
+  for (let i = 0; i < measures.length; i += 1) {
+    const count = measureVelocityCounts[i] || 0;
+    if (count <= 0) {
+      measureDynamics.push(null);
+      continue;
+    }
+    const average = (measureVelocitySums[i] || 0) / count;
+    const dynamic = velocityToDynamicMark(average);
+    if (i === 0 || dynamic !== previousDynamic) {
+      measureDynamics.push(dynamic);
+      previousDynamic = dynamic;
+    } else {
+      measureDynamics.push(null);
+    }
+  }
+
   return {
     measures,
     noteCount,
-    restCount
+    restCount,
+    measureDynamics
   };
+}
+
+function clampMidiVelocity(rawVelocity) {
+  const velocity = Number(rawVelocity);
+  if (!Number.isFinite(velocity)) {
+    return 64;
+  }
+  return Math.max(1, Math.min(127, Math.round(velocity)));
+}
+
+function velocityToDynamicMark(rawVelocity) {
+  const velocity = clampMidiVelocity(rawVelocity);
+  if (velocity <= 39) {
+    return "p";
+  }
+  if (velocity <= 69) {
+    return "mp";
+  }
+  if (velocity <= 99) {
+    return "mf";
+  }
+  return "f";
 }
 
 function pushDurationToken(


### PR DESCRIPTION
## 概要
MIDI→MusicXML変換で、MIDI由来の演奏情報（テンポ変化・強弱・音色/チャンネル）をMusicXMLへ反映できるようにしました。 あわせて、調性（key）の決定ロジックを「MIDIメタ優先、未取得時のみUI/推定利用」に変更しています。

## 変更内容

### 1. MusicXML Writerの拡張（common）
- `score-part` 内に `score-instrument` / `midi-instrument` を出力可能に変更
  - `midi-channel`（1-16）
  - `midi-program`（1-128）
- 小節ごとのテンポ変化を `direction` + `metronome` + `sound tempo` で出力
- 小節ごとの強弱記号（`p/mp/mf/f`）を `direction > dynamics` で出力
- 追加ユーティリティ
  - `normalizeMidiProgram`
  - `normalizeMidiChannel`
  - `resolveMidiInstrumentName`
  - `normalizeDynamicMark`
  - `normalizeTempoChanges`

### 2. MIDI解析・変換ロジックの拡張（midi-to-musicxml）
- 解析結果に全テンポイベント（`tempoEvents`）を保持
- 小節単位テンポ変化を算出する `buildTempoChangesByMeasure` を追加
- 主チャンネルを推定する `detectPrimaryMidiChannel` を追加
- ノート情報に `channel` / `velocity` を保持
- 小節ごとの平均ベロシティから強弱を算出し、`measureDynamics` として保持
  - 追加: `clampMidiVelocity`, `velocityToDynamicMark`
- パート情報に `midiProgram` / `midiChannel` / `measureDynamics` を付与
- `meta` に `tempoChanges` を追加してWriterへ受け渡し

### 3. 調性決定ロジックの見直し
- 変更前: UI指定があるとMIDI調性を上書き
- 変更後:
  1. MIDIのKey Signatureがあればそれを採用（`keySource: midi-meta`）
  2. MIDIで読めない場合のみUI指定を補完として使用（`keySource: manual-fallback`）
  3. UIがautoなら推定値を使用（`keySource: estimated`）

## 変更ファイル
- `docs/music/src/common/ts/musicxml-writer-common.ts`
- `docs/music/src/common/js/musicxml-writer-common.js`
- `docs/music/src/midi-to-musicxml/ts/main.ts`
- `docs/music/src/midi-to-musicxml/js/main.js`
- `docs/music/midi-to-musicxml.html`
- `docs/music/abc-to-musicxml.html`（common writer反映に伴う生成物更新）

## 期待される効果
- 再生時に近いテンポ感・強弱感・音色情報をMusicXMLへ保持可能
- 調性情報の扱いが直感に一致（「読めたらMIDI優先」）
- 生成結果の相互運用性向上（MIDIインストゥルメント情報付与）