### PR TITLE
`git-config-setup` / `git-config-advanced-setup` を Material Web + `lh…

### DIFF
--- a/docs/git/README.md
+++ b/docs/git/README.md
@@ -33,6 +33,14 @@
 - `docs/git/git-pseudo-squash-src.html`
 - `docs/git/src/git-pseudo-squash/css/app.css`
 - `docs/git/src/git-pseudo-squash/js/main.js`
+- `git-config-setup` の編集元:
+- `docs/git/git-config-setup-src.html`
+- `docs/git/src/git-config-setup/css/app.css`
+- `docs/git/src/git-config-setup/js/main.js`
+- `git-config-advanced-setup` の編集元:
+- `docs/git/git-config-advanced-setup-src.html`
+- `docs/git/src/git-config-advanced-setup/css/app.css`
+- `docs/git/src/git-config-advanced-setup/js/main.js`
 - `git-branch-diff` の編集元:
 - `docs/git/git-branch-diff-src.html`
 - `docs/git/src/git-branch-diff/css/app.css`

--- a/docs/git/git-config-advanced-setup-src.html
+++ b/docs/git/git-config-advanced-setup-src.html
@@ -1,0 +1,193 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Git 詳細設定コマンドジェネレータ</title>
+  <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
+  <link rel="stylesheet" href="src/git-config-advanced-setup/css/app.css" />
+  <script src="src/vendor/material-web-outlined-text-field.bundle.js"></script>
+  <script src="../../lht-cmn/js/components.js"></script>
+</head>
+<body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
+        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
+        <path d="M20 4v6h-6"/>
+      </symbol>
+    </defs>
+  </svg>
+
+  <div class="md-surface-card md-card">
+    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
+
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">🔧</span>
+      <span>Git 詳細設定コマンドジェネレータ</span>
+      <lht-help-tooltip label="Git 詳細設定コマンドジェネレータの説明" wide>
+        core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
+      </lht-help-tooltip>
+    </h1>
+
+    <section id="checkSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="32" r="4" fill="#93C5FD"/>
+          <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
+        </svg>
+        <span class="md-title-info-row">
+          <p class="md-section-title">現在の設定を確認</p>
+          <lht-help-tooltip label="現在の設定を確認の説明" wide>
+            設定前に現在の値を確認できます。
+          </lht-help-tooltip>
+        </span>
+      </div>
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">確認コマンド生成</button>
+      <lht-command-block command-id="checkCmd"></lht-command-block>
+    </section>
+
+    <div class="md-flow-divider">
+      <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+        <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
+        <rect x="96" y="18" width="110" height="28" rx="8" fill="#E8DDF7" />
+        <rect x="214" y="18" width="70" height="28" rx="8" fill="#D9F5F0" />
+        <rect x="292" y="18" width="110" height="28" rx="8" fill="#FCE7F3" />
+        <path d="M40 32h26" stroke="#93C5FD" stroke-width="4" stroke-linecap="round"/>
+        <path d="M116 32h70" stroke="#C4B5FD" stroke-width="4" stroke-linecap="round"/>
+        <path d="M236 32h26" stroke="#A7F3D0" stroke-width="4" stroke-linecap="round"/>
+        <path d="M312 32h70" stroke="#F9A8D4" stroke-width="4" stroke-linecap="round"/>
+        <circle cx="384" cy="32" r="6" fill="#86EFAC"/>
+      </svg>
+    </div>
+
+    <section class="md-section md-stack-lg">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M24 20H34" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 20H44" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="md-title-info-row">
+          <p class="md-section-title">詳細設定を行う</p>
+          <lht-help-tooltip label="詳細設定を行うの説明" wide>
+            必要な詳細設定を選択して、コマンドを生成します。
+          </lht-help-tooltip>
+        </span>
+      </div>
+
+      <div class="md-choice-card md-stack-md">
+        <div class="md-form-row md-form-row--start">
+          <lht-switch-help switch-id="enableAutocrlf" label="core.autocrlf を設定" help-label="core.autocrlf の説明" on-change="toggleAutocrlfOptions" help-wide>
+            改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+          </lht-switch-help>
+        </div>
+
+        <div id="autocrlfOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
+          <div class="md-choice-row">
+            <input type="radio" id="autocrlf-true" name="autocrlf" value="true" disabled>
+            <label for="autocrlf-true" class="md-choice-sub">
+              <span>true</span>
+              <small>Windows用（LF ↔ CRLF 自動変換）</small>
+            </label>
+          </div>
+          <div class="md-choice-row">
+            <input type="radio" id="autocrlf-input" name="autocrlf" value="input" disabled>
+            <label for="autocrlf-input" class="md-choice-sub">
+              <span>input</span>
+              <small>Mac/Linux用（コミット時のみCRLF → LF）</small>
+              <span class="md-chip md-chip--primary">推奨</span>
+            </label>
+          </div>
+          <div class="md-choice-row">
+            <input type="radio" id="autocrlf-false" name="autocrlf" value="false" disabled>
+            <label for="autocrlf-false" class="md-choice-sub">
+              <span>false</span>
+              <small>変換なし（デフォルト）</small>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="md-choice-card md-stack-md">
+        <div class="md-form-row md-form-row--start">
+          <lht-switch-help switch-id="enablePushDefault" label="push.default を設定" help-label="push.default の説明" on-change="togglePushDefaultOptions" help-wide>
+            push時のデフォルト動作を指定します。指定しないと予期しない動作をすることがあります。
+          </lht-switch-help>
+        </div>
+
+        <div id="pushDefaultOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
+          <div class="md-choice-row">
+            <input type="radio" id="pushdefault-simple" name="pushdefault" value="simple" disabled>
+            <label for="pushdefault-simple" class="md-choice-sub">
+              <span>simple</span>
+              <small>同名ブランチにpush（Git 2.0以降のデフォルト）</small>
+              <span class="md-chip md-chip--primary">推奨</span>
+            </label>
+          </div>
+          <div class="md-choice-row">
+            <input type="radio" id="pushdefault-current" name="pushdefault" value="current" disabled>
+            <label for="pushdefault-current" class="md-choice-sub">
+              <span>current</span>
+              <small>現在のブランチ名でpush</small>
+            </label>
+          </div>
+          <div class="md-choice-row">
+            <input type="radio" id="pushdefault-upstream" name="pushdefault" value="upstream" disabled>
+            <label for="pushdefault-upstream" class="md-choice-sub">
+              <span>upstream</span>
+              <small>追跡ブランチにpush</small>
+            </label>
+          </div>
+          <div class="md-choice-row">
+            <input type="radio" id="pushdefault-matching" name="pushdefault" value="matching" disabled>
+            <label for="pushdefault-matching" class="md-choice-sub">
+              <span>matching</span>
+              <small>マッチングブランチすべてをpush</small>
+              <span class="md-chip md-chip--warn">非推奨</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <button type="button" onclick="generateConfigCommand()" class="md-button md-button--primary">設定コマンド生成</button>
+    <lht-command-block command-id="configCmd"></lht-command-block>
+
+    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+  </div>
+
+  <script src="src/git-config-advanced-setup/js/main.js"></script>
+</body>
+</html>

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -19,7 +19,174 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git 詳細設定コマンドジェネレータ</title>
+  
+  
+  
+  
   <style>
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-help-text-field {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
     /* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
     :root {
       --md-danger: #b3261e;
@@ -439,6 +606,8 @@ limitations under the License.
     .md-switch {
       position: relative;
       width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
       height: 24px;
       background: #f0ebf7;
       border-radius: 9999px;
@@ -872,10 +1041,9 @@ limitations under the License.
     .md-section { margin-bottom: 1rem; }
     .md-stack-md > * + * { margin-top: 0.75rem; }
     .md-stack-sm > * + * { margin-top: 0.5rem; }
-    .md-stack-lg > * + * { margin-top: 1.5rem; }
 
     .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
-    .md-form-row--start { align-items: flex-start; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
     .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
     .md-label--block { margin-bottom: 0.5rem; }
 
@@ -884,7 +1052,7 @@ limitations under the License.
     .md-title-info-row .md-section-title { margin: 0; }
     .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
-    .md-step-icon { width: 3.5rem; height: 3.5rem; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; flex: 0 0 auto; }
     .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
     .md-flow-strip { width: 100%; max-width: 36rem; height: 2.5rem; }
 
@@ -899,14 +1067,16 @@ limitations under the License.
       color: var(--md-sys-color-on-surface);
       transition: border-color 150ms ease, box-shadow 150ms ease;
     }
+    .md-select--inline { flex: 1 1 18rem; min-width: 14rem; }
+    .md-input { flex: 1 1 16rem; min-width: 12rem; }
     .md-input:focus,
     .md-select:focus {
       outline: none;
       border-color: var(--md-sys-color-primary);
       box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
     }
-    .md-input:disabled,
-    .md-select:disabled {
+    .md-input.md-disabled,
+    .md-select.md-disabled {
       background: #f3f0f7;
     }
 
@@ -958,6 +1128,7 @@ limitations under the License.
     }
     .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
     .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+    .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
 
     .md-icon-btn {
       width: 40px;
@@ -985,6 +1156,8 @@ limitations under the License.
       font-size: 0.8125rem;
       font-weight: 400;
       line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       letter-spacing: 0.01em;
     }
@@ -1003,41 +1176,40 @@ limitations under the License.
     }
     .md-info-icon { width: 18px; height: 18px; }
 
-    .md-choice-card {
-      border: 1px solid #e2dcec;
-      border-radius: 16px;
-      padding: 1rem;
-      background: #ffffff;
-    }
-    .md-choice-card--muted {
-      background: #f7f3fb;
-    }
-    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; }
-    .md-choice-row input { margin: 0; }
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .md-choice-inline { display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem; }
+    .md-choice-text { font-size: 0.9rem; color: #4a4458; }
 
-    .md-choice-sub { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675; }
-    .md-choice-sub small { font-size: 0.75rem; color: #7b7784; }
-
-    .md-chip {
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
       display: inline-flex;
       align-items: center;
-      justify-content: center;
-      padding: 0.15rem 0.6rem;
-      border-radius: 9999px;
-      font-size: 0.7rem;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
     }
-    .md-chip--primary {
-      background: #e2d9f7;
-      color: #4a1e9e;
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transform: translateX(0);
+      transition: transform 150ms ease;
     }
-    .md-chip--warn {
-      background: #f7ece1;
-      color: #8a4b0f;
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
+      background: #8b5cf6;
+      box-shadow: inset 0 0 0 1px #7c3aed;
     }
-
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
     .md-snackbar {
       background: #2b2831;
       color: #ffffff;
@@ -1057,10 +1229,14 @@ limitations under the License.
     }
     .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
 
-    .md-divider { border: none; border-top: 1px solid #e6e1ee; margin: 1.5rem 0; }
-    .md-hidden { display: none; }
     .md-dimmed { opacity: 0.6; }
+    .md-hidden { display: none; }
     .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+      .md-switch-label { white-space: normal; }
+    }
   </style>
 </head>
 <body class="md-page">
@@ -1081,25 +1257,16 @@ limitations under the License.
       </symbol>
     </defs>
   </svg>
+
   <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
-      </svg>
-    </button>
-    <div id="menuPanel" class="md-menu-panel md-hidden">
-      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
-    </div>
+    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 
     <h1 class="md-headline">
       <span aria-hidden="true" class="md-headline__icon">🔧</span>
       <span>Git 詳細設定コマンドジェネレータ</span>
-      <span class="md-tooltip-group">
-        <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-        <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-          core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
-        </span>
-      </span>
+      <lht-help-tooltip label="Git 詳細設定コマンドジェネレータの説明" wide>
+        core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
+      </lht-help-tooltip>
     </h1>
 
     <section id="checkSection" class="md-section md-stack-md">
@@ -1113,25 +1280,13 @@ limitations under the License.
         </svg>
         <span class="md-title-info-row">
           <p class="md-section-title">現在の設定を確認</p>
-          <span class="md-tooltip-group">
-            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              設定前に現在の値を確認できます。
-            </span>
-          </span>
+          <lht-help-tooltip label="現在の設定を確認の説明" wide>
+            設定前に現在の値を確認できます。
+          </lht-help-tooltip>
         </span>
       </div>
-      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">
-        確認コマンド生成
-      </button>
-      <div class="md-code-block">
-        <code id="checkCmd" class="md-code"></code>
-        <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
-          <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
-          </svg>
-        </button>
-      </div>
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">確認コマンド生成</button>
+      <lht-command-block command-id="checkCmd"></lht-command-block>
     </section>
 
     <div class="md-flow-divider">
@@ -1161,30 +1316,17 @@ limitations under the License.
         </svg>
         <span class="md-title-info-row">
           <p class="md-section-title">詳細設定を行う</p>
-          <span class="md-tooltip-group">
-            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              必要な詳細設定を選択して、コマンドを生成します。
-            </span>
-          </span>
+          <lht-help-tooltip label="詳細設定を行うの説明" wide>
+            必要な詳細設定を選択して、コマンドを生成します。
+          </lht-help-tooltip>
         </span>
       </div>
 
-      <!-- core.autocrlf セクション -->
       <div class="md-choice-card md-stack-md">
         <div class="md-form-row md-form-row--start">
-          <label for="enableAutocrlf" class="md-choice-row">
-            <input type="checkbox" id="enableAutocrlf" onchange="toggleAutocrlfOptions()">
-            <span class="md-label">
-              <span>core.autocrlf を設定</span>
-              <span class="md-tooltip-group">
-                <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-                <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                  改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
-                </span>
-              </span>
-            </span>
-          </label>
+          <lht-switch-help switch-id="enableAutocrlf" label="core.autocrlf を設定" help-label="core.autocrlf の説明" on-change="toggleAutocrlfOptions" help-wide>
+            改行コード自動変換の設定です。Windows/Mac/Linux間での改行コード問題を対策します。
+          </lht-switch-help>
         </div>
 
         <div id="autocrlfOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
@@ -1213,21 +1355,11 @@ limitations under the License.
         </div>
       </div>
 
-      <!-- push.default セクション -->
       <div class="md-choice-card md-stack-md">
         <div class="md-form-row md-form-row--start">
-          <label for="enablePushDefault" class="md-choice-row">
-            <input type="checkbox" id="enablePushDefault" onchange="togglePushDefaultOptions()">
-            <span class="md-label">
-              <span>push.default を設定</span>
-              <span class="md-tooltip-group">
-                <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-                <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                  push時のデフォルト動作を指定します。指定しないと予期しない動作をすることがあります。
-                </span>
-              </span>
-            </span>
-          </label>
+          <lht-switch-help switch-id="enablePushDefault" label="push.default を設定" help-label="push.default の説明" on-change="togglePushDefaultOptions" help-wide>
+            push時のデフォルト動作を指定します。指定しないと予期しない動作をすることがあります。
+          </lht-switch-help>
         </div>
 
         <div id="pushDefaultOptions" class="md-stack-sm md-choice-card md-choice-card--muted md-dimmed">
@@ -1265,109 +1397,777 @@ limitations under the License.
       </div>
     </section>
 
-    <button onclick="generateConfigCommand()" class="md-button md-button--primary">
-      設定コマンド生成
-    </button>
+    <button type="button" onclick="generateConfigCommand()" class="md-button md-button--primary">設定コマンド生成</button>
+    <lht-command-block command-id="configCmd"></lht-command-block>
 
-    <div class="md-code-block">
-      <code id="configCmd" class="md-code"></code>
-      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('configCmd')" aria-label="コピー">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
-          </svg>
-      </button>
-    </div>
-
-    <div id="toast" class="md-snackbar-host md-snackbar">
-      コピーしました
-    </div>
+    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
   </div>
 
+  
   <script>
-    function generateCheckCommand() {
-      const lines = [
-        "git config --global core.autocrlf",
-        "git config --global push.default"
-      ];
-      document.getElementById("checkCmd").textContent = lines.join("\n");
-    }
+(()=>{function n(o,e,t,r){var i=arguments.length,s=i<3?e:r===null?r=Object.getOwnPropertyDescriptor(e,t):r,a;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")s=Reflect.decorate(o,e,t,r);else for(var d=o.length-1;d>=0;d--)(a=o[d])&&(s=(i<3?a(s):i>3?a(e,t,s):a(e,t))||s);return i>3&&s&&Object.defineProperty(e,t,s),s}var T=o=>(e,t)=>{t!==void 0?t.addInitializer(()=>{customElements.define(o,e)}):customElements.define(o,e)};var Je=globalThis,Qe=Je.ShadowRoot&&(Je.ShadyCSS===void 0||Je.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,Lt=Symbol(),xr=new WeakMap,Me=class{constructor(e,t,r){if(this._$cssResult$=!0,r!==Lt)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o,t=this.t;if(Qe&&e===void 0){let r=t!==void 0&&t.length===1;r&&(e=xr.get(t)),e===void 0&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),r&&xr.set(t,e))}return e}toString(){return this.cssText}},_r=o=>new Me(typeof o=="string"?o:o+"",void 0,Lt),x=(o,...e)=>{let t=o.length===1?o[0]:e.reduce((r,i,s)=>r+(a=>{if(a._$cssResult$===!0)return a.cssText;if(typeof a=="number")return a;throw Error("Value passed to 'css' function must be a 'css' function result: "+a+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+o[s+1],o[0]);return new Me(t,o,Lt)},wr=(o,e)=>{if(Qe)o.adoptedStyleSheets=e.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(let t of e){let r=document.createElement("style"),i=Je.litNonce;i!==void 0&&r.setAttribute("nonce",i),r.textContent=t.cssText,o.appendChild(r)}},Dt=Qe?o=>o:o=>o instanceof CSSStyleSheet?(e=>{let t="";for(let r of e.cssRules)t+=r.cssText;return _r(t)})(o):o;var{is:Eo,defineProperty:Ao,getOwnPropertyDescriptor:Co,getOwnPropertyNames:To,getOwnPropertySymbols:$o,getPrototypeOf:So}=Object,le=globalThis,Er=le.trustedTypes,Io=Er?Er.emptyScript:"",ko=le.reactiveElementPolyfillSupport,Ne=(o,e)=>o,Be={toAttribute(o,e){switch(e){case Boolean:o=o?Io:null;break;case Object:case Array:o=o==null?o:JSON.stringify(o)}return o},fromAttribute(o,e){let t=o;switch(e){case Boolean:t=o!==null;break;case Number:t=o===null?null:Number(o);break;case Object:case Array:try{t=JSON.parse(o)}catch{t=null}}return t}},et=(o,e)=>!Eo(o,e),Ar={attribute:!0,type:String,converter:Be,reflect:!1,useDefault:!1,hasChanged:et};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),le.litPropertyMetadata??(le.litPropertyMetadata=new WeakMap);var ee=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??(this.l=[])).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=Ar){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){let r=Symbol(),i=this.getPropertyDescriptor(e,r,t);i!==void 0&&Ao(this.prototype,e,i)}}static getPropertyDescriptor(e,t,r){let{get:i,set:s}=Co(this.prototype,e)??{get(){return this[t]},set(a){this[t]=a}};return{get:i,set(a){let d=i?.call(this);s?.call(this,a),this.requestUpdate(e,d,r)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??Ar}static _$Ei(){if(this.hasOwnProperty(Ne("elementProperties")))return;let e=So(this);e.finalize(),e.l!==void 0&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(Ne("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Ne("properties"))){let t=this.properties,r=[...To(t),...$o(t)];for(let i of r)this.createProperty(i,t[i])}let e=this[Symbol.metadata];if(e!==null){let t=litPropertyMetadata.get(e);if(t!==void 0)for(let[r,i]of t)this.elementProperties.set(r,i)}this._$Eh=new Map;for(let[t,r]of this.elementProperties){let i=this._$Eu(t,r);i!==void 0&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){let t=[];if(Array.isArray(e)){let r=new Set(e.flat(1/0).reverse());for(let i of r)t.unshift(Dt(i))}else e!==void 0&&t.push(Dt(e));return t}static _$Eu(e,t){let r=t.attribute;return r===!1?void 0:typeof r=="string"?r:typeof e=="string"?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??(this._$EO=new Set)).add(e),this.renderRoot!==void 0&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){let e=new Map,t=this.constructor.elementProperties;for(let r of t.keys())this.hasOwnProperty(r)&&(e.set(r,this[r]),delete this[r]);e.size>0&&(this._$Ep=e)}createRenderRoot(){let e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return wr(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,r){this._$AK(e,r)}_$ET(e,t){let r=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,r);if(i!==void 0&&r.reflect===!0){let s=(r.converter?.toAttribute!==void 0?r.converter:Be).toAttribute(t,r.type);this._$Em=e,s==null?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){let r=this.constructor,i=r._$Eh.get(e);if(i!==void 0&&this._$Em!==i){let s=r.getPropertyOptions(i),a=typeof s.converter=="function"?{fromAttribute:s.converter}:s.converter?.fromAttribute!==void 0?s.converter:Be;this._$Em=i;let d=a.fromAttribute(t,s.type);this[i]=d??this._$Ej?.get(i)??d,this._$Em=null}}requestUpdate(e,t,r,i=!1,s){if(e!==void 0){let a=this.constructor;if(i===!1&&(s=this[e]),r??(r=a.getPropertyOptions(e)),!((r.hasChanged??et)(s,t)||r.useDefault&&r.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(a._$Eu(e,r))))return;this.C(e,t,r)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(e,t,{useDefault:r,reflect:i,wrapped:s},a){r&&!(this._$Ej??(this._$Ej=new Map)).has(e)&&(this._$Ej.set(e,a??t??this[e]),s!==!0||a!==void 0)||(this._$AL.has(e)||(this.hasUpdated||r||(t=void 0),this._$AL.set(e,t)),i===!0&&this._$Em!==e&&(this._$Eq??(this._$Eq=new Set)).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}let e=this.scheduleUpdate();return e!=null&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[i,s]of this._$Ep)this[i]=s;this._$Ep=void 0}let r=this.constructor.elementProperties;if(r.size>0)for(let[i,s]of r){let{wrapped:a}=s,d=this[i];a!==!0||this._$AL.has(i)||d===void 0||this.C(i,void 0,s,d)}}let e=!1,t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(r=>r.hostUpdate?.()),this.update(t)):this._$EM()}catch(r){throw e=!1,this._$EM(),r}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&(this._$Eq=this._$Eq.forEach(t=>this._$ET(t,this[t]))),this._$EM()}updated(e){}firstUpdated(e){}};ee.elementStyles=[],ee.shadowRootOptions={mode:"open"},ee[Ne("elementProperties")]=new Map,ee[Ne("finalized")]=new Map,ko?.({ReactiveElement:ee}),(le.reactiveElementVersions??(le.reactiveElementVersions=[])).push("2.1.2");var Oo={attribute:!0,type:String,converter:Be,reflect:!1,hasChanged:et},Ro=(o=Oo,e,t)=>{let{kind:r,metadata:i}=t,s=globalThis.litPropertyMetadata.get(i);if(s===void 0&&globalThis.litPropertyMetadata.set(i,s=new Map),r==="setter"&&((o=Object.create(o)).wrapped=!0),s.set(t.name,o),r==="accessor"){let{name:a}=t;return{set(d){let c=e.get.call(this);e.set.call(this,d),this.requestUpdate(a,c,o,!0,d)},init(d){return d!==void 0&&this.C(a,void 0,o,d),d}}}if(r==="setter"){let{name:a}=t;return function(d){let c=this[a];e.call(this,d),this.requestUpdate(a,c,o,!0,d)}}throw Error("Unsupported decorator location: "+r)};function l(o){return(e,t)=>typeof t=="object"?Ro(o,e,t):((r,i,s)=>{let a=i.hasOwnProperty(s);return i.constructor.createProperty(s,r),a?Object.getOwnPropertyDescriptor(i,s):void 0})(o,e,t)}function I(o){return l({...o,state:!0,attribute:!1})}var J=(o,e,t)=>(t.configurable=!0,t.enumerable=!0,Reflect.decorate&&typeof e!="object"&&Object.defineProperty(o,e,t),t);function k(o,e){return(t,r,i)=>{let s=a=>a.renderRoot?.querySelector(o)??null;if(e){let{get:a,set:d}=typeof r=="object"?t:i??(()=>{let c=Symbol();return{get(){return this[c]},set(h){this[c]=h}}})();return J(t,r,{get(){let c=a.call(this);return c===void 0&&(c=s(this),(c!==null||this.hasUpdated)&&d.call(this,c)),c}})}return J(t,r,{get(){return s(this)}})}}var Po;function Cr(o){return(e,t)=>J(e,t,{get(){return(this.renderRoot??Po??(Po=document.createDocumentFragment())).querySelectorAll(o)}})}function q(o){return(e,t)=>{let{slot:r,selector:i}=o??{},s="slot"+(r?`[name=${r}]`:":not([name])");return J(e,t,{get(){let a=this.renderRoot?.querySelector(s),d=a?.assignedElements(o)??[];return i===void 0?d:d.filter(c=>c.matches(i))}})}}function tt(o){return(e,t)=>{let{slot:r}=o??{},i="slot"+(r?`[name=${r}]`:":not([name])");return J(e,t,{get(){return this.renderRoot?.querySelector(i)?.assignedNodes(o)??[]}})}}var Ue=globalThis,Tr=o=>o,rt=Ue.trustedTypes,$r=rt?rt.createPolicy("lit-html",{createHTML:o=>o}):void 0,Mt="$lit$",te=`lit$${Math.random().toFixed(9).slice(2)}$`,Nt="?"+te,Lo=`<${Nt}>`,xe=document,qe=()=>xe.createComment(""),Ve=o=>o===null||typeof o!="object"&&typeof o!="function",Bt=Array.isArray,Pr=o=>Bt(o)||typeof o?.[Symbol.iterator]=="function",zt=`[ 	
+\f\r]`,Fe=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Sr=/-->/g,Ir=/>/g,ye=RegExp(`>|${zt}(?:([^\\s"'>=/]+)(${zt}*=${zt}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),kr=/'/g,Or=/"/g,Lr=/^(?:script|style|textarea|title)$/i,Ft=o=>(e,...t)=>({_$litType$:o,strings:e,values:t}),p=Ft(1),Dr=Ft(2),zr=Ft(3),B=Symbol.for("lit-noChange"),u=Symbol.for("lit-nothing"),Rr=new WeakMap,be=xe.createTreeWalker(xe,129);function Mr(o,e){if(!Bt(o)||!o.hasOwnProperty("raw"))throw Error("invalid template strings array");return $r!==void 0?$r.createHTML(e):e}var Nr=(o,e)=>{let t=o.length-1,r=[],i,s=e===2?"<svg>":e===3?"<math>":"",a=Fe;for(let d=0;d<t;d++){let c=o[d],h,m,f=-1,b=0;for(;b<c.length&&(a.lastIndex=b,m=a.exec(c),m!==null);)b=a.lastIndex,a===Fe?m[1]==="!--"?a=Sr:m[1]!==void 0?a=Ir:m[2]!==void 0?(Lr.test(m[2])&&(i=RegExp("</"+m[2],"g")),a=ye):m[3]!==void 0&&(a=ye):a===ye?m[0]===">"?(a=i??Fe,f=-1):m[1]===void 0?f=-2:(f=a.lastIndex-m[2].length,h=m[1],a=m[3]===void 0?ye:m[3]==='"'?Or:kr):a===Or||a===kr?a=ye:a===Sr||a===Ir?a=Fe:(a=ye,i=void 0);let g=a===ye&&o[d+1].startsWith("/>")?" ":"";s+=a===Fe?c+Lo:f>=0?(r.push(h),c.slice(0,f)+Mt+c.slice(f)+te+g):c+te+(f===-2?d:g)}return[Mr(o,s+(o[t]||"<?>")+(e===2?"</svg>":e===3?"</math>":"")),r]},He=class o{constructor({strings:e,_$litType$:t},r){let i;this.parts=[];let s=0,a=0,d=e.length-1,c=this.parts,[h,m]=Nr(e,t);if(this.el=o.createElement(h,r),be.currentNode=this.el.content,t===2||t===3){let f=this.el.content.firstChild;f.replaceWith(...f.childNodes)}for(;(i=be.nextNode())!==null&&c.length<d;){if(i.nodeType===1){if(i.hasAttributes())for(let f of i.getAttributeNames())if(f.endsWith(Mt)){let b=m[a++],g=i.getAttribute(f).split(te),S=/([.?@])?(.*)/.exec(b);c.push({type:1,index:s,name:S[2],strings:g,ctor:S[1]==="."?it:S[1]==="?"?st:S[1]==="@"?nt:we}),i.removeAttribute(f)}else f.startsWith(te)&&(c.push({type:6,index:s}),i.removeAttribute(f));if(Lr.test(i.tagName)){let f=i.textContent.split(te),b=f.length-1;if(b>0){i.textContent=rt?rt.emptyScript:"";for(let g=0;g<b;g++)i.append(f[g],qe()),be.nextNode(),c.push({type:2,index:++s});i.append(f[b],qe())}}}else if(i.nodeType===8)if(i.data===Nt)c.push({type:2,index:s});else{let f=-1;for(;(f=i.data.indexOf(te,f+1))!==-1;)c.push({type:7,index:s}),f+=te.length-1}s++}}static createElement(e,t){let r=xe.createElement("template");return r.innerHTML=e,r}};function _e(o,e,t=o,r){if(e===B)return e;let i=r!==void 0?t._$Co?.[r]:t._$Cl,s=Ve(e)?void 0:e._$litDirective$;return i?.constructor!==s&&(i?._$AO?.(!1),s===void 0?i=void 0:(i=new s(o),i._$AT(o,t,r)),r!==void 0?(t._$Co??(t._$Co=[]))[r]=i:t._$Cl=i),i!==void 0&&(e=_e(o,i._$AS(o,e.values),i,r)),e}var ot=class{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){let{el:{content:t},parts:r}=this._$AD,i=(e?.creationScope??xe).importNode(t,!0);be.currentNode=i;let s=be.nextNode(),a=0,d=0,c=r[0];for(;c!==void 0;){if(a===c.index){let h;c.type===2?h=new Te(s,s.nextSibling,this,e):c.type===1?h=new c.ctor(s,c.name,c.strings,this,e):c.type===6&&(h=new at(s,this,e)),this._$AV.push(h),c=r[++d]}a!==c?.index&&(s=be.nextNode(),a++)}return be.currentNode=xe,i}p(e){let t=0;for(let r of this._$AV)r!==void 0&&(r.strings!==void 0?(r._$AI(e,r,t),t+=r.strings.length-2):r._$AI(e[t])),t++}},Te=class o{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,r,i){this.type=2,this._$AH=u,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=r,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode,t=this._$AM;return t!==void 0&&e?.nodeType===11&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=_e(this,e,t),Ve(e)?e===u||e==null||e===""?(this._$AH!==u&&this._$AR(),this._$AH=u):e!==this._$AH&&e!==B&&this._(e):e._$litType$!==void 0?this.$(e):e.nodeType!==void 0?this.T(e):Pr(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==u&&Ve(this._$AH)?this._$AA.nextSibling.data=e:this.T(xe.createTextNode(e)),this._$AH=e}$(e){let{values:t,_$litType$:r}=e,i=typeof r=="number"?this._$AC(e):(r.el===void 0&&(r.el=He.createElement(Mr(r.h,r.h[0]),this.options)),r);if(this._$AH?._$AD===i)this._$AH.p(t);else{let s=new ot(i,this),a=s.u(this.options);s.p(t),this.T(a),this._$AH=s}}_$AC(e){let t=Rr.get(e.strings);return t===void 0&&Rr.set(e.strings,t=new He(e)),t}k(e){Bt(this._$AH)||(this._$AH=[],this._$AR());let t=this._$AH,r,i=0;for(let s of e)i===t.length?t.push(r=new o(this.O(qe()),this.O(qe()),this,this.options)):r=t[i],r._$AI(s),i++;i<t.length&&(this._$AR(r&&r._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){let r=Tr(e).nextSibling;Tr(e).remove(),e=r}}setConnected(e){this._$AM===void 0&&(this._$Cv=e,this._$AP?.(e))}},we=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,r,i,s){this.type=1,this._$AH=u,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,r.length>2||r[0]!==""||r[1]!==""?(this._$AH=Array(r.length-1).fill(new String),this.strings=r):this._$AH=u}_$AI(e,t=this,r,i){let s=this.strings,a=!1;if(s===void 0)e=_e(this,e,t,0),a=!Ve(e)||e!==this._$AH&&e!==B,a&&(this._$AH=e);else{let d=e,c,h;for(e=s[0],c=0;c<s.length-1;c++)h=_e(this,d[r+c],t,c),h===B&&(h=this._$AH[c]),a||(a=!Ve(h)||h!==this._$AH[c]),h===u?e=u:e!==u&&(e+=(h??"")+s[c+1]),this._$AH[c]=h}a&&!i&&this.j(e)}j(e){e===u?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}},it=class extends we{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===u?void 0:e}},st=class extends we{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==u)}},nt=class extends we{constructor(e,t,r,i,s){super(e,t,r,i,s),this.type=5}_$AI(e,t=this){if((e=_e(this,e,t,0)??u)===B)return;let r=this._$AH,i=e===u&&r!==u||e.capture!==r.capture||e.once!==r.once||e.passive!==r.passive,s=e!==u&&(r===u||i);i&&this.element.removeEventListener(this.name,this,r),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}},at=class{constructor(e,t,r){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=r}get _$AU(){return this._$AM._$AU}_$AI(e){_e(this,e)}},Br={M:Mt,P:te,A:Nt,C:1,L:Nr,R:ot,D:Pr,V:_e,I:Te,H:we,N:st,U:nt,B:it,F:at},Do=Ue.litHtmlPolyfillSupport;Do?.(He,Te),(Ue.litHtmlVersions??(Ue.litHtmlVersions=[])).push("3.3.2");var $e=(o,e,t)=>{let r=t?.renderBefore??e,i=r._$litPart$;if(i===void 0){let s=t?.renderBefore??null;r._$litPart$=i=new Te(e.insertBefore(qe(),s),s,void 0,t??{})}return i._$AI(o),i};var je=globalThis,y=class extends ee{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var t;let e=super.createRenderRoot();return(t=this.renderOptions).renderBefore??(t.renderBefore=e.firstChild),e}update(e){let t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=$e(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return B}};y._$litElement$=!0,y.finalized=!0,je.litElementHydrateSupport?.({LitElement:y});var zo=je.litElementPolyfillSupport;zo?.({LitElement:y});(je.litElementVersions??(je.litElementVersions=[])).push("4.2.2");var Y={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4,EVENT:5,ELEMENT:6},Se=o=>(...e)=>({_$litDirective$:o,values:e}),de=class{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,r){this._$Ct=e,this._$AM=t,this._$Ci=r}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}};var R=Se(class extends de{constructor(o){if(super(o),o.type!==Y.ATTRIBUTE||o.name!=="class"||o.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(o){return" "+Object.keys(o).filter(e=>o[e]).join(" ")+" "}update(o,[e]){if(this.st===void 0){this.st=new Set,o.strings!==void 0&&(this.nt=new Set(o.strings.join(" ").split(/\s/).filter(r=>r!=="")));for(let r in e)e[r]&&!this.nt?.has(r)&&this.st.add(r);return this.render(e)}let t=o.element.classList;for(let r of this.st)r in e||(t.remove(r),this.st.delete(r));for(let r in e){let i=!!e[r];i===this.st.has(r)||this.nt?.has(r)||(i?(t.add(r),this.st.add(r)):(t.remove(r),this.st.delete(r)))}return B}});var re={STANDARD:"cubic-bezier(0.2, 0, 0, 1)",STANDARD_ACCELERATE:"cubic-bezier(.3,0,1,1)",STANDARD_DECELERATE:"cubic-bezier(0,0,0,1)",EMPHASIZED:"cubic-bezier(.3,0,0,1)",EMPHASIZED_ACCELERATE:"cubic-bezier(.3,0,.8,.15)",EMPHASIZED_DECELERATE:"cubic-bezier(.05,.7,.1,1)"};function Fr(){let o=null;return{start(){return o?.abort(),o=new AbortController,o.signal},finish(){o=null}}}var A=class extends y{constructor(){super(...arguments),this.disabled=!1,this.error=!1,this.focused=!1,this.label="",this.noAsterisk=!1,this.populated=!1,this.required=!1,this.resizable=!1,this.supportingText="",this.errorText="",this.count=-1,this.max=-1,this.hasStart=!1,this.hasEnd=!1,this.isAnimating=!1,this.refreshErrorAlert=!1,this.disableTransitions=!1}get counterText(){let e=this.count??-1,t=this.max??-1;return e<0||t<=0?"":`${e} / ${t}`}get supportingOrErrorText(){return this.error&&this.errorText?this.errorText:this.supportingText}reannounceError(){this.refreshErrorAlert=!0}update(e){e.has("disabled")&&e.get("disabled")!==void 0&&(this.disableTransitions=!0),this.disabled&&this.focused&&(e.set("focused",!0),this.focused=!1),this.animateLabelIfNeeded({wasFocused:e.get("focused"),wasPopulated:e.get("populated")}),super.update(e)}render(){let e=this.renderLabel(!0),t=this.renderLabel(!1),r=this.renderOutline?.(e),i={disabled:this.disabled,"disable-transitions":this.disableTransitions,error:this.error&&!this.disabled,focused:this.focused,"with-start":this.hasStart,"with-end":this.hasEnd,populated:this.populated,resizable:this.resizable,required:this.required,"no-label":!this.label};return p`
+      <div class="field ${R(i)}">
+        <div class="container-overflow">
+          ${this.renderBackground?.()}
+          <slot name="container"></slot>
+          ${this.renderStateLayer?.()} ${this.renderIndicator?.()} ${r}
+          <div class="container">
+            <div class="start">
+              <slot name="start"></slot>
+            </div>
+            <div class="middle">
+              <div class="label-wrapper">
+                ${t} ${r?u:e}
+              </div>
+              <div class="content">
+                <slot></slot>
+              </div>
+            </div>
+            <div class="end">
+              <slot name="end"></slot>
+            </div>
+          </div>
+        </div>
+        ${this.renderSupportingText()}
+      </div>
+    `}updated(e){(e.has("supportingText")||e.has("errorText")||e.has("count")||e.has("max"))&&this.updateSlottedAriaDescribedBy(),this.refreshErrorAlert&&requestAnimationFrame(()=>{this.refreshErrorAlert=!1}),this.disableTransitions&&requestAnimationFrame(()=>{this.disableTransitions=!1})}renderSupportingText(){let{supportingOrErrorText:e,counterText:t}=this;if(!e&&!t)return u;let r=p`<span>${e}</span>`,i=t?p`<span class="counter">${t}</span>`:u,a=this.error&&this.errorText&&!this.refreshErrorAlert?"alert":u;return p`
+      <div class="supporting-text" role=${a}>${r}${i}</div>
+      <slot
+        name="aria-describedby"
+        @slotchange=${this.updateSlottedAriaDescribedBy}></slot>
+    `}updateSlottedAriaDescribedBy(){for(let e of this.slottedAriaDescribedBy)$e(p`${this.supportingOrErrorText} ${this.counterText}`,e),e.setAttribute("hidden","")}renderLabel(e){if(!this.label)return u;let t;e?t=this.focused||this.populated||this.isAnimating:t=!this.focused&&!this.populated&&!this.isAnimating;let r={hidden:!t,floating:e,resting:!e},i=`${this.label}${this.required&&!this.noAsterisk?"*":""}`;return p`
+      <span class="label ${R(r)}" aria-hidden=${!t}
+        >${i}</span
+      >
+    `}animateLabelIfNeeded({wasFocused:e,wasPopulated:t}){if(!this.label)return;e??(e=this.focused),t??(t=this.populated);let r=e||t,i=this.focused||this.populated;r!==i&&(this.isAnimating=!0,this.labelAnimation?.cancel(),this.labelAnimation=this.floatingLabelEl?.animate(this.getLabelKeyframes(),{duration:150,easing:re.STANDARD}),this.labelAnimation?.addEventListener("finish",()=>{this.isAnimating=!1}))}getLabelKeyframes(){let{floatingLabelEl:e,restingLabelEl:t}=this;if(!e||!t)return[];let{x:r,y:i,height:s}=e.getBoundingClientRect(),{x:a,y:d,height:c}=t.getBoundingClientRect(),h=e.scrollWidth,m=t.scrollWidth,f=m/h,b=a-r,g=d-i+Math.round((c-s*f)/2),S=`translateX(${b}px) translateY(${g}px) scale(${f})`,w="translateX(0) translateY(0) scale(1)",O=t.clientWidth,E=m>O?`${O/f}px`:"";return this.focused||this.populated?[{transform:S,width:E},{transform:w,width:E}]:[{transform:w,width:E},{transform:S,width:E}]}getSurfacePositionClientRect(){return this.containerEl.getBoundingClientRect()}};n([l({type:Boolean})],A.prototype,"disabled",void 0);n([l({type:Boolean})],A.prototype,"error",void 0);n([l({type:Boolean})],A.prototype,"focused",void 0);n([l()],A.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],A.prototype,"noAsterisk",void 0);n([l({type:Boolean})],A.prototype,"populated",void 0);n([l({type:Boolean})],A.prototype,"required",void 0);n([l({type:Boolean})],A.prototype,"resizable",void 0);n([l({attribute:"supporting-text"})],A.prototype,"supportingText",void 0);n([l({attribute:"error-text"})],A.prototype,"errorText",void 0);n([l({type:Number})],A.prototype,"count",void 0);n([l({type:Number})],A.prototype,"max",void 0);n([l({type:Boolean,attribute:"has-start"})],A.prototype,"hasStart",void 0);n([l({type:Boolean,attribute:"has-end"})],A.prototype,"hasEnd",void 0);n([q({slot:"aria-describedby"})],A.prototype,"slottedAriaDescribedBy",void 0);n([I()],A.prototype,"isAnimating",void 0);n([I()],A.prototype,"refreshErrorAlert",void 0);n([I()],A.prototype,"disableTransitions",void 0);n([k(".label.floating")],A.prototype,"floatingLabelEl",void 0);n([k(".label.resting")],A.prototype,"restingLabelEl",void 0);n([k(".container")],A.prototype,"containerEl",void 0);var lt=class extends A{renderOutline(e){return p`
+      <div class="outline">
+        <div class="outline-start"></div>
+        <div class="outline-notch">
+          <div class="outline-panel-inactive"></div>
+          <div class="outline-panel-active"></div>
+          <div class="outline-label">${e}</div>
+        </div>
+        <div class="outline-end"></div>
+      </div>
+    `}};var Ur=x`@layer styles{:host{--_bottom-space: var(--md-outlined-field-bottom-space, 16px);--_content-color: var(--md-outlined-field-content-color, var(--md-sys-color-on-surface, #1d1b20));--_content-font: var(--md-outlined-field-content-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_content-line-height: var(--md-outlined-field-content-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_content-size: var(--md-outlined-field-content-size, var(--md-sys-typescale-body-large-size, 1rem));--_content-space: var(--md-outlined-field-content-space, 16px);--_content-weight: var(--md-outlined-field-content-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_disabled-content-color: var(--md-outlined-field-disabled-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-content-opacity: var(--md-outlined-field-disabled-content-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-field-disabled-label-text-opacity, 0.38);--_disabled-leading-content-color: var(--md-outlined-field-disabled-leading-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-content-opacity: var(--md-outlined-field-disabled-leading-content-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-content-color: var(--md-outlined-field-disabled-trailing-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-content-opacity: var(--md-outlined-field-disabled-trailing-content-opacity, 0.38);--_error-content-color: var(--md-outlined-field-error-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-content-color: var(--md-outlined-field-error-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-content-color: var(--md-outlined-field-error-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-content-color: var(--md-outlined-field-error-focus-trailing-content-color, var(--md-sys-color-error, #b3261e));--_error-hover-content-color: var(--md-outlined-field-error-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-content-color: var(--md-outlined-field-error-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-content-color: var(--md-outlined-field-error-hover-trailing-content-color, var(--md-sys-color-on-error-container, #410e0b));--_error-label-text-color: var(--md-outlined-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-content-color: var(--md-outlined-field-error-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-content-color: var(--md-outlined-field-error-trailing-content-color, var(--md-sys-color-error, #b3261e));--_focus-content-color: var(--md-outlined-field-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-content-color: var(--md-outlined-field-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-content-color: var(--md-outlined-field-focus-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-content-color: var(--md-outlined-field-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-content-color: var(--md-outlined-field-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-content-color: var(--md-outlined-field-hover-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-color: var(--md-outlined-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-padding-bottom: var(--md-outlined-field-label-text-padding-bottom, 8px);--_label-text-populated-line-height: var(--md-outlined-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-content-color: var(--md-outlined-field-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-space: var(--md-outlined-field-leading-space, 16px);--_outline-color: var(--md-outlined-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-label-padding: var(--md-outlined-field-outline-label-padding, 4px);--_outline-width: var(--md-outlined-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-leading-space: var(--md-outlined-field-supporting-text-leading-space, 16px);--_supporting-text-line-height: var(--md-outlined-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-top-space: var(--md-outlined-field-supporting-text-top-space, 4px);--_supporting-text-trailing-space: var(--md-outlined-field-supporting-text-trailing-space, 16px);--_supporting-text-weight: var(--md-outlined-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_top-space: var(--md-outlined-field-top-space, 16px);--_trailing-content-color: var(--md-outlined-field-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-space: var(--md-outlined-field-trailing-space, 16px);--_with-leading-content-leading-space: var(--md-outlined-field-with-leading-content-leading-space, 12px);--_with-trailing-content-trailing-space: var(--md-outlined-field-with-trailing-content-trailing-space, 12px);--_container-shape-start-start: var(--md-outlined-field-container-shape-start-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-field-container-shape-start-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-field-container-shape-end-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-field-container-shape-end-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)))}.outline{border-color:var(--_outline-color);border-radius:inherit;display:flex;pointer-events:none;height:100%;position:absolute;width:100%;z-index:1}.outline-start::before,.outline-start::after,.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after,.outline-end::before,.outline-end::after{border:inherit;content:"";inset:0;position:absolute}.outline-start,.outline-end{border:inherit;border-radius:inherit;box-sizing:border-box;position:relative}.outline-start::before,.outline-start::after,.outline-end::before,.outline-end::after{border-bottom-style:solid;border-top-style:solid}.outline-start::after,.outline-end::after{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-start::after,.focused .outline-end::after{opacity:1}.outline-start::before,.outline-start::after{border-inline-start-style:solid;border-inline-end-style:none;border-start-start-radius:inherit;border-start-end-radius:0;border-end-start-radius:inherit;border-end-end-radius:0;margin-inline-end:var(--_outline-label-padding)}.outline-end{flex-grow:1;margin-inline-start:calc(-1*var(--_outline-label-padding))}.outline-end::before,.outline-end::after{border-inline-start-style:none;border-inline-end-style:solid;border-start-start-radius:0;border-start-end-radius:inherit;border-end-start-radius:0;border-end-end-radius:inherit}.outline-notch{align-items:flex-start;border:inherit;display:flex;margin-inline-start:calc(-1*var(--_outline-label-padding));margin-inline-end:var(--_outline-label-padding);max-width:calc(100% - var(--_leading-space) - var(--_trailing-space));padding:0 var(--_outline-label-padding);position:relative}.no-label .outline-notch{display:none}.outline-panel-inactive,.outline-panel-active{border:inherit;border-bottom-style:solid;inset:0;position:absolute}.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after{border-top-style:solid;border-bottom:none;bottom:auto;transform:scaleX(1);transition:transform 150ms cubic-bezier(0.2, 0, 0, 1)}.outline-panel-inactive::before,.outline-panel-active::before{right:50%;transform-origin:top left}.outline-panel-inactive::after,.outline-panel-active::after{left:50%;transform-origin:top right}.populated .outline-panel-inactive::before,.populated .outline-panel-inactive::after,.populated .outline-panel-active::before,.populated .outline-panel-active::after,.focused .outline-panel-inactive::before,.focused .outline-panel-inactive::after,.focused .outline-panel-active::before,.focused .outline-panel-active::after{transform:scaleX(0)}.outline-panel-active{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-panel-active{opacity:1}.outline-label{display:flex;max-width:100%;transform:translateY(calc(-100% + var(--_label-text-padding-bottom)))}.outline-start,.field:not(.with-start) .content ::slotted(*){padding-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-start) .label-wrapper{margin-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-end) .content ::slotted(*){padding-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.field:not(.with-end) .label-wrapper{margin-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.outline-start::before,.outline-end::before,.outline-panel-inactive,.outline-panel-inactive::before,.outline-panel-inactive::after{border-width:var(--_outline-width)}:hover .outline{border-color:var(--_hover-outline-color);color:var(--_hover-outline-color)}:hover .outline-start::before,:hover .outline-end::before,:hover .outline-panel-inactive,:hover .outline-panel-inactive::before,:hover .outline-panel-inactive::after{border-width:var(--_hover-outline-width)}.focused .outline{border-color:var(--_focus-outline-color);color:var(--_focus-outline-color)}.outline-start::after,.outline-end::after,.outline-panel-active,.outline-panel-active::before,.outline-panel-active::after{border-width:var(--_focus-outline-width)}.disabled .outline{border-color:var(--_disabled-outline-color);color:var(--_disabled-outline-color)}.disabled .outline-start,.disabled .outline-end,.disabled .outline-panel-inactive{opacity:var(--_disabled-outline-opacity)}.disabled .outline-start::before,.disabled .outline-end::before,.disabled .outline-panel-inactive,.disabled .outline-panel-inactive::before,.disabled .outline-panel-inactive::after{border-width:var(--_disabled-outline-width)}.error .outline{border-color:var(--_error-outline-color);color:var(--_error-outline-color)}.error:hover .outline{border-color:var(--_error-hover-outline-color);color:var(--_error-hover-outline-color)}.error.focused .outline{border-color:var(--_error-focus-outline-color);color:var(--_error-focus-outline-color)}.resizable .container{bottom:var(--_focus-outline-width);inset-inline-end:var(--_focus-outline-width);clip-path:inset(var(--_focus-outline-width) 0 0 var(--_focus-outline-width))}.resizable .container>*{top:var(--_focus-outline-width);inset-inline-start:var(--_focus-outline-width)}.resizable .container:dir(rtl){clip-path:inset(var(--_focus-outline-width) var(--_focus-outline-width) 0 0)}}@layer hcm{@media(forced-colors: active){.disabled .outline{border-color:GrayText;color:GrayText}.disabled :is(.outline-start,.outline-end,.outline-panel-inactive){opacity:1}}}
+`;var qr=x`:host{display:inline-flex;resize:both}.field{display:flex;flex:1;flex-direction:column;writing-mode:horizontal-tb;max-width:100%}.container-overflow{border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-end-radius:var(--_container-shape-end-end);border-end-start-radius:var(--_container-shape-end-start);display:flex;height:100%;position:relative}.container{align-items:center;border-radius:inherit;display:flex;flex:1;max-height:100%;min-height:100%;min-width:min-content;position:relative}.field,.container-overflow{resize:inherit}.resizable:not(.disabled) .container{resize:inherit;overflow:hidden}.disabled{pointer-events:none}slot[name=container]{border-radius:inherit}slot[name=container]::slotted(*){border-radius:inherit;inset:0;pointer-events:none;position:absolute}@layer styles{.start,.middle,.end{display:flex;box-sizing:border-box;height:100%;position:relative}.start{color:var(--_leading-content-color)}.end{color:var(--_trailing-content-color)}.start,.end{align-items:center;justify-content:center}.with-start .start{margin-inline:var(--_with-leading-content-leading-space) var(--_content-space)}.with-end .end{margin-inline:var(--_content-space) var(--_with-trailing-content-trailing-space)}.middle{align-items:stretch;align-self:baseline;flex:1}.content{color:var(--_content-color);display:flex;flex:1;opacity:0;transition:opacity 83ms cubic-bezier(0.2, 0, 0, 1)}.no-label .content,.focused .content,.populated .content{opacity:1;transition-delay:67ms}:is(.disabled,.disable-transitions) .content{transition:none}.content ::slotted(*){all:unset;color:currentColor;font-family:var(--_content-font);font-size:var(--_content-size);line-height:var(--_content-line-height);font-weight:var(--_content-weight);width:100%;overflow-wrap:revert;white-space:revert}.content ::slotted(:not(textarea)){padding-top:var(--_top-space);padding-bottom:var(--_bottom-space)}.content ::slotted(textarea){margin-top:var(--_top-space);margin-bottom:var(--_bottom-space)}:hover .content{color:var(--_hover-content-color)}:hover .start{color:var(--_hover-leading-content-color)}:hover .end{color:var(--_hover-trailing-content-color)}.focused .content{color:var(--_focus-content-color)}.focused .start{color:var(--_focus-leading-content-color)}.focused .end{color:var(--_focus-trailing-content-color)}.disabled .content{color:var(--_disabled-content-color)}.disabled.no-label .content,.disabled.focused .content,.disabled.populated .content{opacity:var(--_disabled-content-opacity)}.disabled .start{color:var(--_disabled-leading-content-color);opacity:var(--_disabled-leading-content-opacity)}.disabled .end{color:var(--_disabled-trailing-content-color);opacity:var(--_disabled-trailing-content-opacity)}.error .content{color:var(--_error-content-color)}.error .start{color:var(--_error-leading-content-color)}.error .end{color:var(--_error-trailing-content-color)}.error:hover .content{color:var(--_error-hover-content-color)}.error:hover .start{color:var(--_error-hover-leading-content-color)}.error:hover .end{color:var(--_error-hover-trailing-content-color)}.error.focused .content{color:var(--_error-focus-content-color)}.error.focused .start{color:var(--_error-focus-leading-content-color)}.error.focused .end{color:var(--_error-focus-trailing-content-color)}}@layer hcm{@media(forced-colors: active){.disabled :is(.start,.content,.end){color:GrayText;opacity:1}}}@layer styles{.label{box-sizing:border-box;color:var(--_label-text-color);overflow:hidden;max-width:100%;text-overflow:ellipsis;white-space:nowrap;z-index:1;font-family:var(--_label-text-font);font-size:var(--_label-text-size);line-height:var(--_label-text-line-height);font-weight:var(--_label-text-weight);width:min-content}.label-wrapper{inset:0;pointer-events:none;position:absolute}.label.resting{position:absolute;top:var(--_top-space)}.label.floating{font-size:var(--_label-text-populated-size);line-height:var(--_label-text-populated-line-height);transform-origin:top left}.label.hidden{opacity:0}.no-label .label{display:none}.label-wrapper{inset:0;position:absolute;text-align:initial}:hover .label{color:var(--_hover-label-text-color)}.focused .label{color:var(--_focus-label-text-color)}.disabled .label{color:var(--_disabled-label-text-color)}.disabled .label:not(.hidden){opacity:var(--_disabled-label-text-opacity)}.error .label{color:var(--_error-label-text-color)}.error:hover .label{color:var(--_error-hover-label-text-color)}.error.focused .label{color:var(--_error-focus-label-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .label:not(.hidden){color:GrayText;opacity:1}}}@layer styles{.supporting-text{color:var(--_supporting-text-color);display:flex;font-family:var(--_supporting-text-font);font-size:var(--_supporting-text-size);line-height:var(--_supporting-text-line-height);font-weight:var(--_supporting-text-weight);gap:16px;justify-content:space-between;padding-inline-start:var(--_supporting-text-leading-space);padding-inline-end:var(--_supporting-text-trailing-space);padding-top:var(--_supporting-text-top-space)}.supporting-text :nth-child(2){flex-shrink:0}:hover .supporting-text{color:var(--_hover-supporting-text-color)}.focus .supporting-text{color:var(--_focus-supporting-text-color)}.disabled .supporting-text{color:var(--_disabled-supporting-text-color);opacity:var(--_disabled-supporting-text-opacity)}.error .supporting-text{color:var(--_error-supporting-text-color)}.error:hover .supporting-text{color:var(--_error-hover-supporting-text-color)}.error.focus .supporting-text{color:var(--_error-focus-supporting-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .supporting-text{color:GrayText;opacity:1}}}
+`;var Ut=class extends lt{};Ut.styles=[qr,Ur];Ut=n([T("md-outlined-field")],Ut);var Hr=Symbol.for(""),Mo=o=>{if(o?.r===Hr)return o?._$litStatic$};var W=(o,...e)=>({_$litStatic$:e.reduce((t,r,i)=>t+(s=>{if(s._$litStatic$!==void 0)return s._$litStatic$;throw Error(`Value passed to 'literal' function must be a 'literal' result: ${s}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`)})(r)+o[i+1],o[0]),r:Hr}),Vr=new Map,qt=o=>(e,...t)=>{let r=t.length,i,s,a=[],d=[],c,h=0,m=!1;for(;h<r;){for(c=e[h];h<r&&(s=t[h],(i=Mo(s))!==void 0);)c+=i+e[++h],m=!0;h!==r&&d.push(s),a.push(c),h++}if(h===r&&a.push(e[r]),m){let f=a.join("$$lit$$");(e=Vr.get(f))===void 0&&(a.raw=a,Vr.set(f,e=a)),t=d}return o(e,...t)},ce=qt(p),Ns=qt(Dr),Bs=qt(zr);var jr=x`:host{--_caret-color: var(--md-outlined-text-field-caret-color, var(--md-sys-color-primary, #6750a4));--_disabled-input-text-color: var(--md-outlined-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-input-text-opacity: var(--md-outlined-text-field-disabled-input-text-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-text-field-disabled-label-text-opacity, 0.38);--_disabled-leading-icon-color: var(--md-outlined-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-icon-opacity: var(--md-outlined-text-field-disabled-leading-icon-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-text-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-text-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-text-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-icon-color: var(--md-outlined-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-icon-opacity: var(--md-outlined-text-field-disabled-trailing-icon-opacity, 0.38);--_error-focus-caret-color: var(--md-outlined-text-field-error-focus-caret-color, var(--md-sys-color-error, #b3261e));--_error-focus-input-text-color: var(--md-outlined-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-icon-color: var(--md-outlined-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-icon-color: var(--md-outlined-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_error-hover-input-text-color: var(--md-outlined-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-icon-color: var(--md-outlined-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-icon-color: var(--md-outlined-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_error-input-text-color: var(--md-outlined-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-label-text-color: var(--md-outlined-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-icon-color: var(--md-outlined-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-icon-color: var(--md-outlined-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_focus-input-text-color: var(--md-outlined-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-icon-color: var(--md-outlined-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-text-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-icon-color: var(--md-outlined-text-field-focus-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-input-text-color: var(--md-outlined-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-icon-color: var(--md-outlined-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-text-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-icon-color: var(--md-outlined-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-color: var(--md-outlined-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_input-text-font: var(--md-outlined-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_input-text-line-height: var(--md-outlined-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_input-text-placeholder-color: var(--md-outlined-text-field-input-text-placeholder-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-prefix-color: var(--md-outlined-text-field-input-text-prefix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-size: var(--md-outlined-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_input-text-suffix-color: var(--md-outlined-text-field-input-text-suffix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-weight: var(--md-outlined-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_label-text-color: var(--md-outlined-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-populated-line-height: var(--md-outlined-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-icon-color: var(--md-outlined-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-icon-size: var(--md-outlined-text-field-leading-icon-size, 24px);--_outline-color: var(--md-outlined-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-width: var(--md-outlined-text-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-line-height: var(--md-outlined-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-weight: var(--md-outlined-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_trailing-icon-color: var(--md-outlined-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-icon-size: var(--md-outlined-text-field-trailing-icon-size, 24px);--_container-shape-start-start: var(--md-outlined-text-field-container-shape-start-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-text-field-container-shape-start-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-text-field-container-shape-end-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-text-field-container-shape-end-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_icon-input-space: var(--md-outlined-text-field-icon-input-space, 16px);--_leading-space: var(--md-outlined-text-field-leading-space, 16px);--_trailing-space: var(--md-outlined-text-field-trailing-space, 16px);--_top-space: var(--md-outlined-text-field-top-space, 16px);--_bottom-space: var(--md-outlined-text-field-bottom-space, 16px);--_input-text-prefix-trailing-space: var(--md-outlined-text-field-input-text-prefix-trailing-space, 2px);--_input-text-suffix-leading-space: var(--md-outlined-text-field-input-text-suffix-leading-space, 2px);--_focus-caret-color: var(--md-outlined-text-field-focus-caret-color, var(--md-sys-color-primary, #6750a4));--_with-leading-icon-leading-space: var(--md-outlined-text-field-with-leading-icon-leading-space, 12px);--_with-trailing-icon-trailing-space: var(--md-outlined-text-field-with-trailing-icon-trailing-space, 12px);--md-outlined-field-bottom-space: var(--_bottom-space);--md-outlined-field-container-shape-end-end: var(--_container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_container-shape-start-start);--md-outlined-field-content-color: var(--_input-text-color);--md-outlined-field-content-font: var(--_input-text-font);--md-outlined-field-content-line-height: var(--_input-text-line-height);--md-outlined-field-content-size: var(--_input-text-size);--md-outlined-field-content-space: var(--_icon-input-space);--md-outlined-field-content-weight: var(--_input-text-weight);--md-outlined-field-disabled-content-color: var(--_disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_focus-outline-color);--md-outlined-field-focus-outline-width: var(--_focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_hover-outline-color);--md-outlined-field-hover-outline-width: var(--_hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_label-text-color);--md-outlined-field-label-text-font: var(--_label-text-font);--md-outlined-field-label-text-line-height: var(--_label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_label-text-populated-size);--md-outlined-field-label-text-size: var(--_label-text-size);--md-outlined-field-label-text-weight: var(--_label-text-weight);--md-outlined-field-leading-content-color: var(--_leading-icon-color);--md-outlined-field-leading-space: var(--_leading-space);--md-outlined-field-outline-color: var(--_outline-color);--md-outlined-field-outline-width: var(--_outline-width);--md-outlined-field-supporting-text-color: var(--_supporting-text-color);--md-outlined-field-supporting-text-font: var(--_supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_supporting-text-weight);--md-outlined-field-top-space: var(--_top-space);--md-outlined-field-trailing-content-color: var(--_trailing-icon-color);--md-outlined-field-trailing-space: var(--_trailing-space);--md-outlined-field-with-leading-content-leading-space: var(--_with-leading-icon-leading-space);--md-outlined-field-with-trailing-content-trailing-space: var(--_with-trailing-icon-trailing-space)}
+`;var{I:Ws}=Br;var Wr=o=>o.strings===void 0;var No={},Kr=(o,e=No)=>o._$AH=e;var Vt=Se(class extends de{constructor(o){if(super(o),o.type!==Y.PROPERTY&&o.type!==Y.ATTRIBUTE&&o.type!==Y.BOOLEAN_ATTRIBUTE)throw Error("The `live` directive is not allowed on child or event bindings");if(!Wr(o))throw Error("`live` bindings can only contain a single expression")}render(o){return o}update(o,[e]){if(e===B||e===u)return e;let t=o.element,r=o.name;if(o.type===Y.PROPERTY){if(e===t[r])return B}else if(o.type===Y.BOOLEAN_ATTRIBUTE){if(!!e===t.hasAttribute(r))return B}else if(o.type===Y.ATTRIBUTE&&t.getAttribute(r)===e+"")return B;return Kr(o),e}});var Gr="important",Bo=" !"+Gr,Ee=Se(class extends de{constructor(o){if(super(o),o.type!==Y.ATTRIBUTE||o.name!=="style"||o.strings?.length>2)throw Error("The `styleMap` directive must be used in the `style` attribute and must be the only part in the attribute.")}render(o){return Object.keys(o).reduce((e,t)=>{let r=o[t];return r==null?e:e+`${t=t.includes("-")?t:t.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g,"-$&").toLowerCase()}:${r};`},"")}update(o,[e]){let{style:t}=o.element;if(this.ft===void 0)return this.ft=new Set(Object.keys(e)),this.render(e);for(let r of this.ft)e[r]==null&&(this.ft.delete(r),r.includes("-")?t.removeProperty(r):t[r]=null);for(let r in e){let i=e[r];if(i!=null){this.ft.add(r);let s=typeof i=="string"&&i.endsWith(Bo);r.includes("-")||s?t.setProperty(r,s?i.slice(0,-11):i,s?Gr:""):t[r]=i}}return B}});var Ht=["role","ariaAtomic","ariaAutoComplete","ariaBusy","ariaChecked","ariaColCount","ariaColIndex","ariaColSpan","ariaCurrent","ariaDisabled","ariaExpanded","ariaHasPopup","ariaHidden","ariaInvalid","ariaKeyShortcuts","ariaLabel","ariaLevel","ariaLive","ariaModal","ariaMultiLine","ariaMultiSelectable","ariaOrientation","ariaPlaceholder","ariaPosInSet","ariaPressed","ariaReadOnly","ariaRequired","ariaRoleDescription","ariaRowCount","ariaRowIndex","ariaRowSpan","ariaSelected","ariaSetSize","ariaSort","ariaValueMax","ariaValueMin","ariaValueNow","ariaValueText"],Fo=Ht.map(jt);function dt(o){return Fo.includes(o)}function jt(o){return o.replace("aria","aria-").replace(/Elements?/g,"").toLowerCase()}var ct=Symbol("privateIgnoreAttributeChangesFor");function G(o){var e;if(!1)return o;class t extends o{constructor(){super(...arguments),this[e]=new Set}attributeChangedCallback(i,s,a){if(!dt(i)){super.attributeChangedCallback(i,s,a);return}if(this[ct].has(i))return;this[ct].add(i),this.removeAttribute(i),this[ct].delete(i);let d=Kt(i);a===null?delete this.dataset[d]:this.dataset[d]=a,this.requestUpdate(Kt(i),s)}getAttribute(i){return dt(i)?super.getAttribute(Wt(i)):super.getAttribute(i)}removeAttribute(i){super.removeAttribute(i),dt(i)&&(super.removeAttribute(Wt(i)),this.requestUpdate())}}return e=ct,Uo(t),t}function Uo(o){for(let e of Ht){let t=jt(e),r=Wt(t),i=Kt(t);o.createProperty(e,{attribute:t,noAccessor:!0}),o.createProperty(Symbol(r),{attribute:r,noAccessor:!0}),Object.defineProperty(o.prototype,e,{configurable:!0,enumerable:!0,get(){return this.dataset[i]??null},set(s){let a=this.dataset[i]??null;s!==a&&(s===null?delete this.dataset[i]:this.dataset[i]=s,this.requestUpdate(e,a))}})}}function Wt(o){return`data-${o}`}function Kt(o){return o.replace(/-\w/,e=>e[1].toUpperCase())}var Yr={fromAttribute(o){return o??""},toAttribute(o){return o||null}};function Ie(o,e){e.bubbles&&(!o.shadowRoot||e.composed)&&e.stopPropagation();let t=Reflect.construct(e.constructor,[e.type,e]),r=o.dispatchEvent(t);return r||e.preventDefault(),r}var L=Symbol("internals"),Gt=Symbol("privateInternals");function ue(o){class e extends o{get[L](){return this[Gt]||(this[Gt]=this.attachInternals()),this[Gt]}}return e}var pe=Symbol("createValidator"),he=Symbol("getValidityAnchor"),Yt=Symbol("privateValidator"),oe=Symbol("privateSyncValidity"),ut=Symbol("privateCustomValidationMessage");function ke(o){var e;class t extends o{constructor(){super(...arguments),this[e]=""}get validity(){return this[oe](),this[L].validity}get validationMessage(){return this[oe](),this[L].validationMessage}get willValidate(){return this[oe](),this[L].willValidate}checkValidity(){return this[oe](),this[L].checkValidity()}reportValidity(){return this[oe](),this[L].reportValidity()}setCustomValidity(i){this[ut]=i,this[oe]()}requestUpdate(i,s,a){super.requestUpdate(i,s,a),this[oe]()}firstUpdated(i){super.firstUpdated(i),this[oe]()}[(e=ut,oe)](){if(!1)return;this[Yt]||(this[Yt]=this[pe]());let{validity:i,validationMessage:s}=this[Yt].getValidity(),a=!!this[ut],d=this[ut]||s;this[L].setValidity({...i,customError:a},d,this[he]()??void 0)}[pe](){throw new Error("Implement [createValidator]")}[he](){throw new Error("Implement [getValidityAnchor]")}}return t}var ie=Symbol("getFormValue"),pt=Symbol("getFormState");function Oe(o){class e extends o{get form(){return this[L].form}get labels(){return this[L].labels}get name(){return this.getAttribute("name")??""}set name(r){this.setAttribute("name",r)}get disabled(){return this.hasAttribute("disabled")}set disabled(r){this.toggleAttribute("disabled",r)}attributeChangedCallback(r,i,s){if(r==="name"||r==="disabled"){let a=r==="disabled"?i!==null:i;this.requestUpdate(r,a);return}super.attributeChangedCallback(r,i,s)}requestUpdate(r,i,s){super.requestUpdate(r,i,s),this[L].setFormValue(this[ie](),this[pt]())}[ie](){throw new Error("Implement [getFormValue]")}[pt](){return this[ie]()}formDisabledCallback(r){this.disabled=r}}return e.formAssociated=!0,n([l({noAccessor:!0})],e.prototype,"name",null),n([l({type:Boolean,noAccessor:!0})],e.prototype,"disabled",null),e}var Re=Symbol("onReportValidity"),ht=Symbol("privateCleanupFormListeners"),ft=Symbol("privateDoNotReportInvalid"),mt=Symbol("privateIsSelfReportingValidity"),vt=Symbol("privateCallOnReportValidity");function gt(o){var e,t,r;class i extends o{constructor(...a){super(...a),this[e]=new AbortController,this[t]=!1,this[r]=!1,!!1&&this.addEventListener("invalid",d=>{this[ft]||!d.isTrusted||this.addEventListener("invalid",()=>{this[vt](d)},{once:!0})},{capture:!0})}checkValidity(){this[ft]=!0;let a=super.checkValidity();return this[ft]=!1,a}reportValidity(){this[mt]=!0;let a=super.reportValidity();return a&&this[vt](null),this[mt]=!1,a}[(e=ht,t=ft,r=mt,vt)](a){let d=a?.defaultPrevented;d||(this[Re](a),!(!d&&a?.defaultPrevented))||(this[mt]||Ho(this[L].form,this))&&this.focus()}[Re](a){throw new Error("Implement [onReportValidity]")}formAssociatedCallback(a){super.formAssociatedCallback&&super.formAssociatedCallback(a),this[ht].abort(),a&&(this[ht]=new AbortController,qo(this,a,()=>{this[vt](null)},this[ht].signal))}}return i}function qo(o,e,t,r){let i=Vo(e),s=!1,a,d=!1;i.addEventListener("before",()=>{d=!0,a=new AbortController,s=!1,o.addEventListener("invalid",()=>{s=!0},{signal:a.signal})},{signal:r}),i.addEventListener("after",()=>{d=!1,a?.abort(),!s&&t()},{signal:r}),e.addEventListener("submit",()=>{d||t()},{signal:r})}var Xt=new WeakMap;function Vo(o){if(!Xt.has(o)){let e=new EventTarget;Xt.set(o,e);for(let t of["reportValidity","requestSubmit"]){let r=o[t];o[t]=function(){e.dispatchEvent(new Event("before"));let i=Reflect.apply(r,this,arguments);return e.dispatchEvent(new Event("after")),i}}}return Xt.get(o)}function Ho(o,e){if(!o)return!0;let t;for(let r of o.elements)if(r.matches(":invalid")){t=r;break}return t===e}var fe=class{constructor(e){this.getCurrentState=e,this.currentValidity={validity:{},validationMessage:""}}getValidity(){let e=this.getCurrentState();if(!(!this.prevState||!this.equals(this.prevState,e)))return this.currentValidity;let{validity:r,validationMessage:i}=this.computeValidity(e);return this.prevState=this.copy(e),this.currentValidity={validationMessage:i,validity:{badInput:r.badInput,customError:r.customError,patternMismatch:r.patternMismatch,rangeOverflow:r.rangeOverflow,rangeUnderflow:r.rangeUnderflow,stepMismatch:r.stepMismatch,tooLong:r.tooLong,tooShort:r.tooShort,typeMismatch:r.typeMismatch,valueMissing:r.valueMissing}},this.currentValidity}};var yt=class extends fe{computeValidity({state:e,renderedControl:t}){let r=t;We(e)&&!r?(r=this.inputControl||document.createElement("input"),this.inputControl=r):r||(r=this.textAreaControl||document.createElement("textarea"),this.textAreaControl=r);let i=We(e)?r:null;if(i&&(i.type=e.type),r.value!==e.value&&(r.value=e.value),r.required=e.required,i){let s=e;s.pattern?i.pattern=s.pattern:i.removeAttribute("pattern"),s.min?i.min=s.min:i.removeAttribute("min"),s.max?i.max=s.max:i.removeAttribute("max"),s.step?i.step=s.step:i.removeAttribute("step")}return(e.minLength??-1)>-1?r.setAttribute("minlength",String(e.minLength)):r.removeAttribute("minlength"),(e.maxLength??-1)>-1?r.setAttribute("maxlength",String(e.maxLength)):r.removeAttribute("maxlength"),{validity:r.validity,validationMessage:r.validationMessage}}equals({state:e},{state:t}){let r=e.type===t.type&&e.value===t.value&&e.required===t.required&&e.minLength===t.minLength&&e.maxLength===t.maxLength;return!We(e)||!We(t)?r:r&&e.pattern===t.pattern&&e.min===t.min&&e.max===t.max&&e.step===t.step}copy({state:e}){return{state:We(e)?this.copyInput(e):this.copyTextArea(e),renderedControl:null}}copyInput(e){let{type:t,pattern:r,min:i,max:s,step:a}=e;return{...this.copySharedState(e),type:t,pattern:r,min:i,max:s,step:a}}copyTextArea(e){return{...this.copySharedState(e),type:e.type}}copySharedState({value:e,required:t,minLength:r,maxLength:i}){return{value:e,required:t,minLength:r,maxLength:i}}};function We(o){return o.type!=="textarea"}var jo=G(gt(ke(Oe(ue(y))))),v=class extends jo{constructor(){super(...arguments),this.error=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.required=!1,this.value="",this.prefixText="",this.suffixText="",this.hasLeadingIcon=!1,this.hasTrailingIcon=!1,this.supportingText="",this.textDirection="",this.rows=2,this.cols=20,this.inputMode="",this.max="",this.maxLength=-1,this.min="",this.minLength=-1,this.noSpinner=!1,this.pattern="",this.placeholder="",this.readOnly=!1,this.multiple=!1,this.step="",this.type="text",this.autocomplete="",this.dirty=!1,this.focused=!1,this.nativeError=!1,this.nativeErrorText=""}get selectionDirection(){return this.getInputOrTextarea().selectionDirection}set selectionDirection(e){this.getInputOrTextarea().selectionDirection=e}get selectionEnd(){return this.getInputOrTextarea().selectionEnd}set selectionEnd(e){this.getInputOrTextarea().selectionEnd=e}get selectionStart(){return this.getInputOrTextarea().selectionStart}set selectionStart(e){this.getInputOrTextarea().selectionStart=e}get valueAsNumber(){let e=this.getInput();return e?e.valueAsNumber:NaN}set valueAsNumber(e){let t=this.getInput();t&&(t.valueAsNumber=e,this.value=t.value)}get valueAsDate(){let e=this.getInput();return e?e.valueAsDate:null}set valueAsDate(e){let t=this.getInput();t&&(t.valueAsDate=e,this.value=t.value)}get hasError(){return this.error||this.nativeError}select(){this.getInputOrTextarea().select()}setRangeText(...e){this.getInputOrTextarea().setRangeText(...e),this.value=this.getInputOrTextarea().value}setSelectionRange(e,t,r){this.getInputOrTextarea().setSelectionRange(e,t,r)}showPicker(){let e=this.getInput();e&&e.showPicker()}stepDown(e){let t=this.getInput();t&&(t.stepDown(e),this.value=t.value)}stepUp(e){let t=this.getInput();t&&(t.stepUp(e),this.value=t.value)}reset(){this.dirty=!1,this.value=this.getAttribute("value")??"",this.nativeError=!1,this.nativeErrorText=""}attributeChangedCallback(e,t,r){e==="value"&&this.dirty||super.attributeChangedCallback(e,t,r)}render(){let e={disabled:this.disabled,error:!this.disabled&&this.hasError,textarea:this.type==="textarea","no-spinner":this.noSpinner};return p`
+      <span class="text-field ${R(e)}">
+        ${this.renderField()}
+      </span>
+    `}updated(e){let t=this.getInputOrTextarea().value;this.value!==t&&(this.value=t)}renderField(){return ce`<${this.fieldTag}
+      class="field"
+      count=${this.value.length}
+      ?disabled=${this.disabled}
+      ?error=${this.hasError}
+      error-text=${this.getErrorText()}
+      ?focused=${this.focused}
+      ?has-end=${this.hasTrailingIcon}
+      ?has-start=${this.hasLeadingIcon}
+      label=${this.label}
+      ?no-asterisk=${this.noAsterisk}
+      max=${this.maxLength}
+      ?populated=${!!this.value}
+      ?required=${this.required}
+      ?resizable=${this.type==="textarea"}
+      supporting-text=${this.supportingText}
+    >
+      ${this.renderLeadingIcon()}
+      ${this.renderInputOrTextarea()}
+      ${this.renderTrailingIcon()}
+      <div id="description" slot="aria-describedby"></div>
+      <slot name="container" slot="container"></slot>
+    </${this.fieldTag}>`}renderLeadingIcon(){return p`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return p`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderInputOrTextarea(){let e={direction:this.textDirection},t=this.ariaLabel||this.label||u,r=this.autocomplete,i=(this.maxLength??-1)>-1,s=(this.minLength??-1)>-1;if(this.type==="textarea")return p`
+        <textarea
+          class="input"
+          style=${Ee(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||u}
+          name=${this.name||u}
+          ?disabled=${this.disabled}
+          maxlength=${i?this.maxLength:u}
+          minlength=${s?this.minLength:u}
+          placeholder=${this.placeholder||u}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          rows=${this.rows}
+          cols=${this.cols}
+          .value=${Vt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent}></textarea>
+      `;let a=this.renderPrefix(),d=this.renderSuffix(),c=this.inputMode;return p`
+      <div class="input-wrapper">
+        ${a}
+        <input
+          class="input"
+          style=${Ee(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||u}
+          name=${this.name||u}
+          ?disabled=${this.disabled}
+          inputmode=${c||u}
+          max=${this.max||u}
+          maxlength=${i?this.maxLength:u}
+          min=${this.min||u}
+          minlength=${s?this.minLength:u}
+          pattern=${this.pattern||u}
+          placeholder=${this.placeholder||u}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          ?multiple=${this.multiple}
+          step=${this.step||u}
+          type=${this.type}
+          .value=${Vt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent} />
+        ${d}
+      </div>
+    `}renderPrefix(){return this.renderAffix(this.prefixText,!1)}renderSuffix(){return this.renderAffix(this.suffixText,!0)}renderAffix(e,t){return e?p`<span class="${R({suffix:t,prefix:!t})}">${e}</span>`:u}getErrorText(){return this.error?this.errorText:this.nativeErrorText}handleFocusChange(){this.focused=this.inputOrTextarea?.matches(":focus")??!1}handleInput(e){this.dirty=!0,this.value=e.target.value}redispatchEvent(e){Ie(this,e)}getInputOrTextarea(){return this.inputOrTextarea||(this.connectedCallback(),this.scheduleUpdate()),this.isUpdatePending&&this.scheduleUpdate(),this.inputOrTextarea}getInput(){return this.type==="textarea"?null:this.getInputOrTextarea()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0,this.hasTrailingIcon=this.trailingIcons.length>0}[ie](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}focus(){this.getInputOrTextarea().focus()}[pe](){return new yt(()=>({state:this,renderedControl:this.inputOrTextarea}))}[he](){return this.inputOrTextarea}[Re](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}};v.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],v.prototype,"error",void 0);n([l({attribute:"error-text"})],v.prototype,"errorText",void 0);n([l()],v.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],v.prototype,"noAsterisk",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"required",void 0);n([l()],v.prototype,"value",void 0);n([l({attribute:"prefix-text"})],v.prototype,"prefixText",void 0);n([l({attribute:"suffix-text"})],v.prototype,"suffixText",void 0);n([l({type:Boolean,attribute:"has-leading-icon"})],v.prototype,"hasLeadingIcon",void 0);n([l({type:Boolean,attribute:"has-trailing-icon"})],v.prototype,"hasTrailingIcon",void 0);n([l({attribute:"supporting-text"})],v.prototype,"supportingText",void 0);n([l({attribute:"text-direction"})],v.prototype,"textDirection",void 0);n([l({type:Number})],v.prototype,"rows",void 0);n([l({type:Number})],v.prototype,"cols",void 0);n([l({reflect:!0})],v.prototype,"inputMode",void 0);n([l()],v.prototype,"max",void 0);n([l({type:Number})],v.prototype,"maxLength",void 0);n([l()],v.prototype,"min",void 0);n([l({type:Number})],v.prototype,"minLength",void 0);n([l({type:Boolean,attribute:"no-spinner"})],v.prototype,"noSpinner",void 0);n([l()],v.prototype,"pattern",void 0);n([l({reflect:!0,converter:Yr})],v.prototype,"placeholder",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"readOnly",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"multiple",void 0);n([l()],v.prototype,"step",void 0);n([l({reflect:!0})],v.prototype,"type",void 0);n([l({reflect:!0})],v.prototype,"autocomplete",void 0);n([I()],v.prototype,"dirty",void 0);n([I()],v.prototype,"focused",void 0);n([I()],v.prototype,"nativeError",void 0);n([I()],v.prototype,"nativeErrorText",void 0);n([k(".input")],v.prototype,"inputOrTextarea",void 0);n([k(".field")],v.prototype,"field",void 0);n([q({slot:"leading-icon"})],v.prototype,"leadingIcons",void 0);n([q({slot:"trailing-icon"})],v.prototype,"trailingIcons",void 0);var bt=class extends v{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};var Xr=x`:host{display:inline-flex;outline:none;resize:both;text-align:start;-webkit-tap-highlight-color:rgba(0,0,0,0)}.text-field,.field{width:100%}.text-field{display:inline-flex}.field{cursor:text}.disabled .field{cursor:default}.text-field,.textarea .field{resize:inherit}slot[name=container]{border-radius:inherit}.icon{color:currentColor;display:flex;align-items:center;justify-content:center;fill:currentColor;position:relative}.icon ::slotted(*){display:flex;position:absolute}[has-start] .icon.leading{font-size:var(--_leading-icon-size);height:var(--_leading-icon-size);width:var(--_leading-icon-size)}[has-end] .icon.trailing{font-size:var(--_trailing-icon-size);height:var(--_trailing-icon-size);width:var(--_trailing-icon-size)}.input-wrapper{display:flex}.input-wrapper>*{all:inherit;padding:0}.input{caret-color:var(--_caret-color);overflow-x:hidden;text-align:inherit}.input::placeholder{color:currentColor;opacity:1}.input::-webkit-calendar-picker-indicator{display:none}.input::-webkit-search-decoration,.input::-webkit-search-cancel-button{display:none}@media(forced-colors: active){.input{background:none}}.no-spinner .input::-webkit-inner-spin-button,.no-spinner .input::-webkit-outer-spin-button{display:none}.no-spinner .input[type=number]{-moz-appearance:textfield}:focus-within .input{caret-color:var(--_focus-caret-color)}.error:focus-within .input{caret-color:var(--_error-focus-caret-color)}.text-field:not(.disabled) .prefix{color:var(--_input-text-prefix-color)}.text-field:not(.disabled) .suffix{color:var(--_input-text-suffix-color)}.text-field:not(.disabled) .input::placeholder{color:var(--_input-text-placeholder-color)}.prefix,.suffix{text-wrap:nowrap;width:min-content}.prefix{padding-inline-end:var(--_input-text-prefix-trailing-space)}.suffix{padding-inline-start:var(--_input-text-suffix-leading-space)}
+`;var Zt=class extends bt{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};Zt.styles=[Xr,jr];Zt=n([T("md-outlined-text-field")],Zt);var xt=class extends y{connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){return p`<span class="shadow"></span>`}};var Zr=x`:host,.shadow,.shadow::before,.shadow::after{border-radius:inherit;inset:0;position:absolute;transition-duration:inherit;transition-property:inherit;transition-timing-function:inherit}:host{display:flex;pointer-events:none;transition-property:box-shadow,opacity}.shadow::before,.shadow::after{content:"";transition-property:box-shadow,opacity;--_level: var(--md-elevation-level, 0);--_shadow-color: var(--md-elevation-shadow-color, var(--md-sys-color-shadow, #000))}.shadow::before{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 3,1) + 2*clamp(0,var(--_level) - 4,1))) calc(1px*(2*clamp(0,var(--_level),1) + clamp(0,var(--_level) - 2,1) + clamp(0,var(--_level) - 4,1))) 0px var(--_shadow-color);opacity:.3}.shadow::after{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 1,1) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(3*clamp(0,var(--_level),2) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(clamp(0,var(--_level),4) + 2*clamp(0,var(--_level) - 4,1))) var(--_shadow-color);opacity:.15}
+`;var Jt=class extends xt{};Jt.styles=[Zr];Jt=n([T("md-elevation")],Jt);var Jr=Symbol("attachableController"),Qr;Qr=new MutationObserver(o=>{for(let e of o)e.target[Jr]?.hostConnected()});var Pe=class{get htmlFor(){return this.host.getAttribute("for")}set htmlFor(e){e===null?this.host.removeAttribute("for"):this.host.setAttribute("for",e)}get control(){return this.host.hasAttribute("for")?!this.htmlFor||!this.host.isConnected?null:this.host.getRootNode().querySelector(`#${this.htmlFor}`):this.currentControl||this.host.parentElement}set control(e){e?this.attach(e):this.detach()}constructor(e,t){this.host=e,this.onControlChange=t,this.currentControl=null,e.addController(this),e[Jr]=this,Qr?.observe(e,{attributeFilter:["for"]})}attach(e){e!==this.currentControl&&(this.setCurrentControl(e),this.host.removeAttribute("for"))}detach(){this.setCurrentControl(null),this.host.setAttribute("for","")}hostConnected(){this.setCurrentControl(this.control)}hostDisconnected(){this.setCurrentControl(null)}setCurrentControl(e){this.onControlChange(this.currentControl,e),this.currentControl=e}};var Wo=["focusin","focusout","pointerdown"],Le=class extends y{constructor(){super(...arguments),this.visible=!1,this.inward=!1,this.attachableController=new Pe(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}handleEvent(e){if(!e[eo]){switch(e.type){default:return;case"focusin":this.visible=this.control?.matches(":focus-visible")??!1;break;case"focusout":case"pointerdown":this.visible=!1;break}e[eo]=!0}}onControlChange(e,t){if(!!1)for(let r of Wo)e?.removeEventListener(r,this),t?.addEventListener(r,this)}update(e){e.has("visible")&&this.dispatchEvent(new Event("visibility-changed")),super.update(e)}};n([l({type:Boolean,reflect:!0})],Le.prototype,"visible",void 0);n([l({type:Boolean,reflect:!0})],Le.prototype,"inward",void 0);var eo=Symbol("handledByFocusRing");var to=x`:host{animation-delay:0s,calc(var(--md-focus-ring-duration, 600ms)*.25);animation-duration:calc(var(--md-focus-ring-duration, 600ms)*.25),calc(var(--md-focus-ring-duration, 600ms)*.75);animation-timing-function:cubic-bezier(0.2, 0, 0, 1);box-sizing:border-box;color:var(--md-focus-ring-color, var(--md-sys-color-secondary, #625b71));display:none;pointer-events:none;position:absolute}:host([visible]){display:flex}:host(:not([inward])){animation-name:outward-grow,outward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));inset:calc(-1*var(--md-focus-ring-outward-offset, 2px));outline:var(--md-focus-ring-width, 3px) solid currentColor}:host([inward]){animation-name:inward-grow,inward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border:var(--md-focus-ring-width, 3px) solid currentColor;inset:var(--md-focus-ring-inward-offset, 0px)}@keyframes outward-grow{from{outline-width:0}to{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes outward-shrink{from{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-grow{from{border-width:0}to{border-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-shrink{from{border-width:var(--md-focus-ring-active-width, 8px)}}@media(prefers-reduced-motion){:host{animation:none}}
+`;var Qt=class extends Le{};Qt.styles=[to];Qt=n([T("md-focus-ring")],Qt);function er(o,e=se){let t=Ke(o,e);return t&&(t.tabIndex=0,t.focus()),t}function tr(o,e=se){let t=rr(o,e);return t&&(t.tabIndex=0,t.focus()),t}function me(o,e=se){for(let t=0;t<o.length;t++){let r=o[t];if(r.tabIndex===0&&e(r))return{item:r,index:t}}return null}function Ke(o,e=se){for(let t of o)if(e(t))return t;return null}function rr(o,e=se){for(let t=o.length-1;t>=0;t--){let r=o[t];if(e(r))return r}return null}function Ko(o,e,t=se,r=!0){for(let i=1;i<o.length;i++){let s=(i+e)%o.length;if(s<e&&!r)return null;let a=o[s];if(t(a))return a}return o[e]?o[e]:null}function Go(o,e,t=se,r=!0){for(let i=1;i<o.length;i++){let s=(e-i+o.length)%o.length;if(s>e&&!r)return null;let a=o[s];if(t(a))return a}return o[e]?o[e]:null}function or(o,e,t=se,r=!0){if(e){let i=Ko(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return er(o,t)}function ir(o,e,t=se,r=!0){if(e){let i=Go(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return tr(o,t)}function se(o){return!o.disabled}var M={ArrowDown:"ArrowDown",ArrowLeft:"ArrowLeft",ArrowUp:"ArrowUp",ArrowRight:"ArrowRight",Home:"Home",End:"End"},_t=class{constructor(e){this.handleKeydown=m=>{let f=m.key;if(m.defaultPrevented||!this.isNavigableKey(f))return;let b=this.items;if(!b.length)return;let g=me(b,this.isActivatable);m.preventDefault();let S=this.isRtl(),w=S?M.ArrowRight:M.ArrowLeft,O=S?M.ArrowLeft:M.ArrowRight,z=null;switch(f){case M.ArrowDown:case O:z=or(b,g,this.isActivatable,this.wrapNavigation());break;case M.ArrowUp:case w:z=ir(b,g,this.isActivatable,this.wrapNavigation());break;case M.Home:z=er(b,this.isActivatable);break;case M.End:z=tr(b,this.isActivatable);break;default:break}z&&g&&g.item!==z&&(g.item.tabIndex=-1)},this.onDeactivateItems=()=>{let m=this.items;for(let f of m)this.deactivateItem(f)},this.onRequestActivation=m=>{this.onDeactivateItems();let f=m.target;this.activateItem(f),f.focus()},this.onSlotchange=()=>{let m=this.items,f=!1;for(let g of m){if(!g.disabled&&g.tabIndex>-1&&!f){f=!0,g.tabIndex=0;continue}g.tabIndex=-1}if(f)return;let b=Ke(m,this.isActivatable);b&&(b.tabIndex=0)};let{isItem:t,getPossibleItems:r,isRtl:i,deactivateItem:s,activateItem:a,isNavigableKey:d,isActivatable:c,wrapNavigation:h}=e;this.isItem=t,this.getPossibleItems=r,this.isRtl=i,this.deactivateItem=s,this.activateItem=a,this.isNavigableKey=d,this.isActivatable=c,this.wrapNavigation=h??(()=>!0)}get items(){let e=this.getPossibleItems(),t=[];for(let r of e){if(this.isItem(r)){t.push(r);continue}let s=r.item;s&&this.isItem(s)&&t.push(s)}return t}activateNextItem(){let e=this.items,t=me(e,this.isActivatable);return t&&(t.item.tabIndex=-1),or(e,t,this.isActivatable,this.wrapNavigation())}activatePreviousItem(){let e=this.items,t=me(e,this.isActivatable);return t&&(t.item.tabIndex=-1),ir(e,t,this.isActivatable,this.wrapNavigation())}};function Yo(o,e){return new CustomEvent("close-menu",{bubbles:!0,composed:!0,detail:{initiator:o,reason:e,itemPath:[o]}})}var nr=Yo;var sr={SPACE:"Space",ENTER:"Enter"},wt={CLICK_SELECTION:"click-selection",KEYDOWN:"keydown"},Xo={ESCAPE:"Escape",SPACE:sr.SPACE,ENTER:sr.ENTER};function Et(o){return Object.values(Xo).some(e=>e===o)}function ro(o){return Object.values(sr).some(e=>e===o)}function Ge(o,e){let t=new Event("md-contains",{bubbles:!0,composed:!0}),r=[],i=a=>{r=a.composedPath()};return e.addEventListener("md-contains",i),o.dispatchEvent(t),e.removeEventListener("md-contains",i),r.length>0}var j={NONE:"none",LIST_ROOT:"list-root",FIRST_ITEM:"first-item",LAST_ITEM:"last-item"};var Ye={END_START:"end-start",END_END:"end-end",START_START:"start-start",START_END:"start-end"},At=class{constructor(e,t){this.host=e,this.getProperties=t,this.surfaceStylesInternal={display:"none"},this.lastValues={isOpen:!1},this.host.addController(this)}get surfaceStyles(){return this.surfaceStylesInternal}async position(){let{surfaceEl:e,anchorEl:t,anchorCorner:r,surfaceCorner:i,positioning:s,xOffset:a,yOffset:d,disableBlockFlip:c,disableInlineFlip:h,repositionStrategy:m}=this.getProperties(),f=r.toLowerCase().trim(),b=i.toLowerCase().trim();if(!e||!t)return;let g=window.innerWidth,S=window.innerHeight,w=document.createElement("div");w.style.opacity="0",w.style.position="fixed",w.style.display="block",w.style.inset="0",document.body.appendChild(w);let O=w.getBoundingClientRect();w.remove();let z=window.innerHeight-O.bottom,E=window.innerWidth-O.right;this.surfaceStylesInternal={display:"block",opacity:"0"},this.host.requestUpdate(),await this.host.updateComplete,e.popover&&e.isConnected&&e.showPopover();let U=e.getSurfacePositionClientRect?e.getSurfacePositionClientRect():e.getBoundingClientRect(),N=t.getSurfacePositionClientRect?t.getSurfacePositionClientRect():t.getBoundingClientRect(),[P,ne]=b.split("-"),[ae,ge]=f.split("-"),Xe=getComputedStyle(e).direction==="ltr",{blockInset:Ae,blockOutOfBoundsCorrection:Z,surfaceBlockProperty:yr}=this.calculateBlock({surfaceRect:U,anchorRect:N,anchorBlock:ae,surfaceBlock:P,yOffset:d,positioning:s,windowInnerHeight:S,blockScrollbarHeight:z});if(Z&&!c){let Rt=P==="start"?"end":"start",Pt=ae==="start"?"end":"start",Q=this.calculateBlock({surfaceRect:U,anchorRect:N,anchorBlock:Pt,surfaceBlock:Rt,yOffset:d,positioning:s,windowInnerHeight:S,blockScrollbarHeight:z});Z>Q.blockOutOfBoundsCorrection&&(Ae=Q.blockInset,Z=Q.blockOutOfBoundsCorrection,yr=Q.surfaceBlockProperty)}let{inlineInset:Ze,inlineOutOfBoundsCorrection:Ce,surfaceInlineProperty:br}=this.calculateInline({surfaceRect:U,anchorRect:N,anchorInline:ge,surfaceInline:ne,xOffset:a,positioning:s,isLTR:Xe,windowInnerWidth:g,inlineScrollbarWidth:E});if(Ce&&!h){let Rt=ne==="start"?"end":"start",Pt=ge==="start"?"end":"start",Q=this.calculateInline({surfaceRect:U,anchorRect:N,anchorInline:Pt,surfaceInline:Rt,xOffset:a,positioning:s,isLTR:Xe,windowInnerWidth:g,inlineScrollbarWidth:E});Math.abs(Ce)>Math.abs(Q.inlineOutOfBoundsCorrection)&&(Ze=Q.inlineInset,Ce=Q.inlineOutOfBoundsCorrection,br=Q.surfaceInlineProperty)}m==="move"&&(Ae=Ae-Z,Ze=Ze-Ce),this.surfaceStylesInternal={display:"block",opacity:"1",[yr]:`${Ae}px`,[br]:`${Ze}px`},m==="resize"&&(Z&&(this.surfaceStylesInternal.height=`${U.height-Z}px`),Ce&&(this.surfaceStylesInternal.width=`${U.width-Ce}px`)),this.host.requestUpdate()}calculateBlock(e){let{surfaceRect:t,anchorRect:r,anchorBlock:i,surfaceBlock:s,yOffset:a,positioning:d,windowInnerHeight:c,blockScrollbarHeight:h}=e,m=d==="fixed"||d==="document"?1:0,f=d==="document"?1:0,b=s==="start"?1:0,g=s==="end"?1:0,w=(i!==s?1:0)*r.height+a,O=b*r.top+g*(c-r.bottom-h),z=b*window.scrollY-g*window.scrollY,E=Math.abs(Math.min(0,c-O-w-t.height));return{blockInset:m*O+f*z+w,blockOutOfBoundsCorrection:E,surfaceBlockProperty:s==="start"?"inset-block-start":"inset-block-end"}}calculateInline(e){let{isLTR:t,surfaceInline:r,anchorInline:i,anchorRect:s,surfaceRect:a,xOffset:d,positioning:c,windowInnerWidth:h,inlineScrollbarWidth:m}=e,f=c==="fixed"||c==="document"?1:0,b=c==="document"?1:0,g=t?1:0,S=t?0:1,w=r==="start"?1:0,O=r==="end"?1:0,E=(i!==r?1:0)*s.width+d,U=w*s.left+O*(h-s.right-m),N=w*(h-s.right-m)+O*s.left,P=g*U+S*N,ne=w*window.scrollX-O*window.scrollX,ae=O*window.scrollX-w*window.scrollX,ge=g*ne+S*ae,Xe=Math.abs(Math.min(0,h-P-E-a.width)),Ae=f*P+E+b*ge,Z=r==="start"?"inset-inline-start":"inset-inline-end";return(c==="document"||c==="fixed")&&(r==="start"&&t||r==="end"&&!t?Z="left":Z="right"),{inlineInset:Ae,inlineOutOfBoundsCorrection:Xe,surfaceInlineProperty:Z}}hostUpdate(){this.onUpdate()}hostUpdated(){this.onUpdate()}async onUpdate(){let e=this.getProperties(),t=!1;for(let[a,d]of Object.entries(e))if(t=t||d!==this.lastValues[a],t)break;let r=this.lastValues.isOpen!==e.isOpen,i=!!e.anchorEl,s=!!e.surfaceEl;t&&i&&s&&(this.lastValues.isOpen=e.isOpen,e.isOpen?(this.lastValues=e,await this.position(),e.onOpen()):r&&(await e.beforeClose(),this.close(),e.onClose()))}close(){this.surfaceStylesInternal={display:"none"},this.host.requestUpdate();let e=this.getProperties().surfaceEl;e?.popover&&e?.isConnected&&e.hidePopover()}};var K={INDEX:0,ITEM:1,TEXT:2},Ct=class{constructor(e){this.getProperties=e,this.typeaheadRecords=[],this.typaheadBuffer="",this.cancelTypeaheadTimeout=0,this.isTypingAhead=!1,this.lastActiveRecord=null,this.onKeydown=t=>{this.isTypingAhead?this.typeahead(t):this.beginTypeahead(t)},this.endTypeahead=()=>{this.isTypingAhead=!1,this.typaheadBuffer="",this.typeaheadRecords=[]}}get items(){return this.getProperties().getItems()}get active(){return this.getProperties().active}beginTypeahead(e){this.active&&(e.code==="Space"||e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"||(this.isTypingAhead=!0,this.typeaheadRecords=this.items.map((t,r)=>[r,t,t.typeaheadText.trim().toLowerCase()]),this.lastActiveRecord=this.typeaheadRecords.find(t=>t[K.ITEM].tabIndex===0)??null,this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.typeahead(e)))}typeahead(e){if(e.defaultPrevented)return;if(clearTimeout(this.cancelTypeaheadTimeout),e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"){this.endTypeahead(),this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1);return}e.code==="Space"&&e.preventDefault(),this.cancelTypeaheadTimeout=setTimeout(this.endTypeahead,this.getProperties().typeaheadBufferTime),this.typaheadBuffer+=e.key.toLowerCase();let t=this.lastActiveRecord?this.lastActiveRecord[K.INDEX]:-1,r=this.typeaheadRecords.length,i=c=>(c[K.INDEX]+r-t)%r,s=this.typeaheadRecords.filter(c=>!c[K.ITEM].disabled&&c[K.TEXT].startsWith(this.typaheadBuffer)).sort((c,h)=>i(c)-i(h));if(s.length===0){clearTimeout(this.cancelTypeaheadTimeout),this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.endTypeahead();return}let a=this.typaheadBuffer.length===1,d;this.lastActiveRecord===s[0]&&a?d=s[1]??s[0]:d=s[0],this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.lastActiveRecord=d,d[K.ITEM].tabIndex=0,d[K.ITEM].focus()}};var ar=200,oo=new Set([M.ArrowDown,M.ArrowUp,M.Home,M.End]),Zo=new Set([M.ArrowLeft,M.ArrowRight,...oo]);function Jo(o=document){let e=o.activeElement;for(;e&&e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e}var C=class extends y{get openDirection(){return this.menuCorner.split("-")[0]==="start"?"DOWN":"UP"}get anchorElement(){return this.anchor?this.getRootNode().querySelector(`#${this.anchor}`):this.currentAnchorElement}set anchorElement(e){this.currentAnchorElement=e,this.requestUpdate("anchorElement")}constructor(){super(),this.anchor="",this.positioning="absolute",this.quick=!1,this.hasOverflow=!1,this.open=!1,this.xOffset=0,this.yOffset=0,this.noHorizontalFlip=!1,this.noVerticalFlip=!1,this.typeaheadDelay=ar,this.anchorCorner=Ye.END_START,this.menuCorner=Ye.START_START,this.stayOpenOnOutsideClick=!1,this.stayOpenOnFocusout=!1,this.skipRestoreFocus=!1,this.defaultFocus=j.FIRST_ITEM,this.noNavigationWrap=!1,this.typeaheadActive=!0,this.isSubmenu=!1,this.pointerPath=[],this.isRepositioning=!1,this.openCloseAnimationSignal=Fr(),this.listController=new _t({isItem:e=>e.hasAttribute("md-menu-item"),getPossibleItems:()=>this.slotItems,isRtl:()=>getComputedStyle(this).direction==="rtl",deactivateItem:e=>{e.selected=!1,e.tabIndex=-1},activateItem:e=>{e.selected=!0,e.tabIndex=0},isNavigableKey:e=>{if(!this.isSubmenu)return Zo.has(e);let r=getComputedStyle(this).direction==="rtl"?M.ArrowLeft:M.ArrowRight;return e===r?!0:oo.has(e)},wrapNavigation:()=>!this.noNavigationWrap}),this.lastFocusedElement=null,this.typeaheadController=new Ct(()=>({getItems:()=>this.items,typeaheadBufferTime:this.typeaheadDelay,active:this.typeaheadActive})),this.currentAnchorElement=null,this.internals=this.attachInternals(),this.menuPositionController=new At(this,()=>({anchorCorner:this.anchorCorner,surfaceCorner:this.menuCorner,surfaceEl:this.surfaceEl,anchorEl:this.anchorElement,positioning:this.positioning==="popover"?"document":this.positioning,isOpen:this.open,xOffset:this.xOffset,yOffset:this.yOffset,disableBlockFlip:this.noVerticalFlip,disableInlineFlip:this.noHorizontalFlip,onOpen:this.onOpened,beforeClose:this.beforeClose,onClose:this.onClosed,repositionStrategy:this.hasOverflow&&this.positioning!=="popover"?"move":"resize"})),this.onWindowResize=()=>{this.isRepositioning||this.positioning!=="document"&&this.positioning!=="fixed"&&this.positioning!=="popover"||(this.isRepositioning=!0,this.reposition(),this.isRepositioning=!1)},this.handleFocusout=async e=>{let t=this.anchorElement;if(this.stayOpenOnFocusout||!this.open||this.pointerPath.includes(t))return;if(e.relatedTarget){if(Ge(e.relatedTarget,this)||this.pointerPath.length!==0&&Ge(e.relatedTarget,t))return}else if(this.pointerPath.includes(this))return;let r=this.skipRestoreFocus;this.skipRestoreFocus=!0,this.close(),await this.updateComplete,this.skipRestoreFocus=r},this.onOpened=async()=>{this.lastFocusedElement=Jo();let e=this.items,t=me(e);t&&this.defaultFocus!==j.NONE&&(t.item.tabIndex=-1);let r=!this.quick;switch(this.quick?this.dispatchEvent(new Event("opening")):r=!!await this.animateOpen(),this.defaultFocus){case j.FIRST_ITEM:let i=Ke(e);i&&(i.tabIndex=0,i.focus(),await i.updateComplete);break;case j.LAST_ITEM:let s=rr(e);s&&(s.tabIndex=0,s.focus(),await s.updateComplete);break;case j.LIST_ROOT:this.focus();break;default:case j.NONE:break}r||this.dispatchEvent(new Event("opened"))},this.beforeClose=async()=>{this.open=!1,this.skipRestoreFocus||this.lastFocusedElement?.focus?.(),this.quick||await this.animateClose()},this.onClosed=()=>{this.quick&&(this.dispatchEvent(new Event("closing")),this.dispatchEvent(new Event("closed")))},this.onWindowPointerdown=e=>{this.pointerPath=e.composedPath()},this.onDocumentClick=e=>{if(!this.open)return;let t=e.composedPath();!this.stayOpenOnOutsideClick&&!t.includes(this)&&!t.includes(this.anchorElement)&&(this.open=!1)},this.internals.role="menu",this.addEventListener("keydown",this.handleKeydown),this.addEventListener("keydown",this.captureKeydown,{capture:!0}),this.addEventListener("focusout",this.handleFocusout)}get items(){return this.listController.items}willUpdate(e){if(e.has("open")){if(this.open){this.removeAttribute("aria-hidden");return}this.setAttribute("aria-hidden","true")}}update(e){e.has("open")&&(this.open?this.setUpGlobalEventListeners():this.cleanUpGlobalEventListeners()),e.has("positioning")&&this.positioning==="popover"&&!this.showPopover&&(this.positioning="fixed"),super.update(e)}connectedCallback(){super.connectedCallback(),this.open&&this.setUpGlobalEventListeners()}disconnectedCallback(){super.disconnectedCallback(),this.cleanUpGlobalEventListeners()}getBoundingClientRect(){return this.surfaceEl?this.surfaceEl.getBoundingClientRect():super.getBoundingClientRect()}getClientRects(){return this.surfaceEl?this.surfaceEl.getClientRects():super.getClientRects()}render(){return this.renderSurface()}renderSurface(){return p`
+      <div
+        class="menu ${R(this.getSurfaceClasses())}"
+        style=${Ee(this.menuPositionController.surfaceStyles)}
+        popover=${this.positioning==="popover"?"manual":u}>
+        ${this.renderElevation()}
+        <div class="items">
+          <div class="item-padding"> ${this.renderMenuItems()} </div>
+        </div>
+      </div>
+    `}renderMenuItems(){return p`<slot
+      @close-menu=${this.onCloseMenu}
+      @deactivate-items=${this.onDeactivateItems}
+      @request-activation=${this.onRequestActivation}
+      @deactivate-typeahead=${this.handleDeactivateTypeahead}
+      @activate-typeahead=${this.handleActivateTypeahead}
+      @stay-open-on-focusout=${this.handleStayOpenOnFocusout}
+      @close-on-focusout=${this.handleCloseOnFocusout}
+      @slotchange=${this.listController.onSlotchange}></slot>`}renderElevation(){return p`<md-elevation part="elevation"></md-elevation>`}getSurfaceClasses(){return{open:this.open,fixed:this.positioning==="fixed","has-overflow":this.hasOverflow}}captureKeydown(e){e.target===this&&!e.defaultPrevented&&Et(e.code)&&(e.preventDefault(),this.close()),this.typeaheadController.onKeydown(e)}async animateOpen(){let e=this.surfaceEl,t=this.slotEl;if(!e||!t)return!0;let r=this.openDirection;this.dispatchEvent(new Event("opening")),e.classList.toggle("animating",!0);let i=this.openCloseAnimationSignal.start(),s=e.offsetHeight,a=r==="UP",d=this.items,c=500,h=50,m=250,f=(c-m)/d.length,b=e.animate([{height:"0px"},{height:`${s}px`}],{duration:c,easing:re.EMPHASIZED}),g=t.animate([{transform:a?`translateY(-${s}px)`:""},{transform:""}],{duration:c,easing:re.EMPHASIZED}),S=e.animate([{opacity:0},{opacity:1}],h),w=[];for(let E=0;E<d.length;E++){let U=a?d.length-1-E:E,N=d[U],P=N.animate([{opacity:0},{opacity:1}],{duration:m,delay:f*E});N.classList.toggle("md-menu-hidden",!0),P.addEventListener("finish",()=>{N.classList.toggle("md-menu-hidden",!1)}),w.push([N,P])}let O=E=>{},z=new Promise(E=>{O=E});return i.addEventListener("abort",()=>{b.cancel(),g.cancel(),S.cancel(),w.forEach(([E,U])=>{E.classList.toggle("md-menu-hidden",!1),U.cancel()}),O(!0)}),b.addEventListener("finish",()=>{e.classList.toggle("animating",!1),this.openCloseAnimationSignal.finish(),O(!1)}),await z}animateClose(){let e,t=new Promise(P=>{e=P}),r=this.surfaceEl,i=this.slotEl;if(!r||!i)return e(!1),t;let a=this.openDirection==="UP";this.dispatchEvent(new Event("closing")),r.classList.toggle("animating",!0);let d=this.openCloseAnimationSignal.start(),c=r.offsetHeight,h=this.items,m=150,f=50,b=m-f,g=50,S=50,w=.35,O=(m-S-g)/h.length,z=r.animate([{height:`${c}px`},{height:`${c*w}px`}],{duration:m,easing:re.EMPHASIZED_ACCELERATE}),E=i.animate([{transform:""},{transform:a?`translateY(-${c*(1-w)}px)`:""}],{duration:m,easing:re.EMPHASIZED_ACCELERATE}),U=r.animate([{opacity:1},{opacity:0}],{duration:f,delay:b}),N=[];for(let P=0;P<h.length;P++){let ne=a?P:h.length-1-P,ae=h[ne],ge=ae.animate([{opacity:1},{opacity:0}],{duration:g,delay:S+O*P});ge.addEventListener("finish",()=>{ae.classList.toggle("md-menu-hidden",!0)}),N.push([ae,ge])}return d.addEventListener("abort",()=>{z.cancel(),E.cancel(),U.cancel(),N.forEach(([P,ne])=>{ne.cancel(),P.classList.toggle("md-menu-hidden",!1)}),e(!1)}),z.addEventListener("finish",()=>{r.classList.toggle("animating",!1),N.forEach(([P])=>{P.classList.toggle("md-menu-hidden",!1)}),this.openCloseAnimationSignal.finish(),this.dispatchEvent(new Event("closed")),e(!0)}),t}handleKeydown(e){this.pointerPath=[],this.listController.handleKeydown(e)}setUpGlobalEventListeners(){document.addEventListener("click",this.onDocumentClick,{capture:!0}),window.addEventListener("pointerdown",this.onWindowPointerdown),document.addEventListener("resize",this.onWindowResize,{passive:!0}),window.addEventListener("resize",this.onWindowResize,{passive:!0})}cleanUpGlobalEventListeners(){document.removeEventListener("click",this.onDocumentClick,{capture:!0}),window.removeEventListener("pointerdown",this.onWindowPointerdown),document.removeEventListener("resize",this.onWindowResize),window.removeEventListener("resize",this.onWindowResize)}onCloseMenu(){this.close()}onDeactivateItems(e){e.stopPropagation(),this.listController.onDeactivateItems()}onRequestActivation(e){e.stopPropagation(),this.listController.onRequestActivation(e)}handleDeactivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!1}handleActivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!0}handleStayOpenOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!0}handleCloseOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!1}close(){this.open=!1,this.slotItems.forEach(t=>{t.close?.()})}show(){this.open=!0}activateNextItem(){return this.listController.activateNextItem()??null}activatePreviousItem(){return this.listController.activatePreviousItem()??null}reposition(){this.open&&this.menuPositionController.position()}};n([k(".menu")],C.prototype,"surfaceEl",void 0);n([k("slot")],C.prototype,"slotEl",void 0);n([l()],C.prototype,"anchor",void 0);n([l()],C.prototype,"positioning",void 0);n([l({type:Boolean})],C.prototype,"quick",void 0);n([l({type:Boolean,attribute:"has-overflow"})],C.prototype,"hasOverflow",void 0);n([l({type:Boolean,reflect:!0})],C.prototype,"open",void 0);n([l({type:Number,attribute:"x-offset"})],C.prototype,"xOffset",void 0);n([l({type:Number,attribute:"y-offset"})],C.prototype,"yOffset",void 0);n([l({type:Boolean,attribute:"no-horizontal-flip"})],C.prototype,"noHorizontalFlip",void 0);n([l({type:Boolean,attribute:"no-vertical-flip"})],C.prototype,"noVerticalFlip",void 0);n([l({type:Number,attribute:"typeahead-delay"})],C.prototype,"typeaheadDelay",void 0);n([l({attribute:"anchor-corner"})],C.prototype,"anchorCorner",void 0);n([l({attribute:"menu-corner"})],C.prototype,"menuCorner",void 0);n([l({type:Boolean,attribute:"stay-open-on-outside-click"})],C.prototype,"stayOpenOnOutsideClick",void 0);n([l({type:Boolean,attribute:"stay-open-on-focusout"})],C.prototype,"stayOpenOnFocusout",void 0);n([l({type:Boolean,attribute:"skip-restore-focus"})],C.prototype,"skipRestoreFocus",void 0);n([l({attribute:"default-focus"})],C.prototype,"defaultFocus",void 0);n([l({type:Boolean,attribute:"no-navigation-wrap"})],C.prototype,"noNavigationWrap",void 0);n([q({flatten:!0})],C.prototype,"slotItems",void 0);n([I()],C.prototype,"typeaheadActive",void 0);var io=x`:host{--md-elevation-level: var(--md-menu-container-elevation, 2);--md-elevation-shadow-color: var(--md-menu-container-shadow-color, var(--md-sys-color-shadow, #000));min-width:112px;color:unset;display:contents}md-focus-ring{--md-focus-ring-shape: var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px))}.menu{border-radius:var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px));display:none;inset:auto;border:none;padding:0px;overflow:visible;background-color:rgba(0,0,0,0);color:inherit;opacity:0;z-index:20;position:absolute;user-select:none;max-height:inherit;height:inherit;min-width:inherit;max-width:inherit;scrollbar-width:inherit}.menu::backdrop{display:none}.fixed{position:fixed}.items{display:block;list-style-type:none;margin:0;outline:none;box-sizing:border-box;background-color:var(--md-menu-container-color, var(--md-sys-color-surface-container, #f3edf7));height:inherit;max-height:inherit;overflow:auto;min-width:inherit;max-width:inherit;border-radius:inherit;scrollbar-width:inherit}.item-padding{padding-block:var(--md-menu-top-space, 8px) var(--md-menu-bottom-space, 8px)}.has-overflow:not([popover]) .items{overflow:visible}.has-overflow.animating .items,.animating .items{overflow:hidden}.has-overflow.animating .items{pointer-events:none}.animating ::slotted(.md-menu-hidden){opacity:0}slot{display:block;height:inherit;max-height:inherit}::slotted(:is(md-divider,[role=separator])){margin:8px 0}@media(forced-colors: active){.menu{border-style:solid;border-color:CanvasText;border-width:1px}}
+`;var lr=class extends C{};lr.styles=[io];lr=n([T("md-menu")],lr);var Tt=class extends fe{computeValidity(e){return this.selectControl||(this.selectControl=document.createElement("select")),$e(p`<option value=${e.value}></option>`,this.selectControl),this.selectControl.value=e.value,this.selectControl.required=e.required,{validity:this.selectControl.validity,validationMessage:this.selectControl.validationMessage}}equals(e,t){return e.value===t.value&&e.required===t.required}copy({value:e,required:t}){return{value:e,required:t}}};function so(o){let e=[];for(let t=0;t<o.length;t++){let r=o[t];r.selected&&e.push([r,t])}return e}var no,$t=Symbol("value"),Qo=G(gt(ke(Oe(ue(y))))),_=class extends Qo{get value(){return this[$t]}set value(e){this.lastUserSetValue=e,this.select(e)}get options(){return this.menu?.items??[]}get selectedIndex(){let[e,t]=(this.getSelectedOptions()??[])[0]??[];return t??-1}set selectedIndex(e){this.lastUserSetSelectedIndex=e,this.selectIndex(e)}get selectedOptions(){return(this.getSelectedOptions()??[]).map(([e])=>e)}get hasError(){return this.error||this.nativeError}constructor(){super(),this.quick=!1,this.required=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.supportingText="",this.error=!1,this.menuPositioning="popover",this.clampMenuWidth=!1,this.typeaheadDelay=ar,this.hasLeadingIcon=!1,this.displayText="",this.menuAlign="start",this[no]="",this.lastUserSetValue=null,this.lastUserSetSelectedIndex=null,this.lastSelectedOption=null,this.lastSelectedOptionRecords=[],this.nativeError=!1,this.nativeErrorText="",this.focused=!1,this.open=!1,this.defaultFocus=j.NONE,this.prevOpen=this.open,this.selectWidth=0,!!1&&(this.addEventListener("focus",this.handleFocus.bind(this)),this.addEventListener("blur",this.handleBlur.bind(this)))}select(e){let t=this.options.find(r=>r.value===e);t&&this.selectItem(t)}selectIndex(e){let t=this.options[e];t&&this.selectItem(t)}reset(){for(let e of this.options)e.selected=e.hasAttribute("selected");this.updateValueAndDisplayText(),this.nativeError=!1,this.nativeErrorText=""}showPicker(){this.open=!0}[(no=$t,Re)](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}update(e){if(this.hasUpdated||this.initUserSelection(),this.prevOpen!==this.open&&this.open){let t=this.getBoundingClientRect();this.selectWidth=t.width}this.prevOpen=this.open,super.update(e)}render(){return p`
+      <span
+        class="select ${R(this.getRenderClasses())}"
+        @focusout=${this.handleFocusout}>
+        ${this.renderField()} ${this.renderMenu()}
+      </span>
+    `}async firstUpdated(e){await this.menu?.updateComplete,this.lastSelectedOptionRecords.length||this.initUserSelection(),!this.lastSelectedOptionRecords.length&&!!1&&!this.options.length&&setTimeout(()=>{this.updateValueAndDisplayText()}),super.firstUpdated(e)}getRenderClasses(){return{disabled:this.disabled,error:this.error,open:this.open}}renderField(){let e=this.ariaLabel||this.label;return ce`
+      <${this.fieldTag}
+          aria-haspopup="listbox"
+          role="combobox"
+          part="field"
+          id="field"
+          tabindex=${this.disabled?"-1":"0"}
+          aria-label=${e||u}
+          aria-describedby="description"
+          aria-expanded=${this.open?"true":"false"}
+          aria-controls="listbox"
+          class="field"
+          label=${this.label}
+          ?no-asterisk=${this.noAsterisk}
+          .focused=${this.focused||this.open}
+          .populated=${!!this.displayText}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          .error=${this.hasError}
+          ?has-start=${this.hasLeadingIcon}
+          has-end
+          supporting-text=${this.supportingText}
+          error-text=${this.getErrorText()}
+          @keydown=${this.handleKeydown}
+          @click=${this.handleClick}>
+         ${this.renderFieldContent()}
+         <div id="description" slot="aria-describedby"></div>
+      </${this.fieldTag}>`}renderFieldContent(){return[this.renderLeadingIcon(),this.renderLabel(),this.renderTrailingIcon()]}renderLeadingIcon(){return p`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return p`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}>
+          <svg height="5" viewBox="7 10 10 5" focusable="false">
+            <polygon
+              class="down"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 10 12 15 17 10"></polygon>
+            <polygon
+              class="up"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 15 12 10 17 15"></polygon>
+          </svg>
+        </slot>
+      </span>
+    `}renderLabel(){return p`<div id="label">${this.displayText||p`&nbsp;`}</div>`}renderMenu(){let e=this.label||this.ariaLabel;return p`<div class="menu-wrapper">
+      <md-menu
+        id="listbox"
+        .defaultFocus=${this.defaultFocus}
+        role="listbox"
+        tabindex="-1"
+        aria-label=${e||u}
+        stay-open-on-focusout
+        part="menu"
+        exportparts="focus-ring: menu-focus-ring"
+        anchor="field"
+        style=${Ee({"--__menu-min-width":`${this.selectWidth}px`,"--__menu-max-width":this.clampMenuWidth?`${this.selectWidth}px`:void 0})}
+        no-navigation-wrap
+        .open=${this.open}
+        .quick=${this.quick}
+        .positioning=${this.menuPositioning}
+        .typeaheadDelay=${this.typeaheadDelay}
+        .anchorCorner=${this.menuAlign==="start"?"end-start":"end-end"}
+        .menuCorner=${this.menuAlign==="start"?"start-start":"start-end"}
+        @opening=${this.handleOpening}
+        @opened=${this.redispatchEvent}
+        @closing=${this.redispatchEvent}
+        @closed=${this.handleClosed}
+        @close-menu=${this.handleCloseMenu}
+        @request-selection=${this.handleRequestSelection}
+        @request-deselection=${this.handleRequestDeselection}>
+        ${this.renderMenuContent()}
+      </md-menu>
+    </div>`}renderMenuContent(){return p`<slot></slot>`}handleKeydown(e){if(this.open||this.disabled||!this.menu)return;let t=this.menu.typeaheadController,r=e.code==="Space"||e.code==="ArrowDown"||e.code==="ArrowUp"||e.code==="End"||e.code==="Home"||e.code==="Enter";if(!t.isTypingAhead&&r){switch(e.preventDefault(),this.open=!0,e.code){case"Space":case"ArrowDown":case"Enter":this.defaultFocus=j.NONE;break;case"End":this.defaultFocus=j.LAST_ITEM;break;case"ArrowUp":case"Home":this.defaultFocus=j.FIRST_ITEM;break;default:break}return}if(e.key.length===1){t.onKeydown(e),e.preventDefault();let{lastActiveRecord:s}=t;if(!s)return;this.labelEl?.setAttribute?.("aria-live","polite"),this.selectItem(s[K.ITEM])&&this.dispatchInteractionEvents()}}handleClick(){this.open=!this.open}handleFocus(){this.focused=!0}handleBlur(){this.focused=!1}handleFocusout(e){e.relatedTarget&&Ge(e.relatedTarget,this)||(this.open=!1)}getSelectedOptions(){if(!this.menu)return this.lastSelectedOptionRecords=[],null;let e=this.menu.items;return this.lastSelectedOptionRecords=so(e),this.lastSelectedOptionRecords}async getUpdateComplete(){return await this.menu?.updateComplete,super.getUpdateComplete()}updateValueAndDisplayText(){let e=this.getSelectedOptions()??[],t=!1;if(e.length){let[r]=e[0];t=this.lastSelectedOption!==r,this.lastSelectedOption=r,this[$t]=r.value,this.displayText=r.displayText}else t=this.lastSelectedOption!==null,this.lastSelectedOption=null,this[$t]="",this.displayText="";return t}async handleOpening(e){if(this.labelEl?.removeAttribute?.("aria-live"),this.redispatchEvent(e),this.defaultFocus!==j.NONE)return;let t=this.menu.items,r=me(t)?.item,[i]=this.lastSelectedOptionRecords[0]??[null];r&&r!==i&&(r.tabIndex=-1),i=i??t[0],i&&(i.tabIndex=0,i.focus())}redispatchEvent(e){Ie(this,e)}handleClosed(e){this.open=!1,this.redispatchEvent(e)}handleCloseMenu(e){let t=e.detail.reason,r=e.detail.itemPath[0];this.open=!1;let i=!1;t.kind==="click-selection"?i=this.selectItem(r):t.kind==="keydown"&&ro(t.key)?i=this.selectItem(r):(r.tabIndex=-1,r.blur()),i&&this.dispatchInteractionEvents()}selectItem(e){return(this.getSelectedOptions()??[]).forEach(([r])=>{e!==r&&(r.selected=!1)}),e.selected=!0,this.updateValueAndDisplayText()}handleRequestSelection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)||this.selectItem(t)}handleRequestDeselection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)&&this.updateValueAndDisplayText()}initUserSelection(){this.lastUserSetValue&&!this.lastSelectedOptionRecords.length?this.select(this.lastUserSetValue):this.lastUserSetSelectedIndex!==null&&!this.lastSelectedOptionRecords.length?this.selectIndex(this.lastUserSetSelectedIndex):this.updateValueAndDisplayText()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0}dispatchInteractionEvents(){this.dispatchEvent(new Event("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0}))}getErrorText(){return this.error?this.errorText:this.nativeErrorText}[ie](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}click(){this.field?.click()}[pe](){return new Tt(()=>this)}[he](){return this.field}};_.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean})],_.prototype,"quick",void 0);n([l({type:Boolean})],_.prototype,"required",void 0);n([l({type:String,attribute:"error-text"})],_.prototype,"errorText",void 0);n([l()],_.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],_.prototype,"noAsterisk",void 0);n([l({type:String,attribute:"supporting-text"})],_.prototype,"supportingText",void 0);n([l({type:Boolean,reflect:!0})],_.prototype,"error",void 0);n([l({attribute:"menu-positioning"})],_.prototype,"menuPositioning",void 0);n([l({type:Boolean,attribute:"clamp-menu-width"})],_.prototype,"clampMenuWidth",void 0);n([l({type:Number,attribute:"typeahead-delay"})],_.prototype,"typeaheadDelay",void 0);n([l({type:Boolean,attribute:"has-leading-icon"})],_.prototype,"hasLeadingIcon",void 0);n([l({attribute:"display-text"})],_.prototype,"displayText",void 0);n([l({attribute:"menu-align"})],_.prototype,"menuAlign",void 0);n([l()],_.prototype,"value",null);n([l({type:Number,attribute:"selected-index"})],_.prototype,"selectedIndex",null);n([I()],_.prototype,"nativeError",void 0);n([I()],_.prototype,"nativeErrorText",void 0);n([I()],_.prototype,"focused",void 0);n([I()],_.prototype,"open",void 0);n([I()],_.prototype,"defaultFocus",void 0);n([k(".field")],_.prototype,"field",void 0);n([k("md-menu")],_.prototype,"menu",void 0);n([k("#label")],_.prototype,"labelEl",void 0);n([q({slot:"leading-icon",flatten:!0})],_.prototype,"leadingIcons",void 0);var St=class extends _{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};var ao=x`:host{--_text-field-disabled-input-text-color: var(--md-outlined-select-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-input-text-opacity: var(--md-outlined-select-text-field-disabled-input-text-opacity, 0.38);--_text-field-disabled-label-text-color: var(--md-outlined-select-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-label-text-opacity: var(--md-outlined-select-text-field-disabled-label-text-opacity, 0.38);--_text-field-disabled-leading-icon-color: var(--md-outlined-select-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-leading-icon-opacity: var(--md-outlined-select-text-field-disabled-leading-icon-opacity, 0.38);--_text-field-disabled-outline-color: var(--md-outlined-select-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-outline-opacity: var(--md-outlined-select-text-field-disabled-outline-opacity, 0.12);--_text-field-disabled-outline-width: var(--md-outlined-select-text-field-disabled-outline-width, 1px);--_text-field-disabled-supporting-text-color: var(--md-outlined-select-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-supporting-text-opacity: var(--md-outlined-select-text-field-disabled-supporting-text-opacity, 0.38);--_text-field-disabled-trailing-icon-color: var(--md-outlined-select-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-trailing-icon-opacity: var(--md-outlined-select-text-field-disabled-trailing-icon-opacity, 0.38);--_text-field-error-focus-input-text-color: var(--md-outlined-select-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-focus-label-text-color: var(--md-outlined-select-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-leading-icon-color: var(--md-outlined-select-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-focus-outline-color: var(--md-outlined-select-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-supporting-text-color: var(--md-outlined-select-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-trailing-icon-color: var(--md-outlined-select-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-input-text-color: var(--md-outlined-select-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-hover-label-text-color: var(--md-outlined-select-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-leading-icon-color: var(--md-outlined-select-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-hover-outline-color: var(--md-outlined-select-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-supporting-text-color: var(--md-outlined-select-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-trailing-icon-color: var(--md-outlined-select-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-input-text-color: var(--md-outlined-select-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-label-text-color: var(--md-outlined-select-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-leading-icon-color: var(--md-outlined-select-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-outline-color: var(--md-outlined-select-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-supporting-text-color: var(--md-outlined-select-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-trailing-icon-color: var(--md-outlined-select-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-focus-input-text-color: var(--md-outlined-select-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-focus-label-text-color: var(--md-outlined-select-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-leading-icon-color: var(--md-outlined-select-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-outline-color: var(--md-outlined-select-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-outline-width: var(--md-outlined-select-text-field-focus-outline-width, 3px);--_text-field-focus-supporting-text-color: var(--md-outlined-select-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-trailing-icon-color: var(--md-outlined-select-text-field-focus-trailing-icon-color, var(--md-sys-color-primary, #6750a4));--_text-field-hover-input-text-color: var(--md-outlined-select-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-label-text-color: var(--md-outlined-select-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-leading-icon-color: var(--md-outlined-select-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-outline-color: var(--md-outlined-select-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-outline-width: var(--md-outlined-select-text-field-hover-outline-width, 1px);--_text-field-hover-supporting-text-color: var(--md-outlined-select-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-trailing-icon-color: var(--md-outlined-select-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-input-text-color: var(--md-outlined-select-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-input-text-font: var(--md-outlined-select-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-input-text-line-height: var(--md-outlined-select-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-input-text-size: var(--md-outlined-select-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-input-text-weight: var(--md-outlined-select-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-label-text-color: var(--md-outlined-select-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-label-text-font: var(--md-outlined-select-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-label-text-line-height: var(--md-outlined-select-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-label-text-populated-line-height: var(--md-outlined-select-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-label-text-populated-size: var(--md-outlined-select-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-label-text-size: var(--md-outlined-select-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-label-text-weight: var(--md-outlined-select-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-leading-icon-color: var(--md-outlined-select-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-leading-icon-size: var(--md-outlined-select-text-field-leading-icon-size, 24px);--_text-field-outline-color: var(--md-outlined-select-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_text-field-outline-width: var(--md-outlined-select-text-field-outline-width, 1px);--_text-field-supporting-text-color: var(--md-outlined-select-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-supporting-text-font: var(--md-outlined-select-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-supporting-text-line-height: var(--md-outlined-select-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-supporting-text-size: var(--md-outlined-select-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-supporting-text-weight: var(--md-outlined-select-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-trailing-icon-color: var(--md-outlined-select-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-trailing-icon-size: var(--md-outlined-select-text-field-trailing-icon-size, 24px);--_text-field-container-shape-start-start: var(--md-outlined-select-text-field-container-shape-start-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-start-end: var(--md-outlined-select-text-field-container-shape-start-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-end: var(--md-outlined-select-text-field-container-shape-end-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-start: var(--md-outlined-select-text-field-container-shape-end-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--md-outlined-field-container-shape-end-end: var(--_text-field-container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_text-field-container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_text-field-container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_text-field-container-shape-start-start);--md-outlined-field-content-color: var(--_text-field-input-text-color);--md-outlined-field-content-font: var(--_text-field-input-text-font);--md-outlined-field-content-line-height: var(--_text-field-input-text-line-height);--md-outlined-field-content-size: var(--_text-field-input-text-size);--md-outlined-field-content-weight: var(--_text-field-input-text-weight);--md-outlined-field-disabled-content-color: var(--_text-field-disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_text-field-disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_text-field-disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_text-field-disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_text-field-disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_text-field-disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_text-field-disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_text-field-disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_text-field-disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_text-field-disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_text-field-disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_text-field-disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_text-field-disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_text-field-error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_text-field-error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_text-field-error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_text-field-error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_text-field-error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_text-field-error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_text-field-error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_text-field-error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_text-field-error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_text-field-error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_text-field-error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_text-field-error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_text-field-error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_text-field-error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_text-field-error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_text-field-error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_text-field-error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_text-field-error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_text-field-focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_text-field-focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_text-field-focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_text-field-focus-outline-color);--md-outlined-field-focus-outline-width: var(--_text-field-focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_text-field-focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_text-field-focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_text-field-hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_text-field-hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_text-field-hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_text-field-hover-outline-color);--md-outlined-field-hover-outline-width: var(--_text-field-hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_text-field-hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_text-field-hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_text-field-label-text-color);--md-outlined-field-label-text-font: var(--_text-field-label-text-font);--md-outlined-field-label-text-line-height: var(--_text-field-label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_text-field-label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_text-field-label-text-populated-size);--md-outlined-field-label-text-size: var(--_text-field-label-text-size);--md-outlined-field-label-text-weight: var(--_text-field-label-text-weight);--md-outlined-field-leading-content-color: var(--_text-field-leading-icon-color);--md-outlined-field-outline-color: var(--_text-field-outline-color);--md-outlined-field-outline-width: var(--_text-field-outline-width);--md-outlined-field-supporting-text-color: var(--_text-field-supporting-text-color);--md-outlined-field-supporting-text-font: var(--_text-field-supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_text-field-supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_text-field-supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_text-field-supporting-text-weight);--md-outlined-field-trailing-content-color: var(--_text-field-trailing-icon-color)}[has-start] .icon.leading{font-size:var(--_text-field-leading-icon-size);height:var(--_text-field-leading-icon-size);width:var(--_text-field-leading-icon-size)}.icon.trailing{font-size:var(--_text-field-trailing-icon-size);height:var(--_text-field-trailing-icon-size);width:var(--_text-field-trailing-icon-size)}
+`;var lo=x`:host{color:unset;min-width:210px;display:flex}.field{cursor:default;outline:none}.select{position:relative;flex-direction:column}.icon.trailing svg,.icon ::slotted(*){fill:currentColor}.icon ::slotted(*){width:inherit;height:inherit;font-size:inherit}.icon slot{display:flex;height:100%;width:100%;align-items:center;justify-content:center}.icon.trailing :is(.up,.down){opacity:0;transition:opacity 75ms linear 75ms}.select:not(.open) .down,.select.open .up{opacity:1}.field,.select,md-menu{min-width:inherit;width:inherit;max-width:inherit;display:flex}md-menu{min-width:var(--__menu-min-width);max-width:var(--__menu-max-width, inherit)}.menu-wrapper{width:0px;height:0px;max-width:inherit}md-menu ::slotted(:not[disabled]){cursor:pointer}.field,.select{width:100%}:host{display:inline-flex}:host([disabled]){pointer-events:none}
+`;var dr=class extends St{};dr.styles=[lo,ao];dr=n([T("md-outlined-select")],dr);var It=x`:host{display:flex;--md-ripple-hover-color: var(--md-menu-item-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-menu-item-hover-state-layer-opacity, 0.08);--md-ripple-pressed-color: var(--md-menu-item-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-opacity: var(--md-menu-item-pressed-state-layer-opacity, 0.12)}:host([disabled]){opacity:var(--md-menu-item-disabled-opacity, 0.3);pointer-events:none}md-focus-ring{z-index:1;--md-focus-ring-shape: 8px}a,button,li{background:none;border:none;padding:0;margin:0;text-align:unset;text-decoration:none}.list-item{border-radius:inherit;display:flex;flex:1;max-width:inherit;min-width:inherit;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}.list-item:not(.disabled){cursor:pointer}[slot=container]{pointer-events:none}md-ripple{border-radius:inherit}md-item{border-radius:inherit;flex:1;color:var(--md-menu-item-label-text-color, var(--md-sys-color-on-surface, #1d1b20));font-family:var(--md-menu-item-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));line-height:var(--md-menu-item-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));font-weight:var(--md-menu-item-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));min-height:var(--md-menu-item-one-line-container-height, 56px);padding-top:var(--md-menu-item-top-space, 12px);padding-bottom:var(--md-menu-item-bottom-space, 12px);padding-inline-start:var(--md-menu-item-leading-space, 16px);padding-inline-end:var(--md-menu-item-trailing-space, 16px)}md-item[multiline]{min-height:var(--md-menu-item-two-line-container-height, 72px)}[slot=supporting-text]{color:var(--md-menu-item-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-supporting-text-font, var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-supporting-text-size, var(--md-sys-typescale-body-medium-size, 0.875rem));line-height:var(--md-menu-item-supporting-text-line-height, var(--md-sys-typescale-body-medium-line-height, 1.25rem));font-weight:var(--md-menu-item-supporting-text-weight, var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400)))}[slot=trailing-supporting-text]{color:var(--md-menu-item-trailing-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-trailing-supporting-text-font, var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-trailing-supporting-text-size, var(--md-sys-typescale-label-small-size, 0.6875rem));line-height:var(--md-menu-item-trailing-supporting-text-line-height, var(--md-sys-typescale-label-small-line-height, 1rem));font-weight:var(--md-menu-item-trailing-supporting-text-weight, var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500)))}:is([slot=start],[slot=end])::slotted(*){fill:currentColor}[slot=start]{color:var(--md-menu-item-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}[slot=end]{color:var(--md-menu-item-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}.list-item{background-color:var(--md-menu-item-container-color, transparent)}.list-item.selected{background-color:var(--md-menu-item-selected-container-color, var(--md-sys-color-secondary-container, #e8def8))}.selected:not(.disabled) ::slotted(*){color:var(--md-menu-item-selected-label-text-color, var(--md-sys-color-on-secondary-container, #1d192b))}@media(forced-colors: active){:host([disabled]),:host([disabled]) slot{color:GrayText;opacity:1}.list-item{position:relative}.list-item.selected::before{content:"";position:absolute;inset:0;box-sizing:border-box;border-radius:inherit;pointer-events:none;border:3px double CanvasText}}
+`;var De=class extends y{constructor(){super(...arguments),this.multiline=!1}render(){return p`
+      <slot name="container"></slot>
+      <slot class="non-text" name="start"></slot>
+      <div class="text">
+        <slot name="overline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          class="default-slot"
+          @slotchange=${this.handleTextSlotChange}></slot>
+        <slot name="headline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          name="supporting-text"
+          @slotchange=${this.handleTextSlotChange}></slot>
+      </div>
+      <slot class="non-text" name="trailing-supporting-text"></slot>
+      <slot class="non-text" name="end"></slot>
+    `}handleTextSlotChange(){let e=!1,t=0;for(let r of this.textSlots)if(ei(r)&&(t+=1),t>1){e=!0;break}this.multiline=e}};n([l({type:Boolean,reflect:!0})],De.prototype,"multiline",void 0);n([Cr(".text slot")],De.prototype,"textSlots",void 0);function ei(o){for(let e of o.assignedNodes({flatten:!0})){let t=e.nodeType===Node.ELEMENT_NODE,r=e.nodeType===Node.TEXT_NODE&&e.textContent?.match(/\S/);if(t||r)return!0}return!1}var co=x`:host{color:var(--md-sys-color-on-surface, #1d1b20);font-family:var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-large-size, 1rem);font-weight:var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-large-line-height, 1.5rem);align-items:center;box-sizing:border-box;display:flex;gap:16px;min-height:56px;overflow:hidden;padding:12px 16px;position:relative;text-overflow:ellipsis}:host([multiline]){min-height:72px}[name=overline]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-medium-size, 0.875rem);font-weight:var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-medium-line-height, 1.25rem)}[name=trailing-supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=container]::slotted(*){inset:0;position:absolute}.default-slot{display:inline}.default-slot,.text ::slotted(*){overflow:hidden;text-overflow:ellipsis}.text{display:flex;flex:1;flex-direction:column;overflow:hidden}
+`;var cr=class extends De{};cr.styles=[co];cr=n([T("md-item")],cr);var ti=450,uo=225,ri=.2,oi=10,ii=75,si=.35,ni="::after",ai="forwards",V;(function(o){o[o.INACTIVE=0]="INACTIVE",o[o.TOUCH_DELAY=1]="TOUCH_DELAY",o[o.HOLDING=2]="HOLDING",o[o.WAITING_FOR_CLICK=3]="WAITING_FOR_CLICK"})(V||(V={}));var li=["click","contextmenu","pointercancel","pointerdown","pointerenter","pointerleave","pointerup"],di=150,ci=window.matchMedia("(forced-colors: active)"),ve=class extends y{constructor(){super(...arguments),this.disabled=!1,this.hovered=!1,this.pressed=!1,this.rippleSize="",this.rippleScale="",this.initialSize=0,this.state=V.INACTIVE,this.attachableController=new Pe(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){let e={hovered:this.hovered,pressed:this.pressed};return p`<div class="surface ${R(e)}"></div>`}update(e){e.has("disabled")&&this.disabled&&(this.hovered=!1,this.pressed=!1),super.update(e)}handlePointerenter(e){this.shouldReactToEvent(e)&&(this.hovered=!0)}handlePointerleave(e){this.shouldReactToEvent(e)&&(this.hovered=!1,this.state!==V.INACTIVE&&this.endPressAnimation())}handlePointerup(e){if(this.shouldReactToEvent(e)){if(this.state===V.HOLDING){this.state=V.WAITING_FOR_CLICK;return}if(this.state===V.TOUCH_DELAY){this.state=V.WAITING_FOR_CLICK,this.startPressAnimation(this.rippleStartEvent);return}}}async handlePointerdown(e){if(this.shouldReactToEvent(e)){if(this.rippleStartEvent=e,!this.isTouch(e)){this.state=V.WAITING_FOR_CLICK,this.startPressAnimation(e);return}this.state=V.TOUCH_DELAY,await new Promise(t=>{setTimeout(t,di)}),this.state===V.TOUCH_DELAY&&(this.state=V.HOLDING,this.startPressAnimation(e))}}handleClick(){if(!this.disabled){if(this.state===V.WAITING_FOR_CLICK){this.endPressAnimation();return}this.state===V.INACTIVE&&(this.startPressAnimation(),this.endPressAnimation())}}handlePointercancel(e){this.shouldReactToEvent(e)&&this.endPressAnimation()}handleContextmenu(){this.disabled||this.endPressAnimation()}determineRippleSize(){let{height:e,width:t}=this.getBoundingClientRect(),r=Math.max(e,t),i=Math.max(si*r,ii),s=this.currentCSSZoom??1,a=Math.floor(r*ri/s),c=Math.sqrt(t**2+e**2)+oi;this.initialSize=a;let h=(c+i)/a;this.rippleScale=`${h/s}`,this.rippleSize=`${a}px`}getNormalizedPointerEventCoords(e){let{scrollX:t,scrollY:r}=window,{left:i,top:s}=this.getBoundingClientRect(),a=t+i,d=r+s,{pageX:c,pageY:h}=e,m=this.currentCSSZoom??1;return{x:(c-a)/m,y:(h-d)/m}}getTranslationCoordinates(e){let{height:t,width:r}=this.getBoundingClientRect(),i=this.currentCSSZoom??1,s={x:(r/i-this.initialSize)/2,y:(t/i-this.initialSize)/2},a;return e instanceof PointerEvent?a=this.getNormalizedPointerEventCoords(e):a={x:r/i/2,y:t/i/2},a={x:a.x-this.initialSize/2,y:a.y-this.initialSize/2},{startPoint:a,endPoint:s}}startPressAnimation(e){if(!this.mdRoot)return;this.pressed=!0,this.growAnimation?.cancel(),this.determineRippleSize();let{startPoint:t,endPoint:r}=this.getTranslationCoordinates(e),i=`${t.x}px, ${t.y}px`,s=`${r.x}px, ${r.y}px`;this.growAnimation=this.mdRoot.animate({top:[0,0],left:[0,0],height:[this.rippleSize,this.rippleSize],width:[this.rippleSize,this.rippleSize],transform:[`translate(${i}) scale(1)`,`translate(${s}) scale(${this.rippleScale})`]},{pseudoElement:ni,duration:ti,easing:re.STANDARD,fill:ai})}async endPressAnimation(){this.rippleStartEvent=void 0,this.state=V.INACTIVE;let e=this.growAnimation,t=1/0;if(typeof e?.currentTime=="number"?t=e.currentTime:e?.currentTime&&(t=e.currentTime.to("ms").value),t>=uo){this.pressed=!1;return}await new Promise(r=>{setTimeout(r,uo-t)}),this.growAnimation===e&&(this.pressed=!1)}shouldReactToEvent(e){if(this.disabled||!e.isPrimary||this.rippleStartEvent&&this.rippleStartEvent.pointerId!==e.pointerId)return!1;if(e.type==="pointerenter"||e.type==="pointerleave")return!this.isTouch(e);let t=e.buttons===1;return this.isTouch(e)||t}isTouch({pointerType:e}){return e==="touch"}async handleEvent(e){if(!ci?.matches)switch(e.type){case"click":this.handleClick();break;case"contextmenu":this.handleContextmenu();break;case"pointercancel":this.handlePointercancel(e);break;case"pointerdown":await this.handlePointerdown(e);break;case"pointerenter":this.handlePointerenter(e);break;case"pointerleave":this.handlePointerleave(e);break;case"pointerup":this.handlePointerup(e);break;default:break}}onControlChange(e,t){if(!!1)for(let r of li)e?.removeEventListener(r,this),t?.addEventListener(r,this)}};n([l({type:Boolean,reflect:!0})],ve.prototype,"disabled",void 0);n([I()],ve.prototype,"hovered",void 0);n([I()],ve.prototype,"pressed",void 0);n([k(".surface")],ve.prototype,"mdRoot",void 0);var po=x`:host{display:flex;margin:auto;pointer-events:none}:host([disabled]){display:none}@media(forced-colors: active){:host{display:none}}:host,.surface{border-radius:inherit;position:absolute;inset:0;overflow:hidden}.surface{-webkit-tap-highlight-color:rgba(0,0,0,0)}.surface::before,.surface::after{content:"";opacity:0;position:absolute}.surface::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));inset:0;transition:opacity 15ms linear,background-color 15ms linear}.surface::after{background:radial-gradient(closest-side, var(--md-ripple-pressed-color, var(--md-sys-color-on-surface, #1d1b20)) max(100% - 70px, 65%), transparent 100%);transform-origin:center center;transition:opacity 375ms linear}.hovered::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-ripple-hover-opacity, 0.08)}.pressed::after{opacity:var(--md-ripple-pressed-opacity, 0.12);transition-duration:105ms}
+`;var ur=class extends ve{};ur.styles=[po];ur=n([T("md-ripple")],ur);var ze=class{constructor(e,t){this.host=e,this.internalTypeaheadText=null,this.onClick=()=>{this.host.keepOpen||this.host.dispatchEvent(nr(this.host,{kind:wt.CLICK_SELECTION}))},this.onKeydown=r=>{if(this.host.href&&r.code==="Enter"){let s=this.getInteractiveElement();s instanceof HTMLAnchorElement&&s.click()}if(r.defaultPrevented)return;let i=r.code;this.host.keepOpen&&i!=="Escape"||Et(i)&&(r.preventDefault(),this.host.dispatchEvent(nr(this.host,{kind:wt.KEYDOWN,key:i})))},this.getHeadlineElements=t.getHeadlineElements,this.getSupportingTextElements=t.getSupportingTextElements,this.getDefaultElements=t.getDefaultElements,this.getInteractiveElement=t.getInteractiveElement,this.host.addController(this)}get typeaheadText(){if(this.internalTypeaheadText!==null)return this.internalTypeaheadText;let e=this.getHeadlineElements(),t=[];return e.forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getDefaultElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getSupportingTextElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.join(" ")}get tagName(){switch(this.host.type){case"link":return"a";case"button":return"button";default:case"menuitem":case"option":return"li"}}get role(){return this.host.type==="option"?"option":"menuitem"}hostConnected(){this.host.toggleAttribute("md-menu-item",!0)}hostUpdate(){this.host.href&&(this.host.type="link")}setTypeaheadText(e){this.internalTypeaheadText=e}};function ui(){return new Event("request-selection",{bubbles:!0,composed:!0})}function pi(){return new Event("request-deselection",{bubbles:!0,composed:!0})}var kt=class{get role(){return this.menuItemController.role}get typeaheadText(){return this.menuItemController.typeaheadText}setTypeaheadText(e){this.menuItemController.setTypeaheadText(e)}get displayText(){return this.internalDisplayText!==null?this.internalDisplayText:this.menuItemController.typeaheadText}setDisplayText(e){this.internalDisplayText=e}constructor(e,t){this.host=e,this.internalDisplayText=null,this.firstUpdate=!0,this.onClick=()=>{this.menuItemController.onClick()},this.onKeydown=r=>{this.menuItemController.onKeydown(r)},this.lastSelected=this.host.selected,this.menuItemController=new ze(e,t),e.addController(this)}hostUpdate(){this.lastSelected!==this.host.selected&&(this.host.ariaSelected=this.host.selected?"true":"false")}hostUpdated(){this.lastSelected!==this.host.selected&&!this.firstUpdate&&(this.host.selected?this.host.dispatchEvent(ui()):this.host.dispatchEvent(pi())),this.lastSelected=this.host.selected,this.firstUpdate=!1}};var hi=G(y),H=class extends hi{constructor(){super(...arguments),this.disabled=!1,this.isMenuItem=!0,this.selected=!1,this.value="",this.type="option",this.selectOptionController=new kt(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.selectOptionController.typeaheadText}set typeaheadText(e){this.selectOptionController.setTypeaheadText(e)}get displayText(){return this.selectOptionController.displayText}set displayText(e){this.selectOptionController.setDisplayText(e)}render(){return this.renderListItem(p`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){return p`
+      <li
+        id="item"
+        tabindex=${this.disabled?-1:0}
+        role=${this.selectOptionController.role}
+        aria-label=${this.ariaLabel||u}
+        aria-selected=${this.ariaSelected||u}
+        aria-checked=${this.ariaChecked||u}
+        aria-expanded=${this.ariaExpanded||u}
+        aria-haspopup=${this.ariaHasPopup||u}
+        class="list-item ${R(this.getRenderClasses())}"
+        @click=${this.selectOptionController.onClick}
+        @keydown=${this.selectOptionController.onKeydown}
+        >${e}</li
+      >
+    `}renderRipple(){return p` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return p` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return p`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};H.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],H.prototype,"disabled",void 0);n([l({type:Boolean,attribute:"md-menu-item",reflect:!0})],H.prototype,"isMenuItem",void 0);n([l({type:Boolean})],H.prototype,"selected",void 0);n([l()],H.prototype,"value",void 0);n([k(".list-item")],H.prototype,"listItemRoot",void 0);n([q({slot:"headline"})],H.prototype,"headlineElements",void 0);n([q({slot:"supporting-text"})],H.prototype,"supportingTextElements",void 0);n([tt({slot:""})],H.prototype,"defaultElements",void 0);n([l({attribute:"typeahead-text"})],H.prototype,"typeaheadText",null);n([l({attribute:"display-text"})],H.prototype,"displayText",null);var pr=class extends H{};pr.styles=[It];pr=n([T("md-select-option")],pr);var fi=G(y),F=class extends fi{constructor(){super(...arguments),this.disabled=!1,this.type="menuitem",this.href="",this.target="",this.keepOpen=!1,this.selected=!1,this.menuItemController=new ze(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.menuItemController.typeaheadText}set typeaheadText(e){this.menuItemController.setTypeaheadText(e)}render(){return this.renderListItem(p`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){let t=this.type==="link",r;switch(this.menuItemController.tagName){case"a":r=W`a`;break;case"button":r=W`button`;break;default:case"li":r=W`li`;break}let i=t&&this.target?this.target:u;return ce`
+      <${r}
+        id="item"
+        tabindex=${this.disabled&&!t?-1:0}
+        role=${this.menuItemController.role}
+        aria-label=${this.ariaLabel||u}
+        aria-selected=${this.ariaSelected||u}
+        aria-checked=${this.ariaChecked||u}
+        aria-expanded=${this.ariaExpanded||u}
+        aria-haspopup=${this.ariaHasPopup||u}
+        class="list-item ${R(this.getRenderClasses())}"
+        href=${this.href||u}
+        target=${i}
+        @click=${this.menuItemController.onClick}
+        @keydown=${this.menuItemController.onKeydown}
+      >${e}</${r}>
+    `}renderRipple(){return p` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return p` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return p`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};F.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],F.prototype,"disabled",void 0);n([l()],F.prototype,"type",void 0);n([l()],F.prototype,"href",void 0);n([l()],F.prototype,"target",void 0);n([l({type:Boolean,attribute:"keep-open"})],F.prototype,"keepOpen",void 0);n([l({type:Boolean})],F.prototype,"selected",void 0);n([k(".list-item")],F.prototype,"listItemRoot",void 0);n([q({slot:"headline"})],F.prototype,"headlineElements",void 0);n([q({slot:"supporting-text"})],F.prototype,"supportingTextElements",void 0);n([tt({slot:""})],F.prototype,"defaultElements",void 0);n([l({attribute:"typeahead-text"})],F.prototype,"typeaheadText",null);var hr=class extends F{};hr.styles=[It];hr=n([T("md-menu-item")],hr);function ho(o){o.addInitializer(e=>{let t=e;t.addEventListener("click",async r=>{let{type:i,[L]:s}=t,{form:a}=s;if(!(!a||i==="button")&&(await new Promise(d=>{setTimeout(d)}),!r.defaultPrevented)){if(i==="reset"){a.reset();return}a.addEventListener("submit",d=>{Object.defineProperty(d,"submitter",{configurable:!0,enumerable:!0,get:()=>t})},{capture:!0,once:!0}),s.setFormValue(t.value),a.requestSubmit()}})})}function fr(o,e=!0){return e&&getComputedStyle(o).getPropertyValue("direction").trim()==="rtl"}var mi=G(ue(y)),D=class extends mi{get name(){return this.getAttribute("name")??""}set name(e){this.setAttribute("name",e)}get form(){return this[L].form}get labels(){return this[L].labels}constructor(){super(),this.disabled=!1,this.softDisabled=!1,this.flipIconInRtl=!1,this.href="",this.download="",this.target="",this.ariaLabelSelected="",this.toggle=!1,this.selected=!1,this.type="submit",this.value="",this.flipIcon=fr(this,this.flipIconInRtl),this.addEventListener("click",this.handleClick.bind(this))}willUpdate(){this.href&&(this.disabled=!1,this.softDisabled=!1)}render(){let e=this.href?W`div`:W`button`,{ariaLabel:t,ariaHasPopup:r,ariaExpanded:i}=this,s=t&&this.ariaLabelSelected,a=this.toggle?this.selected:u,d=u;return this.href||(d=s&&this.selected?this.ariaLabelSelected:t),ce`<${e}
+        class="icon-button ${R(this.getRenderClasses())}"
+        id="button"
+        aria-label="${d||u}"
+        aria-haspopup="${!this.href&&r||u}"
+        aria-expanded="${!this.href&&i||u}"
+        aria-pressed="${a}"
+        aria-disabled=${!this.href&&this.softDisabled||u}
+        ?disabled="${!this.href&&this.disabled}"
+        @click="${this.handleClickOnChild}">
+        ${this.renderFocusRing()}
+        ${this.renderRipple()}
+        ${this.selected?u:this.renderIcon()}
+        ${this.selected?this.renderSelectedIcon():u}
+        ${this.href?this.renderLink():this.renderTouchTarget()}
+  </${e}>`}renderLink(){let{ariaLabel:e}=this;return p`
+      <a
+        class="link"
+        id="link"
+        href="${this.href}"
+        download="${this.download||u}"
+        target="${this.target||u}"
+        aria-label="${e||u}">
+        ${this.renderTouchTarget()}
+      </a>
+    `}getRenderClasses(){return{"flip-icon":this.flipIcon,selected:this.toggle&&this.selected}}renderIcon(){return p`<span class="icon"><slot></slot></span>`}renderSelectedIcon(){return p`<span class="icon icon--selected"
+      ><slot name="selected"><slot></slot></slot
+    ></span>`}renderTouchTarget(){return p`<span class="touch"></span>`}renderFocusRing(){return p`<md-focus-ring
+      part="focus-ring"
+      for=${this.href?"link":"button"}></md-focus-ring>`}renderRipple(){let e=!this.href&&(this.disabled||this.softDisabled);return p`<md-ripple
+      for=${this.href?"link":u}
+      ?disabled="${e}"></md-ripple>`}connectedCallback(){this.flipIcon=fr(this,this.flipIconInRtl),super.connectedCallback()}handleClick(e){if(!this.href&&this.softDisabled){e.stopImmediatePropagation(),e.preventDefault();return}}async handleClickOnChild(e){await 0,!(!this.toggle||this.disabled||this.softDisabled||e.defaultPrevented)&&(this.selected=!this.selected,this.dispatchEvent(new InputEvent("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0})))}};ho(D);D.formAssociated=!0;D.shadowRootOptions={mode:"open",delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],D.prototype,"disabled",void 0);n([l({type:Boolean,attribute:"soft-disabled",reflect:!0})],D.prototype,"softDisabled",void 0);n([l({type:Boolean,attribute:"flip-icon-in-rtl"})],D.prototype,"flipIconInRtl",void 0);n([l()],D.prototype,"href",void 0);n([l()],D.prototype,"download",void 0);n([l()],D.prototype,"target",void 0);n([l({attribute:"aria-label-selected"})],D.prototype,"ariaLabelSelected",void 0);n([l({type:Boolean})],D.prototype,"toggle",void 0);n([l({type:Boolean,reflect:!0})],D.prototype,"selected",void 0);n([l()],D.prototype,"type",void 0);n([l({reflect:!0})],D.prototype,"value",void 0);n([I()],D.prototype,"flipIcon",void 0);var fo=x`:host{display:inline-flex;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0);height:var(--_container-height);width:var(--_container-width);justify-content:center}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_container-height))/2) max(0px,(48px - var(--_container-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_container-shape-start-start);--md-focus-ring-shape-start-end: var(--_container-shape-start-end);--md-focus-ring-shape-end-end: var(--_container-shape-end-end);--md-focus-ring-shape-end-start: var(--_container-shape-end-start)}:host(:is([disabled],[soft-disabled])){pointer-events:none}.icon-button{place-items:center;background:none;border:none;box-sizing:border-box;cursor:pointer;display:flex;place-content:center;outline:none;padding:0;position:relative;text-decoration:none;user-select:none;z-index:0;flex:1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.icon ::slotted(*){font-size:var(--_icon-size);height:var(--_icon-size);width:var(--_icon-size);font-weight:inherit}md-ripple{z-index:-1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.flip-icon .icon{transform:scaleX(-1)}.icon{display:inline-flex}.link{display:grid;height:100%;outline:none;place-items:center;position:absolute;width:100%}.touch{position:absolute;height:max(48px,100%);width:max(48px,100%)}:host([touch-target=none]) .touch{display:none}@media(forced-colors: active){:host(:is([disabled],[soft-disabled])){--_disabled-icon-color: GrayText;--_disabled-icon-opacity: 1}}
+`;var mo=x`:host{--_disabled-icon-color: var(--md-icon-button-disabled-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-icon-opacity: var(--md-icon-button-disabled-icon-opacity, 0.38);--_icon-size: var(--md-icon-button-icon-size, 24px);--_selected-focus-icon-color: var(--md-icon-button-selected-focus-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-icon-color: var(--md-icon-button-selected-hover-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-color: var(--md-icon-button-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-opacity: var(--md-icon-button-selected-hover-state-layer-opacity, 0.08);--_selected-icon-color: var(--md-icon-button-selected-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-icon-color: var(--md-icon-button-selected-pressed-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-color: var(--md-icon-button-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-opacity: var(--md-icon-button-selected-pressed-state-layer-opacity, 0.12);--_state-layer-height: var(--md-icon-button-state-layer-height, 40px);--_state-layer-shape: var(--md-icon-button-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));--_state-layer-width: var(--md-icon-button-state-layer-width, 40px);--_focus-icon-color: var(--md-icon-button-focus-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-icon-color: var(--md-icon-button-hover-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-color: var(--md-icon-button-hover-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-opacity: var(--md-icon-button-hover-state-layer-opacity, 0.08);--_icon-color: var(--md-icon-button-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-icon-color: var(--md-icon-button-pressed-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-color: var(--md-icon-button-pressed-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-opacity: var(--md-icon-button-pressed-state-layer-opacity, 0.12);--_container-shape-start-start: 0;--_container-shape-start-end: 0;--_container-shape-end-end: 0;--_container-shape-end-start: 0;--_container-height: 0;--_container-width: 0;height:var(--_state-layer-height);width:var(--_state-layer-width)}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_state-layer-height))/2) max(0px,(48px - var(--_state-layer-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_state-layer-shape);--md-focus-ring-shape-start-end: var(--_state-layer-shape);--md-focus-ring-shape-end-end: var(--_state-layer-shape);--md-focus-ring-shape-end-start: var(--_state-layer-shape)}.standard{background-color:rgba(0,0,0,0);color:var(--_icon-color);--md-ripple-hover-color: var(--_hover-state-layer-color);--md-ripple-hover-opacity: var(--_hover-state-layer-opacity);--md-ripple-pressed-color: var(--_pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_pressed-state-layer-opacity)}.standard:hover{color:var(--_hover-icon-color)}.standard:focus{color:var(--_focus-icon-color)}.standard:active{color:var(--_pressed-icon-color)}.standard:is(:disabled,[aria-disabled=true]){color:var(--_disabled-icon-color)}md-ripple{border-radius:var(--_state-layer-shape)}.standard:is(:disabled,[aria-disabled=true]){opacity:var(--_disabled-icon-opacity)}.selected:not(:disabled,[aria-disabled=true]){color:var(--_selected-icon-color)}.selected:not(:disabled,[aria-disabled=true]):hover{color:var(--_selected-hover-icon-color)}.selected:not(:disabled,[aria-disabled=true]):focus{color:var(--_selected-focus-icon-color)}.selected:not(:disabled,[aria-disabled=true]):active{color:var(--_selected-pressed-icon-color)}.selected{--md-ripple-hover-color: var(--_selected-hover-state-layer-color);--md-ripple-hover-opacity: var(--_selected-hover-state-layer-opacity);--md-ripple-pressed-color: var(--_selected-pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_selected-pressed-state-layer-opacity)}
+`;var mr=class extends D{getRenderClasses(){return{...super.getRenderClasses(),standard:!0}}};mr.styles=[fo,mo];mr=n([T("md-icon-button")],mr);var go=Symbol("dispatchHooks");function yo(o,e){let t=o[go];if(!t)throw new Error(`'${o.type}' event needs setupDispatchHooks().`);t.addEventListener("after",e)}var vo=new WeakMap;function bo(o,...e){let t=vo.get(o);t||(t=new Set,vo.set(o,t));for(let r of e){if(t.has(r))continue;let i=!1;o.addEventListener(r,s=>{if(i)return;s.stopImmediatePropagation();let a=Reflect.construct(s.constructor,[s.type,s]),d=new EventTarget;a[go]=d,i=!0;let c=o.dispatchEvent(a);i=!1,c||s.preventDefault(),d.dispatchEvent(new Event("after"))},{capture:!0}),t.add(r)}}function xo(o){let e=new MouseEvent("click",{bubbles:!0});return o.dispatchEvent(e),e}function _o(o){return o.currentTarget!==o.target||o.composedPath()[0]!==o.target||o.target.disabled?!1:!vi(o)}function vi(o){let e=vr;return e&&(o.preventDefault(),o.stopImmediatePropagation()),gi(),e}var vr=!1;async function gi(){vr=!0,await null,vr=!1}var Ot=class extends fe{computeValidity(e){return this.checkboxControl||(this.checkboxControl=document.createElement("input"),this.checkboxControl.type="checkbox"),this.checkboxControl.checked=e.checked,this.checkboxControl.required=e.required,{validity:this.checkboxControl.validity,validationMessage:this.checkboxControl.validationMessage}}equals(e,t){return e.checked===t.checked&&e.required===t.required}copy({checked:e,required:t}){return{checked:e,required:t}}};var yi=G(ke(Oe(ue(y)))),X=class extends yi{constructor(){super(),this.selected=!1,this.icons=!1,this.showOnlySelectedIcon=!1,this.required=!1,this.value="on",!!1&&(this.addEventListener("click",e=>{!_o(e)||!this.input||(this.focus(),xo(this.input))}),bo(this,"keydown"),this.addEventListener("keydown",e=>{yo(e,()=>{e.defaultPrevented||e.key!=="Enter"||this.disabled||!this.input||this.input.click()})}))}render(){return p`
+      <div class="switch ${R(this.getRenderClasses())}">
+        <input
+          id="switch"
+          class="touch"
+          type="checkbox"
+          role="switch"
+          aria-label=${this.ariaLabel||u}
+          ?checked=${this.selected}
+          ?disabled=${this.disabled}
+          ?required=${this.required}
+          @input=${this.handleInput}
+          @change=${this.handleChange} />
 
-    function toggleAutocrlfOptions() {
-      const enabled = document.getElementById("enableAutocrlf").checked;
-      const options = document.querySelectorAll("#autocrlfOptions input[type='radio']");
-      options.forEach(opt => {
-        opt.disabled = !enabled;
+        <md-focus-ring part="focus-ring" for="switch"></md-focus-ring>
+        <span class="track"> ${this.renderHandle()} </span>
+      </div>
+    `}getRenderClasses(){return{selected:this.selected,unselected:!this.selected,disabled:this.disabled}}renderHandle(){let e={"with-icon":this.showOnlySelectedIcon?this.selected:this.icons};return p`
+      ${this.renderTouchTarget()}
+      <span class="handle-container">
+        <md-ripple for="switch" ?disabled="${this.disabled}"></md-ripple>
+        <span class="handle ${R(e)}">
+          ${this.shouldShowIcons()?this.renderIcons():p``}
+        </span>
+      </span>
+    `}renderIcons(){return p`
+      <div class="icons">
+        ${this.renderOnIcon()}
+        ${this.showOnlySelectedIcon?p``:this.renderOffIcon()}
+      </div>
+    `}renderOnIcon(){return p`
+      <slot class="icon icon--on" name="on-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M9.55 18.2 3.65 12.3 5.275 10.675 9.55 14.95 18.725 5.775 20.35 7.4Z" />
+        </svg>
+      </slot>
+    `}renderOffIcon(){return p`
+      <slot class="icon icon--off" name="off-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M6.4 19.2 4.8 17.6 10.4 12 4.8 6.4 6.4 4.8 12 10.4 17.6 4.8 19.2 6.4 13.6 12 19.2 17.6 17.6 19.2 12 13.6Z" />
+        </svg>
+      </slot>
+    `}renderTouchTarget(){return p`<span class="touch"></span>`}shouldShowIcons(){return this.icons||this.showOnlySelectedIcon}handleInput(e){let t=e.target;this.selected=t.checked}handleChange(e){Ie(this,e)}[ie](){return this.selected?this.value:null}[pt](){return String(this.selected)}formResetCallback(){this.selected=this.hasAttribute("selected")}formStateRestoreCallback(e){this.selected=e==="true"}[pe](){return new Ot(()=>({checked:this.selected,required:this.required}))}[he](){return this.input}};X.shadowRootOptions={mode:"open",delegatesFocus:!0};n([l({type:Boolean})],X.prototype,"selected",void 0);n([l({type:Boolean})],X.prototype,"icons",void 0);n([l({type:Boolean,attribute:"show-only-selected-icon"})],X.prototype,"showOnlySelectedIcon",void 0);n([l({type:Boolean})],X.prototype,"required",void 0);n([l()],X.prototype,"value",void 0);n([k("input")],X.prototype,"input",void 0);var wo=x`@layer styles, hcm;@layer styles{:host{display:inline-flex;outline:none;vertical-align:top;-webkit-tap-highlight-color:rgba(0,0,0,0);cursor:pointer}:host([disabled]){cursor:default}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--md-switch-track-height, 32px))/2) 0px}md-focus-ring{--md-focus-ring-shape-start-start: var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-start-end: var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-end: var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-start: var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}.switch{align-items:center;display:inline-flex;flex-shrink:0;position:relative;width:var(--md-switch-track-width, 52px);height:var(--md-switch-track-height, 32px);border-start-start-radius:var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}input{appearance:none;height:max(100%,var(--md-switch-touch-target-size, 48px));outline:none;margin:0;position:absolute;width:max(100%,var(--md-switch-touch-target-size, 48px));z-index:1;cursor:inherit;top:50%;left:50%;transform:translate(-50%, -50%)}:host([touch-target=none]) input{display:none}}@layer styles{.track{position:absolute;width:100%;height:100%;box-sizing:border-box;border-radius:inherit;display:flex;justify-content:center;align-items:center}.track::before{content:"";display:flex;position:absolute;height:100%;width:100%;border-radius:inherit;box-sizing:border-box;transition-property:opacity,background-color;transition-timing-function:linear;transition-duration:67ms}.disabled .track{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0)}.disabled .track::before,.disabled .track::after{transition:none;opacity:var(--md-switch-disabled-track-opacity, 0.12)}.disabled .track::before{background-clip:content-box}.selected .track::before{background-color:var(--md-switch-selected-track-color, var(--md-sys-color-primary, #6750a4))}.selected:hover .track::before{background-color:var(--md-switch-selected-hover-track-color, var(--md-sys-color-primary, #6750a4))}.selected:focus-within .track::before{background-color:var(--md-switch-selected-focus-track-color, var(--md-sys-color-primary, #6750a4))}.selected:active .track::before{background-color:var(--md-switch-selected-pressed-track-color, var(--md-sys-color-primary, #6750a4))}.selected.disabled .track{background-clip:border-box}.selected.disabled .track::before{background-color:var(--md-switch-disabled-selected-track-color, var(--md-sys-color-on-surface, #1d1b20))}.unselected .track::before{background-color:var(--md-switch-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-track-outline-color, var(--md-sys-color-outline, #79747e));border-style:solid;border-width:var(--md-switch-track-outline-width, 2px)}.unselected:hover .track::before{background-color:var(--md-switch-hover-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-hover-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:focus-visible .track::before{background-color:var(--md-switch-focus-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-focus-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:active .track::before{background-color:var(--md-switch-pressed-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-pressed-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected.disabled .track::before{background-color:var(--md-switch-disabled-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-disabled-track-outline-color, var(--md-sys-color-on-surface, #1d1b20))}}@layer hcm{@media(forced-colors: active){.selected .track::before{background:ButtonText;border-color:ButtonText}.disabled .track::before{border-color:GrayText;opacity:1}.disabled.selected .track::before{background:GrayText}}}@layer styles{.handle-container{display:flex;place-content:center;place-items:center;position:relative;transition:margin 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275)}.selected .handle-container{margin-inline-start:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.unselected .handle-container{margin-inline-end:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.disabled .handle-container{transition:none}.handle{border-start-start-radius:var(--md-switch-handle-shape-start-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-handle-shape-start-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-handle-shape-end-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-handle-shape-end-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));height:var(--md-switch-handle-height, 16px);width:var(--md-switch-handle-width, 16px);transform-origin:center;transition-property:height,width;transition-duration:250ms,250ms;transition-timing-function:cubic-bezier(0.2, 0, 0, 1),cubic-bezier(0.2, 0, 0, 1);z-index:0}.handle::before{content:"";display:flex;inset:0;position:absolute;border-radius:inherit;box-sizing:border-box;transition:background-color 67ms linear}.disabled .handle,.disabled .handle::before{transition:none}.selected .handle{height:var(--md-switch-selected-handle-height, 24px);width:var(--md-switch-selected-handle-width, 24px)}.handle.with-icon{height:var(--md-switch-with-icon-handle-height, 24px);width:var(--md-switch-with-icon-handle-width, 24px)}.selected:not(.disabled):active .handle,.unselected:not(.disabled):active .handle{height:var(--md-switch-pressed-handle-height, 28px);width:var(--md-switch-pressed-handle-width, 28px);transition-timing-function:linear;transition-duration:100ms}.selected .handle::before{background-color:var(--md-switch-selected-handle-color, var(--md-sys-color-on-primary, #fff))}.selected:hover .handle::before{background-color:var(--md-switch-selected-hover-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:focus-within .handle::before{background-color:var(--md-switch-selected-focus-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:active .handle::before{background-color:var(--md-switch-selected-pressed-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected.disabled .handle::before{background-color:var(--md-switch-disabled-selected-handle-color, var(--md-sys-color-surface, #fef7ff));opacity:var(--md-switch-disabled-selected-handle-opacity, 1)}.unselected .handle::before{background-color:var(--md-switch-handle-color, var(--md-sys-color-outline, #79747e))}.unselected:hover .handle::before{background-color:var(--md-switch-hover-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:focus-within .handle::before{background-color:var(--md-switch-focus-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:active .handle::before{background-color:var(--md-switch-pressed-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected.disabled .handle::before{background-color:var(--md-switch-disabled-handle-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-handle-opacity, 0.38)}md-ripple{border-radius:var(--md-switch-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));height:var(--md-switch-state-layer-size, 40px);inset:unset;width:var(--md-switch-state-layer-size, 40px)}.selected md-ripple{--md-ripple-hover-color: var(--md-switch-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-pressed-color: var(--md-switch-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-hover-opacity: var(--md-switch-selected-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-selected-pressed-state-layer-opacity, 0.12)}.unselected md-ripple{--md-ripple-hover-color: var(--md-switch-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-color: var(--md-switch-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-switch-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-pressed-state-layer-opacity, 0.12)}}@layer hcm{@media(forced-colors: active){.unselected .handle::before{background:ButtonText}.disabled .handle::before{opacity:1}.disabled.unselected .handle::before{background:GrayText}}}@layer styles{.icons{position:relative;height:100%;width:100%}.icon{position:absolute;inset:0;margin:auto;display:flex;align-items:center;justify-content:center;fill:currentColor;transition:fill 67ms linear,opacity 33ms linear,transform 167ms cubic-bezier(0.2, 0, 0, 1);opacity:0}.disabled .icon{transition:none}.selected .icon--on,.unselected .icon--off{opacity:1}.unselected .handle:not(.with-icon) .icon--on{transform:rotate(-45deg)}.icon--off{width:var(--md-switch-icon-size, 16px);height:var(--md-switch-icon-size, 16px);color:var(--md-switch-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:hover .icon--off{color:var(--md-switch-hover-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:focus-within .icon--off{color:var(--md-switch-focus-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:active .icon--off{color:var(--md-switch-pressed-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected.disabled .icon--off{color:var(--md-switch-disabled-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9));opacity:var(--md-switch-disabled-icon-opacity, 0.38)}.icon--on{width:var(--md-switch-selected-icon-size, 16px);height:var(--md-switch-selected-icon-size, 16px);color:var(--md-switch-selected-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:hover .icon--on{color:var(--md-switch-selected-hover-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:focus-within .icon--on{color:var(--md-switch-selected-focus-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:active .icon--on{color:var(--md-switch-selected-pressed-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected.disabled .icon--on{color:var(--md-switch-disabled-selected-icon-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-selected-icon-opacity, 0.38)}}@layer hcm{@media(forced-colors: active){.icon--off{fill:Canvas}.icon--on{fill:ButtonText}.disabled.unselected .icon--off,.disabled.selected .icon--on{opacity:1}.disabled .icon--on{fill:GrayText}}}
+`;var gr=class extends X{};gr.styles=[wo];gr=n([T("md-switch")],gr);})();
+  </script>
+
+  <script>
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtHelpTextField extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) field.required = true;
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    if (helpText) {
+      field.addEventListener("focus", () => {
+        field.supportingText = helpText;
       });
-      document.getElementById("autocrlfOptions").classList.toggle("md-dimmed", !enabled);
-    }
-
-    function togglePushDefaultOptions() {
-      const enabled = document.getElementById("enablePushDefault").checked;
-      const options = document.querySelectorAll("#pushDefaultOptions input[type='radio']");
-      options.forEach(opt => {
-        opt.disabled = !enabled;
+      field.addEventListener("blur", () => {
+        field.supportingText = "";
       });
-      document.getElementById("pushDefaultOptions").classList.toggle("md-dimmed", !enabled);
     }
 
-    function generateConfigCommand() {
-      const enableAutocrlf = document.getElementById("enableAutocrlf").checked;
-      const enablePushDefault = document.getElementById("enablePushDefault").checked;
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
 
-      if (!enableAutocrlf && !enablePushDefault) {
-        alert("設定を1つ以上選択してください。");
-        return;
-      }
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
 
-      const lines = [];
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
 
-      if (enableAutocrlf) {
-        const autocrlfValue = document.querySelector("input[name='autocrlf']:checked");
-        if (autocrlfValue) {
-          lines.push(`git config --global core.autocrlf ${autocrlfValue.value}`);
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
         }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
       }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
 
-      if (enablePushDefault) {
-        const pushDefaultValue = document.querySelector("input[name='pushdefault']:checked");
-        if (pushDefaultValue) {
-          lines.push(`git config --global push.default ${pushDefaultValue.value}`);
-        }
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
       }
-
-      document.getElementById("configCmd").textContent = lines.join("\n");
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
     }
+  }
+}
 
-    function copyToClipboard(id) {
-      const text = document.getElementById(id).textContent;
-      if (!text) return;
-      const temp = document.createElement("textarea");
-      temp.value = text;
-      document.body.appendChild(temp);
-      temp.select();
-      document.execCommand("copy");
-      document.body.removeChild(temp);
-      showToast("コピーしました");
-    }
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
 
-    function showToast(message) {
-      const toast = document.getElementById("toast");
-      toast.textContent = message;
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-      }, 2000);
-    }
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
 
-    function toggleMenu() {
-      const panel = document.getElementById("menuPanel");
-      if (!panel) return;
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><use href="#md-icon-menu" xlink:href="#md-icon-menu"></use></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
       panel.classList.toggle("md-hidden");
-    }
+    });
 
-    // Initialize
-    toggleAutocrlfOptions();
-    togglePushDefaultOptions();
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-help-text-field")) {
+  customElements.define("lht-help-text-field", LhtHelpTextField);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
+  <script>
+function getToggleSelected(id, fallbackValue = false) {
+  const element = document.getElementById(id);
+  if (!element) return !!fallbackValue;
+  if ("selected" in element) return !!element.selected;
+  return !!element.checked;
+}
+
+function generateCheckCommand() {
+  const lines = [
+    "git config --global core.autocrlf",
+    "git config --global push.default"
+  ];
+  document.getElementById("checkCmd").textContent = lines.join("\n");
+}
+
+function toggleAutocrlfOptions() {
+  const enabled = getToggleSelected("enableAutocrlf", false);
+  const options = document.querySelectorAll("#autocrlfOptions input[type='radio']");
+  options.forEach((opt) => {
+    opt.disabled = !enabled;
+  });
+  document.getElementById("autocrlfOptions").classList.toggle("md-dimmed", !enabled);
+}
+
+function togglePushDefaultOptions() {
+  const enabled = getToggleSelected("enablePushDefault", false);
+  const options = document.querySelectorAll("#pushDefaultOptions input[type='radio']");
+  options.forEach((opt) => {
+    opt.disabled = !enabled;
+  });
+  document.getElementById("pushDefaultOptions").classList.toggle("md-dimmed", !enabled);
+}
+
+function generateConfigCommand({ silent = false } = {}) {
+  const enableAutocrlf = getToggleSelected("enableAutocrlf", false);
+  const enablePushDefault = getToggleSelected("enablePushDefault", false);
+
+  if (!enableAutocrlf && !enablePushDefault) {
+    if (!silent) alert("設定を1つ以上選択してください。");
+    document.getElementById("configCmd").textContent = "";
+    return;
+  }
+
+  const lines = [];
+
+  if (enableAutocrlf) {
+    const autocrlfValue = document.querySelector("input[name='autocrlf']:checked");
+    if (autocrlfValue) {
+      lines.push(`git config --global core.autocrlf ${autocrlfValue.value}`);
+    }
+  }
+
+  if (enablePushDefault) {
+    const pushDefaultValue = document.querySelector("input[name='pushdefault']:checked");
+    if (pushDefaultValue) {
+      lines.push(`git config --global push.default ${pushDefaultValue.value}`);
+    }
+  }
+
+  document.getElementById("configCmd").textContent = lines.join("\n");
+}
+
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.add("md-visible");
+  setTimeout(() => {
+    toast.classList.remove("md-visible");
+  }, 2000);
+}
+
+function setupAutoUpdate() {
+  const handler = () => generateConfigCommand({ silent: true });
+  ["autocrlf-true", "autocrlf-input", "autocrlf-false", "pushdefault-simple", "pushdefault-current", "pushdefault-upstream", "pushdefault-matching", "enableAutocrlf", "enablePushDefault"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener("change", handler);
+    el.addEventListener("input", handler);
+  });
+}
+
+generateCheckCommand();
+toggleAutocrlfOptions();
+togglePushDefaultOptions();
+setupAutoUpdate();
+generateConfigCommand({ silent: true });
   </script>
 </body>
 </html>

--- a/docs/git/git-config-setup-src.html
+++ b/docs/git/git-config-setup-src.html
@@ -1,0 +1,108 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Git ユーザー設定コマンドジェネレータ</title>
+  <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
+  <link rel="stylesheet" href="src/git-config-setup/css/app.css" />
+  <script src="src/vendor/material-web-outlined-text-field.bundle.js"></script>
+  <script src="../../lht-cmn/js/components.js"></script>
+</head>
+<body class="md-page">
+  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
+    <defs>
+      <symbol id="md-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 6h16"/>
+        <path d="M4 12h16"/>
+        <path d="M4 18h16"/>
+      </symbol>
+      <symbol id="md-icon-copy" viewBox="0 0 24 24">
+        <rect x="9" y="9" width="11" height="11" rx="2"/>
+        <rect x="4" y="4" width="11" height="11" rx="2"/>
+      </symbol>
+    </defs>
+  </svg>
+
+  <div class="md-surface-card md-card">
+    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
+
+    <h1 class="md-headline">
+      <span aria-hidden="true" class="md-headline__icon">⚙️</span>
+      <span>Git ユーザー設定コマンドジェネレータ</span>
+      <lht-help-tooltip label="Git ユーザー設定コマンドジェネレータの説明" wide>
+        グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+      </lht-help-tooltip>
+    </h1>
+
+    <section id="checkSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="32" r="4" fill="#93C5FD"/>
+          <path d="M24 32H34" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 32H44" stroke="#93C5FD" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="32" r="4" fill="#93C5FD"/>
+        </svg>
+        <span class="md-title-info-row">
+          <p class="md-section-title">現在の設定を確認</p>
+          <lht-help-tooltip label="現在の設定を確認の説明" wide>
+            設定前に現在のユーザー名とメールアドレスを確認できます。
+          </lht-help-tooltip>
+        </span>
+      </div>
+
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">確認コマンド生成</button>
+      <lht-command-block command-id="checkCmd"></lht-command-block>
+    </section>
+
+    <hr class="md-divider" />
+
+    <section id="setupSection" class="md-section md-stack-md">
+      <div class="md-flow-row">
+        <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
+          <circle cx="20" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M24 20H34" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <path d="M34 20H44" stroke="#A78BFA" stroke-width="3" stroke-linecap="round"/>
+          <circle cx="48" cy="20" r="4" fill="#A78BFA"/>
+          <path d="M20 44L32 32L44 44" stroke="#34D399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="md-title-info-row">
+          <p class="md-section-title">ユーザー情報を設定</p>
+          <lht-help-tooltip label="ユーザー情報を設定の説明" wide>
+            グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
+          </lht-help-tooltip>
+        </span>
+      </div>
+
+      <div class="md-stack-md">
+        <lht-help-text-field field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-help-text-field>
+        <lht-help-text-field field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-help-text-field>
+      </div>
+    </section>
+
+    <button type="button" onclick="generateSetupCommand()" class="md-button md-button--primary">設定コマンド生成</button>
+    <lht-command-block command-id="setupCmd"></lht-command-block>
+
+    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+  </div>
+
+  <script src="src/git-config-setup/js/main.js"></script>
+</body>
+</html>

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -19,7 +19,174 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Git ユーザー設定コマンドジェネレータ</title>
+  
+  
+  
+  
   <style>
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-help-text-field {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
     /* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
     :root {
       --md-danger: #b3261e;
@@ -439,6 +606,8 @@ limitations under the License.
     .md-switch {
       position: relative;
       width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
       height: 24px;
       background: #f0ebf7;
       border-radius: 9999px;
@@ -883,9 +1052,10 @@ limitations under the License.
     .md-title-info-row .md-section-title { margin: 0; }
     .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
-    .md-step-icon { width: 3.5rem; height: 3.5rem; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; flex: 0 0 auto; }
 
-    .md-input {
+    .md-input,
+    .md-select {
       width: 100%;
       background: #ffffff;
       border: 1px solid var(--md-sys-color-outline);
@@ -895,11 +1065,17 @@ limitations under the License.
       color: var(--md-sys-color-on-surface);
       transition: border-color 150ms ease, box-shadow 150ms ease;
     }
+    .md-select--inline { flex: 1 1 18rem; min-width: 14rem; }
     .md-input { flex: 1 1 16rem; min-width: 12rem; }
-    .md-input:focus {
+    .md-input:focus,
+    .md-select:focus {
       outline: none;
       border-color: var(--md-sys-color-primary);
       box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
+    .md-input.md-disabled,
+    .md-select.md-disabled {
+      background: #f3f0f7;
     }
 
     .md-button {
@@ -950,6 +1126,7 @@ limitations under the License.
     }
     .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
     .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+    .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
 
     .md-icon-btn {
       width: 40px;
@@ -977,6 +1154,8 @@ limitations under the License.
       font-size: 0.8125rem;
       font-weight: 400;
       line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
       letter-spacing: 0.01em;
     }
@@ -995,6 +1174,40 @@ limitations under the License.
     }
     .md-info-icon { width: 18px; height: 18px; }
 
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .md-choice-inline { display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem; }
+    .md-choice-text { font-size: 0.9rem; color: #4a4458; }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transform: translateX(0);
+      transition: transform 150ms ease;
+    }
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
+      background: #8b5cf6;
+      box-shadow: inset 0 0 0 1px #7c3aed;
+    }
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
     .md-snackbar {
       background: #2b2831;
       color: #ffffff;
@@ -1014,13 +1227,12 @@ limitations under the License.
     }
     .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
 
-    .md-divider { border: none; border-top: 1px solid #e6e1ee; margin: 1.5rem 0; }
-
     .md-hidden { display: none; }
-    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
 
     @media (max-width: 640px) {
       .md-form-row--nowrap { flex-wrap: wrap; }
+      .md-switch-label { white-space: normal; }
     }
   </style>
 </head>
@@ -1036,31 +1248,18 @@ limitations under the License.
         <rect x="9" y="9" width="11" height="11" rx="2"/>
         <rect x="4" y="4" width="11" height="11" rx="2"/>
       </symbol>
-      <symbol id="md-icon-refresh" viewBox="0 0 24 24">
-        <path d="M20 12a8 8 0 1 1-2.34-5.66"/>
-        <path d="M20 4v6h-6"/>
-      </symbol>
     </defs>
   </svg>
+
   <div class="md-surface-card md-card">
-    <button type="button" class="md-menu-button md-icon-btn" aria-label="メニュー" onclick="toggleMenu()">
-      <svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
-        <use href="#md-icon-menu" xlink:href="#md-icon-menu"></use>
-      </svg>
-    </button>
-    <div id="menuPanel" class="md-menu-panel md-hidden">
-      <a href="../index.html" class="md-menu-link">トップへ戻る</a>
-    </div>
+    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 
     <h1 class="md-headline">
       <span aria-hidden="true" class="md-headline__icon">⚙️</span>
       <span>Git ユーザー設定コマンドジェネレータ</span>
-      <span class="md-tooltip-group">
-        <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-        <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-          グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
-        </span>
-      </span>
+      <lht-help-tooltip label="Git ユーザー設定コマンドジェネレータの説明" wide>
+        グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+      </lht-help-tooltip>
     </h1>
 
     <section id="checkSection" class="md-section md-stack-md">
@@ -1074,25 +1273,14 @@ limitations under the License.
         </svg>
         <span class="md-title-info-row">
           <p class="md-section-title">現在の設定を確認</p>
-          <span class="md-tooltip-group">
-            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              設定前に現在のユーザー名とメールアドレスを確認できます。
-            </span>
-          </span>
+          <lht-help-tooltip label="現在の設定を確認の説明" wide>
+            設定前に現在のユーザー名とメールアドレスを確認できます。
+          </lht-help-tooltip>
         </span>
       </div>
-      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">
-        確認コマンド生成
-      </button>
-      <div class="md-code-block">
-        <code id="checkCmd" class="md-code"></code>
-        <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('checkCmd')" aria-label="コピー">
-          <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
-          </svg>
-        </button>
-      </div>
+
+      <button type="button" onclick="generateCheckCommand()" class="md-button md-button--primary">確認コマンド生成</button>
+      <lht-command-block command-id="checkCmd"></lht-command-block>
     </section>
 
     <hr class="md-divider" />
@@ -1109,130 +1297,764 @@ limitations under the License.
         </svg>
         <span class="md-title-info-row">
           <p class="md-section-title">ユーザー情報を設定</p>
-          <span class="md-tooltip-group">
-            <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-            <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-              グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
-            </span>
-          </span>
+          <lht-help-tooltip label="ユーザー情報を設定の説明" wide>
+            グローバル設定でユーザー名とメールアドレスを設定するコマンドを生成します。
+          </lht-help-tooltip>
         </span>
       </div>
 
       <div class="md-stack-md">
-        <div class="md-form-row md-form-row--nowrap">
-          <label class="md-label">
-            <span>ユーザー名</span>
-            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
-            <span class="md-tooltip-group">
-              <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                Gitコミットに記録される名前です。本名またはニックネームを入力してください。
-              </span>
-            </span>
-            <span>：</span>
-          </label>
-          <input type="text" id="userName" placeholder="例: Taro Yamada" class="md-input">
-        </div>
-
-        <div class="md-form-row md-form-row--nowrap">
-          <label class="md-label">
-            <span>メールアドレス</span>
-            <span class="md-required" aria-hidden="true">Required</span><span class="md-sr-only">必須</span>
-            <span class="md-tooltip-group">
-              <span class="md-info-chip"><svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg></span>
-              <span class="md-tooltip-content md-tooltip md-tooltip--rich md-tooltip--wide">
-                Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。
-              </span>
-            </span>
-            <span>：</span>
-          </label>
-          <input type="email" id="userEmail" placeholder="例: taro@example.com" class="md-input">
-        </div>
+        <lht-help-text-field field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-help-text-field>
+        <lht-help-text-field field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-help-text-field>
       </div>
     </section>
 
-    <button onclick="generateSetupCommand()" class="md-button md-button--primary">
-      設定コマンド生成
-    </button>
+    <button type="button" onclick="generateSetupCommand()" class="md-button md-button--primary">設定コマンド生成</button>
+    <lht-command-block command-id="setupCmd"></lht-command-block>
 
-    <div class="md-code-block">
-      <code id="setupCmd" class="md-code"></code>
-      <button class="md-copy-button md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="copyToClipboard('setupCmd')" aria-label="コピー">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
-          </svg>
-      </button>
-    </div>
-
-    <div id="toast" class="md-snackbar-host md-snackbar">
-      コピーしました
-    </div>
+    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
   </div>
 
+  
   <script>
-    function quoteIfNeeded(value) {
-      if (!value) return value;
-      if (/[^\w@%+=:,./-]/.test(value)) {
-        const escaped = value.replace(/"/g, '\\"');
-        return `"${escaped}"`;
+(()=>{function n(o,e,t,r){var i=arguments.length,s=i<3?e:r===null?r=Object.getOwnPropertyDescriptor(e,t):r,a;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")s=Reflect.decorate(o,e,t,r);else for(var d=o.length-1;d>=0;d--)(a=o[d])&&(s=(i<3?a(s):i>3?a(e,t,s):a(e,t))||s);return i>3&&s&&Object.defineProperty(e,t,s),s}var T=o=>(e,t)=>{t!==void 0?t.addInitializer(()=>{customElements.define(o,e)}):customElements.define(o,e)};var Je=globalThis,Qe=Je.ShadowRoot&&(Je.ShadyCSS===void 0||Je.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,Lt=Symbol(),xr=new WeakMap,Me=class{constructor(e,t,r){if(this._$cssResult$=!0,r!==Lt)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o,t=this.t;if(Qe&&e===void 0){let r=t!==void 0&&t.length===1;r&&(e=xr.get(t)),e===void 0&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),r&&xr.set(t,e))}return e}toString(){return this.cssText}},_r=o=>new Me(typeof o=="string"?o:o+"",void 0,Lt),x=(o,...e)=>{let t=o.length===1?o[0]:e.reduce((r,i,s)=>r+(a=>{if(a._$cssResult$===!0)return a.cssText;if(typeof a=="number")return a;throw Error("Value passed to 'css' function must be a 'css' function result: "+a+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+o[s+1],o[0]);return new Me(t,o,Lt)},wr=(o,e)=>{if(Qe)o.adoptedStyleSheets=e.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(let t of e){let r=document.createElement("style"),i=Je.litNonce;i!==void 0&&r.setAttribute("nonce",i),r.textContent=t.cssText,o.appendChild(r)}},Dt=Qe?o=>o:o=>o instanceof CSSStyleSheet?(e=>{let t="";for(let r of e.cssRules)t+=r.cssText;return _r(t)})(o):o;var{is:Eo,defineProperty:Ao,getOwnPropertyDescriptor:Co,getOwnPropertyNames:To,getOwnPropertySymbols:$o,getPrototypeOf:So}=Object,le=globalThis,Er=le.trustedTypes,Io=Er?Er.emptyScript:"",ko=le.reactiveElementPolyfillSupport,Ne=(o,e)=>o,Be={toAttribute(o,e){switch(e){case Boolean:o=o?Io:null;break;case Object:case Array:o=o==null?o:JSON.stringify(o)}return o},fromAttribute(o,e){let t=o;switch(e){case Boolean:t=o!==null;break;case Number:t=o===null?null:Number(o);break;case Object:case Array:try{t=JSON.parse(o)}catch{t=null}}return t}},et=(o,e)=>!Eo(o,e),Ar={attribute:!0,type:String,converter:Be,reflect:!1,useDefault:!1,hasChanged:et};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),le.litPropertyMetadata??(le.litPropertyMetadata=new WeakMap);var ee=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??(this.l=[])).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=Ar){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){let r=Symbol(),i=this.getPropertyDescriptor(e,r,t);i!==void 0&&Ao(this.prototype,e,i)}}static getPropertyDescriptor(e,t,r){let{get:i,set:s}=Co(this.prototype,e)??{get(){return this[t]},set(a){this[t]=a}};return{get:i,set(a){let d=i?.call(this);s?.call(this,a),this.requestUpdate(e,d,r)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??Ar}static _$Ei(){if(this.hasOwnProperty(Ne("elementProperties")))return;let e=So(this);e.finalize(),e.l!==void 0&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(Ne("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Ne("properties"))){let t=this.properties,r=[...To(t),...$o(t)];for(let i of r)this.createProperty(i,t[i])}let e=this[Symbol.metadata];if(e!==null){let t=litPropertyMetadata.get(e);if(t!==void 0)for(let[r,i]of t)this.elementProperties.set(r,i)}this._$Eh=new Map;for(let[t,r]of this.elementProperties){let i=this._$Eu(t,r);i!==void 0&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){let t=[];if(Array.isArray(e)){let r=new Set(e.flat(1/0).reverse());for(let i of r)t.unshift(Dt(i))}else e!==void 0&&t.push(Dt(e));return t}static _$Eu(e,t){let r=t.attribute;return r===!1?void 0:typeof r=="string"?r:typeof e=="string"?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??(this._$EO=new Set)).add(e),this.renderRoot!==void 0&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){let e=new Map,t=this.constructor.elementProperties;for(let r of t.keys())this.hasOwnProperty(r)&&(e.set(r,this[r]),delete this[r]);e.size>0&&(this._$Ep=e)}createRenderRoot(){let e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return wr(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,r){this._$AK(e,r)}_$ET(e,t){let r=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,r);if(i!==void 0&&r.reflect===!0){let s=(r.converter?.toAttribute!==void 0?r.converter:Be).toAttribute(t,r.type);this._$Em=e,s==null?this.removeAttribute(i):this.setAttribute(i,s),this._$Em=null}}_$AK(e,t){let r=this.constructor,i=r._$Eh.get(e);if(i!==void 0&&this._$Em!==i){let s=r.getPropertyOptions(i),a=typeof s.converter=="function"?{fromAttribute:s.converter}:s.converter?.fromAttribute!==void 0?s.converter:Be;this._$Em=i;let d=a.fromAttribute(t,s.type);this[i]=d??this._$Ej?.get(i)??d,this._$Em=null}}requestUpdate(e,t,r,i=!1,s){if(e!==void 0){let a=this.constructor;if(i===!1&&(s=this[e]),r??(r=a.getPropertyOptions(e)),!((r.hasChanged??et)(s,t)||r.useDefault&&r.reflect&&s===this._$Ej?.get(e)&&!this.hasAttribute(a._$Eu(e,r))))return;this.C(e,t,r)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(e,t,{useDefault:r,reflect:i,wrapped:s},a){r&&!(this._$Ej??(this._$Ej=new Map)).has(e)&&(this._$Ej.set(e,a??t??this[e]),s!==!0||a!==void 0)||(this._$AL.has(e)||(this.hasUpdated||r||(t=void 0),this._$AL.set(e,t)),i===!0&&this._$Em!==e&&(this._$Eq??(this._$Eq=new Set)).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}let e=this.scheduleUpdate();return e!=null&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[i,s]of this._$Ep)this[i]=s;this._$Ep=void 0}let r=this.constructor.elementProperties;if(r.size>0)for(let[i,s]of r){let{wrapped:a}=s,d=this[i];a!==!0||this._$AL.has(i)||d===void 0||this.C(i,void 0,s,d)}}let e=!1,t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(r=>r.hostUpdate?.()),this.update(t)):this._$EM()}catch(r){throw e=!1,this._$EM(),r}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&(this._$Eq=this._$Eq.forEach(t=>this._$ET(t,this[t]))),this._$EM()}updated(e){}firstUpdated(e){}};ee.elementStyles=[],ee.shadowRootOptions={mode:"open"},ee[Ne("elementProperties")]=new Map,ee[Ne("finalized")]=new Map,ko?.({ReactiveElement:ee}),(le.reactiveElementVersions??(le.reactiveElementVersions=[])).push("2.1.2");var Oo={attribute:!0,type:String,converter:Be,reflect:!1,hasChanged:et},Ro=(o=Oo,e,t)=>{let{kind:r,metadata:i}=t,s=globalThis.litPropertyMetadata.get(i);if(s===void 0&&globalThis.litPropertyMetadata.set(i,s=new Map),r==="setter"&&((o=Object.create(o)).wrapped=!0),s.set(t.name,o),r==="accessor"){let{name:a}=t;return{set(d){let c=e.get.call(this);e.set.call(this,d),this.requestUpdate(a,c,o,!0,d)},init(d){return d!==void 0&&this.C(a,void 0,o,d),d}}}if(r==="setter"){let{name:a}=t;return function(d){let c=this[a];e.call(this,d),this.requestUpdate(a,c,o,!0,d)}}throw Error("Unsupported decorator location: "+r)};function l(o){return(e,t)=>typeof t=="object"?Ro(o,e,t):((r,i,s)=>{let a=i.hasOwnProperty(s);return i.constructor.createProperty(s,r),a?Object.getOwnPropertyDescriptor(i,s):void 0})(o,e,t)}function I(o){return l({...o,state:!0,attribute:!1})}var J=(o,e,t)=>(t.configurable=!0,t.enumerable=!0,Reflect.decorate&&typeof e!="object"&&Object.defineProperty(o,e,t),t);function k(o,e){return(t,r,i)=>{let s=a=>a.renderRoot?.querySelector(o)??null;if(e){let{get:a,set:d}=typeof r=="object"?t:i??(()=>{let c=Symbol();return{get(){return this[c]},set(h){this[c]=h}}})();return J(t,r,{get(){let c=a.call(this);return c===void 0&&(c=s(this),(c!==null||this.hasUpdated)&&d.call(this,c)),c}})}return J(t,r,{get(){return s(this)}})}}var Po;function Cr(o){return(e,t)=>J(e,t,{get(){return(this.renderRoot??Po??(Po=document.createDocumentFragment())).querySelectorAll(o)}})}function q(o){return(e,t)=>{let{slot:r,selector:i}=o??{},s="slot"+(r?`[name=${r}]`:":not([name])");return J(e,t,{get(){let a=this.renderRoot?.querySelector(s),d=a?.assignedElements(o)??[];return i===void 0?d:d.filter(c=>c.matches(i))}})}}function tt(o){return(e,t)=>{let{slot:r}=o??{},i="slot"+(r?`[name=${r}]`:":not([name])");return J(e,t,{get(){return this.renderRoot?.querySelector(i)?.assignedNodes(o)??[]}})}}var Ue=globalThis,Tr=o=>o,rt=Ue.trustedTypes,$r=rt?rt.createPolicy("lit-html",{createHTML:o=>o}):void 0,Mt="$lit$",te=`lit$${Math.random().toFixed(9).slice(2)}$`,Nt="?"+te,Lo=`<${Nt}>`,xe=document,qe=()=>xe.createComment(""),Ve=o=>o===null||typeof o!="object"&&typeof o!="function",Bt=Array.isArray,Pr=o=>Bt(o)||typeof o?.[Symbol.iterator]=="function",zt=`[ 	
+\f\r]`,Fe=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Sr=/-->/g,Ir=/>/g,ye=RegExp(`>|${zt}(?:([^\\s"'>=/]+)(${zt}*=${zt}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),kr=/'/g,Or=/"/g,Lr=/^(?:script|style|textarea|title)$/i,Ft=o=>(e,...t)=>({_$litType$:o,strings:e,values:t}),p=Ft(1),Dr=Ft(2),zr=Ft(3),B=Symbol.for("lit-noChange"),u=Symbol.for("lit-nothing"),Rr=new WeakMap,be=xe.createTreeWalker(xe,129);function Mr(o,e){if(!Bt(o)||!o.hasOwnProperty("raw"))throw Error("invalid template strings array");return $r!==void 0?$r.createHTML(e):e}var Nr=(o,e)=>{let t=o.length-1,r=[],i,s=e===2?"<svg>":e===3?"<math>":"",a=Fe;for(let d=0;d<t;d++){let c=o[d],h,m,f=-1,b=0;for(;b<c.length&&(a.lastIndex=b,m=a.exec(c),m!==null);)b=a.lastIndex,a===Fe?m[1]==="!--"?a=Sr:m[1]!==void 0?a=Ir:m[2]!==void 0?(Lr.test(m[2])&&(i=RegExp("</"+m[2],"g")),a=ye):m[3]!==void 0&&(a=ye):a===ye?m[0]===">"?(a=i??Fe,f=-1):m[1]===void 0?f=-2:(f=a.lastIndex-m[2].length,h=m[1],a=m[3]===void 0?ye:m[3]==='"'?Or:kr):a===Or||a===kr?a=ye:a===Sr||a===Ir?a=Fe:(a=ye,i=void 0);let g=a===ye&&o[d+1].startsWith("/>")?" ":"";s+=a===Fe?c+Lo:f>=0?(r.push(h),c.slice(0,f)+Mt+c.slice(f)+te+g):c+te+(f===-2?d:g)}return[Mr(o,s+(o[t]||"<?>")+(e===2?"</svg>":e===3?"</math>":"")),r]},He=class o{constructor({strings:e,_$litType$:t},r){let i;this.parts=[];let s=0,a=0,d=e.length-1,c=this.parts,[h,m]=Nr(e,t);if(this.el=o.createElement(h,r),be.currentNode=this.el.content,t===2||t===3){let f=this.el.content.firstChild;f.replaceWith(...f.childNodes)}for(;(i=be.nextNode())!==null&&c.length<d;){if(i.nodeType===1){if(i.hasAttributes())for(let f of i.getAttributeNames())if(f.endsWith(Mt)){let b=m[a++],g=i.getAttribute(f).split(te),S=/([.?@])?(.*)/.exec(b);c.push({type:1,index:s,name:S[2],strings:g,ctor:S[1]==="."?it:S[1]==="?"?st:S[1]==="@"?nt:we}),i.removeAttribute(f)}else f.startsWith(te)&&(c.push({type:6,index:s}),i.removeAttribute(f));if(Lr.test(i.tagName)){let f=i.textContent.split(te),b=f.length-1;if(b>0){i.textContent=rt?rt.emptyScript:"";for(let g=0;g<b;g++)i.append(f[g],qe()),be.nextNode(),c.push({type:2,index:++s});i.append(f[b],qe())}}}else if(i.nodeType===8)if(i.data===Nt)c.push({type:2,index:s});else{let f=-1;for(;(f=i.data.indexOf(te,f+1))!==-1;)c.push({type:7,index:s}),f+=te.length-1}s++}}static createElement(e,t){let r=xe.createElement("template");return r.innerHTML=e,r}};function _e(o,e,t=o,r){if(e===B)return e;let i=r!==void 0?t._$Co?.[r]:t._$Cl,s=Ve(e)?void 0:e._$litDirective$;return i?.constructor!==s&&(i?._$AO?.(!1),s===void 0?i=void 0:(i=new s(o),i._$AT(o,t,r)),r!==void 0?(t._$Co??(t._$Co=[]))[r]=i:t._$Cl=i),i!==void 0&&(e=_e(o,i._$AS(o,e.values),i,r)),e}var ot=class{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){let{el:{content:t},parts:r}=this._$AD,i=(e?.creationScope??xe).importNode(t,!0);be.currentNode=i;let s=be.nextNode(),a=0,d=0,c=r[0];for(;c!==void 0;){if(a===c.index){let h;c.type===2?h=new Te(s,s.nextSibling,this,e):c.type===1?h=new c.ctor(s,c.name,c.strings,this,e):c.type===6&&(h=new at(s,this,e)),this._$AV.push(h),c=r[++d]}a!==c?.index&&(s=be.nextNode(),a++)}return be.currentNode=xe,i}p(e){let t=0;for(let r of this._$AV)r!==void 0&&(r.strings!==void 0?(r._$AI(e,r,t),t+=r.strings.length-2):r._$AI(e[t])),t++}},Te=class o{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,r,i){this.type=2,this._$AH=u,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=r,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode,t=this._$AM;return t!==void 0&&e?.nodeType===11&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=_e(this,e,t),Ve(e)?e===u||e==null||e===""?(this._$AH!==u&&this._$AR(),this._$AH=u):e!==this._$AH&&e!==B&&this._(e):e._$litType$!==void 0?this.$(e):e.nodeType!==void 0?this.T(e):Pr(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==u&&Ve(this._$AH)?this._$AA.nextSibling.data=e:this.T(xe.createTextNode(e)),this._$AH=e}$(e){let{values:t,_$litType$:r}=e,i=typeof r=="number"?this._$AC(e):(r.el===void 0&&(r.el=He.createElement(Mr(r.h,r.h[0]),this.options)),r);if(this._$AH?._$AD===i)this._$AH.p(t);else{let s=new ot(i,this),a=s.u(this.options);s.p(t),this.T(a),this._$AH=s}}_$AC(e){let t=Rr.get(e.strings);return t===void 0&&Rr.set(e.strings,t=new He(e)),t}k(e){Bt(this._$AH)||(this._$AH=[],this._$AR());let t=this._$AH,r,i=0;for(let s of e)i===t.length?t.push(r=new o(this.O(qe()),this.O(qe()),this,this.options)):r=t[i],r._$AI(s),i++;i<t.length&&(this._$AR(r&&r._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){let r=Tr(e).nextSibling;Tr(e).remove(),e=r}}setConnected(e){this._$AM===void 0&&(this._$Cv=e,this._$AP?.(e))}},we=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,r,i,s){this.type=1,this._$AH=u,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=s,r.length>2||r[0]!==""||r[1]!==""?(this._$AH=Array(r.length-1).fill(new String),this.strings=r):this._$AH=u}_$AI(e,t=this,r,i){let s=this.strings,a=!1;if(s===void 0)e=_e(this,e,t,0),a=!Ve(e)||e!==this._$AH&&e!==B,a&&(this._$AH=e);else{let d=e,c,h;for(e=s[0],c=0;c<s.length-1;c++)h=_e(this,d[r+c],t,c),h===B&&(h=this._$AH[c]),a||(a=!Ve(h)||h!==this._$AH[c]),h===u?e=u:e!==u&&(e+=(h??"")+s[c+1]),this._$AH[c]=h}a&&!i&&this.j(e)}j(e){e===u?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}},it=class extends we{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===u?void 0:e}},st=class extends we{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==u)}},nt=class extends we{constructor(e,t,r,i,s){super(e,t,r,i,s),this.type=5}_$AI(e,t=this){if((e=_e(this,e,t,0)??u)===B)return;let r=this._$AH,i=e===u&&r!==u||e.capture!==r.capture||e.once!==r.once||e.passive!==r.passive,s=e!==u&&(r===u||i);i&&this.element.removeEventListener(this.name,this,r),s&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}},at=class{constructor(e,t,r){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=r}get _$AU(){return this._$AM._$AU}_$AI(e){_e(this,e)}},Br={M:Mt,P:te,A:Nt,C:1,L:Nr,R:ot,D:Pr,V:_e,I:Te,H:we,N:st,U:nt,B:it,F:at},Do=Ue.litHtmlPolyfillSupport;Do?.(He,Te),(Ue.litHtmlVersions??(Ue.litHtmlVersions=[])).push("3.3.2");var $e=(o,e,t)=>{let r=t?.renderBefore??e,i=r._$litPart$;if(i===void 0){let s=t?.renderBefore??null;r._$litPart$=i=new Te(e.insertBefore(qe(),s),s,void 0,t??{})}return i._$AI(o),i};var je=globalThis,y=class extends ee{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var t;let e=super.createRenderRoot();return(t=this.renderOptions).renderBefore??(t.renderBefore=e.firstChild),e}update(e){let t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=$e(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return B}};y._$litElement$=!0,y.finalized=!0,je.litElementHydrateSupport?.({LitElement:y});var zo=je.litElementPolyfillSupport;zo?.({LitElement:y});(je.litElementVersions??(je.litElementVersions=[])).push("4.2.2");var Y={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4,EVENT:5,ELEMENT:6},Se=o=>(...e)=>({_$litDirective$:o,values:e}),de=class{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,r){this._$Ct=e,this._$AM=t,this._$Ci=r}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}};var R=Se(class extends de{constructor(o){if(super(o),o.type!==Y.ATTRIBUTE||o.name!=="class"||o.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(o){return" "+Object.keys(o).filter(e=>o[e]).join(" ")+" "}update(o,[e]){if(this.st===void 0){this.st=new Set,o.strings!==void 0&&(this.nt=new Set(o.strings.join(" ").split(/\s/).filter(r=>r!=="")));for(let r in e)e[r]&&!this.nt?.has(r)&&this.st.add(r);return this.render(e)}let t=o.element.classList;for(let r of this.st)r in e||(t.remove(r),this.st.delete(r));for(let r in e){let i=!!e[r];i===this.st.has(r)||this.nt?.has(r)||(i?(t.add(r),this.st.add(r)):(t.remove(r),this.st.delete(r)))}return B}});var re={STANDARD:"cubic-bezier(0.2, 0, 0, 1)",STANDARD_ACCELERATE:"cubic-bezier(.3,0,1,1)",STANDARD_DECELERATE:"cubic-bezier(0,0,0,1)",EMPHASIZED:"cubic-bezier(.3,0,0,1)",EMPHASIZED_ACCELERATE:"cubic-bezier(.3,0,.8,.15)",EMPHASIZED_DECELERATE:"cubic-bezier(.05,.7,.1,1)"};function Fr(){let o=null;return{start(){return o?.abort(),o=new AbortController,o.signal},finish(){o=null}}}var A=class extends y{constructor(){super(...arguments),this.disabled=!1,this.error=!1,this.focused=!1,this.label="",this.noAsterisk=!1,this.populated=!1,this.required=!1,this.resizable=!1,this.supportingText="",this.errorText="",this.count=-1,this.max=-1,this.hasStart=!1,this.hasEnd=!1,this.isAnimating=!1,this.refreshErrorAlert=!1,this.disableTransitions=!1}get counterText(){let e=this.count??-1,t=this.max??-1;return e<0||t<=0?"":`${e} / ${t}`}get supportingOrErrorText(){return this.error&&this.errorText?this.errorText:this.supportingText}reannounceError(){this.refreshErrorAlert=!0}update(e){e.has("disabled")&&e.get("disabled")!==void 0&&(this.disableTransitions=!0),this.disabled&&this.focused&&(e.set("focused",!0),this.focused=!1),this.animateLabelIfNeeded({wasFocused:e.get("focused"),wasPopulated:e.get("populated")}),super.update(e)}render(){let e=this.renderLabel(!0),t=this.renderLabel(!1),r=this.renderOutline?.(e),i={disabled:this.disabled,"disable-transitions":this.disableTransitions,error:this.error&&!this.disabled,focused:this.focused,"with-start":this.hasStart,"with-end":this.hasEnd,populated:this.populated,resizable:this.resizable,required:this.required,"no-label":!this.label};return p`
+      <div class="field ${R(i)}">
+        <div class="container-overflow">
+          ${this.renderBackground?.()}
+          <slot name="container"></slot>
+          ${this.renderStateLayer?.()} ${this.renderIndicator?.()} ${r}
+          <div class="container">
+            <div class="start">
+              <slot name="start"></slot>
+            </div>
+            <div class="middle">
+              <div class="label-wrapper">
+                ${t} ${r?u:e}
+              </div>
+              <div class="content">
+                <slot></slot>
+              </div>
+            </div>
+            <div class="end">
+              <slot name="end"></slot>
+            </div>
+          </div>
+        </div>
+        ${this.renderSupportingText()}
+      </div>
+    `}updated(e){(e.has("supportingText")||e.has("errorText")||e.has("count")||e.has("max"))&&this.updateSlottedAriaDescribedBy(),this.refreshErrorAlert&&requestAnimationFrame(()=>{this.refreshErrorAlert=!1}),this.disableTransitions&&requestAnimationFrame(()=>{this.disableTransitions=!1})}renderSupportingText(){let{supportingOrErrorText:e,counterText:t}=this;if(!e&&!t)return u;let r=p`<span>${e}</span>`,i=t?p`<span class="counter">${t}</span>`:u,a=this.error&&this.errorText&&!this.refreshErrorAlert?"alert":u;return p`
+      <div class="supporting-text" role=${a}>${r}${i}</div>
+      <slot
+        name="aria-describedby"
+        @slotchange=${this.updateSlottedAriaDescribedBy}></slot>
+    `}updateSlottedAriaDescribedBy(){for(let e of this.slottedAriaDescribedBy)$e(p`${this.supportingOrErrorText} ${this.counterText}`,e),e.setAttribute("hidden","")}renderLabel(e){if(!this.label)return u;let t;e?t=this.focused||this.populated||this.isAnimating:t=!this.focused&&!this.populated&&!this.isAnimating;let r={hidden:!t,floating:e,resting:!e},i=`${this.label}${this.required&&!this.noAsterisk?"*":""}`;return p`
+      <span class="label ${R(r)}" aria-hidden=${!t}
+        >${i}</span
+      >
+    `}animateLabelIfNeeded({wasFocused:e,wasPopulated:t}){if(!this.label)return;e??(e=this.focused),t??(t=this.populated);let r=e||t,i=this.focused||this.populated;r!==i&&(this.isAnimating=!0,this.labelAnimation?.cancel(),this.labelAnimation=this.floatingLabelEl?.animate(this.getLabelKeyframes(),{duration:150,easing:re.STANDARD}),this.labelAnimation?.addEventListener("finish",()=>{this.isAnimating=!1}))}getLabelKeyframes(){let{floatingLabelEl:e,restingLabelEl:t}=this;if(!e||!t)return[];let{x:r,y:i,height:s}=e.getBoundingClientRect(),{x:a,y:d,height:c}=t.getBoundingClientRect(),h=e.scrollWidth,m=t.scrollWidth,f=m/h,b=a-r,g=d-i+Math.round((c-s*f)/2),S=`translateX(${b}px) translateY(${g}px) scale(${f})`,w="translateX(0) translateY(0) scale(1)",O=t.clientWidth,E=m>O?`${O/f}px`:"";return this.focused||this.populated?[{transform:S,width:E},{transform:w,width:E}]:[{transform:w,width:E},{transform:S,width:E}]}getSurfacePositionClientRect(){return this.containerEl.getBoundingClientRect()}};n([l({type:Boolean})],A.prototype,"disabled",void 0);n([l({type:Boolean})],A.prototype,"error",void 0);n([l({type:Boolean})],A.prototype,"focused",void 0);n([l()],A.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],A.prototype,"noAsterisk",void 0);n([l({type:Boolean})],A.prototype,"populated",void 0);n([l({type:Boolean})],A.prototype,"required",void 0);n([l({type:Boolean})],A.prototype,"resizable",void 0);n([l({attribute:"supporting-text"})],A.prototype,"supportingText",void 0);n([l({attribute:"error-text"})],A.prototype,"errorText",void 0);n([l({type:Number})],A.prototype,"count",void 0);n([l({type:Number})],A.prototype,"max",void 0);n([l({type:Boolean,attribute:"has-start"})],A.prototype,"hasStart",void 0);n([l({type:Boolean,attribute:"has-end"})],A.prototype,"hasEnd",void 0);n([q({slot:"aria-describedby"})],A.prototype,"slottedAriaDescribedBy",void 0);n([I()],A.prototype,"isAnimating",void 0);n([I()],A.prototype,"refreshErrorAlert",void 0);n([I()],A.prototype,"disableTransitions",void 0);n([k(".label.floating")],A.prototype,"floatingLabelEl",void 0);n([k(".label.resting")],A.prototype,"restingLabelEl",void 0);n([k(".container")],A.prototype,"containerEl",void 0);var lt=class extends A{renderOutline(e){return p`
+      <div class="outline">
+        <div class="outline-start"></div>
+        <div class="outline-notch">
+          <div class="outline-panel-inactive"></div>
+          <div class="outline-panel-active"></div>
+          <div class="outline-label">${e}</div>
+        </div>
+        <div class="outline-end"></div>
+      </div>
+    `}};var Ur=x`@layer styles{:host{--_bottom-space: var(--md-outlined-field-bottom-space, 16px);--_content-color: var(--md-outlined-field-content-color, var(--md-sys-color-on-surface, #1d1b20));--_content-font: var(--md-outlined-field-content-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_content-line-height: var(--md-outlined-field-content-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_content-size: var(--md-outlined-field-content-size, var(--md-sys-typescale-body-large-size, 1rem));--_content-space: var(--md-outlined-field-content-space, 16px);--_content-weight: var(--md-outlined-field-content-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_disabled-content-color: var(--md-outlined-field-disabled-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-content-opacity: var(--md-outlined-field-disabled-content-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-field-disabled-label-text-opacity, 0.38);--_disabled-leading-content-color: var(--md-outlined-field-disabled-leading-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-content-opacity: var(--md-outlined-field-disabled-leading-content-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-content-color: var(--md-outlined-field-disabled-trailing-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-content-opacity: var(--md-outlined-field-disabled-trailing-content-opacity, 0.38);--_error-content-color: var(--md-outlined-field-error-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-content-color: var(--md-outlined-field-error-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-content-color: var(--md-outlined-field-error-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-content-color: var(--md-outlined-field-error-focus-trailing-content-color, var(--md-sys-color-error, #b3261e));--_error-hover-content-color: var(--md-outlined-field-error-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-content-color: var(--md-outlined-field-error-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-content-color: var(--md-outlined-field-error-hover-trailing-content-color, var(--md-sys-color-on-error-container, #410e0b));--_error-label-text-color: var(--md-outlined-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-content-color: var(--md-outlined-field-error-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-content-color: var(--md-outlined-field-error-trailing-content-color, var(--md-sys-color-error, #b3261e));--_focus-content-color: var(--md-outlined-field-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-content-color: var(--md-outlined-field-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-content-color: var(--md-outlined-field-focus-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-content-color: var(--md-outlined-field-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-content-color: var(--md-outlined-field-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-content-color: var(--md-outlined-field-hover-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-color: var(--md-outlined-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-padding-bottom: var(--md-outlined-field-label-text-padding-bottom, 8px);--_label-text-populated-line-height: var(--md-outlined-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-content-color: var(--md-outlined-field-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-space: var(--md-outlined-field-leading-space, 16px);--_outline-color: var(--md-outlined-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-label-padding: var(--md-outlined-field-outline-label-padding, 4px);--_outline-width: var(--md-outlined-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-leading-space: var(--md-outlined-field-supporting-text-leading-space, 16px);--_supporting-text-line-height: var(--md-outlined-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-top-space: var(--md-outlined-field-supporting-text-top-space, 4px);--_supporting-text-trailing-space: var(--md-outlined-field-supporting-text-trailing-space, 16px);--_supporting-text-weight: var(--md-outlined-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_top-space: var(--md-outlined-field-top-space, 16px);--_trailing-content-color: var(--md-outlined-field-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-space: var(--md-outlined-field-trailing-space, 16px);--_with-leading-content-leading-space: var(--md-outlined-field-with-leading-content-leading-space, 12px);--_with-trailing-content-trailing-space: var(--md-outlined-field-with-trailing-content-trailing-space, 12px);--_container-shape-start-start: var(--md-outlined-field-container-shape-start-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-field-container-shape-start-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-field-container-shape-end-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-field-container-shape-end-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)))}.outline{border-color:var(--_outline-color);border-radius:inherit;display:flex;pointer-events:none;height:100%;position:absolute;width:100%;z-index:1}.outline-start::before,.outline-start::after,.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after,.outline-end::before,.outline-end::after{border:inherit;content:"";inset:0;position:absolute}.outline-start,.outline-end{border:inherit;border-radius:inherit;box-sizing:border-box;position:relative}.outline-start::before,.outline-start::after,.outline-end::before,.outline-end::after{border-bottom-style:solid;border-top-style:solid}.outline-start::after,.outline-end::after{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-start::after,.focused .outline-end::after{opacity:1}.outline-start::before,.outline-start::after{border-inline-start-style:solid;border-inline-end-style:none;border-start-start-radius:inherit;border-start-end-radius:0;border-end-start-radius:inherit;border-end-end-radius:0;margin-inline-end:var(--_outline-label-padding)}.outline-end{flex-grow:1;margin-inline-start:calc(-1*var(--_outline-label-padding))}.outline-end::before,.outline-end::after{border-inline-start-style:none;border-inline-end-style:solid;border-start-start-radius:0;border-start-end-radius:inherit;border-end-start-radius:0;border-end-end-radius:inherit}.outline-notch{align-items:flex-start;border:inherit;display:flex;margin-inline-start:calc(-1*var(--_outline-label-padding));margin-inline-end:var(--_outline-label-padding);max-width:calc(100% - var(--_leading-space) - var(--_trailing-space));padding:0 var(--_outline-label-padding);position:relative}.no-label .outline-notch{display:none}.outline-panel-inactive,.outline-panel-active{border:inherit;border-bottom-style:solid;inset:0;position:absolute}.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after{border-top-style:solid;border-bottom:none;bottom:auto;transform:scaleX(1);transition:transform 150ms cubic-bezier(0.2, 0, 0, 1)}.outline-panel-inactive::before,.outline-panel-active::before{right:50%;transform-origin:top left}.outline-panel-inactive::after,.outline-panel-active::after{left:50%;transform-origin:top right}.populated .outline-panel-inactive::before,.populated .outline-panel-inactive::after,.populated .outline-panel-active::before,.populated .outline-panel-active::after,.focused .outline-panel-inactive::before,.focused .outline-panel-inactive::after,.focused .outline-panel-active::before,.focused .outline-panel-active::after{transform:scaleX(0)}.outline-panel-active{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-panel-active{opacity:1}.outline-label{display:flex;max-width:100%;transform:translateY(calc(-100% + var(--_label-text-padding-bottom)))}.outline-start,.field:not(.with-start) .content ::slotted(*){padding-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-start) .label-wrapper{margin-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-end) .content ::slotted(*){padding-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.field:not(.with-end) .label-wrapper{margin-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.outline-start::before,.outline-end::before,.outline-panel-inactive,.outline-panel-inactive::before,.outline-panel-inactive::after{border-width:var(--_outline-width)}:hover .outline{border-color:var(--_hover-outline-color);color:var(--_hover-outline-color)}:hover .outline-start::before,:hover .outline-end::before,:hover .outline-panel-inactive,:hover .outline-panel-inactive::before,:hover .outline-panel-inactive::after{border-width:var(--_hover-outline-width)}.focused .outline{border-color:var(--_focus-outline-color);color:var(--_focus-outline-color)}.outline-start::after,.outline-end::after,.outline-panel-active,.outline-panel-active::before,.outline-panel-active::after{border-width:var(--_focus-outline-width)}.disabled .outline{border-color:var(--_disabled-outline-color);color:var(--_disabled-outline-color)}.disabled .outline-start,.disabled .outline-end,.disabled .outline-panel-inactive{opacity:var(--_disabled-outline-opacity)}.disabled .outline-start::before,.disabled .outline-end::before,.disabled .outline-panel-inactive,.disabled .outline-panel-inactive::before,.disabled .outline-panel-inactive::after{border-width:var(--_disabled-outline-width)}.error .outline{border-color:var(--_error-outline-color);color:var(--_error-outline-color)}.error:hover .outline{border-color:var(--_error-hover-outline-color);color:var(--_error-hover-outline-color)}.error.focused .outline{border-color:var(--_error-focus-outline-color);color:var(--_error-focus-outline-color)}.resizable .container{bottom:var(--_focus-outline-width);inset-inline-end:var(--_focus-outline-width);clip-path:inset(var(--_focus-outline-width) 0 0 var(--_focus-outline-width))}.resizable .container>*{top:var(--_focus-outline-width);inset-inline-start:var(--_focus-outline-width)}.resizable .container:dir(rtl){clip-path:inset(var(--_focus-outline-width) var(--_focus-outline-width) 0 0)}}@layer hcm{@media(forced-colors: active){.disabled .outline{border-color:GrayText;color:GrayText}.disabled :is(.outline-start,.outline-end,.outline-panel-inactive){opacity:1}}}
+`;var qr=x`:host{display:inline-flex;resize:both}.field{display:flex;flex:1;flex-direction:column;writing-mode:horizontal-tb;max-width:100%}.container-overflow{border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-end-radius:var(--_container-shape-end-end);border-end-start-radius:var(--_container-shape-end-start);display:flex;height:100%;position:relative}.container{align-items:center;border-radius:inherit;display:flex;flex:1;max-height:100%;min-height:100%;min-width:min-content;position:relative}.field,.container-overflow{resize:inherit}.resizable:not(.disabled) .container{resize:inherit;overflow:hidden}.disabled{pointer-events:none}slot[name=container]{border-radius:inherit}slot[name=container]::slotted(*){border-radius:inherit;inset:0;pointer-events:none;position:absolute}@layer styles{.start,.middle,.end{display:flex;box-sizing:border-box;height:100%;position:relative}.start{color:var(--_leading-content-color)}.end{color:var(--_trailing-content-color)}.start,.end{align-items:center;justify-content:center}.with-start .start{margin-inline:var(--_with-leading-content-leading-space) var(--_content-space)}.with-end .end{margin-inline:var(--_content-space) var(--_with-trailing-content-trailing-space)}.middle{align-items:stretch;align-self:baseline;flex:1}.content{color:var(--_content-color);display:flex;flex:1;opacity:0;transition:opacity 83ms cubic-bezier(0.2, 0, 0, 1)}.no-label .content,.focused .content,.populated .content{opacity:1;transition-delay:67ms}:is(.disabled,.disable-transitions) .content{transition:none}.content ::slotted(*){all:unset;color:currentColor;font-family:var(--_content-font);font-size:var(--_content-size);line-height:var(--_content-line-height);font-weight:var(--_content-weight);width:100%;overflow-wrap:revert;white-space:revert}.content ::slotted(:not(textarea)){padding-top:var(--_top-space);padding-bottom:var(--_bottom-space)}.content ::slotted(textarea){margin-top:var(--_top-space);margin-bottom:var(--_bottom-space)}:hover .content{color:var(--_hover-content-color)}:hover .start{color:var(--_hover-leading-content-color)}:hover .end{color:var(--_hover-trailing-content-color)}.focused .content{color:var(--_focus-content-color)}.focused .start{color:var(--_focus-leading-content-color)}.focused .end{color:var(--_focus-trailing-content-color)}.disabled .content{color:var(--_disabled-content-color)}.disabled.no-label .content,.disabled.focused .content,.disabled.populated .content{opacity:var(--_disabled-content-opacity)}.disabled .start{color:var(--_disabled-leading-content-color);opacity:var(--_disabled-leading-content-opacity)}.disabled .end{color:var(--_disabled-trailing-content-color);opacity:var(--_disabled-trailing-content-opacity)}.error .content{color:var(--_error-content-color)}.error .start{color:var(--_error-leading-content-color)}.error .end{color:var(--_error-trailing-content-color)}.error:hover .content{color:var(--_error-hover-content-color)}.error:hover .start{color:var(--_error-hover-leading-content-color)}.error:hover .end{color:var(--_error-hover-trailing-content-color)}.error.focused .content{color:var(--_error-focus-content-color)}.error.focused .start{color:var(--_error-focus-leading-content-color)}.error.focused .end{color:var(--_error-focus-trailing-content-color)}}@layer hcm{@media(forced-colors: active){.disabled :is(.start,.content,.end){color:GrayText;opacity:1}}}@layer styles{.label{box-sizing:border-box;color:var(--_label-text-color);overflow:hidden;max-width:100%;text-overflow:ellipsis;white-space:nowrap;z-index:1;font-family:var(--_label-text-font);font-size:var(--_label-text-size);line-height:var(--_label-text-line-height);font-weight:var(--_label-text-weight);width:min-content}.label-wrapper{inset:0;pointer-events:none;position:absolute}.label.resting{position:absolute;top:var(--_top-space)}.label.floating{font-size:var(--_label-text-populated-size);line-height:var(--_label-text-populated-line-height);transform-origin:top left}.label.hidden{opacity:0}.no-label .label{display:none}.label-wrapper{inset:0;position:absolute;text-align:initial}:hover .label{color:var(--_hover-label-text-color)}.focused .label{color:var(--_focus-label-text-color)}.disabled .label{color:var(--_disabled-label-text-color)}.disabled .label:not(.hidden){opacity:var(--_disabled-label-text-opacity)}.error .label{color:var(--_error-label-text-color)}.error:hover .label{color:var(--_error-hover-label-text-color)}.error.focused .label{color:var(--_error-focus-label-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .label:not(.hidden){color:GrayText;opacity:1}}}@layer styles{.supporting-text{color:var(--_supporting-text-color);display:flex;font-family:var(--_supporting-text-font);font-size:var(--_supporting-text-size);line-height:var(--_supporting-text-line-height);font-weight:var(--_supporting-text-weight);gap:16px;justify-content:space-between;padding-inline-start:var(--_supporting-text-leading-space);padding-inline-end:var(--_supporting-text-trailing-space);padding-top:var(--_supporting-text-top-space)}.supporting-text :nth-child(2){flex-shrink:0}:hover .supporting-text{color:var(--_hover-supporting-text-color)}.focus .supporting-text{color:var(--_focus-supporting-text-color)}.disabled .supporting-text{color:var(--_disabled-supporting-text-color);opacity:var(--_disabled-supporting-text-opacity)}.error .supporting-text{color:var(--_error-supporting-text-color)}.error:hover .supporting-text{color:var(--_error-hover-supporting-text-color)}.error.focus .supporting-text{color:var(--_error-focus-supporting-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .supporting-text{color:GrayText;opacity:1}}}
+`;var Ut=class extends lt{};Ut.styles=[qr,Ur];Ut=n([T("md-outlined-field")],Ut);var Hr=Symbol.for(""),Mo=o=>{if(o?.r===Hr)return o?._$litStatic$};var W=(o,...e)=>({_$litStatic$:e.reduce((t,r,i)=>t+(s=>{if(s._$litStatic$!==void 0)return s._$litStatic$;throw Error(`Value passed to 'literal' function must be a 'literal' result: ${s}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`)})(r)+o[i+1],o[0]),r:Hr}),Vr=new Map,qt=o=>(e,...t)=>{let r=t.length,i,s,a=[],d=[],c,h=0,m=!1;for(;h<r;){for(c=e[h];h<r&&(s=t[h],(i=Mo(s))!==void 0);)c+=i+e[++h],m=!0;h!==r&&d.push(s),a.push(c),h++}if(h===r&&a.push(e[r]),m){let f=a.join("$$lit$$");(e=Vr.get(f))===void 0&&(a.raw=a,Vr.set(f,e=a)),t=d}return o(e,...t)},ce=qt(p),Ns=qt(Dr),Bs=qt(zr);var jr=x`:host{--_caret-color: var(--md-outlined-text-field-caret-color, var(--md-sys-color-primary, #6750a4));--_disabled-input-text-color: var(--md-outlined-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-input-text-opacity: var(--md-outlined-text-field-disabled-input-text-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-text-field-disabled-label-text-opacity, 0.38);--_disabled-leading-icon-color: var(--md-outlined-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-icon-opacity: var(--md-outlined-text-field-disabled-leading-icon-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-text-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-text-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-text-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-icon-color: var(--md-outlined-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-icon-opacity: var(--md-outlined-text-field-disabled-trailing-icon-opacity, 0.38);--_error-focus-caret-color: var(--md-outlined-text-field-error-focus-caret-color, var(--md-sys-color-error, #b3261e));--_error-focus-input-text-color: var(--md-outlined-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-icon-color: var(--md-outlined-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-icon-color: var(--md-outlined-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_error-hover-input-text-color: var(--md-outlined-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-icon-color: var(--md-outlined-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-icon-color: var(--md-outlined-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_error-input-text-color: var(--md-outlined-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-label-text-color: var(--md-outlined-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-icon-color: var(--md-outlined-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-icon-color: var(--md-outlined-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_focus-input-text-color: var(--md-outlined-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-icon-color: var(--md-outlined-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-text-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-icon-color: var(--md-outlined-text-field-focus-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-input-text-color: var(--md-outlined-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-icon-color: var(--md-outlined-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-text-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-icon-color: var(--md-outlined-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-color: var(--md-outlined-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_input-text-font: var(--md-outlined-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_input-text-line-height: var(--md-outlined-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_input-text-placeholder-color: var(--md-outlined-text-field-input-text-placeholder-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-prefix-color: var(--md-outlined-text-field-input-text-prefix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-size: var(--md-outlined-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_input-text-suffix-color: var(--md-outlined-text-field-input-text-suffix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-weight: var(--md-outlined-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_label-text-color: var(--md-outlined-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-populated-line-height: var(--md-outlined-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-icon-color: var(--md-outlined-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-icon-size: var(--md-outlined-text-field-leading-icon-size, 24px);--_outline-color: var(--md-outlined-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-width: var(--md-outlined-text-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-line-height: var(--md-outlined-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-weight: var(--md-outlined-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_trailing-icon-color: var(--md-outlined-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-icon-size: var(--md-outlined-text-field-trailing-icon-size, 24px);--_container-shape-start-start: var(--md-outlined-text-field-container-shape-start-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-text-field-container-shape-start-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-text-field-container-shape-end-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-text-field-container-shape-end-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_icon-input-space: var(--md-outlined-text-field-icon-input-space, 16px);--_leading-space: var(--md-outlined-text-field-leading-space, 16px);--_trailing-space: var(--md-outlined-text-field-trailing-space, 16px);--_top-space: var(--md-outlined-text-field-top-space, 16px);--_bottom-space: var(--md-outlined-text-field-bottom-space, 16px);--_input-text-prefix-trailing-space: var(--md-outlined-text-field-input-text-prefix-trailing-space, 2px);--_input-text-suffix-leading-space: var(--md-outlined-text-field-input-text-suffix-leading-space, 2px);--_focus-caret-color: var(--md-outlined-text-field-focus-caret-color, var(--md-sys-color-primary, #6750a4));--_with-leading-icon-leading-space: var(--md-outlined-text-field-with-leading-icon-leading-space, 12px);--_with-trailing-icon-trailing-space: var(--md-outlined-text-field-with-trailing-icon-trailing-space, 12px);--md-outlined-field-bottom-space: var(--_bottom-space);--md-outlined-field-container-shape-end-end: var(--_container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_container-shape-start-start);--md-outlined-field-content-color: var(--_input-text-color);--md-outlined-field-content-font: var(--_input-text-font);--md-outlined-field-content-line-height: var(--_input-text-line-height);--md-outlined-field-content-size: var(--_input-text-size);--md-outlined-field-content-space: var(--_icon-input-space);--md-outlined-field-content-weight: var(--_input-text-weight);--md-outlined-field-disabled-content-color: var(--_disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_focus-outline-color);--md-outlined-field-focus-outline-width: var(--_focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_hover-outline-color);--md-outlined-field-hover-outline-width: var(--_hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_label-text-color);--md-outlined-field-label-text-font: var(--_label-text-font);--md-outlined-field-label-text-line-height: var(--_label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_label-text-populated-size);--md-outlined-field-label-text-size: var(--_label-text-size);--md-outlined-field-label-text-weight: var(--_label-text-weight);--md-outlined-field-leading-content-color: var(--_leading-icon-color);--md-outlined-field-leading-space: var(--_leading-space);--md-outlined-field-outline-color: var(--_outline-color);--md-outlined-field-outline-width: var(--_outline-width);--md-outlined-field-supporting-text-color: var(--_supporting-text-color);--md-outlined-field-supporting-text-font: var(--_supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_supporting-text-weight);--md-outlined-field-top-space: var(--_top-space);--md-outlined-field-trailing-content-color: var(--_trailing-icon-color);--md-outlined-field-trailing-space: var(--_trailing-space);--md-outlined-field-with-leading-content-leading-space: var(--_with-leading-icon-leading-space);--md-outlined-field-with-trailing-content-trailing-space: var(--_with-trailing-icon-trailing-space)}
+`;var{I:Ws}=Br;var Wr=o=>o.strings===void 0;var No={},Kr=(o,e=No)=>o._$AH=e;var Vt=Se(class extends de{constructor(o){if(super(o),o.type!==Y.PROPERTY&&o.type!==Y.ATTRIBUTE&&o.type!==Y.BOOLEAN_ATTRIBUTE)throw Error("The `live` directive is not allowed on child or event bindings");if(!Wr(o))throw Error("`live` bindings can only contain a single expression")}render(o){return o}update(o,[e]){if(e===B||e===u)return e;let t=o.element,r=o.name;if(o.type===Y.PROPERTY){if(e===t[r])return B}else if(o.type===Y.BOOLEAN_ATTRIBUTE){if(!!e===t.hasAttribute(r))return B}else if(o.type===Y.ATTRIBUTE&&t.getAttribute(r)===e+"")return B;return Kr(o),e}});var Gr="important",Bo=" !"+Gr,Ee=Se(class extends de{constructor(o){if(super(o),o.type!==Y.ATTRIBUTE||o.name!=="style"||o.strings?.length>2)throw Error("The `styleMap` directive must be used in the `style` attribute and must be the only part in the attribute.")}render(o){return Object.keys(o).reduce((e,t)=>{let r=o[t];return r==null?e:e+`${t=t.includes("-")?t:t.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g,"-$&").toLowerCase()}:${r};`},"")}update(o,[e]){let{style:t}=o.element;if(this.ft===void 0)return this.ft=new Set(Object.keys(e)),this.render(e);for(let r of this.ft)e[r]==null&&(this.ft.delete(r),r.includes("-")?t.removeProperty(r):t[r]=null);for(let r in e){let i=e[r];if(i!=null){this.ft.add(r);let s=typeof i=="string"&&i.endsWith(Bo);r.includes("-")||s?t.setProperty(r,s?i.slice(0,-11):i,s?Gr:""):t[r]=i}}return B}});var Ht=["role","ariaAtomic","ariaAutoComplete","ariaBusy","ariaChecked","ariaColCount","ariaColIndex","ariaColSpan","ariaCurrent","ariaDisabled","ariaExpanded","ariaHasPopup","ariaHidden","ariaInvalid","ariaKeyShortcuts","ariaLabel","ariaLevel","ariaLive","ariaModal","ariaMultiLine","ariaMultiSelectable","ariaOrientation","ariaPlaceholder","ariaPosInSet","ariaPressed","ariaReadOnly","ariaRequired","ariaRoleDescription","ariaRowCount","ariaRowIndex","ariaRowSpan","ariaSelected","ariaSetSize","ariaSort","ariaValueMax","ariaValueMin","ariaValueNow","ariaValueText"],Fo=Ht.map(jt);function dt(o){return Fo.includes(o)}function jt(o){return o.replace("aria","aria-").replace(/Elements?/g,"").toLowerCase()}var ct=Symbol("privateIgnoreAttributeChangesFor");function G(o){var e;if(!1)return o;class t extends o{constructor(){super(...arguments),this[e]=new Set}attributeChangedCallback(i,s,a){if(!dt(i)){super.attributeChangedCallback(i,s,a);return}if(this[ct].has(i))return;this[ct].add(i),this.removeAttribute(i),this[ct].delete(i);let d=Kt(i);a===null?delete this.dataset[d]:this.dataset[d]=a,this.requestUpdate(Kt(i),s)}getAttribute(i){return dt(i)?super.getAttribute(Wt(i)):super.getAttribute(i)}removeAttribute(i){super.removeAttribute(i),dt(i)&&(super.removeAttribute(Wt(i)),this.requestUpdate())}}return e=ct,Uo(t),t}function Uo(o){for(let e of Ht){let t=jt(e),r=Wt(t),i=Kt(t);o.createProperty(e,{attribute:t,noAccessor:!0}),o.createProperty(Symbol(r),{attribute:r,noAccessor:!0}),Object.defineProperty(o.prototype,e,{configurable:!0,enumerable:!0,get(){return this.dataset[i]??null},set(s){let a=this.dataset[i]??null;s!==a&&(s===null?delete this.dataset[i]:this.dataset[i]=s,this.requestUpdate(e,a))}})}}function Wt(o){return`data-${o}`}function Kt(o){return o.replace(/-\w/,e=>e[1].toUpperCase())}var Yr={fromAttribute(o){return o??""},toAttribute(o){return o||null}};function Ie(o,e){e.bubbles&&(!o.shadowRoot||e.composed)&&e.stopPropagation();let t=Reflect.construct(e.constructor,[e.type,e]),r=o.dispatchEvent(t);return r||e.preventDefault(),r}var L=Symbol("internals"),Gt=Symbol("privateInternals");function ue(o){class e extends o{get[L](){return this[Gt]||(this[Gt]=this.attachInternals()),this[Gt]}}return e}var pe=Symbol("createValidator"),he=Symbol("getValidityAnchor"),Yt=Symbol("privateValidator"),oe=Symbol("privateSyncValidity"),ut=Symbol("privateCustomValidationMessage");function ke(o){var e;class t extends o{constructor(){super(...arguments),this[e]=""}get validity(){return this[oe](),this[L].validity}get validationMessage(){return this[oe](),this[L].validationMessage}get willValidate(){return this[oe](),this[L].willValidate}checkValidity(){return this[oe](),this[L].checkValidity()}reportValidity(){return this[oe](),this[L].reportValidity()}setCustomValidity(i){this[ut]=i,this[oe]()}requestUpdate(i,s,a){super.requestUpdate(i,s,a),this[oe]()}firstUpdated(i){super.firstUpdated(i),this[oe]()}[(e=ut,oe)](){if(!1)return;this[Yt]||(this[Yt]=this[pe]());let{validity:i,validationMessage:s}=this[Yt].getValidity(),a=!!this[ut],d=this[ut]||s;this[L].setValidity({...i,customError:a},d,this[he]()??void 0)}[pe](){throw new Error("Implement [createValidator]")}[he](){throw new Error("Implement [getValidityAnchor]")}}return t}var ie=Symbol("getFormValue"),pt=Symbol("getFormState");function Oe(o){class e extends o{get form(){return this[L].form}get labels(){return this[L].labels}get name(){return this.getAttribute("name")??""}set name(r){this.setAttribute("name",r)}get disabled(){return this.hasAttribute("disabled")}set disabled(r){this.toggleAttribute("disabled",r)}attributeChangedCallback(r,i,s){if(r==="name"||r==="disabled"){let a=r==="disabled"?i!==null:i;this.requestUpdate(r,a);return}super.attributeChangedCallback(r,i,s)}requestUpdate(r,i,s){super.requestUpdate(r,i,s),this[L].setFormValue(this[ie](),this[pt]())}[ie](){throw new Error("Implement [getFormValue]")}[pt](){return this[ie]()}formDisabledCallback(r){this.disabled=r}}return e.formAssociated=!0,n([l({noAccessor:!0})],e.prototype,"name",null),n([l({type:Boolean,noAccessor:!0})],e.prototype,"disabled",null),e}var Re=Symbol("onReportValidity"),ht=Symbol("privateCleanupFormListeners"),ft=Symbol("privateDoNotReportInvalid"),mt=Symbol("privateIsSelfReportingValidity"),vt=Symbol("privateCallOnReportValidity");function gt(o){var e,t,r;class i extends o{constructor(...a){super(...a),this[e]=new AbortController,this[t]=!1,this[r]=!1,!!1&&this.addEventListener("invalid",d=>{this[ft]||!d.isTrusted||this.addEventListener("invalid",()=>{this[vt](d)},{once:!0})},{capture:!0})}checkValidity(){this[ft]=!0;let a=super.checkValidity();return this[ft]=!1,a}reportValidity(){this[mt]=!0;let a=super.reportValidity();return a&&this[vt](null),this[mt]=!1,a}[(e=ht,t=ft,r=mt,vt)](a){let d=a?.defaultPrevented;d||(this[Re](a),!(!d&&a?.defaultPrevented))||(this[mt]||Ho(this[L].form,this))&&this.focus()}[Re](a){throw new Error("Implement [onReportValidity]")}formAssociatedCallback(a){super.formAssociatedCallback&&super.formAssociatedCallback(a),this[ht].abort(),a&&(this[ht]=new AbortController,qo(this,a,()=>{this[vt](null)},this[ht].signal))}}return i}function qo(o,e,t,r){let i=Vo(e),s=!1,a,d=!1;i.addEventListener("before",()=>{d=!0,a=new AbortController,s=!1,o.addEventListener("invalid",()=>{s=!0},{signal:a.signal})},{signal:r}),i.addEventListener("after",()=>{d=!1,a?.abort(),!s&&t()},{signal:r}),e.addEventListener("submit",()=>{d||t()},{signal:r})}var Xt=new WeakMap;function Vo(o){if(!Xt.has(o)){let e=new EventTarget;Xt.set(o,e);for(let t of["reportValidity","requestSubmit"]){let r=o[t];o[t]=function(){e.dispatchEvent(new Event("before"));let i=Reflect.apply(r,this,arguments);return e.dispatchEvent(new Event("after")),i}}}return Xt.get(o)}function Ho(o,e){if(!o)return!0;let t;for(let r of o.elements)if(r.matches(":invalid")){t=r;break}return t===e}var fe=class{constructor(e){this.getCurrentState=e,this.currentValidity={validity:{},validationMessage:""}}getValidity(){let e=this.getCurrentState();if(!(!this.prevState||!this.equals(this.prevState,e)))return this.currentValidity;let{validity:r,validationMessage:i}=this.computeValidity(e);return this.prevState=this.copy(e),this.currentValidity={validationMessage:i,validity:{badInput:r.badInput,customError:r.customError,patternMismatch:r.patternMismatch,rangeOverflow:r.rangeOverflow,rangeUnderflow:r.rangeUnderflow,stepMismatch:r.stepMismatch,tooLong:r.tooLong,tooShort:r.tooShort,typeMismatch:r.typeMismatch,valueMissing:r.valueMissing}},this.currentValidity}};var yt=class extends fe{computeValidity({state:e,renderedControl:t}){let r=t;We(e)&&!r?(r=this.inputControl||document.createElement("input"),this.inputControl=r):r||(r=this.textAreaControl||document.createElement("textarea"),this.textAreaControl=r);let i=We(e)?r:null;if(i&&(i.type=e.type),r.value!==e.value&&(r.value=e.value),r.required=e.required,i){let s=e;s.pattern?i.pattern=s.pattern:i.removeAttribute("pattern"),s.min?i.min=s.min:i.removeAttribute("min"),s.max?i.max=s.max:i.removeAttribute("max"),s.step?i.step=s.step:i.removeAttribute("step")}return(e.minLength??-1)>-1?r.setAttribute("minlength",String(e.minLength)):r.removeAttribute("minlength"),(e.maxLength??-1)>-1?r.setAttribute("maxlength",String(e.maxLength)):r.removeAttribute("maxlength"),{validity:r.validity,validationMessage:r.validationMessage}}equals({state:e},{state:t}){let r=e.type===t.type&&e.value===t.value&&e.required===t.required&&e.minLength===t.minLength&&e.maxLength===t.maxLength;return!We(e)||!We(t)?r:r&&e.pattern===t.pattern&&e.min===t.min&&e.max===t.max&&e.step===t.step}copy({state:e}){return{state:We(e)?this.copyInput(e):this.copyTextArea(e),renderedControl:null}}copyInput(e){let{type:t,pattern:r,min:i,max:s,step:a}=e;return{...this.copySharedState(e),type:t,pattern:r,min:i,max:s,step:a}}copyTextArea(e){return{...this.copySharedState(e),type:e.type}}copySharedState({value:e,required:t,minLength:r,maxLength:i}){return{value:e,required:t,minLength:r,maxLength:i}}};function We(o){return o.type!=="textarea"}var jo=G(gt(ke(Oe(ue(y))))),v=class extends jo{constructor(){super(...arguments),this.error=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.required=!1,this.value="",this.prefixText="",this.suffixText="",this.hasLeadingIcon=!1,this.hasTrailingIcon=!1,this.supportingText="",this.textDirection="",this.rows=2,this.cols=20,this.inputMode="",this.max="",this.maxLength=-1,this.min="",this.minLength=-1,this.noSpinner=!1,this.pattern="",this.placeholder="",this.readOnly=!1,this.multiple=!1,this.step="",this.type="text",this.autocomplete="",this.dirty=!1,this.focused=!1,this.nativeError=!1,this.nativeErrorText=""}get selectionDirection(){return this.getInputOrTextarea().selectionDirection}set selectionDirection(e){this.getInputOrTextarea().selectionDirection=e}get selectionEnd(){return this.getInputOrTextarea().selectionEnd}set selectionEnd(e){this.getInputOrTextarea().selectionEnd=e}get selectionStart(){return this.getInputOrTextarea().selectionStart}set selectionStart(e){this.getInputOrTextarea().selectionStart=e}get valueAsNumber(){let e=this.getInput();return e?e.valueAsNumber:NaN}set valueAsNumber(e){let t=this.getInput();t&&(t.valueAsNumber=e,this.value=t.value)}get valueAsDate(){let e=this.getInput();return e?e.valueAsDate:null}set valueAsDate(e){let t=this.getInput();t&&(t.valueAsDate=e,this.value=t.value)}get hasError(){return this.error||this.nativeError}select(){this.getInputOrTextarea().select()}setRangeText(...e){this.getInputOrTextarea().setRangeText(...e),this.value=this.getInputOrTextarea().value}setSelectionRange(e,t,r){this.getInputOrTextarea().setSelectionRange(e,t,r)}showPicker(){let e=this.getInput();e&&e.showPicker()}stepDown(e){let t=this.getInput();t&&(t.stepDown(e),this.value=t.value)}stepUp(e){let t=this.getInput();t&&(t.stepUp(e),this.value=t.value)}reset(){this.dirty=!1,this.value=this.getAttribute("value")??"",this.nativeError=!1,this.nativeErrorText=""}attributeChangedCallback(e,t,r){e==="value"&&this.dirty||super.attributeChangedCallback(e,t,r)}render(){let e={disabled:this.disabled,error:!this.disabled&&this.hasError,textarea:this.type==="textarea","no-spinner":this.noSpinner};return p`
+      <span class="text-field ${R(e)}">
+        ${this.renderField()}
+      </span>
+    `}updated(e){let t=this.getInputOrTextarea().value;this.value!==t&&(this.value=t)}renderField(){return ce`<${this.fieldTag}
+      class="field"
+      count=${this.value.length}
+      ?disabled=${this.disabled}
+      ?error=${this.hasError}
+      error-text=${this.getErrorText()}
+      ?focused=${this.focused}
+      ?has-end=${this.hasTrailingIcon}
+      ?has-start=${this.hasLeadingIcon}
+      label=${this.label}
+      ?no-asterisk=${this.noAsterisk}
+      max=${this.maxLength}
+      ?populated=${!!this.value}
+      ?required=${this.required}
+      ?resizable=${this.type==="textarea"}
+      supporting-text=${this.supportingText}
+    >
+      ${this.renderLeadingIcon()}
+      ${this.renderInputOrTextarea()}
+      ${this.renderTrailingIcon()}
+      <div id="description" slot="aria-describedby"></div>
+      <slot name="container" slot="container"></slot>
+    </${this.fieldTag}>`}renderLeadingIcon(){return p`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return p`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderInputOrTextarea(){let e={direction:this.textDirection},t=this.ariaLabel||this.label||u,r=this.autocomplete,i=(this.maxLength??-1)>-1,s=(this.minLength??-1)>-1;if(this.type==="textarea")return p`
+        <textarea
+          class="input"
+          style=${Ee(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||u}
+          name=${this.name||u}
+          ?disabled=${this.disabled}
+          maxlength=${i?this.maxLength:u}
+          minlength=${s?this.minLength:u}
+          placeholder=${this.placeholder||u}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          rows=${this.rows}
+          cols=${this.cols}
+          .value=${Vt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent}></textarea>
+      `;let a=this.renderPrefix(),d=this.renderSuffix(),c=this.inputMode;return p`
+      <div class="input-wrapper">
+        ${a}
+        <input
+          class="input"
+          style=${Ee(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||u}
+          name=${this.name||u}
+          ?disabled=${this.disabled}
+          inputmode=${c||u}
+          max=${this.max||u}
+          maxlength=${i?this.maxLength:u}
+          min=${this.min||u}
+          minlength=${s?this.minLength:u}
+          pattern=${this.pattern||u}
+          placeholder=${this.placeholder||u}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          ?multiple=${this.multiple}
+          step=${this.step||u}
+          type=${this.type}
+          .value=${Vt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent} />
+        ${d}
+      </div>
+    `}renderPrefix(){return this.renderAffix(this.prefixText,!1)}renderSuffix(){return this.renderAffix(this.suffixText,!0)}renderAffix(e,t){return e?p`<span class="${R({suffix:t,prefix:!t})}">${e}</span>`:u}getErrorText(){return this.error?this.errorText:this.nativeErrorText}handleFocusChange(){this.focused=this.inputOrTextarea?.matches(":focus")??!1}handleInput(e){this.dirty=!0,this.value=e.target.value}redispatchEvent(e){Ie(this,e)}getInputOrTextarea(){return this.inputOrTextarea||(this.connectedCallback(),this.scheduleUpdate()),this.isUpdatePending&&this.scheduleUpdate(),this.inputOrTextarea}getInput(){return this.type==="textarea"?null:this.getInputOrTextarea()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0,this.hasTrailingIcon=this.trailingIcons.length>0}[ie](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}focus(){this.getInputOrTextarea().focus()}[pe](){return new yt(()=>({state:this,renderedControl:this.inputOrTextarea}))}[he](){return this.inputOrTextarea}[Re](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}};v.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],v.prototype,"error",void 0);n([l({attribute:"error-text"})],v.prototype,"errorText",void 0);n([l()],v.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],v.prototype,"noAsterisk",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"required",void 0);n([l()],v.prototype,"value",void 0);n([l({attribute:"prefix-text"})],v.prototype,"prefixText",void 0);n([l({attribute:"suffix-text"})],v.prototype,"suffixText",void 0);n([l({type:Boolean,attribute:"has-leading-icon"})],v.prototype,"hasLeadingIcon",void 0);n([l({type:Boolean,attribute:"has-trailing-icon"})],v.prototype,"hasTrailingIcon",void 0);n([l({attribute:"supporting-text"})],v.prototype,"supportingText",void 0);n([l({attribute:"text-direction"})],v.prototype,"textDirection",void 0);n([l({type:Number})],v.prototype,"rows",void 0);n([l({type:Number})],v.prototype,"cols",void 0);n([l({reflect:!0})],v.prototype,"inputMode",void 0);n([l()],v.prototype,"max",void 0);n([l({type:Number})],v.prototype,"maxLength",void 0);n([l()],v.prototype,"min",void 0);n([l({type:Number})],v.prototype,"minLength",void 0);n([l({type:Boolean,attribute:"no-spinner"})],v.prototype,"noSpinner",void 0);n([l()],v.prototype,"pattern",void 0);n([l({reflect:!0,converter:Yr})],v.prototype,"placeholder",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"readOnly",void 0);n([l({type:Boolean,reflect:!0})],v.prototype,"multiple",void 0);n([l()],v.prototype,"step",void 0);n([l({reflect:!0})],v.prototype,"type",void 0);n([l({reflect:!0})],v.prototype,"autocomplete",void 0);n([I()],v.prototype,"dirty",void 0);n([I()],v.prototype,"focused",void 0);n([I()],v.prototype,"nativeError",void 0);n([I()],v.prototype,"nativeErrorText",void 0);n([k(".input")],v.prototype,"inputOrTextarea",void 0);n([k(".field")],v.prototype,"field",void 0);n([q({slot:"leading-icon"})],v.prototype,"leadingIcons",void 0);n([q({slot:"trailing-icon"})],v.prototype,"trailingIcons",void 0);var bt=class extends v{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};var Xr=x`:host{display:inline-flex;outline:none;resize:both;text-align:start;-webkit-tap-highlight-color:rgba(0,0,0,0)}.text-field,.field{width:100%}.text-field{display:inline-flex}.field{cursor:text}.disabled .field{cursor:default}.text-field,.textarea .field{resize:inherit}slot[name=container]{border-radius:inherit}.icon{color:currentColor;display:flex;align-items:center;justify-content:center;fill:currentColor;position:relative}.icon ::slotted(*){display:flex;position:absolute}[has-start] .icon.leading{font-size:var(--_leading-icon-size);height:var(--_leading-icon-size);width:var(--_leading-icon-size)}[has-end] .icon.trailing{font-size:var(--_trailing-icon-size);height:var(--_trailing-icon-size);width:var(--_trailing-icon-size)}.input-wrapper{display:flex}.input-wrapper>*{all:inherit;padding:0}.input{caret-color:var(--_caret-color);overflow-x:hidden;text-align:inherit}.input::placeholder{color:currentColor;opacity:1}.input::-webkit-calendar-picker-indicator{display:none}.input::-webkit-search-decoration,.input::-webkit-search-cancel-button{display:none}@media(forced-colors: active){.input{background:none}}.no-spinner .input::-webkit-inner-spin-button,.no-spinner .input::-webkit-outer-spin-button{display:none}.no-spinner .input[type=number]{-moz-appearance:textfield}:focus-within .input{caret-color:var(--_focus-caret-color)}.error:focus-within .input{caret-color:var(--_error-focus-caret-color)}.text-field:not(.disabled) .prefix{color:var(--_input-text-prefix-color)}.text-field:not(.disabled) .suffix{color:var(--_input-text-suffix-color)}.text-field:not(.disabled) .input::placeholder{color:var(--_input-text-placeholder-color)}.prefix,.suffix{text-wrap:nowrap;width:min-content}.prefix{padding-inline-end:var(--_input-text-prefix-trailing-space)}.suffix{padding-inline-start:var(--_input-text-suffix-leading-space)}
+`;var Zt=class extends bt{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};Zt.styles=[Xr,jr];Zt=n([T("md-outlined-text-field")],Zt);var xt=class extends y{connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){return p`<span class="shadow"></span>`}};var Zr=x`:host,.shadow,.shadow::before,.shadow::after{border-radius:inherit;inset:0;position:absolute;transition-duration:inherit;transition-property:inherit;transition-timing-function:inherit}:host{display:flex;pointer-events:none;transition-property:box-shadow,opacity}.shadow::before,.shadow::after{content:"";transition-property:box-shadow,opacity;--_level: var(--md-elevation-level, 0);--_shadow-color: var(--md-elevation-shadow-color, var(--md-sys-color-shadow, #000))}.shadow::before{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 3,1) + 2*clamp(0,var(--_level) - 4,1))) calc(1px*(2*clamp(0,var(--_level),1) + clamp(0,var(--_level) - 2,1) + clamp(0,var(--_level) - 4,1))) 0px var(--_shadow-color);opacity:.3}.shadow::after{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 1,1) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(3*clamp(0,var(--_level),2) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(clamp(0,var(--_level),4) + 2*clamp(0,var(--_level) - 4,1))) var(--_shadow-color);opacity:.15}
+`;var Jt=class extends xt{};Jt.styles=[Zr];Jt=n([T("md-elevation")],Jt);var Jr=Symbol("attachableController"),Qr;Qr=new MutationObserver(o=>{for(let e of o)e.target[Jr]?.hostConnected()});var Pe=class{get htmlFor(){return this.host.getAttribute("for")}set htmlFor(e){e===null?this.host.removeAttribute("for"):this.host.setAttribute("for",e)}get control(){return this.host.hasAttribute("for")?!this.htmlFor||!this.host.isConnected?null:this.host.getRootNode().querySelector(`#${this.htmlFor}`):this.currentControl||this.host.parentElement}set control(e){e?this.attach(e):this.detach()}constructor(e,t){this.host=e,this.onControlChange=t,this.currentControl=null,e.addController(this),e[Jr]=this,Qr?.observe(e,{attributeFilter:["for"]})}attach(e){e!==this.currentControl&&(this.setCurrentControl(e),this.host.removeAttribute("for"))}detach(){this.setCurrentControl(null),this.host.setAttribute("for","")}hostConnected(){this.setCurrentControl(this.control)}hostDisconnected(){this.setCurrentControl(null)}setCurrentControl(e){this.onControlChange(this.currentControl,e),this.currentControl=e}};var Wo=["focusin","focusout","pointerdown"],Le=class extends y{constructor(){super(...arguments),this.visible=!1,this.inward=!1,this.attachableController=new Pe(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}handleEvent(e){if(!e[eo]){switch(e.type){default:return;case"focusin":this.visible=this.control?.matches(":focus-visible")??!1;break;case"focusout":case"pointerdown":this.visible=!1;break}e[eo]=!0}}onControlChange(e,t){if(!!1)for(let r of Wo)e?.removeEventListener(r,this),t?.addEventListener(r,this)}update(e){e.has("visible")&&this.dispatchEvent(new Event("visibility-changed")),super.update(e)}};n([l({type:Boolean,reflect:!0})],Le.prototype,"visible",void 0);n([l({type:Boolean,reflect:!0})],Le.prototype,"inward",void 0);var eo=Symbol("handledByFocusRing");var to=x`:host{animation-delay:0s,calc(var(--md-focus-ring-duration, 600ms)*.25);animation-duration:calc(var(--md-focus-ring-duration, 600ms)*.25),calc(var(--md-focus-ring-duration, 600ms)*.75);animation-timing-function:cubic-bezier(0.2, 0, 0, 1);box-sizing:border-box;color:var(--md-focus-ring-color, var(--md-sys-color-secondary, #625b71));display:none;pointer-events:none;position:absolute}:host([visible]){display:flex}:host(:not([inward])){animation-name:outward-grow,outward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));inset:calc(-1*var(--md-focus-ring-outward-offset, 2px));outline:var(--md-focus-ring-width, 3px) solid currentColor}:host([inward]){animation-name:inward-grow,inward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border:var(--md-focus-ring-width, 3px) solid currentColor;inset:var(--md-focus-ring-inward-offset, 0px)}@keyframes outward-grow{from{outline-width:0}to{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes outward-shrink{from{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-grow{from{border-width:0}to{border-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-shrink{from{border-width:var(--md-focus-ring-active-width, 8px)}}@media(prefers-reduced-motion){:host{animation:none}}
+`;var Qt=class extends Le{};Qt.styles=[to];Qt=n([T("md-focus-ring")],Qt);function er(o,e=se){let t=Ke(o,e);return t&&(t.tabIndex=0,t.focus()),t}function tr(o,e=se){let t=rr(o,e);return t&&(t.tabIndex=0,t.focus()),t}function me(o,e=se){for(let t=0;t<o.length;t++){let r=o[t];if(r.tabIndex===0&&e(r))return{item:r,index:t}}return null}function Ke(o,e=se){for(let t of o)if(e(t))return t;return null}function rr(o,e=se){for(let t=o.length-1;t>=0;t--){let r=o[t];if(e(r))return r}return null}function Ko(o,e,t=se,r=!0){for(let i=1;i<o.length;i++){let s=(i+e)%o.length;if(s<e&&!r)return null;let a=o[s];if(t(a))return a}return o[e]?o[e]:null}function Go(o,e,t=se,r=!0){for(let i=1;i<o.length;i++){let s=(e-i+o.length)%o.length;if(s>e&&!r)return null;let a=o[s];if(t(a))return a}return o[e]?o[e]:null}function or(o,e,t=se,r=!0){if(e){let i=Ko(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return er(o,t)}function ir(o,e,t=se,r=!0){if(e){let i=Go(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return tr(o,t)}function se(o){return!o.disabled}var M={ArrowDown:"ArrowDown",ArrowLeft:"ArrowLeft",ArrowUp:"ArrowUp",ArrowRight:"ArrowRight",Home:"Home",End:"End"},_t=class{constructor(e){this.handleKeydown=m=>{let f=m.key;if(m.defaultPrevented||!this.isNavigableKey(f))return;let b=this.items;if(!b.length)return;let g=me(b,this.isActivatable);m.preventDefault();let S=this.isRtl(),w=S?M.ArrowRight:M.ArrowLeft,O=S?M.ArrowLeft:M.ArrowRight,z=null;switch(f){case M.ArrowDown:case O:z=or(b,g,this.isActivatable,this.wrapNavigation());break;case M.ArrowUp:case w:z=ir(b,g,this.isActivatable,this.wrapNavigation());break;case M.Home:z=er(b,this.isActivatable);break;case M.End:z=tr(b,this.isActivatable);break;default:break}z&&g&&g.item!==z&&(g.item.tabIndex=-1)},this.onDeactivateItems=()=>{let m=this.items;for(let f of m)this.deactivateItem(f)},this.onRequestActivation=m=>{this.onDeactivateItems();let f=m.target;this.activateItem(f),f.focus()},this.onSlotchange=()=>{let m=this.items,f=!1;for(let g of m){if(!g.disabled&&g.tabIndex>-1&&!f){f=!0,g.tabIndex=0;continue}g.tabIndex=-1}if(f)return;let b=Ke(m,this.isActivatable);b&&(b.tabIndex=0)};let{isItem:t,getPossibleItems:r,isRtl:i,deactivateItem:s,activateItem:a,isNavigableKey:d,isActivatable:c,wrapNavigation:h}=e;this.isItem=t,this.getPossibleItems=r,this.isRtl=i,this.deactivateItem=s,this.activateItem=a,this.isNavigableKey=d,this.isActivatable=c,this.wrapNavigation=h??(()=>!0)}get items(){let e=this.getPossibleItems(),t=[];for(let r of e){if(this.isItem(r)){t.push(r);continue}let s=r.item;s&&this.isItem(s)&&t.push(s)}return t}activateNextItem(){let e=this.items,t=me(e,this.isActivatable);return t&&(t.item.tabIndex=-1),or(e,t,this.isActivatable,this.wrapNavigation())}activatePreviousItem(){let e=this.items,t=me(e,this.isActivatable);return t&&(t.item.tabIndex=-1),ir(e,t,this.isActivatable,this.wrapNavigation())}};function Yo(o,e){return new CustomEvent("close-menu",{bubbles:!0,composed:!0,detail:{initiator:o,reason:e,itemPath:[o]}})}var nr=Yo;var sr={SPACE:"Space",ENTER:"Enter"},wt={CLICK_SELECTION:"click-selection",KEYDOWN:"keydown"},Xo={ESCAPE:"Escape",SPACE:sr.SPACE,ENTER:sr.ENTER};function Et(o){return Object.values(Xo).some(e=>e===o)}function ro(o){return Object.values(sr).some(e=>e===o)}function Ge(o,e){let t=new Event("md-contains",{bubbles:!0,composed:!0}),r=[],i=a=>{r=a.composedPath()};return e.addEventListener("md-contains",i),o.dispatchEvent(t),e.removeEventListener("md-contains",i),r.length>0}var j={NONE:"none",LIST_ROOT:"list-root",FIRST_ITEM:"first-item",LAST_ITEM:"last-item"};var Ye={END_START:"end-start",END_END:"end-end",START_START:"start-start",START_END:"start-end"},At=class{constructor(e,t){this.host=e,this.getProperties=t,this.surfaceStylesInternal={display:"none"},this.lastValues={isOpen:!1},this.host.addController(this)}get surfaceStyles(){return this.surfaceStylesInternal}async position(){let{surfaceEl:e,anchorEl:t,anchorCorner:r,surfaceCorner:i,positioning:s,xOffset:a,yOffset:d,disableBlockFlip:c,disableInlineFlip:h,repositionStrategy:m}=this.getProperties(),f=r.toLowerCase().trim(),b=i.toLowerCase().trim();if(!e||!t)return;let g=window.innerWidth,S=window.innerHeight,w=document.createElement("div");w.style.opacity="0",w.style.position="fixed",w.style.display="block",w.style.inset="0",document.body.appendChild(w);let O=w.getBoundingClientRect();w.remove();let z=window.innerHeight-O.bottom,E=window.innerWidth-O.right;this.surfaceStylesInternal={display:"block",opacity:"0"},this.host.requestUpdate(),await this.host.updateComplete,e.popover&&e.isConnected&&e.showPopover();let U=e.getSurfacePositionClientRect?e.getSurfacePositionClientRect():e.getBoundingClientRect(),N=t.getSurfacePositionClientRect?t.getSurfacePositionClientRect():t.getBoundingClientRect(),[P,ne]=b.split("-"),[ae,ge]=f.split("-"),Xe=getComputedStyle(e).direction==="ltr",{blockInset:Ae,blockOutOfBoundsCorrection:Z,surfaceBlockProperty:yr}=this.calculateBlock({surfaceRect:U,anchorRect:N,anchorBlock:ae,surfaceBlock:P,yOffset:d,positioning:s,windowInnerHeight:S,blockScrollbarHeight:z});if(Z&&!c){let Rt=P==="start"?"end":"start",Pt=ae==="start"?"end":"start",Q=this.calculateBlock({surfaceRect:U,anchorRect:N,anchorBlock:Pt,surfaceBlock:Rt,yOffset:d,positioning:s,windowInnerHeight:S,blockScrollbarHeight:z});Z>Q.blockOutOfBoundsCorrection&&(Ae=Q.blockInset,Z=Q.blockOutOfBoundsCorrection,yr=Q.surfaceBlockProperty)}let{inlineInset:Ze,inlineOutOfBoundsCorrection:Ce,surfaceInlineProperty:br}=this.calculateInline({surfaceRect:U,anchorRect:N,anchorInline:ge,surfaceInline:ne,xOffset:a,positioning:s,isLTR:Xe,windowInnerWidth:g,inlineScrollbarWidth:E});if(Ce&&!h){let Rt=ne==="start"?"end":"start",Pt=ge==="start"?"end":"start",Q=this.calculateInline({surfaceRect:U,anchorRect:N,anchorInline:Pt,surfaceInline:Rt,xOffset:a,positioning:s,isLTR:Xe,windowInnerWidth:g,inlineScrollbarWidth:E});Math.abs(Ce)>Math.abs(Q.inlineOutOfBoundsCorrection)&&(Ze=Q.inlineInset,Ce=Q.inlineOutOfBoundsCorrection,br=Q.surfaceInlineProperty)}m==="move"&&(Ae=Ae-Z,Ze=Ze-Ce),this.surfaceStylesInternal={display:"block",opacity:"1",[yr]:`${Ae}px`,[br]:`${Ze}px`},m==="resize"&&(Z&&(this.surfaceStylesInternal.height=`${U.height-Z}px`),Ce&&(this.surfaceStylesInternal.width=`${U.width-Ce}px`)),this.host.requestUpdate()}calculateBlock(e){let{surfaceRect:t,anchorRect:r,anchorBlock:i,surfaceBlock:s,yOffset:a,positioning:d,windowInnerHeight:c,blockScrollbarHeight:h}=e,m=d==="fixed"||d==="document"?1:0,f=d==="document"?1:0,b=s==="start"?1:0,g=s==="end"?1:0,w=(i!==s?1:0)*r.height+a,O=b*r.top+g*(c-r.bottom-h),z=b*window.scrollY-g*window.scrollY,E=Math.abs(Math.min(0,c-O-w-t.height));return{blockInset:m*O+f*z+w,blockOutOfBoundsCorrection:E,surfaceBlockProperty:s==="start"?"inset-block-start":"inset-block-end"}}calculateInline(e){let{isLTR:t,surfaceInline:r,anchorInline:i,anchorRect:s,surfaceRect:a,xOffset:d,positioning:c,windowInnerWidth:h,inlineScrollbarWidth:m}=e,f=c==="fixed"||c==="document"?1:0,b=c==="document"?1:0,g=t?1:0,S=t?0:1,w=r==="start"?1:0,O=r==="end"?1:0,E=(i!==r?1:0)*s.width+d,U=w*s.left+O*(h-s.right-m),N=w*(h-s.right-m)+O*s.left,P=g*U+S*N,ne=w*window.scrollX-O*window.scrollX,ae=O*window.scrollX-w*window.scrollX,ge=g*ne+S*ae,Xe=Math.abs(Math.min(0,h-P-E-a.width)),Ae=f*P+E+b*ge,Z=r==="start"?"inset-inline-start":"inset-inline-end";return(c==="document"||c==="fixed")&&(r==="start"&&t||r==="end"&&!t?Z="left":Z="right"),{inlineInset:Ae,inlineOutOfBoundsCorrection:Xe,surfaceInlineProperty:Z}}hostUpdate(){this.onUpdate()}hostUpdated(){this.onUpdate()}async onUpdate(){let e=this.getProperties(),t=!1;for(let[a,d]of Object.entries(e))if(t=t||d!==this.lastValues[a],t)break;let r=this.lastValues.isOpen!==e.isOpen,i=!!e.anchorEl,s=!!e.surfaceEl;t&&i&&s&&(this.lastValues.isOpen=e.isOpen,e.isOpen?(this.lastValues=e,await this.position(),e.onOpen()):r&&(await e.beforeClose(),this.close(),e.onClose()))}close(){this.surfaceStylesInternal={display:"none"},this.host.requestUpdate();let e=this.getProperties().surfaceEl;e?.popover&&e?.isConnected&&e.hidePopover()}};var K={INDEX:0,ITEM:1,TEXT:2},Ct=class{constructor(e){this.getProperties=e,this.typeaheadRecords=[],this.typaheadBuffer="",this.cancelTypeaheadTimeout=0,this.isTypingAhead=!1,this.lastActiveRecord=null,this.onKeydown=t=>{this.isTypingAhead?this.typeahead(t):this.beginTypeahead(t)},this.endTypeahead=()=>{this.isTypingAhead=!1,this.typaheadBuffer="",this.typeaheadRecords=[]}}get items(){return this.getProperties().getItems()}get active(){return this.getProperties().active}beginTypeahead(e){this.active&&(e.code==="Space"||e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"||(this.isTypingAhead=!0,this.typeaheadRecords=this.items.map((t,r)=>[r,t,t.typeaheadText.trim().toLowerCase()]),this.lastActiveRecord=this.typeaheadRecords.find(t=>t[K.ITEM].tabIndex===0)??null,this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.typeahead(e)))}typeahead(e){if(e.defaultPrevented)return;if(clearTimeout(this.cancelTypeaheadTimeout),e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"){this.endTypeahead(),this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1);return}e.code==="Space"&&e.preventDefault(),this.cancelTypeaheadTimeout=setTimeout(this.endTypeahead,this.getProperties().typeaheadBufferTime),this.typaheadBuffer+=e.key.toLowerCase();let t=this.lastActiveRecord?this.lastActiveRecord[K.INDEX]:-1,r=this.typeaheadRecords.length,i=c=>(c[K.INDEX]+r-t)%r,s=this.typeaheadRecords.filter(c=>!c[K.ITEM].disabled&&c[K.TEXT].startsWith(this.typaheadBuffer)).sort((c,h)=>i(c)-i(h));if(s.length===0){clearTimeout(this.cancelTypeaheadTimeout),this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.endTypeahead();return}let a=this.typaheadBuffer.length===1,d;this.lastActiveRecord===s[0]&&a?d=s[1]??s[0]:d=s[0],this.lastActiveRecord&&(this.lastActiveRecord[K.ITEM].tabIndex=-1),this.lastActiveRecord=d,d[K.ITEM].tabIndex=0,d[K.ITEM].focus()}};var ar=200,oo=new Set([M.ArrowDown,M.ArrowUp,M.Home,M.End]),Zo=new Set([M.ArrowLeft,M.ArrowRight,...oo]);function Jo(o=document){let e=o.activeElement;for(;e&&e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e}var C=class extends y{get openDirection(){return this.menuCorner.split("-")[0]==="start"?"DOWN":"UP"}get anchorElement(){return this.anchor?this.getRootNode().querySelector(`#${this.anchor}`):this.currentAnchorElement}set anchorElement(e){this.currentAnchorElement=e,this.requestUpdate("anchorElement")}constructor(){super(),this.anchor="",this.positioning="absolute",this.quick=!1,this.hasOverflow=!1,this.open=!1,this.xOffset=0,this.yOffset=0,this.noHorizontalFlip=!1,this.noVerticalFlip=!1,this.typeaheadDelay=ar,this.anchorCorner=Ye.END_START,this.menuCorner=Ye.START_START,this.stayOpenOnOutsideClick=!1,this.stayOpenOnFocusout=!1,this.skipRestoreFocus=!1,this.defaultFocus=j.FIRST_ITEM,this.noNavigationWrap=!1,this.typeaheadActive=!0,this.isSubmenu=!1,this.pointerPath=[],this.isRepositioning=!1,this.openCloseAnimationSignal=Fr(),this.listController=new _t({isItem:e=>e.hasAttribute("md-menu-item"),getPossibleItems:()=>this.slotItems,isRtl:()=>getComputedStyle(this).direction==="rtl",deactivateItem:e=>{e.selected=!1,e.tabIndex=-1},activateItem:e=>{e.selected=!0,e.tabIndex=0},isNavigableKey:e=>{if(!this.isSubmenu)return Zo.has(e);let r=getComputedStyle(this).direction==="rtl"?M.ArrowLeft:M.ArrowRight;return e===r?!0:oo.has(e)},wrapNavigation:()=>!this.noNavigationWrap}),this.lastFocusedElement=null,this.typeaheadController=new Ct(()=>({getItems:()=>this.items,typeaheadBufferTime:this.typeaheadDelay,active:this.typeaheadActive})),this.currentAnchorElement=null,this.internals=this.attachInternals(),this.menuPositionController=new At(this,()=>({anchorCorner:this.anchorCorner,surfaceCorner:this.menuCorner,surfaceEl:this.surfaceEl,anchorEl:this.anchorElement,positioning:this.positioning==="popover"?"document":this.positioning,isOpen:this.open,xOffset:this.xOffset,yOffset:this.yOffset,disableBlockFlip:this.noVerticalFlip,disableInlineFlip:this.noHorizontalFlip,onOpen:this.onOpened,beforeClose:this.beforeClose,onClose:this.onClosed,repositionStrategy:this.hasOverflow&&this.positioning!=="popover"?"move":"resize"})),this.onWindowResize=()=>{this.isRepositioning||this.positioning!=="document"&&this.positioning!=="fixed"&&this.positioning!=="popover"||(this.isRepositioning=!0,this.reposition(),this.isRepositioning=!1)},this.handleFocusout=async e=>{let t=this.anchorElement;if(this.stayOpenOnFocusout||!this.open||this.pointerPath.includes(t))return;if(e.relatedTarget){if(Ge(e.relatedTarget,this)||this.pointerPath.length!==0&&Ge(e.relatedTarget,t))return}else if(this.pointerPath.includes(this))return;let r=this.skipRestoreFocus;this.skipRestoreFocus=!0,this.close(),await this.updateComplete,this.skipRestoreFocus=r},this.onOpened=async()=>{this.lastFocusedElement=Jo();let e=this.items,t=me(e);t&&this.defaultFocus!==j.NONE&&(t.item.tabIndex=-1);let r=!this.quick;switch(this.quick?this.dispatchEvent(new Event("opening")):r=!!await this.animateOpen(),this.defaultFocus){case j.FIRST_ITEM:let i=Ke(e);i&&(i.tabIndex=0,i.focus(),await i.updateComplete);break;case j.LAST_ITEM:let s=rr(e);s&&(s.tabIndex=0,s.focus(),await s.updateComplete);break;case j.LIST_ROOT:this.focus();break;default:case j.NONE:break}r||this.dispatchEvent(new Event("opened"))},this.beforeClose=async()=>{this.open=!1,this.skipRestoreFocus||this.lastFocusedElement?.focus?.(),this.quick||await this.animateClose()},this.onClosed=()=>{this.quick&&(this.dispatchEvent(new Event("closing")),this.dispatchEvent(new Event("closed")))},this.onWindowPointerdown=e=>{this.pointerPath=e.composedPath()},this.onDocumentClick=e=>{if(!this.open)return;let t=e.composedPath();!this.stayOpenOnOutsideClick&&!t.includes(this)&&!t.includes(this.anchorElement)&&(this.open=!1)},this.internals.role="menu",this.addEventListener("keydown",this.handleKeydown),this.addEventListener("keydown",this.captureKeydown,{capture:!0}),this.addEventListener("focusout",this.handleFocusout)}get items(){return this.listController.items}willUpdate(e){if(e.has("open")){if(this.open){this.removeAttribute("aria-hidden");return}this.setAttribute("aria-hidden","true")}}update(e){e.has("open")&&(this.open?this.setUpGlobalEventListeners():this.cleanUpGlobalEventListeners()),e.has("positioning")&&this.positioning==="popover"&&!this.showPopover&&(this.positioning="fixed"),super.update(e)}connectedCallback(){super.connectedCallback(),this.open&&this.setUpGlobalEventListeners()}disconnectedCallback(){super.disconnectedCallback(),this.cleanUpGlobalEventListeners()}getBoundingClientRect(){return this.surfaceEl?this.surfaceEl.getBoundingClientRect():super.getBoundingClientRect()}getClientRects(){return this.surfaceEl?this.surfaceEl.getClientRects():super.getClientRects()}render(){return this.renderSurface()}renderSurface(){return p`
+      <div
+        class="menu ${R(this.getSurfaceClasses())}"
+        style=${Ee(this.menuPositionController.surfaceStyles)}
+        popover=${this.positioning==="popover"?"manual":u}>
+        ${this.renderElevation()}
+        <div class="items">
+          <div class="item-padding"> ${this.renderMenuItems()} </div>
+        </div>
+      </div>
+    `}renderMenuItems(){return p`<slot
+      @close-menu=${this.onCloseMenu}
+      @deactivate-items=${this.onDeactivateItems}
+      @request-activation=${this.onRequestActivation}
+      @deactivate-typeahead=${this.handleDeactivateTypeahead}
+      @activate-typeahead=${this.handleActivateTypeahead}
+      @stay-open-on-focusout=${this.handleStayOpenOnFocusout}
+      @close-on-focusout=${this.handleCloseOnFocusout}
+      @slotchange=${this.listController.onSlotchange}></slot>`}renderElevation(){return p`<md-elevation part="elevation"></md-elevation>`}getSurfaceClasses(){return{open:this.open,fixed:this.positioning==="fixed","has-overflow":this.hasOverflow}}captureKeydown(e){e.target===this&&!e.defaultPrevented&&Et(e.code)&&(e.preventDefault(),this.close()),this.typeaheadController.onKeydown(e)}async animateOpen(){let e=this.surfaceEl,t=this.slotEl;if(!e||!t)return!0;let r=this.openDirection;this.dispatchEvent(new Event("opening")),e.classList.toggle("animating",!0);let i=this.openCloseAnimationSignal.start(),s=e.offsetHeight,a=r==="UP",d=this.items,c=500,h=50,m=250,f=(c-m)/d.length,b=e.animate([{height:"0px"},{height:`${s}px`}],{duration:c,easing:re.EMPHASIZED}),g=t.animate([{transform:a?`translateY(-${s}px)`:""},{transform:""}],{duration:c,easing:re.EMPHASIZED}),S=e.animate([{opacity:0},{opacity:1}],h),w=[];for(let E=0;E<d.length;E++){let U=a?d.length-1-E:E,N=d[U],P=N.animate([{opacity:0},{opacity:1}],{duration:m,delay:f*E});N.classList.toggle("md-menu-hidden",!0),P.addEventListener("finish",()=>{N.classList.toggle("md-menu-hidden",!1)}),w.push([N,P])}let O=E=>{},z=new Promise(E=>{O=E});return i.addEventListener("abort",()=>{b.cancel(),g.cancel(),S.cancel(),w.forEach(([E,U])=>{E.classList.toggle("md-menu-hidden",!1),U.cancel()}),O(!0)}),b.addEventListener("finish",()=>{e.classList.toggle("animating",!1),this.openCloseAnimationSignal.finish(),O(!1)}),await z}animateClose(){let e,t=new Promise(P=>{e=P}),r=this.surfaceEl,i=this.slotEl;if(!r||!i)return e(!1),t;let a=this.openDirection==="UP";this.dispatchEvent(new Event("closing")),r.classList.toggle("animating",!0);let d=this.openCloseAnimationSignal.start(),c=r.offsetHeight,h=this.items,m=150,f=50,b=m-f,g=50,S=50,w=.35,O=(m-S-g)/h.length,z=r.animate([{height:`${c}px`},{height:`${c*w}px`}],{duration:m,easing:re.EMPHASIZED_ACCELERATE}),E=i.animate([{transform:""},{transform:a?`translateY(-${c*(1-w)}px)`:""}],{duration:m,easing:re.EMPHASIZED_ACCELERATE}),U=r.animate([{opacity:1},{opacity:0}],{duration:f,delay:b}),N=[];for(let P=0;P<h.length;P++){let ne=a?P:h.length-1-P,ae=h[ne],ge=ae.animate([{opacity:1},{opacity:0}],{duration:g,delay:S+O*P});ge.addEventListener("finish",()=>{ae.classList.toggle("md-menu-hidden",!0)}),N.push([ae,ge])}return d.addEventListener("abort",()=>{z.cancel(),E.cancel(),U.cancel(),N.forEach(([P,ne])=>{ne.cancel(),P.classList.toggle("md-menu-hidden",!1)}),e(!1)}),z.addEventListener("finish",()=>{r.classList.toggle("animating",!1),N.forEach(([P])=>{P.classList.toggle("md-menu-hidden",!1)}),this.openCloseAnimationSignal.finish(),this.dispatchEvent(new Event("closed")),e(!0)}),t}handleKeydown(e){this.pointerPath=[],this.listController.handleKeydown(e)}setUpGlobalEventListeners(){document.addEventListener("click",this.onDocumentClick,{capture:!0}),window.addEventListener("pointerdown",this.onWindowPointerdown),document.addEventListener("resize",this.onWindowResize,{passive:!0}),window.addEventListener("resize",this.onWindowResize,{passive:!0})}cleanUpGlobalEventListeners(){document.removeEventListener("click",this.onDocumentClick,{capture:!0}),window.removeEventListener("pointerdown",this.onWindowPointerdown),document.removeEventListener("resize",this.onWindowResize),window.removeEventListener("resize",this.onWindowResize)}onCloseMenu(){this.close()}onDeactivateItems(e){e.stopPropagation(),this.listController.onDeactivateItems()}onRequestActivation(e){e.stopPropagation(),this.listController.onRequestActivation(e)}handleDeactivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!1}handleActivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!0}handleStayOpenOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!0}handleCloseOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!1}close(){this.open=!1,this.slotItems.forEach(t=>{t.close?.()})}show(){this.open=!0}activateNextItem(){return this.listController.activateNextItem()??null}activatePreviousItem(){return this.listController.activatePreviousItem()??null}reposition(){this.open&&this.menuPositionController.position()}};n([k(".menu")],C.prototype,"surfaceEl",void 0);n([k("slot")],C.prototype,"slotEl",void 0);n([l()],C.prototype,"anchor",void 0);n([l()],C.prototype,"positioning",void 0);n([l({type:Boolean})],C.prototype,"quick",void 0);n([l({type:Boolean,attribute:"has-overflow"})],C.prototype,"hasOverflow",void 0);n([l({type:Boolean,reflect:!0})],C.prototype,"open",void 0);n([l({type:Number,attribute:"x-offset"})],C.prototype,"xOffset",void 0);n([l({type:Number,attribute:"y-offset"})],C.prototype,"yOffset",void 0);n([l({type:Boolean,attribute:"no-horizontal-flip"})],C.prototype,"noHorizontalFlip",void 0);n([l({type:Boolean,attribute:"no-vertical-flip"})],C.prototype,"noVerticalFlip",void 0);n([l({type:Number,attribute:"typeahead-delay"})],C.prototype,"typeaheadDelay",void 0);n([l({attribute:"anchor-corner"})],C.prototype,"anchorCorner",void 0);n([l({attribute:"menu-corner"})],C.prototype,"menuCorner",void 0);n([l({type:Boolean,attribute:"stay-open-on-outside-click"})],C.prototype,"stayOpenOnOutsideClick",void 0);n([l({type:Boolean,attribute:"stay-open-on-focusout"})],C.prototype,"stayOpenOnFocusout",void 0);n([l({type:Boolean,attribute:"skip-restore-focus"})],C.prototype,"skipRestoreFocus",void 0);n([l({attribute:"default-focus"})],C.prototype,"defaultFocus",void 0);n([l({type:Boolean,attribute:"no-navigation-wrap"})],C.prototype,"noNavigationWrap",void 0);n([q({flatten:!0})],C.prototype,"slotItems",void 0);n([I()],C.prototype,"typeaheadActive",void 0);var io=x`:host{--md-elevation-level: var(--md-menu-container-elevation, 2);--md-elevation-shadow-color: var(--md-menu-container-shadow-color, var(--md-sys-color-shadow, #000));min-width:112px;color:unset;display:contents}md-focus-ring{--md-focus-ring-shape: var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px))}.menu{border-radius:var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px));display:none;inset:auto;border:none;padding:0px;overflow:visible;background-color:rgba(0,0,0,0);color:inherit;opacity:0;z-index:20;position:absolute;user-select:none;max-height:inherit;height:inherit;min-width:inherit;max-width:inherit;scrollbar-width:inherit}.menu::backdrop{display:none}.fixed{position:fixed}.items{display:block;list-style-type:none;margin:0;outline:none;box-sizing:border-box;background-color:var(--md-menu-container-color, var(--md-sys-color-surface-container, #f3edf7));height:inherit;max-height:inherit;overflow:auto;min-width:inherit;max-width:inherit;border-radius:inherit;scrollbar-width:inherit}.item-padding{padding-block:var(--md-menu-top-space, 8px) var(--md-menu-bottom-space, 8px)}.has-overflow:not([popover]) .items{overflow:visible}.has-overflow.animating .items,.animating .items{overflow:hidden}.has-overflow.animating .items{pointer-events:none}.animating ::slotted(.md-menu-hidden){opacity:0}slot{display:block;height:inherit;max-height:inherit}::slotted(:is(md-divider,[role=separator])){margin:8px 0}@media(forced-colors: active){.menu{border-style:solid;border-color:CanvasText;border-width:1px}}
+`;var lr=class extends C{};lr.styles=[io];lr=n([T("md-menu")],lr);var Tt=class extends fe{computeValidity(e){return this.selectControl||(this.selectControl=document.createElement("select")),$e(p`<option value=${e.value}></option>`,this.selectControl),this.selectControl.value=e.value,this.selectControl.required=e.required,{validity:this.selectControl.validity,validationMessage:this.selectControl.validationMessage}}equals(e,t){return e.value===t.value&&e.required===t.required}copy({value:e,required:t}){return{value:e,required:t}}};function so(o){let e=[];for(let t=0;t<o.length;t++){let r=o[t];r.selected&&e.push([r,t])}return e}var no,$t=Symbol("value"),Qo=G(gt(ke(Oe(ue(y))))),_=class extends Qo{get value(){return this[$t]}set value(e){this.lastUserSetValue=e,this.select(e)}get options(){return this.menu?.items??[]}get selectedIndex(){let[e,t]=(this.getSelectedOptions()??[])[0]??[];return t??-1}set selectedIndex(e){this.lastUserSetSelectedIndex=e,this.selectIndex(e)}get selectedOptions(){return(this.getSelectedOptions()??[]).map(([e])=>e)}get hasError(){return this.error||this.nativeError}constructor(){super(),this.quick=!1,this.required=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.supportingText="",this.error=!1,this.menuPositioning="popover",this.clampMenuWidth=!1,this.typeaheadDelay=ar,this.hasLeadingIcon=!1,this.displayText="",this.menuAlign="start",this[no]="",this.lastUserSetValue=null,this.lastUserSetSelectedIndex=null,this.lastSelectedOption=null,this.lastSelectedOptionRecords=[],this.nativeError=!1,this.nativeErrorText="",this.focused=!1,this.open=!1,this.defaultFocus=j.NONE,this.prevOpen=this.open,this.selectWidth=0,!!1&&(this.addEventListener("focus",this.handleFocus.bind(this)),this.addEventListener("blur",this.handleBlur.bind(this)))}select(e){let t=this.options.find(r=>r.value===e);t&&this.selectItem(t)}selectIndex(e){let t=this.options[e];t&&this.selectItem(t)}reset(){for(let e of this.options)e.selected=e.hasAttribute("selected");this.updateValueAndDisplayText(),this.nativeError=!1,this.nativeErrorText=""}showPicker(){this.open=!0}[(no=$t,Re)](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}update(e){if(this.hasUpdated||this.initUserSelection(),this.prevOpen!==this.open&&this.open){let t=this.getBoundingClientRect();this.selectWidth=t.width}this.prevOpen=this.open,super.update(e)}render(){return p`
+      <span
+        class="select ${R(this.getRenderClasses())}"
+        @focusout=${this.handleFocusout}>
+        ${this.renderField()} ${this.renderMenu()}
+      </span>
+    `}async firstUpdated(e){await this.menu?.updateComplete,this.lastSelectedOptionRecords.length||this.initUserSelection(),!this.lastSelectedOptionRecords.length&&!!1&&!this.options.length&&setTimeout(()=>{this.updateValueAndDisplayText()}),super.firstUpdated(e)}getRenderClasses(){return{disabled:this.disabled,error:this.error,open:this.open}}renderField(){let e=this.ariaLabel||this.label;return ce`
+      <${this.fieldTag}
+          aria-haspopup="listbox"
+          role="combobox"
+          part="field"
+          id="field"
+          tabindex=${this.disabled?"-1":"0"}
+          aria-label=${e||u}
+          aria-describedby="description"
+          aria-expanded=${this.open?"true":"false"}
+          aria-controls="listbox"
+          class="field"
+          label=${this.label}
+          ?no-asterisk=${this.noAsterisk}
+          .focused=${this.focused||this.open}
+          .populated=${!!this.displayText}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          .error=${this.hasError}
+          ?has-start=${this.hasLeadingIcon}
+          has-end
+          supporting-text=${this.supportingText}
+          error-text=${this.getErrorText()}
+          @keydown=${this.handleKeydown}
+          @click=${this.handleClick}>
+         ${this.renderFieldContent()}
+         <div id="description" slot="aria-describedby"></div>
+      </${this.fieldTag}>`}renderFieldContent(){return[this.renderLeadingIcon(),this.renderLabel(),this.renderTrailingIcon()]}renderLeadingIcon(){return p`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return p`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}>
+          <svg height="5" viewBox="7 10 10 5" focusable="false">
+            <polygon
+              class="down"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 10 12 15 17 10"></polygon>
+            <polygon
+              class="up"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 15 12 10 17 15"></polygon>
+          </svg>
+        </slot>
+      </span>
+    `}renderLabel(){return p`<div id="label">${this.displayText||p`&nbsp;`}</div>`}renderMenu(){let e=this.label||this.ariaLabel;return p`<div class="menu-wrapper">
+      <md-menu
+        id="listbox"
+        .defaultFocus=${this.defaultFocus}
+        role="listbox"
+        tabindex="-1"
+        aria-label=${e||u}
+        stay-open-on-focusout
+        part="menu"
+        exportparts="focus-ring: menu-focus-ring"
+        anchor="field"
+        style=${Ee({"--__menu-min-width":`${this.selectWidth}px`,"--__menu-max-width":this.clampMenuWidth?`${this.selectWidth}px`:void 0})}
+        no-navigation-wrap
+        .open=${this.open}
+        .quick=${this.quick}
+        .positioning=${this.menuPositioning}
+        .typeaheadDelay=${this.typeaheadDelay}
+        .anchorCorner=${this.menuAlign==="start"?"end-start":"end-end"}
+        .menuCorner=${this.menuAlign==="start"?"start-start":"start-end"}
+        @opening=${this.handleOpening}
+        @opened=${this.redispatchEvent}
+        @closing=${this.redispatchEvent}
+        @closed=${this.handleClosed}
+        @close-menu=${this.handleCloseMenu}
+        @request-selection=${this.handleRequestSelection}
+        @request-deselection=${this.handleRequestDeselection}>
+        ${this.renderMenuContent()}
+      </md-menu>
+    </div>`}renderMenuContent(){return p`<slot></slot>`}handleKeydown(e){if(this.open||this.disabled||!this.menu)return;let t=this.menu.typeaheadController,r=e.code==="Space"||e.code==="ArrowDown"||e.code==="ArrowUp"||e.code==="End"||e.code==="Home"||e.code==="Enter";if(!t.isTypingAhead&&r){switch(e.preventDefault(),this.open=!0,e.code){case"Space":case"ArrowDown":case"Enter":this.defaultFocus=j.NONE;break;case"End":this.defaultFocus=j.LAST_ITEM;break;case"ArrowUp":case"Home":this.defaultFocus=j.FIRST_ITEM;break;default:break}return}if(e.key.length===1){t.onKeydown(e),e.preventDefault();let{lastActiveRecord:s}=t;if(!s)return;this.labelEl?.setAttribute?.("aria-live","polite"),this.selectItem(s[K.ITEM])&&this.dispatchInteractionEvents()}}handleClick(){this.open=!this.open}handleFocus(){this.focused=!0}handleBlur(){this.focused=!1}handleFocusout(e){e.relatedTarget&&Ge(e.relatedTarget,this)||(this.open=!1)}getSelectedOptions(){if(!this.menu)return this.lastSelectedOptionRecords=[],null;let e=this.menu.items;return this.lastSelectedOptionRecords=so(e),this.lastSelectedOptionRecords}async getUpdateComplete(){return await this.menu?.updateComplete,super.getUpdateComplete()}updateValueAndDisplayText(){let e=this.getSelectedOptions()??[],t=!1;if(e.length){let[r]=e[0];t=this.lastSelectedOption!==r,this.lastSelectedOption=r,this[$t]=r.value,this.displayText=r.displayText}else t=this.lastSelectedOption!==null,this.lastSelectedOption=null,this[$t]="",this.displayText="";return t}async handleOpening(e){if(this.labelEl?.removeAttribute?.("aria-live"),this.redispatchEvent(e),this.defaultFocus!==j.NONE)return;let t=this.menu.items,r=me(t)?.item,[i]=this.lastSelectedOptionRecords[0]??[null];r&&r!==i&&(r.tabIndex=-1),i=i??t[0],i&&(i.tabIndex=0,i.focus())}redispatchEvent(e){Ie(this,e)}handleClosed(e){this.open=!1,this.redispatchEvent(e)}handleCloseMenu(e){let t=e.detail.reason,r=e.detail.itemPath[0];this.open=!1;let i=!1;t.kind==="click-selection"?i=this.selectItem(r):t.kind==="keydown"&&ro(t.key)?i=this.selectItem(r):(r.tabIndex=-1,r.blur()),i&&this.dispatchInteractionEvents()}selectItem(e){return(this.getSelectedOptions()??[]).forEach(([r])=>{e!==r&&(r.selected=!1)}),e.selected=!0,this.updateValueAndDisplayText()}handleRequestSelection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)||this.selectItem(t)}handleRequestDeselection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)&&this.updateValueAndDisplayText()}initUserSelection(){this.lastUserSetValue&&!this.lastSelectedOptionRecords.length?this.select(this.lastUserSetValue):this.lastUserSetSelectedIndex!==null&&!this.lastSelectedOptionRecords.length?this.selectIndex(this.lastUserSetSelectedIndex):this.updateValueAndDisplayText()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0}dispatchInteractionEvents(){this.dispatchEvent(new Event("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0}))}getErrorText(){return this.error?this.errorText:this.nativeErrorText}[ie](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}click(){this.field?.click()}[pe](){return new Tt(()=>this)}[he](){return this.field}};_.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean})],_.prototype,"quick",void 0);n([l({type:Boolean})],_.prototype,"required",void 0);n([l({type:String,attribute:"error-text"})],_.prototype,"errorText",void 0);n([l()],_.prototype,"label",void 0);n([l({type:Boolean,attribute:"no-asterisk"})],_.prototype,"noAsterisk",void 0);n([l({type:String,attribute:"supporting-text"})],_.prototype,"supportingText",void 0);n([l({type:Boolean,reflect:!0})],_.prototype,"error",void 0);n([l({attribute:"menu-positioning"})],_.prototype,"menuPositioning",void 0);n([l({type:Boolean,attribute:"clamp-menu-width"})],_.prototype,"clampMenuWidth",void 0);n([l({type:Number,attribute:"typeahead-delay"})],_.prototype,"typeaheadDelay",void 0);n([l({type:Boolean,attribute:"has-leading-icon"})],_.prototype,"hasLeadingIcon",void 0);n([l({attribute:"display-text"})],_.prototype,"displayText",void 0);n([l({attribute:"menu-align"})],_.prototype,"menuAlign",void 0);n([l()],_.prototype,"value",null);n([l({type:Number,attribute:"selected-index"})],_.prototype,"selectedIndex",null);n([I()],_.prototype,"nativeError",void 0);n([I()],_.prototype,"nativeErrorText",void 0);n([I()],_.prototype,"focused",void 0);n([I()],_.prototype,"open",void 0);n([I()],_.prototype,"defaultFocus",void 0);n([k(".field")],_.prototype,"field",void 0);n([k("md-menu")],_.prototype,"menu",void 0);n([k("#label")],_.prototype,"labelEl",void 0);n([q({slot:"leading-icon",flatten:!0})],_.prototype,"leadingIcons",void 0);var St=class extends _{constructor(){super(...arguments),this.fieldTag=W`md-outlined-field`}};var ao=x`:host{--_text-field-disabled-input-text-color: var(--md-outlined-select-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-input-text-opacity: var(--md-outlined-select-text-field-disabled-input-text-opacity, 0.38);--_text-field-disabled-label-text-color: var(--md-outlined-select-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-label-text-opacity: var(--md-outlined-select-text-field-disabled-label-text-opacity, 0.38);--_text-field-disabled-leading-icon-color: var(--md-outlined-select-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-leading-icon-opacity: var(--md-outlined-select-text-field-disabled-leading-icon-opacity, 0.38);--_text-field-disabled-outline-color: var(--md-outlined-select-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-outline-opacity: var(--md-outlined-select-text-field-disabled-outline-opacity, 0.12);--_text-field-disabled-outline-width: var(--md-outlined-select-text-field-disabled-outline-width, 1px);--_text-field-disabled-supporting-text-color: var(--md-outlined-select-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-supporting-text-opacity: var(--md-outlined-select-text-field-disabled-supporting-text-opacity, 0.38);--_text-field-disabled-trailing-icon-color: var(--md-outlined-select-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-trailing-icon-opacity: var(--md-outlined-select-text-field-disabled-trailing-icon-opacity, 0.38);--_text-field-error-focus-input-text-color: var(--md-outlined-select-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-focus-label-text-color: var(--md-outlined-select-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-leading-icon-color: var(--md-outlined-select-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-focus-outline-color: var(--md-outlined-select-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-supporting-text-color: var(--md-outlined-select-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-trailing-icon-color: var(--md-outlined-select-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-input-text-color: var(--md-outlined-select-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-hover-label-text-color: var(--md-outlined-select-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-leading-icon-color: var(--md-outlined-select-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-hover-outline-color: var(--md-outlined-select-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-supporting-text-color: var(--md-outlined-select-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-trailing-icon-color: var(--md-outlined-select-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-input-text-color: var(--md-outlined-select-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-label-text-color: var(--md-outlined-select-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-leading-icon-color: var(--md-outlined-select-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-outline-color: var(--md-outlined-select-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-supporting-text-color: var(--md-outlined-select-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-trailing-icon-color: var(--md-outlined-select-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-focus-input-text-color: var(--md-outlined-select-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-focus-label-text-color: var(--md-outlined-select-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-leading-icon-color: var(--md-outlined-select-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-outline-color: var(--md-outlined-select-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-outline-width: var(--md-outlined-select-text-field-focus-outline-width, 3px);--_text-field-focus-supporting-text-color: var(--md-outlined-select-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-trailing-icon-color: var(--md-outlined-select-text-field-focus-trailing-icon-color, var(--md-sys-color-primary, #6750a4));--_text-field-hover-input-text-color: var(--md-outlined-select-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-label-text-color: var(--md-outlined-select-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-leading-icon-color: var(--md-outlined-select-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-outline-color: var(--md-outlined-select-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-outline-width: var(--md-outlined-select-text-field-hover-outline-width, 1px);--_text-field-hover-supporting-text-color: var(--md-outlined-select-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-trailing-icon-color: var(--md-outlined-select-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-input-text-color: var(--md-outlined-select-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-input-text-font: var(--md-outlined-select-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-input-text-line-height: var(--md-outlined-select-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-input-text-size: var(--md-outlined-select-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-input-text-weight: var(--md-outlined-select-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-label-text-color: var(--md-outlined-select-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-label-text-font: var(--md-outlined-select-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-label-text-line-height: var(--md-outlined-select-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-label-text-populated-line-height: var(--md-outlined-select-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-label-text-populated-size: var(--md-outlined-select-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-label-text-size: var(--md-outlined-select-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-label-text-weight: var(--md-outlined-select-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-leading-icon-color: var(--md-outlined-select-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-leading-icon-size: var(--md-outlined-select-text-field-leading-icon-size, 24px);--_text-field-outline-color: var(--md-outlined-select-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_text-field-outline-width: var(--md-outlined-select-text-field-outline-width, 1px);--_text-field-supporting-text-color: var(--md-outlined-select-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-supporting-text-font: var(--md-outlined-select-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-supporting-text-line-height: var(--md-outlined-select-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-supporting-text-size: var(--md-outlined-select-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-supporting-text-weight: var(--md-outlined-select-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-trailing-icon-color: var(--md-outlined-select-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-trailing-icon-size: var(--md-outlined-select-text-field-trailing-icon-size, 24px);--_text-field-container-shape-start-start: var(--md-outlined-select-text-field-container-shape-start-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-start-end: var(--md-outlined-select-text-field-container-shape-start-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-end: var(--md-outlined-select-text-field-container-shape-end-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-start: var(--md-outlined-select-text-field-container-shape-end-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--md-outlined-field-container-shape-end-end: var(--_text-field-container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_text-field-container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_text-field-container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_text-field-container-shape-start-start);--md-outlined-field-content-color: var(--_text-field-input-text-color);--md-outlined-field-content-font: var(--_text-field-input-text-font);--md-outlined-field-content-line-height: var(--_text-field-input-text-line-height);--md-outlined-field-content-size: var(--_text-field-input-text-size);--md-outlined-field-content-weight: var(--_text-field-input-text-weight);--md-outlined-field-disabled-content-color: var(--_text-field-disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_text-field-disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_text-field-disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_text-field-disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_text-field-disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_text-field-disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_text-field-disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_text-field-disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_text-field-disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_text-field-disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_text-field-disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_text-field-disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_text-field-disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_text-field-error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_text-field-error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_text-field-error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_text-field-error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_text-field-error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_text-field-error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_text-field-error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_text-field-error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_text-field-error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_text-field-error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_text-field-error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_text-field-error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_text-field-error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_text-field-error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_text-field-error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_text-field-error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_text-field-error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_text-field-error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_text-field-focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_text-field-focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_text-field-focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_text-field-focus-outline-color);--md-outlined-field-focus-outline-width: var(--_text-field-focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_text-field-focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_text-field-focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_text-field-hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_text-field-hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_text-field-hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_text-field-hover-outline-color);--md-outlined-field-hover-outline-width: var(--_text-field-hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_text-field-hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_text-field-hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_text-field-label-text-color);--md-outlined-field-label-text-font: var(--_text-field-label-text-font);--md-outlined-field-label-text-line-height: var(--_text-field-label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_text-field-label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_text-field-label-text-populated-size);--md-outlined-field-label-text-size: var(--_text-field-label-text-size);--md-outlined-field-label-text-weight: var(--_text-field-label-text-weight);--md-outlined-field-leading-content-color: var(--_text-field-leading-icon-color);--md-outlined-field-outline-color: var(--_text-field-outline-color);--md-outlined-field-outline-width: var(--_text-field-outline-width);--md-outlined-field-supporting-text-color: var(--_text-field-supporting-text-color);--md-outlined-field-supporting-text-font: var(--_text-field-supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_text-field-supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_text-field-supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_text-field-supporting-text-weight);--md-outlined-field-trailing-content-color: var(--_text-field-trailing-icon-color)}[has-start] .icon.leading{font-size:var(--_text-field-leading-icon-size);height:var(--_text-field-leading-icon-size);width:var(--_text-field-leading-icon-size)}.icon.trailing{font-size:var(--_text-field-trailing-icon-size);height:var(--_text-field-trailing-icon-size);width:var(--_text-field-trailing-icon-size)}
+`;var lo=x`:host{color:unset;min-width:210px;display:flex}.field{cursor:default;outline:none}.select{position:relative;flex-direction:column}.icon.trailing svg,.icon ::slotted(*){fill:currentColor}.icon ::slotted(*){width:inherit;height:inherit;font-size:inherit}.icon slot{display:flex;height:100%;width:100%;align-items:center;justify-content:center}.icon.trailing :is(.up,.down){opacity:0;transition:opacity 75ms linear 75ms}.select:not(.open) .down,.select.open .up{opacity:1}.field,.select,md-menu{min-width:inherit;width:inherit;max-width:inherit;display:flex}md-menu{min-width:var(--__menu-min-width);max-width:var(--__menu-max-width, inherit)}.menu-wrapper{width:0px;height:0px;max-width:inherit}md-menu ::slotted(:not[disabled]){cursor:pointer}.field,.select{width:100%}:host{display:inline-flex}:host([disabled]){pointer-events:none}
+`;var dr=class extends St{};dr.styles=[lo,ao];dr=n([T("md-outlined-select")],dr);var It=x`:host{display:flex;--md-ripple-hover-color: var(--md-menu-item-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-menu-item-hover-state-layer-opacity, 0.08);--md-ripple-pressed-color: var(--md-menu-item-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-opacity: var(--md-menu-item-pressed-state-layer-opacity, 0.12)}:host([disabled]){opacity:var(--md-menu-item-disabled-opacity, 0.3);pointer-events:none}md-focus-ring{z-index:1;--md-focus-ring-shape: 8px}a,button,li{background:none;border:none;padding:0;margin:0;text-align:unset;text-decoration:none}.list-item{border-radius:inherit;display:flex;flex:1;max-width:inherit;min-width:inherit;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}.list-item:not(.disabled){cursor:pointer}[slot=container]{pointer-events:none}md-ripple{border-radius:inherit}md-item{border-radius:inherit;flex:1;color:var(--md-menu-item-label-text-color, var(--md-sys-color-on-surface, #1d1b20));font-family:var(--md-menu-item-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));line-height:var(--md-menu-item-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));font-weight:var(--md-menu-item-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));min-height:var(--md-menu-item-one-line-container-height, 56px);padding-top:var(--md-menu-item-top-space, 12px);padding-bottom:var(--md-menu-item-bottom-space, 12px);padding-inline-start:var(--md-menu-item-leading-space, 16px);padding-inline-end:var(--md-menu-item-trailing-space, 16px)}md-item[multiline]{min-height:var(--md-menu-item-two-line-container-height, 72px)}[slot=supporting-text]{color:var(--md-menu-item-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-supporting-text-font, var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-supporting-text-size, var(--md-sys-typescale-body-medium-size, 0.875rem));line-height:var(--md-menu-item-supporting-text-line-height, var(--md-sys-typescale-body-medium-line-height, 1.25rem));font-weight:var(--md-menu-item-supporting-text-weight, var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400)))}[slot=trailing-supporting-text]{color:var(--md-menu-item-trailing-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-trailing-supporting-text-font, var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-trailing-supporting-text-size, var(--md-sys-typescale-label-small-size, 0.6875rem));line-height:var(--md-menu-item-trailing-supporting-text-line-height, var(--md-sys-typescale-label-small-line-height, 1rem));font-weight:var(--md-menu-item-trailing-supporting-text-weight, var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500)))}:is([slot=start],[slot=end])::slotted(*){fill:currentColor}[slot=start]{color:var(--md-menu-item-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}[slot=end]{color:var(--md-menu-item-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}.list-item{background-color:var(--md-menu-item-container-color, transparent)}.list-item.selected{background-color:var(--md-menu-item-selected-container-color, var(--md-sys-color-secondary-container, #e8def8))}.selected:not(.disabled) ::slotted(*){color:var(--md-menu-item-selected-label-text-color, var(--md-sys-color-on-secondary-container, #1d192b))}@media(forced-colors: active){:host([disabled]),:host([disabled]) slot{color:GrayText;opacity:1}.list-item{position:relative}.list-item.selected::before{content:"";position:absolute;inset:0;box-sizing:border-box;border-radius:inherit;pointer-events:none;border:3px double CanvasText}}
+`;var De=class extends y{constructor(){super(...arguments),this.multiline=!1}render(){return p`
+      <slot name="container"></slot>
+      <slot class="non-text" name="start"></slot>
+      <div class="text">
+        <slot name="overline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          class="default-slot"
+          @slotchange=${this.handleTextSlotChange}></slot>
+        <slot name="headline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          name="supporting-text"
+          @slotchange=${this.handleTextSlotChange}></slot>
+      </div>
+      <slot class="non-text" name="trailing-supporting-text"></slot>
+      <slot class="non-text" name="end"></slot>
+    `}handleTextSlotChange(){let e=!1,t=0;for(let r of this.textSlots)if(ei(r)&&(t+=1),t>1){e=!0;break}this.multiline=e}};n([l({type:Boolean,reflect:!0})],De.prototype,"multiline",void 0);n([Cr(".text slot")],De.prototype,"textSlots",void 0);function ei(o){for(let e of o.assignedNodes({flatten:!0})){let t=e.nodeType===Node.ELEMENT_NODE,r=e.nodeType===Node.TEXT_NODE&&e.textContent?.match(/\S/);if(t||r)return!0}return!1}var co=x`:host{color:var(--md-sys-color-on-surface, #1d1b20);font-family:var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-large-size, 1rem);font-weight:var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-large-line-height, 1.5rem);align-items:center;box-sizing:border-box;display:flex;gap:16px;min-height:56px;overflow:hidden;padding:12px 16px;position:relative;text-overflow:ellipsis}:host([multiline]){min-height:72px}[name=overline]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-medium-size, 0.875rem);font-weight:var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-medium-line-height, 1.25rem)}[name=trailing-supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=container]::slotted(*){inset:0;position:absolute}.default-slot{display:inline}.default-slot,.text ::slotted(*){overflow:hidden;text-overflow:ellipsis}.text{display:flex;flex:1;flex-direction:column;overflow:hidden}
+`;var cr=class extends De{};cr.styles=[co];cr=n([T("md-item")],cr);var ti=450,uo=225,ri=.2,oi=10,ii=75,si=.35,ni="::after",ai="forwards",V;(function(o){o[o.INACTIVE=0]="INACTIVE",o[o.TOUCH_DELAY=1]="TOUCH_DELAY",o[o.HOLDING=2]="HOLDING",o[o.WAITING_FOR_CLICK=3]="WAITING_FOR_CLICK"})(V||(V={}));var li=["click","contextmenu","pointercancel","pointerdown","pointerenter","pointerleave","pointerup"],di=150,ci=window.matchMedia("(forced-colors: active)"),ve=class extends y{constructor(){super(...arguments),this.disabled=!1,this.hovered=!1,this.pressed=!1,this.rippleSize="",this.rippleScale="",this.initialSize=0,this.state=V.INACTIVE,this.attachableController=new Pe(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){let e={hovered:this.hovered,pressed:this.pressed};return p`<div class="surface ${R(e)}"></div>`}update(e){e.has("disabled")&&this.disabled&&(this.hovered=!1,this.pressed=!1),super.update(e)}handlePointerenter(e){this.shouldReactToEvent(e)&&(this.hovered=!0)}handlePointerleave(e){this.shouldReactToEvent(e)&&(this.hovered=!1,this.state!==V.INACTIVE&&this.endPressAnimation())}handlePointerup(e){if(this.shouldReactToEvent(e)){if(this.state===V.HOLDING){this.state=V.WAITING_FOR_CLICK;return}if(this.state===V.TOUCH_DELAY){this.state=V.WAITING_FOR_CLICK,this.startPressAnimation(this.rippleStartEvent);return}}}async handlePointerdown(e){if(this.shouldReactToEvent(e)){if(this.rippleStartEvent=e,!this.isTouch(e)){this.state=V.WAITING_FOR_CLICK,this.startPressAnimation(e);return}this.state=V.TOUCH_DELAY,await new Promise(t=>{setTimeout(t,di)}),this.state===V.TOUCH_DELAY&&(this.state=V.HOLDING,this.startPressAnimation(e))}}handleClick(){if(!this.disabled){if(this.state===V.WAITING_FOR_CLICK){this.endPressAnimation();return}this.state===V.INACTIVE&&(this.startPressAnimation(),this.endPressAnimation())}}handlePointercancel(e){this.shouldReactToEvent(e)&&this.endPressAnimation()}handleContextmenu(){this.disabled||this.endPressAnimation()}determineRippleSize(){let{height:e,width:t}=this.getBoundingClientRect(),r=Math.max(e,t),i=Math.max(si*r,ii),s=this.currentCSSZoom??1,a=Math.floor(r*ri/s),c=Math.sqrt(t**2+e**2)+oi;this.initialSize=a;let h=(c+i)/a;this.rippleScale=`${h/s}`,this.rippleSize=`${a}px`}getNormalizedPointerEventCoords(e){let{scrollX:t,scrollY:r}=window,{left:i,top:s}=this.getBoundingClientRect(),a=t+i,d=r+s,{pageX:c,pageY:h}=e,m=this.currentCSSZoom??1;return{x:(c-a)/m,y:(h-d)/m}}getTranslationCoordinates(e){let{height:t,width:r}=this.getBoundingClientRect(),i=this.currentCSSZoom??1,s={x:(r/i-this.initialSize)/2,y:(t/i-this.initialSize)/2},a;return e instanceof PointerEvent?a=this.getNormalizedPointerEventCoords(e):a={x:r/i/2,y:t/i/2},a={x:a.x-this.initialSize/2,y:a.y-this.initialSize/2},{startPoint:a,endPoint:s}}startPressAnimation(e){if(!this.mdRoot)return;this.pressed=!0,this.growAnimation?.cancel(),this.determineRippleSize();let{startPoint:t,endPoint:r}=this.getTranslationCoordinates(e),i=`${t.x}px, ${t.y}px`,s=`${r.x}px, ${r.y}px`;this.growAnimation=this.mdRoot.animate({top:[0,0],left:[0,0],height:[this.rippleSize,this.rippleSize],width:[this.rippleSize,this.rippleSize],transform:[`translate(${i}) scale(1)`,`translate(${s}) scale(${this.rippleScale})`]},{pseudoElement:ni,duration:ti,easing:re.STANDARD,fill:ai})}async endPressAnimation(){this.rippleStartEvent=void 0,this.state=V.INACTIVE;let e=this.growAnimation,t=1/0;if(typeof e?.currentTime=="number"?t=e.currentTime:e?.currentTime&&(t=e.currentTime.to("ms").value),t>=uo){this.pressed=!1;return}await new Promise(r=>{setTimeout(r,uo-t)}),this.growAnimation===e&&(this.pressed=!1)}shouldReactToEvent(e){if(this.disabled||!e.isPrimary||this.rippleStartEvent&&this.rippleStartEvent.pointerId!==e.pointerId)return!1;if(e.type==="pointerenter"||e.type==="pointerleave")return!this.isTouch(e);let t=e.buttons===1;return this.isTouch(e)||t}isTouch({pointerType:e}){return e==="touch"}async handleEvent(e){if(!ci?.matches)switch(e.type){case"click":this.handleClick();break;case"contextmenu":this.handleContextmenu();break;case"pointercancel":this.handlePointercancel(e);break;case"pointerdown":await this.handlePointerdown(e);break;case"pointerenter":this.handlePointerenter(e);break;case"pointerleave":this.handlePointerleave(e);break;case"pointerup":this.handlePointerup(e);break;default:break}}onControlChange(e,t){if(!!1)for(let r of li)e?.removeEventListener(r,this),t?.addEventListener(r,this)}};n([l({type:Boolean,reflect:!0})],ve.prototype,"disabled",void 0);n([I()],ve.prototype,"hovered",void 0);n([I()],ve.prototype,"pressed",void 0);n([k(".surface")],ve.prototype,"mdRoot",void 0);var po=x`:host{display:flex;margin:auto;pointer-events:none}:host([disabled]){display:none}@media(forced-colors: active){:host{display:none}}:host,.surface{border-radius:inherit;position:absolute;inset:0;overflow:hidden}.surface{-webkit-tap-highlight-color:rgba(0,0,0,0)}.surface::before,.surface::after{content:"";opacity:0;position:absolute}.surface::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));inset:0;transition:opacity 15ms linear,background-color 15ms linear}.surface::after{background:radial-gradient(closest-side, var(--md-ripple-pressed-color, var(--md-sys-color-on-surface, #1d1b20)) max(100% - 70px, 65%), transparent 100%);transform-origin:center center;transition:opacity 375ms linear}.hovered::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-ripple-hover-opacity, 0.08)}.pressed::after{opacity:var(--md-ripple-pressed-opacity, 0.12);transition-duration:105ms}
+`;var ur=class extends ve{};ur.styles=[po];ur=n([T("md-ripple")],ur);var ze=class{constructor(e,t){this.host=e,this.internalTypeaheadText=null,this.onClick=()=>{this.host.keepOpen||this.host.dispatchEvent(nr(this.host,{kind:wt.CLICK_SELECTION}))},this.onKeydown=r=>{if(this.host.href&&r.code==="Enter"){let s=this.getInteractiveElement();s instanceof HTMLAnchorElement&&s.click()}if(r.defaultPrevented)return;let i=r.code;this.host.keepOpen&&i!=="Escape"||Et(i)&&(r.preventDefault(),this.host.dispatchEvent(nr(this.host,{kind:wt.KEYDOWN,key:i})))},this.getHeadlineElements=t.getHeadlineElements,this.getSupportingTextElements=t.getSupportingTextElements,this.getDefaultElements=t.getDefaultElements,this.getInteractiveElement=t.getInteractiveElement,this.host.addController(this)}get typeaheadText(){if(this.internalTypeaheadText!==null)return this.internalTypeaheadText;let e=this.getHeadlineElements(),t=[];return e.forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getDefaultElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getSupportingTextElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.join(" ")}get tagName(){switch(this.host.type){case"link":return"a";case"button":return"button";default:case"menuitem":case"option":return"li"}}get role(){return this.host.type==="option"?"option":"menuitem"}hostConnected(){this.host.toggleAttribute("md-menu-item",!0)}hostUpdate(){this.host.href&&(this.host.type="link")}setTypeaheadText(e){this.internalTypeaheadText=e}};function ui(){return new Event("request-selection",{bubbles:!0,composed:!0})}function pi(){return new Event("request-deselection",{bubbles:!0,composed:!0})}var kt=class{get role(){return this.menuItemController.role}get typeaheadText(){return this.menuItemController.typeaheadText}setTypeaheadText(e){this.menuItemController.setTypeaheadText(e)}get displayText(){return this.internalDisplayText!==null?this.internalDisplayText:this.menuItemController.typeaheadText}setDisplayText(e){this.internalDisplayText=e}constructor(e,t){this.host=e,this.internalDisplayText=null,this.firstUpdate=!0,this.onClick=()=>{this.menuItemController.onClick()},this.onKeydown=r=>{this.menuItemController.onKeydown(r)},this.lastSelected=this.host.selected,this.menuItemController=new ze(e,t),e.addController(this)}hostUpdate(){this.lastSelected!==this.host.selected&&(this.host.ariaSelected=this.host.selected?"true":"false")}hostUpdated(){this.lastSelected!==this.host.selected&&!this.firstUpdate&&(this.host.selected?this.host.dispatchEvent(ui()):this.host.dispatchEvent(pi())),this.lastSelected=this.host.selected,this.firstUpdate=!1}};var hi=G(y),H=class extends hi{constructor(){super(...arguments),this.disabled=!1,this.isMenuItem=!0,this.selected=!1,this.value="",this.type="option",this.selectOptionController=new kt(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.selectOptionController.typeaheadText}set typeaheadText(e){this.selectOptionController.setTypeaheadText(e)}get displayText(){return this.selectOptionController.displayText}set displayText(e){this.selectOptionController.setDisplayText(e)}render(){return this.renderListItem(p`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){return p`
+      <li
+        id="item"
+        tabindex=${this.disabled?-1:0}
+        role=${this.selectOptionController.role}
+        aria-label=${this.ariaLabel||u}
+        aria-selected=${this.ariaSelected||u}
+        aria-checked=${this.ariaChecked||u}
+        aria-expanded=${this.ariaExpanded||u}
+        aria-haspopup=${this.ariaHasPopup||u}
+        class="list-item ${R(this.getRenderClasses())}"
+        @click=${this.selectOptionController.onClick}
+        @keydown=${this.selectOptionController.onKeydown}
+        >${e}</li
+      >
+    `}renderRipple(){return p` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return p` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return p`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};H.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],H.prototype,"disabled",void 0);n([l({type:Boolean,attribute:"md-menu-item",reflect:!0})],H.prototype,"isMenuItem",void 0);n([l({type:Boolean})],H.prototype,"selected",void 0);n([l()],H.prototype,"value",void 0);n([k(".list-item")],H.prototype,"listItemRoot",void 0);n([q({slot:"headline"})],H.prototype,"headlineElements",void 0);n([q({slot:"supporting-text"})],H.prototype,"supportingTextElements",void 0);n([tt({slot:""})],H.prototype,"defaultElements",void 0);n([l({attribute:"typeahead-text"})],H.prototype,"typeaheadText",null);n([l({attribute:"display-text"})],H.prototype,"displayText",null);var pr=class extends H{};pr.styles=[It];pr=n([T("md-select-option")],pr);var fi=G(y),F=class extends fi{constructor(){super(...arguments),this.disabled=!1,this.type="menuitem",this.href="",this.target="",this.keepOpen=!1,this.selected=!1,this.menuItemController=new ze(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.menuItemController.typeaheadText}set typeaheadText(e){this.menuItemController.setTypeaheadText(e)}render(){return this.renderListItem(p`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){let t=this.type==="link",r;switch(this.menuItemController.tagName){case"a":r=W`a`;break;case"button":r=W`button`;break;default:case"li":r=W`li`;break}let i=t&&this.target?this.target:u;return ce`
+      <${r}
+        id="item"
+        tabindex=${this.disabled&&!t?-1:0}
+        role=${this.menuItemController.role}
+        aria-label=${this.ariaLabel||u}
+        aria-selected=${this.ariaSelected||u}
+        aria-checked=${this.ariaChecked||u}
+        aria-expanded=${this.ariaExpanded||u}
+        aria-haspopup=${this.ariaHasPopup||u}
+        class="list-item ${R(this.getRenderClasses())}"
+        href=${this.href||u}
+        target=${i}
+        @click=${this.menuItemController.onClick}
+        @keydown=${this.menuItemController.onKeydown}
+      >${e}</${r}>
+    `}renderRipple(){return p` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return p` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return p`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};F.shadowRootOptions={...y.shadowRootOptions,delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],F.prototype,"disabled",void 0);n([l()],F.prototype,"type",void 0);n([l()],F.prototype,"href",void 0);n([l()],F.prototype,"target",void 0);n([l({type:Boolean,attribute:"keep-open"})],F.prototype,"keepOpen",void 0);n([l({type:Boolean})],F.prototype,"selected",void 0);n([k(".list-item")],F.prototype,"listItemRoot",void 0);n([q({slot:"headline"})],F.prototype,"headlineElements",void 0);n([q({slot:"supporting-text"})],F.prototype,"supportingTextElements",void 0);n([tt({slot:""})],F.prototype,"defaultElements",void 0);n([l({attribute:"typeahead-text"})],F.prototype,"typeaheadText",null);var hr=class extends F{};hr.styles=[It];hr=n([T("md-menu-item")],hr);function ho(o){o.addInitializer(e=>{let t=e;t.addEventListener("click",async r=>{let{type:i,[L]:s}=t,{form:a}=s;if(!(!a||i==="button")&&(await new Promise(d=>{setTimeout(d)}),!r.defaultPrevented)){if(i==="reset"){a.reset();return}a.addEventListener("submit",d=>{Object.defineProperty(d,"submitter",{configurable:!0,enumerable:!0,get:()=>t})},{capture:!0,once:!0}),s.setFormValue(t.value),a.requestSubmit()}})})}function fr(o,e=!0){return e&&getComputedStyle(o).getPropertyValue("direction").trim()==="rtl"}var mi=G(ue(y)),D=class extends mi{get name(){return this.getAttribute("name")??""}set name(e){this.setAttribute("name",e)}get form(){return this[L].form}get labels(){return this[L].labels}constructor(){super(),this.disabled=!1,this.softDisabled=!1,this.flipIconInRtl=!1,this.href="",this.download="",this.target="",this.ariaLabelSelected="",this.toggle=!1,this.selected=!1,this.type="submit",this.value="",this.flipIcon=fr(this,this.flipIconInRtl),this.addEventListener("click",this.handleClick.bind(this))}willUpdate(){this.href&&(this.disabled=!1,this.softDisabled=!1)}render(){let e=this.href?W`div`:W`button`,{ariaLabel:t,ariaHasPopup:r,ariaExpanded:i}=this,s=t&&this.ariaLabelSelected,a=this.toggle?this.selected:u,d=u;return this.href||(d=s&&this.selected?this.ariaLabelSelected:t),ce`<${e}
+        class="icon-button ${R(this.getRenderClasses())}"
+        id="button"
+        aria-label="${d||u}"
+        aria-haspopup="${!this.href&&r||u}"
+        aria-expanded="${!this.href&&i||u}"
+        aria-pressed="${a}"
+        aria-disabled=${!this.href&&this.softDisabled||u}
+        ?disabled="${!this.href&&this.disabled}"
+        @click="${this.handleClickOnChild}">
+        ${this.renderFocusRing()}
+        ${this.renderRipple()}
+        ${this.selected?u:this.renderIcon()}
+        ${this.selected?this.renderSelectedIcon():u}
+        ${this.href?this.renderLink():this.renderTouchTarget()}
+  </${e}>`}renderLink(){let{ariaLabel:e}=this;return p`
+      <a
+        class="link"
+        id="link"
+        href="${this.href}"
+        download="${this.download||u}"
+        target="${this.target||u}"
+        aria-label="${e||u}">
+        ${this.renderTouchTarget()}
+      </a>
+    `}getRenderClasses(){return{"flip-icon":this.flipIcon,selected:this.toggle&&this.selected}}renderIcon(){return p`<span class="icon"><slot></slot></span>`}renderSelectedIcon(){return p`<span class="icon icon--selected"
+      ><slot name="selected"><slot></slot></slot
+    ></span>`}renderTouchTarget(){return p`<span class="touch"></span>`}renderFocusRing(){return p`<md-focus-ring
+      part="focus-ring"
+      for=${this.href?"link":"button"}></md-focus-ring>`}renderRipple(){let e=!this.href&&(this.disabled||this.softDisabled);return p`<md-ripple
+      for=${this.href?"link":u}
+      ?disabled="${e}"></md-ripple>`}connectedCallback(){this.flipIcon=fr(this,this.flipIconInRtl),super.connectedCallback()}handleClick(e){if(!this.href&&this.softDisabled){e.stopImmediatePropagation(),e.preventDefault();return}}async handleClickOnChild(e){await 0,!(!this.toggle||this.disabled||this.softDisabled||e.defaultPrevented)&&(this.selected=!this.selected,this.dispatchEvent(new InputEvent("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0})))}};ho(D);D.formAssociated=!0;D.shadowRootOptions={mode:"open",delegatesFocus:!0};n([l({type:Boolean,reflect:!0})],D.prototype,"disabled",void 0);n([l({type:Boolean,attribute:"soft-disabled",reflect:!0})],D.prototype,"softDisabled",void 0);n([l({type:Boolean,attribute:"flip-icon-in-rtl"})],D.prototype,"flipIconInRtl",void 0);n([l()],D.prototype,"href",void 0);n([l()],D.prototype,"download",void 0);n([l()],D.prototype,"target",void 0);n([l({attribute:"aria-label-selected"})],D.prototype,"ariaLabelSelected",void 0);n([l({type:Boolean})],D.prototype,"toggle",void 0);n([l({type:Boolean,reflect:!0})],D.prototype,"selected",void 0);n([l()],D.prototype,"type",void 0);n([l({reflect:!0})],D.prototype,"value",void 0);n([I()],D.prototype,"flipIcon",void 0);var fo=x`:host{display:inline-flex;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0);height:var(--_container-height);width:var(--_container-width);justify-content:center}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_container-height))/2) max(0px,(48px - var(--_container-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_container-shape-start-start);--md-focus-ring-shape-start-end: var(--_container-shape-start-end);--md-focus-ring-shape-end-end: var(--_container-shape-end-end);--md-focus-ring-shape-end-start: var(--_container-shape-end-start)}:host(:is([disabled],[soft-disabled])){pointer-events:none}.icon-button{place-items:center;background:none;border:none;box-sizing:border-box;cursor:pointer;display:flex;place-content:center;outline:none;padding:0;position:relative;text-decoration:none;user-select:none;z-index:0;flex:1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.icon ::slotted(*){font-size:var(--_icon-size);height:var(--_icon-size);width:var(--_icon-size);font-weight:inherit}md-ripple{z-index:-1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.flip-icon .icon{transform:scaleX(-1)}.icon{display:inline-flex}.link{display:grid;height:100%;outline:none;place-items:center;position:absolute;width:100%}.touch{position:absolute;height:max(48px,100%);width:max(48px,100%)}:host([touch-target=none]) .touch{display:none}@media(forced-colors: active){:host(:is([disabled],[soft-disabled])){--_disabled-icon-color: GrayText;--_disabled-icon-opacity: 1}}
+`;var mo=x`:host{--_disabled-icon-color: var(--md-icon-button-disabled-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-icon-opacity: var(--md-icon-button-disabled-icon-opacity, 0.38);--_icon-size: var(--md-icon-button-icon-size, 24px);--_selected-focus-icon-color: var(--md-icon-button-selected-focus-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-icon-color: var(--md-icon-button-selected-hover-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-color: var(--md-icon-button-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-opacity: var(--md-icon-button-selected-hover-state-layer-opacity, 0.08);--_selected-icon-color: var(--md-icon-button-selected-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-icon-color: var(--md-icon-button-selected-pressed-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-color: var(--md-icon-button-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-opacity: var(--md-icon-button-selected-pressed-state-layer-opacity, 0.12);--_state-layer-height: var(--md-icon-button-state-layer-height, 40px);--_state-layer-shape: var(--md-icon-button-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));--_state-layer-width: var(--md-icon-button-state-layer-width, 40px);--_focus-icon-color: var(--md-icon-button-focus-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-icon-color: var(--md-icon-button-hover-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-color: var(--md-icon-button-hover-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-opacity: var(--md-icon-button-hover-state-layer-opacity, 0.08);--_icon-color: var(--md-icon-button-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-icon-color: var(--md-icon-button-pressed-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-color: var(--md-icon-button-pressed-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-opacity: var(--md-icon-button-pressed-state-layer-opacity, 0.12);--_container-shape-start-start: 0;--_container-shape-start-end: 0;--_container-shape-end-end: 0;--_container-shape-end-start: 0;--_container-height: 0;--_container-width: 0;height:var(--_state-layer-height);width:var(--_state-layer-width)}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_state-layer-height))/2) max(0px,(48px - var(--_state-layer-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_state-layer-shape);--md-focus-ring-shape-start-end: var(--_state-layer-shape);--md-focus-ring-shape-end-end: var(--_state-layer-shape);--md-focus-ring-shape-end-start: var(--_state-layer-shape)}.standard{background-color:rgba(0,0,0,0);color:var(--_icon-color);--md-ripple-hover-color: var(--_hover-state-layer-color);--md-ripple-hover-opacity: var(--_hover-state-layer-opacity);--md-ripple-pressed-color: var(--_pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_pressed-state-layer-opacity)}.standard:hover{color:var(--_hover-icon-color)}.standard:focus{color:var(--_focus-icon-color)}.standard:active{color:var(--_pressed-icon-color)}.standard:is(:disabled,[aria-disabled=true]){color:var(--_disabled-icon-color)}md-ripple{border-radius:var(--_state-layer-shape)}.standard:is(:disabled,[aria-disabled=true]){opacity:var(--_disabled-icon-opacity)}.selected:not(:disabled,[aria-disabled=true]){color:var(--_selected-icon-color)}.selected:not(:disabled,[aria-disabled=true]):hover{color:var(--_selected-hover-icon-color)}.selected:not(:disabled,[aria-disabled=true]):focus{color:var(--_selected-focus-icon-color)}.selected:not(:disabled,[aria-disabled=true]):active{color:var(--_selected-pressed-icon-color)}.selected{--md-ripple-hover-color: var(--_selected-hover-state-layer-color);--md-ripple-hover-opacity: var(--_selected-hover-state-layer-opacity);--md-ripple-pressed-color: var(--_selected-pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_selected-pressed-state-layer-opacity)}
+`;var mr=class extends D{getRenderClasses(){return{...super.getRenderClasses(),standard:!0}}};mr.styles=[fo,mo];mr=n([T("md-icon-button")],mr);var go=Symbol("dispatchHooks");function yo(o,e){let t=o[go];if(!t)throw new Error(`'${o.type}' event needs setupDispatchHooks().`);t.addEventListener("after",e)}var vo=new WeakMap;function bo(o,...e){let t=vo.get(o);t||(t=new Set,vo.set(o,t));for(let r of e){if(t.has(r))continue;let i=!1;o.addEventListener(r,s=>{if(i)return;s.stopImmediatePropagation();let a=Reflect.construct(s.constructor,[s.type,s]),d=new EventTarget;a[go]=d,i=!0;let c=o.dispatchEvent(a);i=!1,c||s.preventDefault(),d.dispatchEvent(new Event("after"))},{capture:!0}),t.add(r)}}function xo(o){let e=new MouseEvent("click",{bubbles:!0});return o.dispatchEvent(e),e}function _o(o){return o.currentTarget!==o.target||o.composedPath()[0]!==o.target||o.target.disabled?!1:!vi(o)}function vi(o){let e=vr;return e&&(o.preventDefault(),o.stopImmediatePropagation()),gi(),e}var vr=!1;async function gi(){vr=!0,await null,vr=!1}var Ot=class extends fe{computeValidity(e){return this.checkboxControl||(this.checkboxControl=document.createElement("input"),this.checkboxControl.type="checkbox"),this.checkboxControl.checked=e.checked,this.checkboxControl.required=e.required,{validity:this.checkboxControl.validity,validationMessage:this.checkboxControl.validationMessage}}equals(e,t){return e.checked===t.checked&&e.required===t.required}copy({checked:e,required:t}){return{checked:e,required:t}}};var yi=G(ke(Oe(ue(y)))),X=class extends yi{constructor(){super(),this.selected=!1,this.icons=!1,this.showOnlySelectedIcon=!1,this.required=!1,this.value="on",!!1&&(this.addEventListener("click",e=>{!_o(e)||!this.input||(this.focus(),xo(this.input))}),bo(this,"keydown"),this.addEventListener("keydown",e=>{yo(e,()=>{e.defaultPrevented||e.key!=="Enter"||this.disabled||!this.input||this.input.click()})}))}render(){return p`
+      <div class="switch ${R(this.getRenderClasses())}">
+        <input
+          id="switch"
+          class="touch"
+          type="checkbox"
+          role="switch"
+          aria-label=${this.ariaLabel||u}
+          ?checked=${this.selected}
+          ?disabled=${this.disabled}
+          ?required=${this.required}
+          @input=${this.handleInput}
+          @change=${this.handleChange} />
+
+        <md-focus-ring part="focus-ring" for="switch"></md-focus-ring>
+        <span class="track"> ${this.renderHandle()} </span>
+      </div>
+    `}getRenderClasses(){return{selected:this.selected,unselected:!this.selected,disabled:this.disabled}}renderHandle(){let e={"with-icon":this.showOnlySelectedIcon?this.selected:this.icons};return p`
+      ${this.renderTouchTarget()}
+      <span class="handle-container">
+        <md-ripple for="switch" ?disabled="${this.disabled}"></md-ripple>
+        <span class="handle ${R(e)}">
+          ${this.shouldShowIcons()?this.renderIcons():p``}
+        </span>
+      </span>
+    `}renderIcons(){return p`
+      <div class="icons">
+        ${this.renderOnIcon()}
+        ${this.showOnlySelectedIcon?p``:this.renderOffIcon()}
+      </div>
+    `}renderOnIcon(){return p`
+      <slot class="icon icon--on" name="on-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M9.55 18.2 3.65 12.3 5.275 10.675 9.55 14.95 18.725 5.775 20.35 7.4Z" />
+        </svg>
+      </slot>
+    `}renderOffIcon(){return p`
+      <slot class="icon icon--off" name="off-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M6.4 19.2 4.8 17.6 10.4 12 4.8 6.4 6.4 4.8 12 10.4 17.6 4.8 19.2 6.4 13.6 12 19.2 17.6 17.6 19.2 12 13.6Z" />
+        </svg>
+      </slot>
+    `}renderTouchTarget(){return p`<span class="touch"></span>`}shouldShowIcons(){return this.icons||this.showOnlySelectedIcon}handleInput(e){let t=e.target;this.selected=t.checked}handleChange(e){Ie(this,e)}[ie](){return this.selected?this.value:null}[pt](){return String(this.selected)}formResetCallback(){this.selected=this.hasAttribute("selected")}formStateRestoreCallback(e){this.selected=e==="true"}[pe](){return new Ot(()=>({checked:this.selected,required:this.required}))}[he](){return this.input}};X.shadowRootOptions={mode:"open",delegatesFocus:!0};n([l({type:Boolean})],X.prototype,"selected",void 0);n([l({type:Boolean})],X.prototype,"icons",void 0);n([l({type:Boolean,attribute:"show-only-selected-icon"})],X.prototype,"showOnlySelectedIcon",void 0);n([l({type:Boolean})],X.prototype,"required",void 0);n([l()],X.prototype,"value",void 0);n([k("input")],X.prototype,"input",void 0);var wo=x`@layer styles, hcm;@layer styles{:host{display:inline-flex;outline:none;vertical-align:top;-webkit-tap-highlight-color:rgba(0,0,0,0);cursor:pointer}:host([disabled]){cursor:default}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--md-switch-track-height, 32px))/2) 0px}md-focus-ring{--md-focus-ring-shape-start-start: var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-start-end: var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-end: var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-start: var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}.switch{align-items:center;display:inline-flex;flex-shrink:0;position:relative;width:var(--md-switch-track-width, 52px);height:var(--md-switch-track-height, 32px);border-start-start-radius:var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}input{appearance:none;height:max(100%,var(--md-switch-touch-target-size, 48px));outline:none;margin:0;position:absolute;width:max(100%,var(--md-switch-touch-target-size, 48px));z-index:1;cursor:inherit;top:50%;left:50%;transform:translate(-50%, -50%)}:host([touch-target=none]) input{display:none}}@layer styles{.track{position:absolute;width:100%;height:100%;box-sizing:border-box;border-radius:inherit;display:flex;justify-content:center;align-items:center}.track::before{content:"";display:flex;position:absolute;height:100%;width:100%;border-radius:inherit;box-sizing:border-box;transition-property:opacity,background-color;transition-timing-function:linear;transition-duration:67ms}.disabled .track{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0)}.disabled .track::before,.disabled .track::after{transition:none;opacity:var(--md-switch-disabled-track-opacity, 0.12)}.disabled .track::before{background-clip:content-box}.selected .track::before{background-color:var(--md-switch-selected-track-color, var(--md-sys-color-primary, #6750a4))}.selected:hover .track::before{background-color:var(--md-switch-selected-hover-track-color, var(--md-sys-color-primary, #6750a4))}.selected:focus-within .track::before{background-color:var(--md-switch-selected-focus-track-color, var(--md-sys-color-primary, #6750a4))}.selected:active .track::before{background-color:var(--md-switch-selected-pressed-track-color, var(--md-sys-color-primary, #6750a4))}.selected.disabled .track{background-clip:border-box}.selected.disabled .track::before{background-color:var(--md-switch-disabled-selected-track-color, var(--md-sys-color-on-surface, #1d1b20))}.unselected .track::before{background-color:var(--md-switch-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-track-outline-color, var(--md-sys-color-outline, #79747e));border-style:solid;border-width:var(--md-switch-track-outline-width, 2px)}.unselected:hover .track::before{background-color:var(--md-switch-hover-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-hover-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:focus-visible .track::before{background-color:var(--md-switch-focus-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-focus-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:active .track::before{background-color:var(--md-switch-pressed-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-pressed-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected.disabled .track::before{background-color:var(--md-switch-disabled-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-disabled-track-outline-color, var(--md-sys-color-on-surface, #1d1b20))}}@layer hcm{@media(forced-colors: active){.selected .track::before{background:ButtonText;border-color:ButtonText}.disabled .track::before{border-color:GrayText;opacity:1}.disabled.selected .track::before{background:GrayText}}}@layer styles{.handle-container{display:flex;place-content:center;place-items:center;position:relative;transition:margin 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275)}.selected .handle-container{margin-inline-start:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.unselected .handle-container{margin-inline-end:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.disabled .handle-container{transition:none}.handle{border-start-start-radius:var(--md-switch-handle-shape-start-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-handle-shape-start-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-handle-shape-end-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-handle-shape-end-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));height:var(--md-switch-handle-height, 16px);width:var(--md-switch-handle-width, 16px);transform-origin:center;transition-property:height,width;transition-duration:250ms,250ms;transition-timing-function:cubic-bezier(0.2, 0, 0, 1),cubic-bezier(0.2, 0, 0, 1);z-index:0}.handle::before{content:"";display:flex;inset:0;position:absolute;border-radius:inherit;box-sizing:border-box;transition:background-color 67ms linear}.disabled .handle,.disabled .handle::before{transition:none}.selected .handle{height:var(--md-switch-selected-handle-height, 24px);width:var(--md-switch-selected-handle-width, 24px)}.handle.with-icon{height:var(--md-switch-with-icon-handle-height, 24px);width:var(--md-switch-with-icon-handle-width, 24px)}.selected:not(.disabled):active .handle,.unselected:not(.disabled):active .handle{height:var(--md-switch-pressed-handle-height, 28px);width:var(--md-switch-pressed-handle-width, 28px);transition-timing-function:linear;transition-duration:100ms}.selected .handle::before{background-color:var(--md-switch-selected-handle-color, var(--md-sys-color-on-primary, #fff))}.selected:hover .handle::before{background-color:var(--md-switch-selected-hover-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:focus-within .handle::before{background-color:var(--md-switch-selected-focus-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:active .handle::before{background-color:var(--md-switch-selected-pressed-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected.disabled .handle::before{background-color:var(--md-switch-disabled-selected-handle-color, var(--md-sys-color-surface, #fef7ff));opacity:var(--md-switch-disabled-selected-handle-opacity, 1)}.unselected .handle::before{background-color:var(--md-switch-handle-color, var(--md-sys-color-outline, #79747e))}.unselected:hover .handle::before{background-color:var(--md-switch-hover-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:focus-within .handle::before{background-color:var(--md-switch-focus-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:active .handle::before{background-color:var(--md-switch-pressed-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected.disabled .handle::before{background-color:var(--md-switch-disabled-handle-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-handle-opacity, 0.38)}md-ripple{border-radius:var(--md-switch-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));height:var(--md-switch-state-layer-size, 40px);inset:unset;width:var(--md-switch-state-layer-size, 40px)}.selected md-ripple{--md-ripple-hover-color: var(--md-switch-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-pressed-color: var(--md-switch-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-hover-opacity: var(--md-switch-selected-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-selected-pressed-state-layer-opacity, 0.12)}.unselected md-ripple{--md-ripple-hover-color: var(--md-switch-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-color: var(--md-switch-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-switch-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-pressed-state-layer-opacity, 0.12)}}@layer hcm{@media(forced-colors: active){.unselected .handle::before{background:ButtonText}.disabled .handle::before{opacity:1}.disabled.unselected .handle::before{background:GrayText}}}@layer styles{.icons{position:relative;height:100%;width:100%}.icon{position:absolute;inset:0;margin:auto;display:flex;align-items:center;justify-content:center;fill:currentColor;transition:fill 67ms linear,opacity 33ms linear,transform 167ms cubic-bezier(0.2, 0, 0, 1);opacity:0}.disabled .icon{transition:none}.selected .icon--on,.unselected .icon--off{opacity:1}.unselected .handle:not(.with-icon) .icon--on{transform:rotate(-45deg)}.icon--off{width:var(--md-switch-icon-size, 16px);height:var(--md-switch-icon-size, 16px);color:var(--md-switch-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:hover .icon--off{color:var(--md-switch-hover-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:focus-within .icon--off{color:var(--md-switch-focus-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:active .icon--off{color:var(--md-switch-pressed-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected.disabled .icon--off{color:var(--md-switch-disabled-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9));opacity:var(--md-switch-disabled-icon-opacity, 0.38)}.icon--on{width:var(--md-switch-selected-icon-size, 16px);height:var(--md-switch-selected-icon-size, 16px);color:var(--md-switch-selected-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:hover .icon--on{color:var(--md-switch-selected-hover-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:focus-within .icon--on{color:var(--md-switch-selected-focus-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:active .icon--on{color:var(--md-switch-selected-pressed-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected.disabled .icon--on{color:var(--md-switch-disabled-selected-icon-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-selected-icon-opacity, 0.38)}}@layer hcm{@media(forced-colors: active){.icon--off{fill:Canvas}.icon--on{fill:ButtonText}.disabled.unselected .icon--off,.disabled.selected .icon--on{opacity:1}.disabled .icon--on{fill:GrayText}}}
+`;var gr=class extends X{};gr.styles=[wo];gr=n([T("md-switch")],gr);})();
+  </script>
+
+  <script>
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtHelpTextField extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) field.required = true;
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    if (helpText) {
+      field.addEventListener("focus", () => {
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        field.supportingText = "";
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
       }
-      return value;
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
     }
 
-    function generateCheckCommand() {
-      const lines = [
-        "git config --global user.name",
-        "git config --global user.email"
-      ];
-      document.getElementById("checkCmd").textContent = lines.join("\n");
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
     }
 
-    function generateSetupCommand() {
-      const userName = document.getElementById("userName").value.trim();
-      const userEmail = document.getElementById("userEmail").value.trim();
+    this.appendChild(block);
+  }
 
-      if (!userName) {
-        alert("ユーザー名を入力してください。");
-        return;
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
       }
-      if (!userEmail) {
-        alert("メールアドレスを入力してください。");
-        return;
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
       }
-
-      const lines = [
-        `git config --global user.name ${quoteIfNeeded(userName)}`,
-        `git config --global user.email ${quoteIfNeeded(userEmail)}`
-      ];
-      document.getElementById("setupCmd").textContent = lines.join("\n");
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
     }
+  }
+}
 
-    function copyToClipboard(id) {
-      const text = document.getElementById(id).textContent;
-      if (!text) return;
-      const temp = document.createElement("textarea");
-      temp.value = text;
-      document.body.appendChild(temp);
-      temp.select();
-      document.execCommand("copy");
-      document.body.removeChild(temp);
-      showToast("コピーしました");
-    }
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
 
-    function showToast(message) {
-      const toast = document.getElementById("toast");
-      toast.textContent = message;
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-      }, 2000);
-    }
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
 
-    function toggleMenu() {
-      const panel = document.getElementById("menuPanel");
-      if (!panel) return;
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><use href="#md-icon-menu" xlink:href="#md-icon-menu"></use></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
       panel.classList.toggle("md-hidden");
-    }
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-help-text-field")) {
+  customElements.define("lht-help-text-field", LhtHelpTextField);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
+  <script>
+function quoteIfNeeded(value) {
+  if (!value) return value;
+  if (/[^\w@%+=:,./-]/.test(value)) {
+    const escaped = value.replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  }
+  return value;
+}
+
+function generateCheckCommand() {
+  const lines = [
+    "git config --global user.name",
+    "git config --global user.email"
+  ];
+  document.getElementById("checkCmd").textContent = lines.join("\n");
+}
+
+function generateSetupCommand({ silent = false } = {}) {
+  const userName = document.getElementById("userName").value.trim();
+  const userEmail = document.getElementById("userEmail").value.trim();
+
+  if (!userName) {
+    if (!silent) alert("ユーザー名を入力してください。");
+    document.getElementById("setupCmd").textContent = "";
+    return;
+  }
+  if (!userEmail) {
+    if (!silent) alert("メールアドレスを入力してください。");
+    document.getElementById("setupCmd").textContent = "";
+    return;
+  }
+
+  const lines = [
+    `git config --global user.name ${quoteIfNeeded(userName)}`,
+    `git config --global user.email ${quoteIfNeeded(userEmail)}`
+  ];
+  document.getElementById("setupCmd").textContent = lines.join("\n");
+}
+
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.add("md-visible");
+  setTimeout(() => {
+    toast.classList.remove("md-visible");
+  }, 2000);
+}
+
+function setupAutoUpdate() {
+  const handler = () => generateSetupCommand({ silent: true });
+  ["userName", "userEmail"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener("input", handler);
+    el.addEventListener("change", handler);
+  });
+}
+
+generateCheckCommand();
+setupAutoUpdate();
+generateSetupCommand({ silent: true });
   </script>
 </body>
 </html>

--- a/docs/git/src/git-config-advanced-setup/css/app.css
+++ b/docs/git/src/git-config-advanced-setup/css/app.css
@@ -1,0 +1,1050 @@
+    /* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
+    :root {
+      --md-danger: #b3261e;
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.35);
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-on-tertiary: #FFFFFF;
+      --md-sys-color-on-tertiary-container: #3d2e5a;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-sys-color-state-layer: rgba(98, 0, 238, 0.08);
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-tertiary: #7D5260;
+      --md-sys-color-tertiary-container: #f3e8fd;
+      --md-typography-body-medium: 1rem;
+      --md-typography-body-small: 0.875rem;
+      --md-typography-headline-large: 1.85rem;
+      --md-typography-title-medium: 1.1rem;
+      --md-typography-title-small: 1.05rem;
+      --status-later: #ff9800;
+      --status-ok: #4caf50;
+      --status-todo: #00bcd4;
+    }
+
+    /* local-html-tools MD3 Core Spec v1.0.2 (2026-02-08) */
+    .md-page {
+      background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh;
+    }
+
+    .md-shell {
+      max-width: 980px; margin: 0 auto;
+    }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 18px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
+      border: 1px solid #e9e3f0;
+      padding: 28px;
+    }
+
+    .md-headline {
+      font-size: 1.8rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-subtitle {
+      color: var(--md-sys-color-on-surface-variant); font-size: 0.95rem;
+    }
+
+    .md-section {
+      margin-top: 28px;
+    }
+
+    .md-section-title {
+      font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-grid {
+      display: grid; gap: 16px;
+    }
+
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.35rem;
+    }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.54rem;
+      font-weight: 600;
+      background: #ECEAF1;
+      color: #49454F;
+    }
+
+    .md-input, .md-textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-textarea {
+      min-height: 6.5rem;
+    }
+
+    .md-input:focus, .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-field-block {
+      margin-bottom: 1rem;
+    }
+
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+
+    .md-button--primary:hover {
+      background: #4f00c9;
+    }
+
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      border: none;
+      cursor: pointer;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+
+    .md-tooltip-group {
+      position: relative; display: inline-flex; align-items: center;
+    }
+
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+
+    .md-tooltip-group:hover .md-tooltip-content {
+      opacity: 1;
+    }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+
+    .md-info-icon {
+      width: 18px; height: 18px;
+    }
+
+    .md-code-block {
+      position: relative; margin-top: 0.5rem;
+    }
+
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 2.5rem;
+    }
+
+    .md-copy-button {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      width: 32px;
+      height: 32px;
+      border-radius: 16px;
+      background: #f7f2fa;
+      border: none;
+      cursor: pointer;
+    }
+
+    .md-snackbar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.6rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      font-size: 0.85rem;
+    }
+
+    .md-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 2px 10px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: rgba(98, 0, 238, 0.12);
+      color: var(--md-sys-color-primary);
+      margin-left: 6px;
+    }
+
+    .md-section-wrap {
+      display: grid; gap: 1.75rem;
+    }
+
+    .md-section-card {
+      padding: 1.25rem 1.25rem 1.5rem;
+      border-radius: 24px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ece7f3;
+      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
+    }
+
+    .md-section-subtitle {
+      font-size: var(--md-typography-body-small);
+      color: #6a6675;
+      margin-bottom: 1rem;
+    }
+
+    .md-section-title--spaced {
+      margin-top: 1rem;
+    }
+
+    .md-grid-3 {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .md-card-head {
+      display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+    }
+
+    .md-card-title {
+      font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35;
+    }
+
+    .md-card-arrow {
+      color: #8f8a98; font-size: 1.2rem;
+    }
+
+    .md-card-desc {
+      margin-top: 0.5rem;
+      font-size: var(--md-typography-body-small);
+      color: #5f5a6b;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .md-info-chip:focus-visible {
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
+    }
+
+    .md-tooltip--wide {
+      width: min(32rem, 90vw);
+    }
+
+    .md-tooltip--rich {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-menu-button {
+      position: absolute; top: 16px; right: 16px;
+    }
+
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+
+    .md-menu-link {
+      display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface);
+    }
+
+    .md-menu-link:hover {
+      background: #f2edf8;
+    }
+
+    .md-headline__icon {
+      margin-right: 0.5rem;
+    }
+
+    .md-section-title--lg {
+      font-size: 1.1rem;
+    }
+
+    .md-input, .md-select, .md-textarea {
+      display: block;
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+      box-sizing: border-box;
+    }
+
+    .md-input:focus, .md-select:focus, .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-icon-btn:hover {
+      background: #e6e1ee;
+    }
+
+    .md-icon-btn--small {
+      width: 32px; height: 32px; border-radius: 16px;
+    }
+
+    .md-icon-btn--surface {
+      background: #f7f2fa;
+    }
+
+    .md-snackbar.md-visible {
+      opacity: 1; pointer-events: auto;
+    }
+
+    .md-hidden {
+      display: none;
+    }
+
+        .md-sr-only {
+          position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
+        .md-preview .md-sr-only { display: none !important; }
+
+    .md-stack-sm > * + * {
+      margin-top: 0.75rem;
+    }
+
+    .md-radio-row { display: flex; align-items: flex-start; gap: 0.5rem; }
+    .md-radio {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      color: #3f3b46;
+    }
+
+    .md-radio input {
+      accent-color: var(--md-sys-color-primary);
+    }
+
+    .md-switch-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+    }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 9999px;
+      background: #ffffff;
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transition: transform 150ms ease, background 150ms ease;
+    }
+
+    .md-switch-input {
+      position: absolute; opacity: 0; pointer-events: none;
+    }
+
+    .md-switch-input:checked + .md-switch {
+      background: rgba(98, 0, 238, 0.32);
+      box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
+    }
+
+    .md-switch-input:checked + .md-switch::after {
+      transform: translateX(20px);
+      background: #ffffff;
+    }
+
+    .md-tab-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      border-bottom: 1px solid #e6e1ee;
+      margin-bottom: 1rem;
+    }
+
+    .md-tab-button {
+      border: 1px solid #e6e1ee;
+      border-bottom: none;
+      background: #f3f1f7;
+      padding: 0.4rem 0.9rem;
+      margin-bottom: -1px;
+      border-top-left-radius: 12px;
+      border-top-right-radius: 12px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #3f3b46;
+    }
+
+    .md-tab-button[aria-selected="true"] {
+      background: #ffffff;
+      border-color: #c8c5d0;
+      color: #1c1b1f;
+    }
+
+    .md-tab-panel {
+      border: 1px solid #e6e1ee;
+      border-top: none;
+      padding: 1rem;
+      background: #ffffff;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+      margin-bottom: 1rem;
+    }
+
+    .md-label--row {
+      margin-bottom: 0.5rem;
+    }
+
+    .md-input, .md-select {
+      display: block;
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+      box-sizing: border-box;
+    }
+
+    .md-input:focus, .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-form-grid {
+      display: grid; gap: 0.75rem;
+    }
+
+    .md-button--tonal {
+      background: #f0edf5;
+      color: #3f3b46;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+
+    .md-button--tonal:hover {
+      background: #e6e1ee;
+    }
+
+    .md-chip-row {
+      display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;
+    }
+
+    .md-tooltip--narrow {
+      width: 18rem;
+    }
+
+    .md-surface-card {
+      max-width: 48rem; margin: 0 auto; padding: 24px; position: relative;
+    }
+
+    .md-choice {
+      display: flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.25rem 0;
+    }
+
+    .md-input {
+      width: 100%;
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      font-size: 1rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-button:hover {
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
+    }
+
+    .md-button:active {
+      opacity: 0.7;
+    }
+
+    .md-button--surface {
+      background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline);
+    }
+
+    .md-button--secondary {
+      background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px;
+    }
+
+    .md-button-row {
+      display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px;
+    }
+
+    .md-button--hero {
+      font-size: clamp(1.2rem, 4vw, 1.6rem);
+    }
+
+    .md-field {
+      position: relative; min-width: 200px;
+    }
+
+    .md-field__label {
+      position: absolute;
+      top: -9px;
+      left: 12px;
+      padding: 0 6px;
+      background: var(--md-sys-color-surface);
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+      letter-spacing: 0.02em;
+    }
+
+    .md-field .md-select {
+      appearance: none;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.8rem 2.2rem 0.8rem 0.9rem;
+      font-size: 0.9rem;
+      color: var(--md-sys-color-on-surface);
+      min-width: 200px;
+      line-height: 1.2;
+      background-image: linear-gradient(45deg, transparent 50%, #6c6775 50%), linear-gradient(135deg, #6c6775 50%, transparent 50%);
+      background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
+      background-size: 6px 6px, 6px 6px;
+      background-repeat: no-repeat;
+    }
+
+    .md-field .md-select:focus {
+      outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-stack-md > * + * {
+      margin-top: 0.75rem;
+    }
+
+    .md-grid-2 {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .md-form-row {
+      display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+    }
+
+    .md-form-row--nowrap {
+      flex-wrap: nowrap;
+    }
+
+    .md-label--muted {
+      color: #3f3b46;
+    }
+
+    .md-label--block {
+      margin-bottom: 0.5rem;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+
+    .md-snackbar-host.md-visible {
+      opacity: 1; pointer-events: auto;
+    }
+
+    .md-button:disabled {
+      background: #e6e1ee;
+      color: #9a94a7;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-input-block {
+      margin-bottom: 1rem;
+    }
+
+    .md-section-title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .md-output-wrap {
+      position: relative;
+    }
+
+    .md-output {
+      background: var(--md-sys-color-surface-variant);
+    }
+
+    .md-stack-lg > * + * {
+      margin-top: 1.5rem;
+    }
+
+    .md-form-row--start {
+      align-items: flex-start;
+    }
+
+    .md-input:disabled, .md-select:disabled {
+      background: #f3f0f7;
+    }
+
+    .md-choice-card {
+      border: 1px solid #e2dcec;
+      border-radius: 16px;
+      padding: 1rem;
+      background: #ffffff;
+    }
+
+    .md-choice-card--muted {
+      background: #f7f3fb;
+    }
+
+    .md-choice-row {
+      display: flex; align-items: center; gap: 0.75rem;
+    }
+
+    .md-choice-row input {
+      margin: 0;
+    }
+
+    .md-choice-sub {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675;
+    }
+
+    .md-choice-sub small {
+      font-size: 0.75rem; color: #7b7784;
+    }
+
+    .md-chip--primary {
+      background: #e2d9f7;
+      color: #4a1e9e;
+    }
+
+    .md-chip--warn {
+      background: #f7ece1;
+      color: #8a4b0f;
+    }
+
+    .md-field-stack {
+      display: flex; flex-direction: column; align-items: stretch; gap: 0.5rem;
+    }
+
+    .md-label--full {
+      width: 100%;
+    }
+
+    .md-switch-row {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem;
+    }
+
+    .md-input-wrap {
+      position: relative;
+      flex: 1 1 16rem;
+      min-width: 12rem;
+    }
+
+    .md-input-wrap .md-input {
+      padding-right: 3rem;
+    }
+
+    .md-input-action {
+      position: absolute;
+      top: 50%;
+      right: -0.5rem;
+      transform: translateY(-50%);
+      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+    }
+
+    .md-field-stack .md-input, .md-field-stack .md-select {
+      flex: 0 0 auto;
+    }
+
+    .md-field--dropdown {
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23635b75' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+      background-repeat: no-repeat;
+      background-position: right 0.75rem center;
+      background-size: 1rem 1rem;
+      padding-right: 2.25rem;
+    }
+
+    .md-select--inline {
+      flex: 1 1 18rem; min-width: 14rem;
+    }
+
+    .md-input.md-disabled, .md-select.md-disabled {
+      background: #f3f0f7;
+    }
+
+    .md-choice-inline {
+      display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem;
+    }
+
+    .md-choice-text {
+      font-size: 0.9rem; color: #4a4458;
+    }
+
+
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
+
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+    }
+
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
+
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
+
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
+
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--block { margin-bottom: 0.5rem; }
+
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
+    .md-title-info-row .md-section-title { margin: 0; }
+    .md-title-info-row .md-info-chip { margin-left: 0; }
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; flex: 0 0 auto; }
+    .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
+    .md-flow-strip { width: 100%; max-width: 36rem; height: 2.5rem; }
+
+    .md-input,
+    .md-select {
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid var(--md-sys-color-outline);
+      border-radius: 12px;
+      padding: 0.625rem 0.75rem;
+      font: inherit;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-select--inline { flex: 1 1 18rem; min-width: 14rem; }
+    .md-input { flex: 1 1 16rem; min-width: 12rem; }
+    .md-input:focus,
+    .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
+    .md-input.md-disabled,
+    .md-select.md-disabled {
+      background: #f3f0f7;
+    }
+
+    .md-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.4rem;
+      border-radius: 9999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.22);
+    }
+    .md-button--primary:hover { background: #5a00d6; }
+
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
+
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+    .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
+
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-small { width: 16px; height: 16px; }
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-info-icon { width: 18px; height: 18px; }
+
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .md-choice-inline { display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem; }
+    .md-choice-text { font-size: 0.9rem; color: #4a4458; }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transform: translateX(0);
+      transition: transform 150ms ease;
+    }
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
+      background: #8b5cf6;
+      box-shadow: inset 0 0 0 1px #7c3aed;
+    }
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
+    .md-snackbar {
+      background: #2b2831;
+      color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      letter-spacing: 0.01em;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-dimmed { opacity: 0.6; }
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+      .md-switch-label { white-space: normal; }
+    }

--- a/docs/git/src/git-config-advanced-setup/js/main.js
+++ b/docs/git/src/git-config-advanced-setup/js/main.js
@@ -1,0 +1,87 @@
+function getToggleSelected(id, fallbackValue = false) {
+  const element = document.getElementById(id);
+  if (!element) return !!fallbackValue;
+  if ("selected" in element) return !!element.selected;
+  return !!element.checked;
+}
+
+function generateCheckCommand() {
+  const lines = [
+    "git config --global core.autocrlf",
+    "git config --global push.default"
+  ];
+  document.getElementById("checkCmd").textContent = lines.join("\n");
+}
+
+function toggleAutocrlfOptions() {
+  const enabled = getToggleSelected("enableAutocrlf", false);
+  const options = document.querySelectorAll("#autocrlfOptions input[type='radio']");
+  options.forEach((opt) => {
+    opt.disabled = !enabled;
+  });
+  document.getElementById("autocrlfOptions").classList.toggle("md-dimmed", !enabled);
+}
+
+function togglePushDefaultOptions() {
+  const enabled = getToggleSelected("enablePushDefault", false);
+  const options = document.querySelectorAll("#pushDefaultOptions input[type='radio']");
+  options.forEach((opt) => {
+    opt.disabled = !enabled;
+  });
+  document.getElementById("pushDefaultOptions").classList.toggle("md-dimmed", !enabled);
+}
+
+function generateConfigCommand({ silent = false } = {}) {
+  const enableAutocrlf = getToggleSelected("enableAutocrlf", false);
+  const enablePushDefault = getToggleSelected("enablePushDefault", false);
+
+  if (!enableAutocrlf && !enablePushDefault) {
+    if (!silent) alert("設定を1つ以上選択してください。");
+    document.getElementById("configCmd").textContent = "";
+    return;
+  }
+
+  const lines = [];
+
+  if (enableAutocrlf) {
+    const autocrlfValue = document.querySelector("input[name='autocrlf']:checked");
+    if (autocrlfValue) {
+      lines.push(`git config --global core.autocrlf ${autocrlfValue.value}`);
+    }
+  }
+
+  if (enablePushDefault) {
+    const pushDefaultValue = document.querySelector("input[name='pushdefault']:checked");
+    if (pushDefaultValue) {
+      lines.push(`git config --global push.default ${pushDefaultValue.value}`);
+    }
+  }
+
+  document.getElementById("configCmd").textContent = lines.join("\n");
+}
+
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.add("md-visible");
+  setTimeout(() => {
+    toast.classList.remove("md-visible");
+  }, 2000);
+}
+
+function setupAutoUpdate() {
+  const handler = () => generateConfigCommand({ silent: true });
+  ["autocrlf-true", "autocrlf-input", "autocrlf-false", "pushdefault-simple", "pushdefault-current", "pushdefault-upstream", "pushdefault-matching", "enableAutocrlf", "enablePushDefault"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener("change", handler);
+    el.addEventListener("input", handler);
+  });
+}
+
+generateCheckCommand();
+toggleAutocrlfOptions();
+togglePushDefaultOptions();
+setupAutoUpdate();
+generateConfigCommand({ silent: true });

--- a/docs/git/src/git-config-setup/css/app.css
+++ b/docs/git/src/git-config-setup/css/app.css
@@ -1,0 +1,1047 @@
+    /* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
+    :root {
+      --md-danger: #b3261e;
+      --md-state-layer: rgba(98, 0, 238, 0.12);
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.35);
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-on-secondary: #00332c;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-on-tertiary: #FFFFFF;
+      --md-sys-color-on-tertiary-container: #3d2e5a;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-secondary: #03dac6;
+      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
+      --md-sys-color-state-layer: rgba(98, 0, 238, 0.08);
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-sys-color-tertiary: #7D5260;
+      --md-sys-color-tertiary-container: #f3e8fd;
+      --md-typography-body-medium: 1rem;
+      --md-typography-body-small: 0.875rem;
+      --md-typography-headline-large: 1.85rem;
+      --md-typography-title-medium: 1.1rem;
+      --md-typography-title-small: 1.05rem;
+      --status-later: #ff9800;
+      --status-ok: #4caf50;
+      --status-todo: #00bcd4;
+    }
+
+    /* local-html-tools MD3 Core Spec v1.0.2 (2026-02-08) */
+    .md-page {
+      background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh;
+    }
+
+    .md-shell {
+      max-width: 980px; margin: 0 auto;
+    }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 18px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
+      border: 1px solid #e9e3f0;
+      padding: 28px;
+    }
+
+    .md-headline {
+      font-size: 1.8rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-subtitle {
+      color: var(--md-sys-color-on-surface-variant); font-size: 0.95rem;
+    }
+
+    .md-section {
+      margin-top: 28px;
+    }
+
+    .md-section-title {
+      font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-grid {
+      display: grid; gap: 16px;
+    }
+
+    .md-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.35rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface);
+      margin-bottom: 0.35rem;
+    }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.15rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.54rem;
+      font-weight: 600;
+      background: #ECEAF1;
+      color: #49454F;
+    }
+
+    .md-input, .md-textarea {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-textarea {
+      min-height: 6.5rem;
+    }
+
+    .md-input:focus, .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-field-block {
+      margin-bottom: 1rem;
+    }
+
+    .md-button {
+      border-radius: 999px;
+      padding: 0.6rem 1.2rem;
+      font-weight: 600;
+      font-size: 0.95rem;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+    }
+
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+    }
+
+    .md-button--primary:hover {
+      background: #4f00c9;
+    }
+
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      border: none;
+      cursor: pointer;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+
+    .md-tooltip-group {
+      position: relative; display: inline-flex; align-items: center;
+    }
+
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+      max-width: 90vw;
+    }
+
+    .md-tooltip-group:hover .md-tooltip-content {
+      opacity: 1;
+    }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+
+    .md-info-icon {
+      width: 18px; height: 18px;
+    }
+
+    .md-code-block {
+      position: relative; margin-top: 0.5rem;
+    }
+
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+      min-height: 2.5rem;
+    }
+
+    .md-copy-button {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      width: 32px;
+      height: 32px;
+      border-radius: 16px;
+      background: #f7f2fa;
+      border: none;
+      cursor: pointer;
+    }
+
+    .md-snackbar {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #2b2831;
+      color: #f7f4fb;
+      padding: 0.6rem 1rem;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      font-size: 0.85rem;
+    }
+
+    .md-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      padding: 2px 10px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      background: rgba(98, 0, 238, 0.12);
+      color: var(--md-sys-color-primary);
+      margin-left: 6px;
+    }
+
+    .md-section-wrap {
+      display: grid; gap: 1.75rem;
+    }
+
+    .md-section-card {
+      padding: 1.25rem 1.25rem 1.5rem;
+      border-radius: 24px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ece7f3;
+      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
+    }
+
+    .md-section-subtitle {
+      font-size: var(--md-typography-body-small);
+      color: #6a6675;
+      margin-bottom: 1rem;
+    }
+
+    .md-section-title--spaced {
+      margin-top: 1rem;
+    }
+
+    .md-grid-3 {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .md-card-head {
+      display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+    }
+
+    .md-card-title {
+      font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35;
+    }
+
+    .md-card-arrow {
+      color: #8f8a98; font-size: 1.2rem;
+    }
+
+    .md-card-desc {
+      margin-top: 0.5rem;
+      font-size: var(--md-typography-body-small);
+      color: #5f5a6b;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .md-info-chip:focus-visible {
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
+    }
+
+    .md-tooltip--wide {
+      width: min(32rem, 90vw);
+    }
+
+    .md-tooltip--rich {
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .md-menu-button {
+      position: absolute; top: 16px; right: 16px;
+    }
+
+    .md-menu-panel {
+      position: absolute;
+      top: 56px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 20;
+    }
+
+    .md-menu-link {
+      display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface);
+    }
+
+    .md-menu-link:hover {
+      background: #f2edf8;
+    }
+
+    .md-headline__icon {
+      margin-right: 0.5rem;
+    }
+
+    .md-section-title--lg {
+      font-size: 1.1rem;
+    }
+
+    .md-input, .md-select, .md-textarea {
+      display: block;
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+      box-sizing: border-box;
+    }
+
+    .md-input:focus, .md-select:focus, .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-icon-btn:hover {
+      background: #e6e1ee;
+    }
+
+    .md-icon-btn--small {
+      width: 32px; height: 32px; border-radius: 16px;
+    }
+
+    .md-icon-btn--surface {
+      background: #f7f2fa;
+    }
+
+    .md-snackbar.md-visible {
+      opacity: 1; pointer-events: auto;
+    }
+
+    .md-hidden {
+      display: none;
+    }
+
+        .md-sr-only {
+          position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
+        }
+        .md-preview .md-sr-only { display: none !important; }
+
+    .md-stack-sm > * + * {
+      margin-top: 0.75rem;
+    }
+
+    .md-radio-row { display: flex; align-items: flex-start; gap: 0.5rem; }
+    .md-radio {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.95rem;
+      color: #3f3b46;
+    }
+
+    .md-radio input {
+      accent-color: var(--md-sys-color-primary);
+    }
+
+    .md-switch-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+    }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 9999px;
+      background: #ffffff;
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transition: transform 150ms ease, background 150ms ease;
+    }
+
+    .md-switch-input {
+      position: absolute; opacity: 0; pointer-events: none;
+    }
+
+    .md-switch-input:checked + .md-switch {
+      background: rgba(98, 0, 238, 0.32);
+      box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
+    }
+
+    .md-switch-input:checked + .md-switch::after {
+      transform: translateX(20px);
+      background: #ffffff;
+    }
+
+    .md-tab-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      border-bottom: 1px solid #e6e1ee;
+      margin-bottom: 1rem;
+    }
+
+    .md-tab-button {
+      border: 1px solid #e6e1ee;
+      border-bottom: none;
+      background: #f3f1f7;
+      padding: 0.4rem 0.9rem;
+      margin-bottom: -1px;
+      border-top-left-radius: 12px;
+      border-top-right-radius: 12px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: #3f3b46;
+    }
+
+    .md-tab-button[aria-selected="true"] {
+      background: #ffffff;
+      border-color: #c8c5d0;
+      color: #1c1b1f;
+    }
+
+    .md-tab-panel {
+      border: 1px solid #e6e1ee;
+      border-top: none;
+      padding: 1rem;
+      background: #ffffff;
+      border-bottom-left-radius: 12px;
+      border-bottom-right-radius: 12px;
+      margin-bottom: 1rem;
+    }
+
+    .md-label--row {
+      margin-bottom: 0.5rem;
+    }
+
+    .md-input, .md-select {
+      display: block;
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.75rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+      box-sizing: border-box;
+    }
+
+    .md-input:focus, .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-form-grid {
+      display: grid; gap: 0.75rem;
+    }
+
+    .md-button--tonal {
+      background: #f0edf5;
+      color: #3f3b46;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+
+    .md-button--tonal:hover {
+      background: #e6e1ee;
+    }
+
+    .md-chip-row {
+      display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;
+    }
+
+    .md-tooltip--narrow {
+      width: 18rem;
+    }
+
+    .md-surface-card {
+      max-width: 48rem; margin: 0 auto; padding: 24px; position: relative;
+    }
+
+    .md-choice {
+      display: flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.25rem 0;
+    }
+
+    .md-input {
+      width: 100%;
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      font-size: 1rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-input:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-button:hover {
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
+    }
+
+    .md-button:active {
+      opacity: 0.7;
+    }
+
+    .md-button--surface {
+      background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline);
+    }
+
+    .md-button--secondary {
+      background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px;
+    }
+
+    .md-button-row {
+      display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px;
+    }
+
+    .md-button--hero {
+      font-size: clamp(1.2rem, 4vw, 1.6rem);
+    }
+
+    .md-field {
+      position: relative; min-width: 200px;
+    }
+
+    .md-field__label {
+      position: absolute;
+      top: -9px;
+      left: 12px;
+      padding: 0 6px;
+      background: var(--md-sys-color-surface);
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--md-sys-color-on-surface-variant);
+      letter-spacing: 0.02em;
+    }
+
+    .md-field .md-select {
+      appearance: none;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: var(--md-sys-color-surface);
+      padding: 0.8rem 2.2rem 0.8rem 0.9rem;
+      font-size: 0.9rem;
+      color: var(--md-sys-color-on-surface);
+      min-width: 200px;
+      line-height: 1.2;
+      background-image: linear-gradient(45deg, transparent 50%, #6c6775 50%), linear-gradient(135deg, #6c6775 50%, transparent 50%);
+      background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
+      background-size: 6px 6px, 6px 6px;
+      background-repeat: no-repeat;
+    }
+
+    .md-field .md-select:focus {
+      outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-stack-md > * + * {
+      margin-top: 0.75rem;
+    }
+
+    .md-grid-2 {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .md-form-row {
+      display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
+    }
+
+    .md-form-row--nowrap {
+      flex-wrap: nowrap;
+    }
+
+    .md-label--muted {
+      color: #3f3b46;
+    }
+
+    .md-label--block {
+      margin-bottom: 0.5rem;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+
+    .md-snackbar-host.md-visible {
+      opacity: 1; pointer-events: auto;
+    }
+
+    .md-button:disabled {
+      background: #e6e1ee;
+      color: #9a94a7;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+
+    .md-textarea:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+    }
+
+    .md-input-block {
+      margin-bottom: 1rem;
+    }
+
+    .md-section-title-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .md-output-wrap {
+      position: relative;
+    }
+
+    .md-output {
+      background: var(--md-sys-color-surface-variant);
+    }
+
+    .md-stack-lg > * + * {
+      margin-top: 1.5rem;
+    }
+
+    .md-form-row--start {
+      align-items: flex-start;
+    }
+
+    .md-input:disabled, .md-select:disabled {
+      background: #f3f0f7;
+    }
+
+    .md-choice-card {
+      border: 1px solid #e2dcec;
+      border-radius: 16px;
+      padding: 1rem;
+      background: #ffffff;
+    }
+
+    .md-choice-card--muted {
+      background: #f7f3fb;
+    }
+
+    .md-choice-row {
+      display: flex; align-items: center; gap: 0.75rem;
+    }
+
+    .md-choice-row input {
+      margin: 0;
+    }
+
+    .md-choice-sub {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675;
+    }
+
+    .md-choice-sub small {
+      font-size: 0.75rem; color: #7b7784;
+    }
+
+    .md-chip--primary {
+      background: #e2d9f7;
+      color: #4a1e9e;
+    }
+
+    .md-chip--warn {
+      background: #f7ece1;
+      color: #8a4b0f;
+    }
+
+    .md-field-stack {
+      display: flex; flex-direction: column; align-items: stretch; gap: 0.5rem;
+    }
+
+    .md-label--full {
+      width: 100%;
+    }
+
+    .md-switch-row {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem;
+    }
+
+    .md-input-wrap {
+      position: relative;
+      flex: 1 1 16rem;
+      min-width: 12rem;
+    }
+
+    .md-input-wrap .md-input {
+      padding-right: 3rem;
+    }
+
+    .md-input-action {
+      position: absolute;
+      top: 50%;
+      right: -0.5rem;
+      transform: translateY(-50%);
+      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+    }
+
+    .md-field-stack .md-input, .md-field-stack .md-select {
+      flex: 0 0 auto;
+    }
+
+    .md-field--dropdown {
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23635b75' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+      background-repeat: no-repeat;
+      background-position: right 0.75rem center;
+      background-size: 1rem 1rem;
+      padding-right: 2.25rem;
+    }
+
+    .md-select--inline {
+      flex: 1 1 18rem; min-width: 14rem;
+    }
+
+    .md-input.md-disabled, .md-select.md-disabled {
+      background: #f3f0f7;
+    }
+
+    .md-choice-inline {
+      display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem;
+    }
+
+    .md-choice-text {
+      font-size: 0.9rem; color: #4a4458;
+    }
+
+
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: 1rem; line-height: 1.5; }
+    button { border: none; cursor: pointer; background: transparent; }
+    a { text-decoration: none; color: inherit; }
+
+    .md-page { background-color: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; }
+    .md-surface-card { max-width: 48rem; margin: 0 auto; padding: 24px; position: relative; }
+
+    .md-card {
+      background: var(--md-sys-color-surface);
+      border-radius: 16px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
+      border: 1px solid #ece7f3;
+    }
+
+    .md-menu-button { position: absolute; top: 16px; right: 16px; }
+    .md-menu-panel {
+      position: absolute;
+      top: 48px;
+      right: 16px;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #e6e1ee;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      padding: 4px 0;
+      min-width: 160px;
+    }
+    .md-menu-link { display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface); }
+    .md-menu-link:hover { background: #f2edf8; }
+
+    .md-headline {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+      padding-right: 2.5rem;
+      margin-bottom: 1.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    .md-headline__icon { margin-right: 0.5rem; }
+
+    .md-section { margin-bottom: 1rem; }
+    .md-stack-md > * + * { margin-top: 0.75rem; }
+    .md-stack-sm > * + * { margin-top: 0.5rem; }
+
+    .md-form-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+    .md-form-row--nowrap { flex-wrap: nowrap; }
+    .md-label { display: flex; flex-wrap: wrap; align-items: center; gap: 0.35rem; font-weight: 600; color: var(--md-sys-color-on-surface); }
+    .md-label--block { margin-bottom: 0.5rem; }
+
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
+    .md-title-info-row .md-section-title { margin: 0; }
+    .md-title-info-row .md-info-chip { margin-left: 0; }
+    .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
+    .md-step-icon { width: 3.5rem; height: 3.5rem; flex: 0 0 auto; }
+
+    .md-input,
+    .md-select {
+      width: 100%;
+      background: #ffffff;
+      border: 1px solid var(--md-sys-color-outline);
+      border-radius: 12px;
+      padding: 0.625rem 0.75rem;
+      font: inherit;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .md-select--inline { flex: 1 1 18rem; min-width: 14rem; }
+    .md-input { flex: 1 1 16rem; min-width: 12rem; }
+    .md-input:focus,
+    .md-select:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.18);
+    }
+    .md-input.md-disabled,
+    .md-select.md-disabled {
+      background: #f3f0f7;
+    }
+
+    .md-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6rem 1.4rem;
+      border-radius: 9999px;
+      font-weight: 600;
+      font-size: 0.95rem;
+      letter-spacing: 0.01em;
+      transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: var(--md-sys-color-on-primary);
+      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.22);
+    }
+    .md-button--primary:hover { background: #5a00d6; }
+
+    .md-code-block { position: relative; margin-top: 1rem; }
+    .md-code {
+      display: block;
+      padding: 0.75rem;
+      padding-right: 2.5rem;
+      border-radius: 12px;
+      overflow-x: auto;
+      white-space: pre;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      color: #1f1b2d;
+    }
+    .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
+
+    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: 20rem;
+    }
+    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
+    .md-tooltip--wide { width: 24rem; max-width: 90vw; }
+    .md-tooltip--narrow { width: 18rem; max-width: 90vw; }
+
+    .md-icon-btn {
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: #f0edf5;
+      color: #3f3b46;
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+    .md-icon-btn:hover { background: #e6e1ee; }
+    .md-icon-btn--small { width: 32px; height: 32px; border-radius: 16px; }
+    .md-icon-btn--surface { background: #f7f2fa; }
+    .md-icon-small { width: 16px; height: 16px; }
+    .md-icon-20 { width: 20px; height: 20px; }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      line-height: 1.35;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      letter-spacing: 0.01em;
+    }
+    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      background: transparent;
+      color: #4a4458;
+      margin-left: 0.2rem;
+    }
+    .md-info-icon { width: 18px; height: 18px; }
+
+    .md-choice-row { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+    .md-choice-inline { display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem; }
+    .md-choice-text { font-size: 0.9rem; color: #4a4458; }
+
+    .md-switch {
+      position: relative;
+      width: 44px;
+      min-width: 44px;
+      flex: 0 0 44px;
+      height: 24px;
+      background: #f0ebf7;
+      border-radius: 9999px;
+      display: inline-flex;
+      align-items: center;
+      padding: 2px;
+      transition: background 150ms ease, box-shadow 150ms ease;
+      box-shadow: inset 0 0 0 1px #cfc7dc;
+    }
+    .md-switch::after {
+      content: "";
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: #ffffff;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      transform: translateX(0);
+      transition: transform 150ms ease;
+    }
+    .md-switch-input { position: absolute; opacity: 0; pointer-events: none; }
+    .md-switch-input:checked + .md-switch {
+      background: #8b5cf6;
+      box-shadow: inset 0 0 0 1px #7c3aed;
+    }
+    .md-switch-input:checked + .md-switch::after { transform: translateX(20px); }
+    .md-snackbar {
+      background: #2b2831;
+      color: #ffffff;
+      border-radius: 12px;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      letter-spacing: 0.01em;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 1.25rem;
+      bottom: 1.25rem;
+      padding: 0.5rem 1rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+    .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
+
+    .md-hidden { display: none; }
+    .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: 0; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+
+    @media (max-width: 640px) {
+      .md-form-row--nowrap { flex-wrap: wrap; }
+      .md-switch-label { white-space: normal; }
+    }

--- a/docs/git/src/git-config-setup/js/main.js
+++ b/docs/git/src/git-config-setup/js/main.js
@@ -1,0 +1,62 @@
+function quoteIfNeeded(value) {
+  if (!value) return value;
+  if (/[^\w@%+=:,./-]/.test(value)) {
+    const escaped = value.replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  }
+  return value;
+}
+
+function generateCheckCommand() {
+  const lines = [
+    "git config --global user.name",
+    "git config --global user.email"
+  ];
+  document.getElementById("checkCmd").textContent = lines.join("\n");
+}
+
+function generateSetupCommand({ silent = false } = {}) {
+  const userName = document.getElementById("userName").value.trim();
+  const userEmail = document.getElementById("userEmail").value.trim();
+
+  if (!userName) {
+    if (!silent) alert("ユーザー名を入力してください。");
+    document.getElementById("setupCmd").textContent = "";
+    return;
+  }
+  if (!userEmail) {
+    if (!silent) alert("メールアドレスを入力してください。");
+    document.getElementById("setupCmd").textContent = "";
+    return;
+  }
+
+  const lines = [
+    `git config --global user.name ${quoteIfNeeded(userName)}`,
+    `git config --global user.email ${quoteIfNeeded(userEmail)}`
+  ];
+  document.getElementById("setupCmd").textContent = lines.join("\n");
+}
+
+function showToast(message) {
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.textContent = message;
+  toast.classList.add("md-visible");
+  setTimeout(() => {
+    toast.classList.remove("md-visible");
+  }, 2000);
+}
+
+function setupAutoUpdate() {
+  const handler = () => generateSetupCommand({ silent: true });
+  ["userName", "userEmail"].forEach((id) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.addEventListener("input", handler);
+    el.addEventListener("change", handler);
+  });
+}
+
+generateCheckCommand();
+setupAutoUpdate();
+generateSetupCommand({ silent: true });

--- a/scripts/build-git.mjs
+++ b/scripts/build-git.mjs
@@ -5,6 +5,36 @@ const ROOT = process.cwd();
 
 const TARGETS = [
   {
+    id: "git-config-setup",
+    baseDir: "docs/git",
+    srcHtml: "docs/git/git-config-setup-src.html",
+    outHtml: "docs/git/git-config-setup.html",
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/git-config-setup/css/app.css"
+    ],
+    jsOrder: [
+      "src/vendor/material-web-outlined-text-field.bundle.js",
+      "../../lht-cmn/js/components.js",
+      "src/git-config-setup/js/main.js"
+    ]
+  },
+  {
+    id: "git-config-advanced-setup",
+    baseDir: "docs/git",
+    srcHtml: "docs/git/git-config-advanced-setup-src.html",
+    outHtml: "docs/git/git-config-advanced-setup.html",
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/git-config-advanced-setup/css/app.css"
+    ],
+    jsOrder: [
+      "src/vendor/material-web-outlined-text-field.bundle.js",
+      "../../lht-cmn/js/components.js",
+      "src/git-config-advanced-setup/js/main.js"
+    ]
+  },
+  {
     id: "git-branch-diff",
     baseDir: "docs/git",
     srcHtml: "docs/git/git-branch-diff-src.html",


### PR DESCRIPTION
…t-cmn` 共通部品へ移行

## 概要
`git-config-setup.html` と `git-config-advanced-setup.html` を、既存の `git-pseudo-squash` / `git-branch-diff` と同じ構成に揃えました。 編集元を `*-src.html + src/css + src/js` へ分離し、`lht-cmn` 共通部品を利用する形に置き換えています。

## 変更内容

### 1. `git-config-setup` の Material Web 化・分離
- 追加: `docs/git/git-config-setup-src.html`
- 追加: `docs/git/src/git-config-setup/css/app.css`
- 追加: `docs/git/src/git-config-setup/js/main.js`
- 更新: `docs/git/git-config-setup.html`（生成物）

反映ポイント:
- `lht-page-menu`
- `lht-help-tooltip`
- `lht-help-text-field`（ユーザー名/メールアドレス）
- `lht-command-block`（確認コマンド/設定コマンド）

### 2. `git-config-advanced-setup` の Material Web 化・分離
- 追加: `docs/git/git-config-advanced-setup-src.html`
- 追加: `docs/git/src/git-config-advanced-setup/css/app.css`
- 追加: `docs/git/src/git-config-advanced-setup/js/main.js`
- 更新: `docs/git/git-config-advanced-setup.html`（生成物）

反映ポイント:
- `lht-page-menu`
- `lht-help-tooltip`
- `lht-switch-help`（`core.autocrlf` / `push.default` の有効化トグル）
- `lht-command-block`（確認コマンド/設定コマンド）
- `md-switch` 利用に合わせた状態取得（`selected` / `checked` 互換）

### 3. ビルド設定の拡張
- 更新: `scripts/build-git.mjs`
- 追加ターゲット:
  - `git-config-setup`
  - `git-config-advanced-setup`

### 4. ドキュメント更新
- 更新: `docs/git/README.md`
- 両画面の編集元ファイル（`*-src.html`, `src/css`, `src/js`）を追記

## 補足
- 既存の単一HTML配布形式は維持
- 生成フロー（`build:git:single`）で `docs/git/*.html` へ反映される構成に統一