### PR TITLE
lht-cmn命名整理（`lht-text-field-help` / `lht-select-help`）とREADME方針再編、全体参照更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ docs/
   - 右上メニュー: `lht-page-menu`
   - コマンド表示 + コピー: `lht-command-block`
 - 入力フィールド置換（進行中）:
-  - `lht-help-text-field`: 全ページで適用済み
-  - `lht-help-select`: `ffmpeg-audio-convert-cmdline-gen` / `ffmpeg-mp4-to-wav-gen` / `ffmpeg-replace-audio-with-wav-gen`
+  - `lht-text-field-help`: 全ページで適用済み
+  - `lht-select-help`: `ffmpeg-audio-convert-cmdline-gen` / `ffmpeg-mp4-to-wav-gen` / `ffmpeg-replace-audio-with-wav-gen`
   - `lht-switch-help`: `ffmpeg-loudnorm-cmdline-gen` / `ffmpeg-replace-audio-with-wav-gen`
 - 実装メモ:
-  - `lht-help-text-field` は `min` / `max` / `step` 属性透過に対応
+  - `lht-text-field-help` は `min` / `max` / `step` 属性透過に対応
   - 既存JS互換のため `lht-switch-help` 内部 `md-switch` は `checked` プロパティでも参照可能
 
 ### PR作成時のルール

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - ImageMagick/sox: 画像/音声変換のパラメータ生成（バッチリサイズ/ウォーターマーク）
 - regex/sed/awk: 文字列変換テンプレの生成
 - [後まわし] docker/docker-compose: よくある起動・開発用コマンド生成
+- [方針] `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み
   - 未実装: 生成したMIDI実データ（SMF）のその場再生（MIDIパーサ/プレイヤー経由）
@@ -45,9 +46,9 @@
 - 対象: docs/link/url-encode-decode.html
 - 対象: docs/link/utm-remove.html
 - 対象: docs/text/text-viewer.html
-- [対応] `docs/text/file-rename-cmdline-gen.html` の lht 化（`lht-help-text-field` / `lht-help-select` / `lht-switch-help` への置換）
+- [対応] `docs/text/file-rename-cmdline-gen.html` の lht 化（`lht-text-field-help` / `lht-select-help` / `lht-switch-help` への置換）
 - [対応] ドロップダウン項目（`md-select-option`）の生成ロジックを `lht-cmn/js/components.js` 側へ共通化
-- [対応] `lht-cmn/js/components.js` の読み込み順依存軽減（`defer` 運用 + `lht-help-select` 側で宣言オプション/後着 option を吸収）
+- [対応] `lht-cmn/js/components.js` の読み込み順依存軽減（`defer` 運用 + `lht-select-help` 側で宣言オプション/後着 option を吸収）
 - [クローズ] `docs/text/text-processing.html` の「スペース連打で `.` 自動挿入」は OS 側の自動補正由来として対応終了
 - [クローズ] `docs/index.html` のカード構造JSON化検討は、`lht` 対応で目的を満たしたため対応終了
 - 対象: docs/grep/find-gen.html

--- a/dist/docs/git/git-branch-diff.html
+++ b/dist/docs/git/git-branch-diff.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1269,7 +1269,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -1278,7 +1278,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       </div>
 
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -1299,7 +1299,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </lht-switch-help>
       </div>
       <div id="remoteNameBlock" class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-help-text-field>
+        <lht-text-field-help field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-text-field-help>
       </div>
     </div>
 
@@ -2173,11 +2173,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/dist/docs/git/git-config-advanced-setup.html
+++ b/dist/docs/git/git-config-advanced-setup.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -2258,11 +2258,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/dist/docs/git/git-config-setup.html
+++ b/dist/docs/git/git-config-setup.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1310,8 +1310,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       </div>
 
       <div class="md-stack-md">
-        <lht-help-text-field field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-help-text-field>
-        <lht-help-text-field field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-help-text-field>
+        <lht-text-field-help field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-text-field-help>
+        <lht-text-field-help field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-text-field-help>
       </div>
     </section>
 
@@ -2170,11 +2170,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/dist/docs/git/git-pseudo-squash.html
+++ b/dist/docs/git/git-pseudo-squash.html
@@ -34,13 +34,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1544,7 +1544,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </div>
         <div class="md-form-row md-form-row--nowrap">
           <div class="md-input-wrap md-input-wrap--inline">
-            <lht-help-text-field field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-help-text-field>
+            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
             <button type="button" class="md-icon-btn md-icon-btn--small md-input-action--inline" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>
@@ -2588,11 +2588,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/diagram/graphviz-dot-to-svg-src.html
+++ b/docs/diagram/graphviz-dot-to-svg-src.html
@@ -56,7 +56,7 @@ limitations under the License.
         </div>
 
         <div class="md-field-block">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="dotInput"
             label="ソース"
             type="textarea"
@@ -68,11 +68,11 @@ limitations under the License.
   Start -> Parse -> Render -> Save;
   Parse -> Error [style=dashed];
 }"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
         </div>
 
         <div class="md-row">
-          <lht-help-select
+          <lht-select-help
             field-id="engineSelect"
             label="エンジン"
             help-text="レイアウトアルゴリズムを選択します。一般的な有向グラフは dot が扱いやすいです。"
@@ -105,7 +105,7 @@ limitations under the License.
                 }
               ]
               </script>
-</lht-help-select>
+</lht-select-help>
           <button id="renderBtn" class="md-button md-button--primary" type="button">レンダリング</button>
           <button id="downloadSvgBtn" class="md-button md-button--secondary" type="button" disabled>SVG保存</button>
         </div>

--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -565,7 +565,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </div>
 
         <div class="md-field-block">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="dotInput"
             label="ソース"
             type="textarea"
@@ -577,11 +577,11 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   Start -> Parse -> Render -> Save;
   Parse -> Error [style=dashed];
 }"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
         </div>
 
         <div class="md-row">
-          <lht-help-select
+          <lht-select-help
             field-id="engineSelect"
             label="エンジン"
             help-text="レイアウトアルゴリズムを選択します。一般的な有向グラフは dot が扱いやすいです。"
@@ -614,7 +614,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
                 }
               ]
               </script>
-</lht-help-select>
+</lht-select-help>
           <button id="renderBtn" class="md-button md-button--primary" type="button">レンダリング</button>
           <button id="downloadSvgBtn" class="md-button md-button--secondary" type="button" disabled>SVG保存</button>
         </div>
@@ -1919,11 +1919,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/diagram/mermaid-to-svg-src.html
+++ b/docs/diagram/mermaid-to-svg-src.html
@@ -73,18 +73,18 @@ limitations under the License.
           </span>
         </div>
         <div class="md-field-block">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="mermaidInput"
             label="ソース"
             type="textarea"
             rows="12"
             required
             help-text="Mermaid記法を入力します。未完成の記法はレンダリングでエラーになります。"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
         </div>
 
         <div class="md-row">
-          <lht-help-select
+          <lht-select-help
             field-id="themeSelect"
             label="テーマ"
             help-text="配色テーマを選択します。変更後は再レンダリングで反映されます。"
@@ -110,7 +110,7 @@ limitations under the License.
               }
             ]
             </script>
-</lht-help-select>
+</lht-select-help>
           <button id="renderBtn" class="md-button md-button--primary" type="button">レンダリング</button>
           <button id="downloadSvgBtn" class="md-button md-button--secondary" type="button" disabled>SVG保存</button>
         </div>

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -634,18 +634,18 @@ lht-switch-help .md-switch-label .md-tooltip-content {
           </span>
         </div>
         <div class="md-field-block">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="mermaidInput"
             label="ソース"
             type="textarea"
             rows="12"
             required
             help-text="Mermaid記法を入力します。未完成の記法はレンダリングでエラーになります。"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
         </div>
 
         <div class="md-row">
-          <lht-help-select
+          <lht-select-help
             field-id="themeSelect"
             label="テーマ"
             help-text="配色テーマを選択します。変更後は再レンダリングで反映されます。"
@@ -671,7 +671,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
               }
             ]
             </script>
-</lht-help-select>
+</lht-select-help>
           <button id="renderBtn" class="md-button md-button--primary" type="button">レンダリング</button>
           <button id="downloadSvgBtn" class="md-button md-button--secondary" type="button" disabled>SVG保存</button>
         </div>
@@ -3604,11 +3604,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen-src.html
@@ -45,16 +45,16 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🎧</span>FFmpeg 音声変換 コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル名"
       required
       placeholder="例: sample.wav"
       field-class="md-field-block"
       help-text="例: sample.wav / sample.flac / sample.mp3"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="outputFormat"
       label="出力フォーマット"
       required
@@ -87,10 +87,10 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <div id="bitrateBlock">
-      <lht-help-select
+      <lht-select-help
         field-id="bitrate"
         label="ビットレート"
         field-class="md-field-block"
@@ -121,12 +121,12 @@ limitations under the License.
           }
         ]
         </script>
-</lht-help-select>
+</lht-select-help>
     </div>
 
     <div id="vbrBlock">
       <div class="md-form-grid md-form-grid-2 md-field-block">
-        <lht-help-select
+        <lht-select-help
           field-id="vbrMode"
           label="VBR"
           help-text="ON/OFF を切り替えます。"
@@ -145,8 +145,8 @@ limitations under the License.
             }
           ]
           </script>
-</lht-help-select>
-        <lht-help-select
+</lht-select-help>
+        <lht-select-help
           field-id="vbrQuality"
           label="VBR品質"
           help-text="高め: 音質優先 / 標準: バランス / 低め: 容量優先"
@@ -169,12 +169,12 @@ limitations under the License.
             }
           ]
           </script>
-</lht-help-select>
+</lht-select-help>
       </div>
     </div>
 
     <div id="flacBlock" class="md-hidden">
-      <lht-help-select
+      <lht-select-help
         field-id="flacLevel"
         label="FLAC圧縮レベル"
         field-class="md-field-block"
@@ -197,10 +197,10 @@ limitations under the License.
           }
         ]
         </script>
-</lht-help-select>
+</lht-select-help>
     </div>
 
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -223,7 +223,7 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <div class="md-section">
       <div class="md-section-title">用途別プリセット:</div>

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1228,16 +1228,16 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🎧</span>FFmpeg 音声変換 コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル名"
       required
       placeholder="例: sample.wav"
       field-class="md-field-block"
       help-text="例: sample.wav / sample.flac / sample.mp3"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="outputFormat"
       label="出力フォーマット"
       required
@@ -1270,10 +1270,10 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <div id="bitrateBlock">
-      <lht-help-select
+      <lht-select-help
         field-id="bitrate"
         label="ビットレート"
         field-class="md-field-block"
@@ -1304,12 +1304,12 @@ lht-switch-help .md-switch-label .md-tooltip-content {
           }
         ]
         </script>
-</lht-help-select>
+</lht-select-help>
     </div>
 
     <div id="vbrBlock">
       <div class="md-form-grid md-form-grid-2 md-field-block">
-        <lht-help-select
+        <lht-select-help
           field-id="vbrMode"
           label="VBR"
           help-text="ON/OFF を切り替えます。"
@@ -1328,8 +1328,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
             }
           ]
           </script>
-</lht-help-select>
-        <lht-help-select
+</lht-select-help>
+        <lht-select-help
           field-id="vbrQuality"
           label="VBR品質"
           help-text="高め: 音質優先 / 標準: バランス / 低め: 容量優先"
@@ -1352,12 +1352,12 @@ lht-switch-help .md-switch-label .md-tooltip-content {
             }
           ]
           </script>
-</lht-help-select>
+</lht-select-help>
       </div>
     </div>
 
     <div id="flacBlock" class="md-hidden">
-      <lht-help-select
+      <lht-select-help
         field-id="flacLevel"
         label="FLAC圧縮レベル"
         field-class="md-field-block"
@@ -1380,10 +1380,10 @@ lht-switch-help .md-switch-label .md-tooltip-content {
           }
         ]
         </script>
-</lht-help-select>
+</lht-select-help>
     </div>
 
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -1406,7 +1406,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <div class="md-section">
       <div class="md-section-title">用途別プリセット:</div>
@@ -2327,11 +2327,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen-src.html
@@ -45,7 +45,7 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🧩</span>FFmpeg ファイル結合コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="fileList"
       label="結合する .wav ファイル"
       type="textarea"
@@ -54,7 +54,7 @@ limitations under the License.
       placeholder="例:\nfile1.wav\nfile2.wav"
       field-class="md-field-block"
       help-text="例: file1.wav / file2.wav（1行に1ファイル）"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateConcatCmd()" class="md-button md-button--primary md-field-block">
       filelist.txt + 結合コマンド生成

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1212,7 +1212,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🧩</span>FFmpeg ファイル結合コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="fileList"
       label="結合する .wav ファイル"
       type="textarea"
@@ -1221,7 +1221,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="例:\nfile1.wav\nfile2.wav"
       field-class="md-field-block"
       help-text="例: file1.wav / file2.wav（1行に1ファイル）"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateConcatCmd()" class="md-button md-button--primary md-field-block">
       filelist.txt + 結合コマンド生成
@@ -2081,11 +2081,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen-src.html
@@ -35,14 +35,14 @@ Licensed under the Apache License, Version 2.0
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true">🔊</span>FFmpeg Loudnorm スクリプトジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="filename"
       label="音声ファイル名"
       required
       placeholder="例: 250503_130527_TrMic.WAV"
       field-class="md-field-block"
       help-text="例: 250503_130527_TrMic.WAV"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-section">
       <lht-switch-help switch-id="hires" label="ハイレゾ（192kHz / 24bit）"></lht-switch-help>
@@ -196,7 +196,7 @@ Licensed under the Apache License, Version 2.0
     <div class="md-tab-panel" data-tab="tab-gain" id="tab-gain" hidden>
       <h2 class="md-section-title md-section-title--lg">1. 単純ゲイン</h2>
       <p class="md-muted">測定結果の input_tp を基準に、ピークが目標TPに到達する分だけゲインします。</p>
-      <lht-help-text-field
+      <lht-text-field-help
         field-id="gainTargetTp"
         type="number"
         step="0.1"
@@ -204,7 +204,7 @@ Licensed under the Apache License, Version 2.0
         label="目標TP (dBTP)"
         field-class="md-field-block"
         help-text="最終ピークの目標値です。一般的には -1.0 dBTP 前後を使用します。"
-      ></lht-help-text-field>
+      ></lht-text-field-help>
       <lht-switch-help switch-id="gainUseCompressor" label="軽いコンプを追加（自然にピークを抑える）"></lht-switch-help>
     </div>
 
@@ -217,7 +217,7 @@ Licensed under the Apache License, Version 2.0
 
     <!-- 3. 仕上げフェーズ -->
     <h2 class="md-section-title md-section-title--lg">3. 仕上げフェーズ</h2>
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="jsonInput"
       type="textarea"
       rows="10"
@@ -225,7 +225,7 @@ Licensed under the Apache License, Version 2.0
       placeholder="ffmpeg の出力全文を貼り付けてください"
       field-class="md-field-block"
       help-text="測定フェーズの ffmpeg 出力（JSONを含む全文）を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-tab-panel" data-tab="tab-icu" id="finish-normalize">
       <button onclick="generateNormalizeCmd()" class="md-button md-button--primary md-field-block">正規化コマンド生成</button>

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -19,13 +19,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -673,7 +673,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     }
 
     /* Keep floating labels from visually overlapping explanatory text blocks. */
-    .md-tab-panel .md-muted + lht-help-text-field {
+    .md-tab-panel .md-muted + lht-text-field-help {
       margin-top: 0.85rem;
     }
     
@@ -1299,14 +1299,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true">🔊</span>FFmpeg Loudnorm スクリプトジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="filename"
       label="音声ファイル名"
       required
       placeholder="例: 250503_130527_TrMic.WAV"
       field-class="md-field-block"
       help-text="例: 250503_130527_TrMic.WAV"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-section">
       <lht-switch-help switch-id="hires" label="ハイレゾ（192kHz / 24bit）"></lht-switch-help>
@@ -1460,7 +1460,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <div class="md-tab-panel" data-tab="tab-gain" id="tab-gain" hidden>
       <h2 class="md-section-title md-section-title--lg">1. 単純ゲイン</h2>
       <p class="md-muted">測定結果の input_tp を基準に、ピークが目標TPに到達する分だけゲインします。</p>
-      <lht-help-text-field
+      <lht-text-field-help
         field-id="gainTargetTp"
         type="number"
         step="0.1"
@@ -1468,7 +1468,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         label="目標TP (dBTP)"
         field-class="md-field-block"
         help-text="最終ピークの目標値です。一般的には -1.0 dBTP 前後を使用します。"
-      ></lht-help-text-field>
+      ></lht-text-field-help>
       <lht-switch-help switch-id="gainUseCompressor" label="軽いコンプを追加（自然にピークを抑える）"></lht-switch-help>
     </div>
 
@@ -1481,7 +1481,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <!-- 3. 仕上げフェーズ -->
     <h2 class="md-section-title md-section-title--lg">3. 仕上げフェーズ</h2>
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="jsonInput"
       type="textarea"
       rows="10"
@@ -1489,7 +1489,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="ffmpeg の出力全文を貼り付けてください"
       field-class="md-field-block"
       help-text="測定フェーズの ffmpeg 出力（JSONを含む全文）を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-tab-panel" data-tab="tab-icu" id="finish-normalize">
       <button onclick="generateNormalizeCmd()" class="md-button md-button--primary md-field-block">正規化コマンド生成</button>
@@ -2352,11 +2352,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen-src.html
@@ -45,14 +45,14 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🎵</span>FFmpeg MP4→WAV コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="mp4File"
       label="MP4ファイル名"
       required
       placeholder="例: sample.mp4"
       field-class="md-field-block"
       help-text="例: sample.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <h2 class="md-section-title md-section-title--lg">1. 解析用 ffprobe コマンド</h2>
     <button onclick="generateProbeCommand()" class="md-button md-button--primary md-field-block">
@@ -62,7 +62,7 @@ limitations under the License.
       <lht-command-block command-id="probeCmd"></lht-command-block>
     </div>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="probeOutput"
       type="textarea"
       rows="6"
@@ -70,14 +70,14 @@ limitations under the License.
       placeholder="ffprobe の出力を貼り付けてください"
       field-class="md-field-block"
       help-text="解析用 ffprobe コマンドの出力を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <button onclick="applyProbeResult()" class="md-button md-button--tonal md-field-block">
       解析結果を反映
     </button>
     <p id="probeSummary" class="md-muted md-field-block">解析結果: 未反映</p>
 
     <h2 class="md-section-title md-section-title--lg">2. 抽出設定</h2>
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -104,9 +104,9 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="channels"
       label="チャンネル数"
       field-class="md-field-block"
@@ -129,9 +129,9 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="bitDepth"
       label="ビット深度"
       field-class="md-field-block"
@@ -154,7 +154,7 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <button onclick="generateWavCommand()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1198,7 +1198,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
 
     /* Keep floating labels from visually overlapping explanatory text blocks. */
-    .md-muted + lht-help-text-field {
+    .md-muted + lht-text-field-help {
       margin-top: 0.85rem;
     }
 
@@ -1227,14 +1227,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🎵</span>FFmpeg MP4→WAV コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="mp4File"
       label="MP4ファイル名"
       required
       placeholder="例: sample.mp4"
       field-class="md-field-block"
       help-text="例: sample.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <h2 class="md-section-title md-section-title--lg">1. 解析用 ffprobe コマンド</h2>
     <button onclick="generateProbeCommand()" class="md-button md-button--primary md-field-block">
@@ -1244,7 +1244,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       <lht-command-block command-id="probeCmd"></lht-command-block>
     </div>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="probeOutput"
       type="textarea"
       rows="6"
@@ -1252,14 +1252,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="ffprobe の出力を貼り付けてください"
       field-class="md-field-block"
       help-text="解析用 ffprobe コマンドの出力を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <button onclick="applyProbeResult()" class="md-button md-button--tonal md-field-block">
       解析結果を反映
     </button>
     <p id="probeSummary" class="md-muted md-field-block">解析結果: 未反映</p>
 
     <h2 class="md-section-title md-section-title--lg">2. 抽出設定</h2>
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -1286,9 +1286,9 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="channels"
       label="チャンネル数"
       field-class="md-field-block"
@@ -1311,9 +1311,9 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="bitDepth"
       label="ビット深度"
       field-class="md-field-block"
@@ -1336,7 +1336,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <button onclick="generateWavCommand()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成
@@ -2196,11 +2196,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen-src.html
@@ -45,23 +45,23 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔁</span>FFmpeg 音声差し替え（WAV）コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="videoFile"
       label="元の動画ファイル"
       required
       placeholder="例: input.mp4 / input.mkv / input.mov"
       field-class="md-field-block"
       help-text="例: input.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="差し替える音声ファイル"
       required
       placeholder="例: new_audio.wav"
       field-class="md-field-block"
       help-text="例: new_audio.wav"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <h2 class="md-section-title md-section-title--lg">1. WAV 解析（ffprobe）</h2>
     <button onclick="generateProbeCommand()" class="md-button md-button--primary md-field-block">
@@ -71,7 +71,7 @@ limitations under the License.
       <lht-command-block command-id="probeCmd"></lht-command-block>
     </div>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="probeOutput"
       type="textarea"
       rows="6"
@@ -79,7 +79,7 @@ limitations under the License.
       placeholder="ffprobe の出力を貼り付けてください"
       field-class="md-field-block"
       help-text="解析用 ffprobe コマンドの出力を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <button onclick="applyProbeResult()" class="md-button md-button--tonal md-field-block">
       解析結果を反映
     </button>
@@ -103,7 +103,7 @@ limitations under the License.
       </span>
     </div>
 
-    <lht-help-select
+    <lht-select-help
       field-id="container"
       label="出力コンテナ"
       field-class="md-field-block"
@@ -127,13 +127,13 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <lht-switch-help class="md-field-block" switch-id="regenPts" label="PTS再生成" checked help-wide>
       YouTubeでの音ズレ対策に有効な場合があります。
     </lht-switch-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="audioCodec"
       label="音声エンコード"
       field-class="md-field-block"
@@ -165,9 +165,9 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -198,10 +198,10 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
     <p id="sampleRateNote" class="md-muted md-field-block"></p>
 
-    <lht-help-select
+    <lht-select-help
       field-id="channels"
       label="チャンネル数"
       field-class="md-field-block"
@@ -224,9 +224,9 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="audioBitrate"
       label="音声ビットレート"
       field-class="md-field-block"
@@ -249,24 +249,24 @@ limitations under the License.
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="outputFile"
       label="出力ファイル名"
       placeholder="例: output.mp4"
       field-class="md-field-block"
       help-text="任意。空欄なら自動生成します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioOffsetMs"
       type="number"
       label="音声タイミング調整（ms）"
       placeholder="例: 120（+で遅らせる / -で先行）"
       field-class="md-field-block"
       help-text="正の値は音声を遅らせます。負の値は音声を前に出します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateReplaceAudioCmd()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1266,23 +1266,23 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔁</span>FFmpeg 音声差し替え（WAV）コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="videoFile"
       label="元の動画ファイル"
       required
       placeholder="例: input.mp4 / input.mkv / input.mov"
       field-class="md-field-block"
       help-text="例: input.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="差し替える音声ファイル"
       required
       placeholder="例: new_audio.wav"
       field-class="md-field-block"
       help-text="例: new_audio.wav"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <h2 class="md-section-title md-section-title--lg">1. WAV 解析（ffprobe）</h2>
     <button onclick="generateProbeCommand()" class="md-button md-button--primary md-field-block">
@@ -1292,7 +1292,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       <lht-command-block command-id="probeCmd"></lht-command-block>
     </div>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="probeOutput"
       type="textarea"
       rows="6"
@@ -1300,7 +1300,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="ffprobe の出力を貼り付けてください"
       field-class="md-field-block"
       help-text="解析用 ffprobe コマンドの出力を貼り付けます。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <button onclick="applyProbeResult()" class="md-button md-button--tonal md-field-block">
       解析結果を反映
     </button>
@@ -1324,7 +1324,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       </span>
     </div>
 
-    <lht-help-select
+    <lht-select-help
       field-id="container"
       label="出力コンテナ"
       field-class="md-field-block"
@@ -1348,13 +1348,13 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
     <lht-switch-help class="md-field-block" switch-id="regenPts" label="PTS再生成" checked help-wide>
       YouTubeでの音ズレ対策に有効な場合があります。
     </lht-switch-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="audioCodec"
       label="音声エンコード"
       field-class="md-field-block"
@@ -1386,9 +1386,9 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="sampleRate"
       label="サンプルレート"
       field-class="md-field-block"
@@ -1419,10 +1419,10 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
     <p id="sampleRateNote" class="md-muted md-field-block"></p>
 
-    <lht-help-select
+    <lht-select-help
       field-id="channels"
       label="チャンネル数"
       field-class="md-field-block"
@@ -1445,9 +1445,9 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-select
+    <lht-select-help
       field-id="audioBitrate"
       label="音声ビットレート"
       field-class="md-field-block"
@@ -1470,24 +1470,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         }
       ]
       </script>
-</lht-help-select>
+</lht-select-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="outputFile"
       label="出力ファイル名"
       placeholder="例: output.mp4"
       field-class="md-field-block"
       help-text="任意。空欄なら自動生成します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioOffsetMs"
       type="number"
       label="音声タイミング調整（ms）"
       placeholder="例: 120（+で遅らせる / -で先行）"
       field-class="md-field-block"
       help-text="正の値は音声を遅らせます。負の値は音声を前に出します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateReplaceAudioCmd()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成
@@ -2347,11 +2347,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen-src.html
@@ -35,16 +35,16 @@ Licensed under the Apache License, Version 2.0
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔇</span>FFmpeg 無音区間検出コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル名"
       required
       placeholder="例: input.wav"
       field-class="md-field-block"
       help-text="例: input.wav / input.flac / input.mp3"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="noiseDb"
       type="number"
       step="1"
@@ -52,9 +52,9 @@ Licensed under the Apache License, Version 2.0
       label="無音判定しきい値 (dB)"
       field-class="md-field-block"
       help-text="この値より小さい音を無音として扱います。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="minDuration"
       type="number"
       step="0.1"
@@ -62,7 +62,7 @@ Licensed under the Apache License, Version 2.0
       label="無音とみなす最小時間 (秒)"
       field-class="md-field-block"
       help-text="0.5 は「0.5秒以上続いたら無音」と判定します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <p class="md-muted md-field-block">例: 0.5 は「0.5秒以上続いたら無音」とみなします。</p>
 
     <button onclick="generateSilenceCmd()" class="md-button md-button--primary md-field-block">

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -19,13 +19,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1206,16 +1206,16 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔇</span>FFmpeg 無音区間検出コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル名"
       required
       placeholder="例: input.wav"
       field-class="md-field-block"
       help-text="例: input.wav / input.flac / input.mp3"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="noiseDb"
       type="number"
       step="1"
@@ -1223,9 +1223,9 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       label="無音判定しきい値 (dB)"
       field-class="md-field-block"
       help-text="この値より小さい音を無音として扱います。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="minDuration"
       type="number"
       step="0.1"
@@ -1233,7 +1233,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       label="無音とみなす最小時間 (秒)"
       field-class="md-field-block"
       help-text="0.5 は「0.5秒以上続いたら無音」と判定します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
     <p class="md-muted md-field-block">例: 0.5 は「0.5秒以上続いたら無音」とみなします。</p>
 
     <button onclick="generateSilenceCmd()" class="md-button md-button--primary md-field-block">
@@ -2094,11 +2094,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen-src.html
@@ -45,32 +45,32 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">✂️</span>FFmpeg 切り出しコマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="filename"
       label="入力ファイル名"
       required
       placeholder="例: 250503_130527_TrMic.wav / sample.mp4"
       field-class="md-field-block"
       help-text="例: 250503_130527_TrMic.wav / sample.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="start"
       label="開始時刻（任意）"
       placeholder="例: 3:10 または 190 または 1:15:30"
       field-class="md-field-block"
       help-text="開始位置。時:分:秒 または 秒指定に対応。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="end"
       label="終了時刻（任意）"
       placeholder="例: 12:45 または 765 または 0:12:45"
       field-class="md-field-block"
       help-text="終了位置。未指定なら末尾まで。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="partNumber"
       type="number"
       min="1"
@@ -78,7 +78,7 @@ limitations under the License.
       placeholder="例: 1"
       field-class="md-field-block"
       help-text="出力ファイル名の連番に利用します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateClipCommand()" class="md-button md-button--primary md-field-block">
       切り出しコマンド生成

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1211,32 +1211,32 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">✂️</span>FFmpeg 切り出しコマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="filename"
       label="入力ファイル名"
       required
       placeholder="例: 250503_130527_TrMic.wav / sample.mp4"
       field-class="md-field-block"
       help-text="例: 250503_130527_TrMic.wav / sample.mp4"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="start"
       label="開始時刻（任意）"
       placeholder="例: 3:10 または 190 または 1:15:30"
       field-class="md-field-block"
       help-text="開始位置。時:分:秒 または 秒指定に対応。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="end"
       label="終了時刻（任意）"
       placeholder="例: 12:45 または 765 または 0:12:45"
       field-class="md-field-block"
       help-text="終了位置。未指定なら末尾まで。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="partNumber"
       type="number"
       min="1"
@@ -1244,7 +1244,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="例: 1"
       field-class="md-field-block"
       help-text="出力ファイル名の連番に利用します。"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateClipCommand()" class="md-button md-button--primary md-field-block">
       切り出しコマンド生成
@@ -2104,11 +2104,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen-src.html
@@ -45,23 +45,23 @@ limitations under the License.
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">📺</span>YouTube向け FFmpeg コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル（.wav）"
       required
       placeholder="例: 250503_TrMic-part1.wav"
       field-class="md-field-block"
       help-text="例: 250503_TrMic-part1.wav"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="imageFile"
       label="画像ファイル（.png, .jpg, .jpeg）"
       required
       placeholder="例: Borodin.png"
       field-class="md-field-block"
       help-text="例: Borodin.png"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateYoutubeCmd()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -29,13 +29,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1211,23 +1211,23 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
 <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">📺</span>YouTube向け FFmpeg コマンドジェネレータ</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="audioFile"
       label="音声ファイル（.wav）"
       required
       placeholder="例: 250503_TrMic-part1.wav"
       field-class="md-field-block"
       help-text="例: 250503_TrMic-part1.wav"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
-    <lht-help-text-field
+    <lht-text-field-help
       field-id="imageFile"
       label="画像ファイル（.png, .jpg, .jpeg）"
       required
       placeholder="例: Borodin.png"
       field-class="md-field-block"
       help-text="例: Borodin.png"
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateYoutubeCmd()" class="md-button md-button--primary md-field-block">
       ffmpeg コマンド生成
@@ -2087,11 +2087,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/src/ffmpeg-loudnorm-cmdline-gen/css/app.css
+++ b/docs/ffmpeg/src/ffmpeg-loudnorm-cmdline-gen/css/app.css
@@ -492,7 +492,7 @@
     }
 
     /* Keep floating labels from visually overlapping explanatory text blocks. */
-    .md-tab-panel .md-muted + lht-help-text-field {
+    .md-tab-panel .md-muted + lht-text-field-help {
       margin-top: 0.85rem;
     }
     

--- a/docs/ffmpeg/src/ffmpeg-mp4-to-wav-gen/css/app.css
+++ b/docs/ffmpeg/src/ffmpeg-mp4-to-wav-gen/css/app.css
@@ -1007,7 +1007,7 @@
     .md-sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
 
     /* Keep floating labels from visually overlapping explanatory text blocks. */
-    .md-muted + lht-help-text-field {
+    .md-muted + lht-text-field-help {
       margin-top: 0.85rem;
     }
 

--- a/docs/git/README.md
+++ b/docs/git/README.md
@@ -117,7 +117,7 @@
 - トグル: `md-switch`
 - アイコンボタン: `md-icon-button`
 - ヘルプ `(i)`: `lht-help-tooltip`（内部で `md-icon-button` + tooltip DOM を生成）
-- フィールド活性時ヘルプ表示: `lht-help-text-field`（フォーカス時のみ入力下に説明を表示）
+- フィールド活性時ヘルプ表示: `lht-text-field-help`（フォーカス時のみ入力下に説明を表示）
 - スイッチ + ヘルプ: `lht-switch-help`（`md-switch` + ラベル + `lht-help-tooltip`）
 - コマンド表示 + コピー: `lht-command-block`（`copy-buttons="single|dual"`）
 - 右上メニュー: `lht-page-menu`（`home-href` / `home-label`）
@@ -138,7 +138,7 @@
 - `lht-help-tooltip`
   - 属性: `label`, `wide`
   - 本文: タグ内部テキスト/HTMLをそのままツールチップ本文として扱う
-- `lht-help-text-field`
+- `lht-text-field-help`
   - 属性: `field-id`, `label`, `help-text`, `placeholder`, `required`, `field-class`
   - 入力欄フォーカス時のみ `supportingText` を表示し、ブラー時に非表示に戻す
 - `lht-switch-help`

--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -55,7 +55,7 @@ limitations under the License.
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -64,7 +64,7 @@ limitations under the License.
       </div>
 
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -85,7 +85,7 @@ limitations under the License.
         </lht-switch-help>
       </div>
       <div id="remoteNameBlock" class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-help-text-field>
+        <lht-text-field-help field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-text-field-help>
       </div>
     </div>
 

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1269,7 +1269,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -1278,7 +1278,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       </div>
 
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-help-text-field>
+        <lht-text-field-help field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
         <label class="md-switch-label">
           <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
           <span class="md-switch" aria-hidden="true"></span>
@@ -1299,7 +1299,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </lht-switch-help>
       </div>
       <div id="remoteNameBlock" class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-help-text-field>
+        <lht-text-field-help field-id="remoteName" label="リモート名" placeholder="例: origin" value="origin" help-text="fetch と差分比較に使うリモート名です。"></lht-text-field-help>
       </div>
     </div>
 
@@ -2173,11 +2173,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -2258,11 +2258,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/git/git-config-setup-src.html
+++ b/docs/git/git-config-setup-src.html
@@ -92,8 +92,8 @@ limitations under the License.
       </div>
 
       <div class="md-stack-md">
-        <lht-help-text-field field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-help-text-field>
-        <lht-help-text-field field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-help-text-field>
+        <lht-text-field-help field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-text-field-help>
+        <lht-text-field-help field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-text-field-help>
       </div>
     </section>
 

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1310,8 +1310,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       </div>
 
       <div class="md-stack-md">
-        <lht-help-text-field field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-help-text-field>
-        <lht-help-text-field field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-help-text-field>
+        <lht-text-field-help field-id="userName" label="ユーザー名" required placeholder="例: Taro Yamada" help-text="Gitコミットに記録される名前です。本名またはニックネームを入力してください。"></lht-text-field-help>
+        <lht-text-field-help field-id="userEmail" label="メールアドレス" required placeholder="例: taro@example.com" help-text="Gitコミットに記録されるメールアドレスです。連絡可能なメールアドレスを入力してください。"></lht-text-field-help>
       </div>
     </section>
 
@@ -2170,11 +2170,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -75,7 +75,7 @@ limitations under the License.
         </div>
         <div class="md-form-row md-form-row--nowrap">
           <div class="md-input-wrap md-input-wrap--inline">
-            <lht-help-text-field field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-help-text-field>
+            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
             <button type="button" class="md-icon-btn md-icon-btn--small md-input-action--inline" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -34,13 +34,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1544,7 +1544,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </div>
         <div class="md-form-row md-form-row--nowrap">
           <div class="md-input-wrap md-input-wrap--inline">
-            <lht-help-text-field field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-help-text-field>
+            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
             <button type="button" class="md-icon-btn md-icon-btn--small md-input-action--inline" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>
@@ -2588,11 +2588,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/grep/find-gen-src.html
+++ b/docs/grep/find-gen-src.html
@@ -56,7 +56,7 @@ limitations under the License.
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-help-text-field>
+        <lht-text-field-help field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-text-field-help>
       </div>
       <div class="md-form-row md-form-row--nowrap">
         <md-outlined-select id="targetType" label="対象の種類" class="md-outlined-field" value="file">
@@ -69,11 +69,11 @@ limitations under the License.
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="extension" label="拡張子" placeholder="例: txt / wav / jpg / java"></lht-help-text-field>
+        <lht-text-field-help field-id="extension" label="拡張子" placeholder="例: txt / wav / jpg / java"></lht-text-field-help>
       </div>
       <div class="md-field">
         <div class="md-form-row md-form-row--nowrap">
-          <lht-help-text-field field-id="namePattern" label="名前パターン（ワイルドカード可）" placeholder="例: report / *.log / data??.csv"></lht-help-text-field>
+          <lht-text-field-help field-id="namePattern" label="名前パターン（ワイルドカード可）" placeholder="例: report / *.log / data??.csv"></lht-text-field-help>
         </div>
         <lht-switch-help switch-id="caseInsensitive" label="大文字・小文字を区別しない (-iname)"></lht-switch-help>
       </div>
@@ -88,7 +88,7 @@ limitations under the License.
             <md-select-option value="min" selected><div slot="headline">以上 (&gt;=)</div></md-select-option>
             <md-select-option value="max"><div slot="headline">以下 (&lt;=)</div></md-select-option>
           </md-outlined-select>
-          <lht-help-text-field field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-help-text-field>
+          <lht-text-field-help field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-text-field-help>
           <md-outlined-select id="sizeUnit" label="単位" class="md-outlined-field" value="M">
             <md-select-option value="K"><div slot="headline">KB</div></md-select-option>
             <md-select-option value="M" selected><div slot="headline">MB</div></md-select-option>
@@ -102,21 +102,21 @@ limitations under the License.
             <md-select-option value="within" selected><div slot="headline">直近N日以内</div></md-select-option>
             <md-select-option value="older"><div slot="headline">N日より前</div></md-select-option>
           </md-outlined-select>
-          <lht-help-text-field field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-help-text-field>
+          <lht-text-field-help field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-text-field-help>
           <div class="md-label md-label--muted">日</div>
         </div>
 
         <label class="md-label">深さ条件:</label>
         <div class="md-grid md-grid-2">
-          <lht-help-text-field field-id="minDepth" type="number" label="最小深さ" placeholder="mindepth"></lht-help-text-field>
-          <lht-help-text-field field-id="maxDepth" type="number" label="最大深さ" placeholder="maxdepth"></lht-help-text-field>
+          <lht-text-field-help field-id="minDepth" type="number" label="最小深さ" placeholder="mindepth"></lht-text-field-help>
+          <lht-text-field-help field-id="maxDepth" type="number" label="最大深さ" placeholder="maxdepth"></lht-text-field-help>
         </div>
       </div>
     </details>
 
     <div class="md-section md-stack-sm">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="contentPattern" label="内容検索" placeholder="例: ERROR / TODO / 404"></lht-help-text-field>
+        <lht-text-field-help field-id="contentPattern" label="内容検索" placeholder="例: ERROR / TODO / 404"></lht-text-field-help>
       </div>
       <lht-switch-help switch-id="useRipgrep" label="rg で検索（未チェックなら grep -E を使用）" checked></lht-switch-help>
     </div>

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1271,7 +1271,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-help-text-field>
+        <lht-text-field-help field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-text-field-help>
       </div>
       <div class="md-form-row md-form-row--nowrap">
         <md-outlined-select id="targetType" label="対象の種類" class="md-outlined-field" value="file">
@@ -1284,11 +1284,11 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="extension" label="拡張子" placeholder="例: txt / wav / jpg / java"></lht-help-text-field>
+        <lht-text-field-help field-id="extension" label="拡張子" placeholder="例: txt / wav / jpg / java"></lht-text-field-help>
       </div>
       <div class="md-field">
         <div class="md-form-row md-form-row--nowrap">
-          <lht-help-text-field field-id="namePattern" label="名前パターン（ワイルドカード可）" placeholder="例: report / *.log / data??.csv"></lht-help-text-field>
+          <lht-text-field-help field-id="namePattern" label="名前パターン（ワイルドカード可）" placeholder="例: report / *.log / data??.csv"></lht-text-field-help>
         </div>
         <lht-switch-help switch-id="caseInsensitive" label="大文字・小文字を区別しない (-iname)"></lht-switch-help>
       </div>
@@ -1303,7 +1303,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
             <md-select-option value="min" selected><div slot="headline">以上 (&gt;=)</div></md-select-option>
             <md-select-option value="max"><div slot="headline">以下 (&lt;=)</div></md-select-option>
           </md-outlined-select>
-          <lht-help-text-field field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-help-text-field>
+          <lht-text-field-help field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-text-field-help>
           <md-outlined-select id="sizeUnit" label="単位" class="md-outlined-field" value="M">
             <md-select-option value="K"><div slot="headline">KB</div></md-select-option>
             <md-select-option value="M" selected><div slot="headline">MB</div></md-select-option>
@@ -1317,21 +1317,21 @@ lht-switch-help .md-switch-label .md-tooltip-content {
             <md-select-option value="within" selected><div slot="headline">直近N日以内</div></md-select-option>
             <md-select-option value="older"><div slot="headline">N日より前</div></md-select-option>
           </md-outlined-select>
-          <lht-help-text-field field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-help-text-field>
+          <lht-text-field-help field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-text-field-help>
           <div class="md-label md-label--muted">日</div>
         </div>
 
         <label class="md-label">深さ条件:</label>
         <div class="md-grid md-grid-2">
-          <lht-help-text-field field-id="minDepth" type="number" label="最小深さ" placeholder="mindepth"></lht-help-text-field>
-          <lht-help-text-field field-id="maxDepth" type="number" label="最大深さ" placeholder="maxdepth"></lht-help-text-field>
+          <lht-text-field-help field-id="minDepth" type="number" label="最小深さ" placeholder="mindepth"></lht-text-field-help>
+          <lht-text-field-help field-id="maxDepth" type="number" label="最大深さ" placeholder="maxdepth"></lht-text-field-help>
         </div>
       </div>
     </details>
 
     <div class="md-section md-stack-sm">
       <div class="md-form-row md-form-row--nowrap">
-        <lht-help-text-field field-id="contentPattern" label="内容検索" placeholder="例: ERROR / TODO / 404"></lht-help-text-field>
+        <lht-text-field-help field-id="contentPattern" label="内容検索" placeholder="例: ERROR / TODO / 404"></lht-text-field-help>
       </div>
       <lht-switch-help switch-id="useRipgrep" label="rg で検索（未チェックなら grep -E を使用）" checked></lht-switch-help>
     </div>
@@ -2191,11 +2191,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/img/img2svg-src.html
+++ b/docs/img/img2svg-src.html
@@ -1079,7 +1079,7 @@
 
     <div class="md-grid md-grid-2 md-section">
       <div>
-        <lht-help-select field-id="preset" label="プリセット" help-text="用途に応じた推奨値を選択します。" value="illustration">
+        <lht-select-help field-id="preset" label="プリセット" help-text="用途に応じた推奨値を選択します。" value="illustration">
           <script type="application/json" slot="options">
             [
               { "value": "icon", "label": "アイコン・ロゴ（軽量・鋭利）" },
@@ -1088,28 +1088,28 @@
               { "value": "pixelart", "label": "ドット絵（ピクセル完全再現）" }
             ]
           </script>
-        </lht-help-select>
+        </lht-select-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="colors" type="number" min="2" max="64" value="12" label="色数" help-text="使用する色の数（2〜64）。多いほど詳細ですが重くなります。"></lht-help-text-field>
+        <lht-text-field-help field-id="colors" type="number" min="2" max="64" value="12" label="色数" help-text="使用する色の数（2〜64）。多いほど詳細ですが重くなります。"></lht-text-field-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="ltres" type="number" min="0" max="10" step="0.1" value="1.0" label="輪郭の精度 (ltres)" help-text="低いほど元の形に忠実、高いほどノイズを無視します。"></lht-help-text-field>
+        <lht-text-field-help field-id="ltres" type="number" min="0" max="10" step="0.1" value="1.0" label="輪郭の精度 (ltres)" help-text="低いほど元の形に忠実、高いほどノイズを無視します。"></lht-text-field-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="qtres" type="number" min="0.1" max="10" step="0.1" value="0.1" label="曲線の精度 (qtres)" help-text="低いほど滑らかな曲線、高いほど直線的な描画になります。"></lht-help-text-field>
+        <lht-text-field-help field-id="qtres" type="number" min="0.1" max="10" step="0.1" value="0.1" label="曲線の精度 (qtres)" help-text="低いほど滑らかな曲線、高いほど直線的な描画になります。"></lht-text-field-help>
       </div>
     </div>
 
     <div class="md-grid md-grid-2 md-section">
       <div>
-        <lht-help-text-field field-id="scalePercent" type="number" min="10" max="100" value="100" label="縮小率（前処理）" help-text="小さくしてからトレースすることで、パスの数を減らします（10〜100%）。"></lht-help-text-field>
+        <lht-text-field-help field-id="scalePercent" type="number" min="10" max="100" value="100" label="縮小率（前処理）" help-text="小さくしてからトレースすることで、パスの数を減らします（10〜100%）。"></lht-text-field-help>
       </div>
       <div>
-        <lht-help-text-field field-id="blurPx" type="number" min="0" max="5" step="0.5" value="0" label="ぼかし（前処理）" help-text="0以上の値で細かいノイズをならします（0〜5px）。"></lht-help-text-field>
+        <lht-text-field-help field-id="blurPx" type="number" min="0" max="5" step="0.5" value="0" label="ぼかし（前処理）" help-text="0以上の値で細かいノイズをならします（0〜5px）。"></lht-text-field-help>
       </div>
     </div>
 
@@ -2365,8 +2365,8 @@ if(typeof define === 'function' && define.amd){
     window.addEventListener("DOMContentLoaded", async () => {
       if (window.customElements && typeof window.customElements.whenDefined === "function") {
         await Promise.all([
-          window.customElements.whenDefined("lht-help-text-field"),
-          window.customElements.whenDefined("lht-help-select"),
+          window.customElements.whenDefined("lht-text-field-help"),
+          window.customElements.whenDefined("lht-select-help"),
           window.customElements.whenDefined("lht-file-select")
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1037,13 +1037,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1333,7 +1333,7 @@ lht-index-card-link {
 
     <div class="md-grid md-grid-2 md-section">
       <div>
-        <lht-help-select field-id="preset" label="プリセット" help-text="用途に応じた推奨値を選択します。" value="illustration">
+        <lht-select-help field-id="preset" label="プリセット" help-text="用途に応じた推奨値を選択します。" value="illustration">
           <script type="application/json" slot="options">
             [
               { "value": "icon", "label": "アイコン・ロゴ（軽量・鋭利）" },
@@ -1342,28 +1342,28 @@ lht-index-card-link {
               { "value": "pixelart", "label": "ドット絵（ピクセル完全再現）" }
             ]
           </script>
-        </lht-help-select>
+        </lht-select-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="colors" type="number" min="2" max="64" value="12" label="色数" help-text="使用する色の数（2〜64）。多いほど詳細ですが重くなります。"></lht-help-text-field>
+        <lht-text-field-help field-id="colors" type="number" min="2" max="64" value="12" label="色数" help-text="使用する色の数（2〜64）。多いほど詳細ですが重くなります。"></lht-text-field-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="ltres" type="number" min="0" max="10" step="0.1" value="1.0" label="輪郭の精度 (ltres)" help-text="低いほど元の形に忠実、高いほどノイズを無視します。"></lht-help-text-field>
+        <lht-text-field-help field-id="ltres" type="number" min="0" max="10" step="0.1" value="1.0" label="輪郭の精度 (ltres)" help-text="低いほど元の形に忠実、高いほどノイズを無視します。"></lht-text-field-help>
       </div>
 
       <div>
-        <lht-help-text-field field-id="qtres" type="number" min="0.1" max="10" step="0.1" value="0.1" label="曲線の精度 (qtres)" help-text="低いほど滑らかな曲線、高いほど直線的な描画になります。"></lht-help-text-field>
+        <lht-text-field-help field-id="qtres" type="number" min="0.1" max="10" step="0.1" value="0.1" label="曲線の精度 (qtres)" help-text="低いほど滑らかな曲線、高いほど直線的な描画になります。"></lht-text-field-help>
       </div>
     </div>
 
     <div class="md-grid md-grid-2 md-section">
       <div>
-        <lht-help-text-field field-id="scalePercent" type="number" min="10" max="100" value="100" label="縮小率（前処理）" help-text="小さくしてからトレースすることで、パスの数を減らします（10〜100%）。"></lht-help-text-field>
+        <lht-text-field-help field-id="scalePercent" type="number" min="10" max="100" value="100" label="縮小率（前処理）" help-text="小さくしてからトレースすることで、パスの数を減らします（10〜100%）。"></lht-text-field-help>
       </div>
       <div>
-        <lht-help-text-field field-id="blurPx" type="number" min="0" max="5" step="0.5" value="0" label="ぼかし（前処理）" help-text="0以上の値で細かいノイズをならします（0〜5px）。"></lht-help-text-field>
+        <lht-text-field-help field-id="blurPx" type="number" min="0" max="5" step="0.5" value="0" label="ぼかし（前処理）" help-text="0以上の値で細かいノイズをならします（0〜5px）。"></lht-text-field-help>
       </div>
     </div>
 
@@ -2619,8 +2619,8 @@ if(typeof define === 'function' && define.amd){
     window.addEventListener("DOMContentLoaded", async () => {
       if (window.customElements && typeof window.customElements.whenDefined === "function") {
         await Promise.all([
-          window.customElements.whenDefined("lht-help-text-field"),
-          window.customElements.whenDefined("lht-help-select"),
+          window.customElements.whenDefined("lht-text-field-help"),
+          window.customElements.whenDefined("lht-select-help"),
           window.customElements.whenDefined("lht-file-select")
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -3837,11 +3837,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1034,13 +1034,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -2413,11 +2413,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -946,13 +946,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1732,11 +1732,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/life/japan-weather-src.html
+++ b/docs/life/japan-weather-src.html
@@ -905,8 +905,8 @@
       background-repeat: no-repeat;
     }
     .md-select:focus { outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2); }
-    lht-help-select { display: block; min-width: 200px; }
-    lht-help-select md-outlined-select.md-outlined-field {
+    lht-select-help { display: block; min-width: 200px; }
+    lht-select-help md-outlined-select.md-outlined-field {
       width: 100%;
       --md-outlined-select-text-field-container-shape: 12px;
       --md-outlined-select-text-field-top-space: 10px;
@@ -989,8 +989,8 @@
           <div class="md-headline"><span aria-hidden="true">🌦️</span>Japan Weather</div>
           <p id="update-time" class="md-subtitle"></p>
           <div class="md-filters">
-            <lht-help-select field-id="region-select" label="地域" help-text="表示する都道府県グループを選択します。"></lht-help-select>
-            <lht-help-select field-id="area-select" label="府県/地方" help-text="天気を表示したい府県/地方を選択します。"></lht-help-select>
+            <lht-select-help field-id="region-select" label="地域" help-text="表示する都道府県グループを選択します。"></lht-select-help>
+            <lht-select-help field-id="area-select" label="府県/地方" help-text="天気を表示したい府県/地方を選択します。"></lht-select-help>
           </div>
         </header>
 

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -905,8 +905,8 @@
       background-repeat: no-repeat;
     }
     .md-select:focus { outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2); }
-    lht-help-select { display: block; min-width: 200px; }
-    lht-help-select md-outlined-select.md-outlined-field {
+    lht-select-help { display: block; min-width: 200px; }
+    lht-select-help md-outlined-select.md-outlined-field {
       width: 100%;
       --md-outlined-select-text-field-container-shape: 12px;
       --md-outlined-select-text-field-top-space: 10px;
@@ -971,13 +971,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1159,8 +1159,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
           <div class="md-headline"><span aria-hidden="true">🌦️</span>Japan Weather</div>
           <p id="update-time" class="md-subtitle"></p>
           <div class="md-filters">
-            <lht-help-select field-id="region-select" label="地域" help-text="表示する都道府県グループを選択します。"></lht-help-select>
-            <lht-help-select field-id="area-select" label="府県/地方" help-text="天気を表示したい府県/地方を選択します。"></lht-help-select>
+            <lht-select-help field-id="region-select" label="地域" help-text="表示する都道府県グループを選択します。"></lht-select-help>
+            <lht-select-help field-id="area-select" label="府県/地方" help-text="天気を表示したい府県/地方を選択します。"></lht-select-help>
           </div>
         </header>
 
@@ -2355,11 +2355,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/amazon-dp-extract-src.html
+++ b/docs/link/amazon-dp-extract-src.html
@@ -1046,14 +1046,14 @@ limitations under the License.
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🛒</span>Amazon URL dp 抽出ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="amazonUrl"
       label="AmazonのURL"
       placeholder="例: https://www.amazon.co.jp/dp/B0XXXXXXX"
       help-text="例: /dp/, /gp/product/, /gp/offer-listing/ のURL、またはASIN（10文字）を入力できます。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateDpPath()" class="md-button md-button--primary md-field-block">
       Amazonの短いURLにする

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1031,13 +1031,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1216,14 +1216,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🛒</span>Amazon URL dp 抽出ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="amazonUrl"
       label="AmazonのURL"
       placeholder="例: https://www.amazon.co.jp/dp/B0XXXXXXX"
       help-text="例: /dp/, /gp/product/, /gp/offer-listing/ のURL、またはASIN（10文字）を入力できます。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateDpPath()" class="md-button md-button--primary md-field-block">
       Amazonの短いURLにする
@@ -2181,11 +2181,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/facebook-fbclid-remove-src.html
+++ b/docs/link/facebook-fbclid-remove-src.html
@@ -1046,14 +1046,14 @@ limitations under the License.
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔗</span>Facebook fbclid 除去ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputUrl"
       label="URL"
       placeholder="例: https://example.com/?a=1&fbclid=..."
       help-text="fbclid パラメータだけを削除します。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       Facebook識別子（fbclid）を除去

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1031,13 +1031,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1216,14 +1216,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔗</span>Facebook fbclid 除去ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputUrl"
       label="URL"
       placeholder="例: https://example.com/?a=1&fbclid=..."
       help-text="fbclid パラメータだけを削除します。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       Facebook識別子（fbclid）を除去
@@ -2122,11 +2122,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/mime-base64-src.html
+++ b/docs/link/mime-base64-src.html
@@ -1076,7 +1076,7 @@ limitations under the License.
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">📦</span>MIME Base64 エンコード/デコード</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputText"
       type="textarea"
@@ -1085,7 +1085,7 @@ limitations under the License.
       placeholder="例: こんにちは / SGVsbG8="
       help-text="Base64 をエンコード/デコードします。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <lht-switch-help class="md-field-block" switch-id="mimeWrap" label="76文字で改行（MIME形式）" help-label="MIME改行の説明">
       エンコード時のみ適用されます。

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1061,13 +1061,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1246,7 +1246,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">📦</span>MIME Base64 エンコード/デコード</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputText"
       type="textarea"
@@ -1255,7 +1255,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="例: こんにちは / SGVsbG8="
       help-text="Base64 をエンコード/デコードします。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <lht-switch-help class="md-field-block" switch-id="mimeWrap" label="76文字で改行（MIME形式）" help-label="MIME改行の説明">
       エンコード時のみ適用されます。
@@ -2180,11 +2180,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/url-encode-decode-src.html
+++ b/docs/link/url-encode-decode-src.html
@@ -1047,7 +1047,7 @@ limitations under the License.
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔤</span>URL エンコード/デコード ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputText"
       type="textarea"
@@ -1056,7 +1056,7 @@ limitations under the License.
       placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF"
       help-text="日本語をURLエンコード/デコードします。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;">
       <button onclick="encodeText()" class="md-button md-button--primary">

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1032,13 +1032,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1217,7 +1217,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🔤</span>URL エンコード/デコード ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputText"
       type="textarea"
@@ -1226,7 +1226,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
       placeholder="例: こんにちは / %E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF"
       help-text="日本語をURLエンコード/デコードします。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <div class="md-field-block" style="display:flex; flex-wrap:wrap; gap: 0.5rem;">
       <button onclick="encodeText()" class="md-button md-button--primary">
@@ -2126,11 +2126,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/utm-remove-src.html
+++ b/docs/link/utm-remove-src.html
@@ -1046,14 +1046,14 @@ limitations under the License.
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🧹</span>UTM パラメータ除去ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputUrl"
       label="URL"
       placeholder="例: https://example.com/?utm_source=aaa&x=1"
       help-text="utm_* パラメータを削除します。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       UTMを除去

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1031,13 +1031,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1216,14 +1216,14 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
     <h1 class="md-headline"><span aria-hidden="true" class="md-headline__icon">🧹</span>UTM パラメータ除去ツール</h1>
 
-    <lht-help-text-field
+    <lht-text-field-help
       class="md-field-block"
       field-id="inputUrl"
       label="URL"
       placeholder="例: https://example.com/?utm_source=aaa&x=1"
       help-text="utm_* パラメータを削除します。"
       required
-    ></lht-help-text-field>
+    ></lht-text-field-help>
 
     <button onclick="generateCleanUrl()" class="md-button md-button--primary md-field-block">
       UTMを除去
@@ -2121,11 +2121,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/password/password-gen-src.html
+++ b/docs/password/password-gen-src.html
@@ -69,7 +69,7 @@ limitations under the License.
     </div>
 
     <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
-      <lht-help-text-field field-id="lengthInput" type="number" label="文字数" value="8" field-class="md-input--short"></lht-help-text-field>
+      <lht-text-field-help field-id="lengthInput" type="number" label="文字数" value="8" field-class="md-input--short"></lht-text-field-help>
     </div>
 
     <button type="button" onclick="generatePassword()" class="md-button">パスワード生成</button>

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -33,13 +33,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1263,7 +1263,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     </div>
 
     <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
-      <lht-help-text-field field-id="lengthInput" type="number" label="文字数" value="8" field-class="md-input--short"></lht-help-text-field>
+      <lht-text-field-help field-id="lengthInput" type="number" label="文字数" value="8" field-class="md-input--short"></lht-text-field-help>
     </div>
 
     <button type="button" onclick="generatePassword()" class="md-button">パスワード生成</button>
@@ -2121,11 +2121,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -563,13 +563,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -2130,11 +2130,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/japanese-romaji-guide-src.html
+++ b/docs/text/japanese-romaji-guide-src.html
@@ -653,17 +653,17 @@ limitations under the License.
         </p>
 
         <section class="md-section">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="sourceText"
             type="textarea"
             rows="3"
             label="かな入力（ひらがな / カタカナ）"
             placeholder="さとう たろう&#10;しんじゅく&#10;ちゃづけ"
             help-text="ひらがな・カタカナの入力を比較ローマ字へ変換します。"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
           <div class="md-control-flow">
             <div class="md-control-flow-item">
-              <lht-help-select
+              <lht-select-help
                 field-id="useCaseSelect"
                 label="用途"
                 help-text="氏名・地名・学校学習・方式比較の用途に応じて推奨モードを切り替えます。"
@@ -676,10 +676,10 @@ limitations under the License.
                     { "value": "linguistics_compare", "label": "方式比較（理論検討）" }
                   ]
                 </script>
-              </lht-help-select>
+              </lht-select-help>
             </div>
             <div class="md-control-flow-item">
-              <lht-help-select
+              <lht-select-help
                 field-id="optPassportLongVowelStyle"
                 label="長音"
                 help-text="旅券ローマ字の長音運用を切り替えます（簡略/保持/OH）。"
@@ -691,7 +691,7 @@ limitations under the License.
                     { "value": "oh", "label": "OH表記（SATOU → SATOH）" }
                   ]
                 </script>
-              </lht-help-select>
+              </lht-select-help>
             </div>
             <div class="md-control-flow-item">
               <lht-switch-help switch-id="optUppercase" label="大文字出力" checked></lht-switch-help>
@@ -825,8 +825,8 @@ limitations under the License.
     window.addEventListener("DOMContentLoaded", async function () {
       if (window.customElements && typeof window.customElements.whenDefined === "function") {
         await Promise.all([
-          window.customElements.whenDefined("lht-help-text-field"),
-          window.customElements.whenDefined("lht-help-select"),
+          window.customElements.whenDefined("lht-text-field-help"),
+          window.customElements.whenDefined("lht-select-help"),
           window.customElements.whenDefined("lht-switch-help")
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -643,13 +643,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -823,17 +823,17 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </p>
 
         <section class="md-section">
-          <lht-help-text-field
+          <lht-text-field-help
             field-id="sourceText"
             type="textarea"
             rows="3"
             label="かな入力（ひらがな / カタカナ）"
             placeholder="さとう たろう&#10;しんじゅく&#10;ちゃづけ"
             help-text="ひらがな・カタカナの入力を比較ローマ字へ変換します。"
-          ></lht-help-text-field>
+          ></lht-text-field-help>
           <div class="md-control-flow">
             <div class="md-control-flow-item">
-              <lht-help-select
+              <lht-select-help
                 field-id="useCaseSelect"
                 label="用途"
                 help-text="氏名・地名・学校学習・方式比較の用途に応じて推奨モードを切り替えます。"
@@ -846,10 +846,10 @@ lht-switch-help .md-switch-label .md-tooltip-content {
                     { "value": "linguistics_compare", "label": "方式比較（理論検討）" }
                   ]
                 </script>
-              </lht-help-select>
+              </lht-select-help>
             </div>
             <div class="md-control-flow-item">
-              <lht-help-select
+              <lht-select-help
                 field-id="optPassportLongVowelStyle"
                 label="長音"
                 help-text="旅券ローマ字の長音運用を切り替えます（簡略/保持/OH）。"
@@ -861,7 +861,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
                     { "value": "oh", "label": "OH表記（SATOU → SATOH）" }
                   ]
                 </script>
-              </lht-help-select>
+              </lht-select-help>
             </div>
             <div class="md-control-flow-item">
               <lht-switch-help switch-id="optUppercase" label="大文字出力" checked></lht-switch-help>
@@ -995,8 +995,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     window.addEventListener("DOMContentLoaded", async function () {
       if (window.customElements && typeof window.customElements.whenDefined === "function") {
         await Promise.all([
-          window.customElements.whenDefined("lht-help-text-field"),
-          window.customElements.whenDefined("lht-help-select"),
+          window.customElements.whenDefined("lht-text-field-help"),
+          window.customElements.whenDefined("lht-select-help"),
           window.customElements.whenDefined("lht-switch-help")
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -2170,11 +2170,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/text-processing-src.html
+++ b/docs/text/text-processing-src.html
@@ -1138,7 +1138,7 @@ limitations under the License.
         </span>
 </span>
 </h1>
-<lht-help-text-field
+<lht-text-field-help
   field-id="inputText"
   label="入力テキスト"
   type="textarea"
@@ -1146,7 +1146,7 @@ limitations under the License.
   field-class="md-input-block"
   placeholder="加工したいテキストを入力してください"
   help-text="ここに入力したテキストが変換対象になります。"
-></lht-help-text-field>
+></lht-text-field-help>
 <div class="md-section">
 <div class="md-section-title md-section-title-row">
 <div>
@@ -1164,7 +1164,7 @@ limitations under the License.
 <details class="md-accordion">
 <summary>文字の変換</summary>
 <div class="md-subpanel" id="charConvertPanel">
-<lht-help-select
+<lht-select-help
   field-id="optWidth"
   label="全角/半角"
   help-text="全角と半角の相互変換を指定します。"
@@ -1176,13 +1176,13 @@ limitations under the License.
   { "value": "toFull", "label": "全角に変換" }
 ]
 </script>
-</lht-help-select>
+</lht-select-help>
 <lht-switch-help
   switch-id="optIncludeKana"
   label="仮名を含める"
   help-label="仮名変換の説明"
 >全角/半角変換時に、かな文字も対象へ含めます。</lht-switch-help>
-<lht-help-select
+<lht-select-help
   field-id="optKana"
   label="ひらがな/カタカナ"
   help-text="ひらがなとカタカナの変換方向を指定します。"
@@ -1194,8 +1194,8 @@ limitations under the License.
   { "value": "toHira", "label": "カタカナ → ひらがな" }
 ]
 </script>
-</lht-help-select>
-<lht-help-select
+</lht-select-help>
+<lht-select-help
   field-id="optCase"
   label="大文字/小文字（英字）"
   help-text="英字の大文字化または小文字化を指定します。"
@@ -1207,7 +1207,7 @@ limitations under the License.
   { "value": "lower", "label": "小文字に変換" }
 ]
 </script>
-</lht-help-select>
+</lht-select-help>
 </div>
 </details>
 <details class="md-accordion">
@@ -1976,8 +1976,8 @@ limitations under the License.
     async function initTextProcessingPage() {
       if (window.customElements && typeof window.customElements.whenDefined === 'function') {
         await Promise.all([
-          window.customElements.whenDefined('lht-help-text-field'),
-          window.customElements.whenDefined('lht-help-select'),
+          window.customElements.whenDefined('lht-text-field-help'),
+          window.customElements.whenDefined('lht-select-help'),
           window.customElements.whenDefined('lht-switch-help')
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1117,13 +1117,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -1308,7 +1308,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
         </span>
 </span>
 </h1>
-<lht-help-text-field
+<lht-text-field-help
   field-id="inputText"
   label="入力テキスト"
   type="textarea"
@@ -1316,7 +1316,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   field-class="md-input-block"
   placeholder="加工したいテキストを入力してください"
   help-text="ここに入力したテキストが変換対象になります。"
-></lht-help-text-field>
+></lht-text-field-help>
 <div class="md-section">
 <div class="md-section-title md-section-title-row">
 <div>
@@ -1334,7 +1334,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 <details class="md-accordion">
 <summary>文字の変換</summary>
 <div class="md-subpanel" id="charConvertPanel">
-<lht-help-select
+<lht-select-help
   field-id="optWidth"
   label="全角/半角"
   help-text="全角と半角の相互変換を指定します。"
@@ -1346,13 +1346,13 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   { "value": "toFull", "label": "全角に変換" }
 ]
 </script>
-</lht-help-select>
+</lht-select-help>
 <lht-switch-help
   switch-id="optIncludeKana"
   label="仮名を含める"
   help-label="仮名変換の説明"
 >全角/半角変換時に、かな文字も対象へ含めます。</lht-switch-help>
-<lht-help-select
+<lht-select-help
   field-id="optKana"
   label="ひらがな/カタカナ"
   help-text="ひらがなとカタカナの変換方向を指定します。"
@@ -1364,8 +1364,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   { "value": "toHira", "label": "カタカナ → ひらがな" }
 ]
 </script>
-</lht-help-select>
-<lht-help-select
+</lht-select-help>
+<lht-select-help
   field-id="optCase"
   label="大文字/小文字（英字）"
   help-text="英字の大文字化または小文字化を指定します。"
@@ -1377,7 +1377,7 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   { "value": "lower", "label": "小文字に変換" }
 ]
 </script>
-</lht-help-select>
+</lht-select-help>
 </div>
 </details>
 <details class="md-accordion">
@@ -2146,8 +2146,8 @@ lht-switch-help .md-switch-label .md-tooltip-content {
     async function initTextProcessingPage() {
       if (window.customElements && typeof window.customElements.whenDefined === 'function') {
         await Promise.all([
-          window.customElements.whenDefined('lht-help-text-field'),
-          window.customElements.whenDefined('lht-help-select'),
+          window.customElements.whenDefined('lht-text-field-help'),
+          window.customElements.whenDefined('lht-select-help'),
           window.customElements.whenDefined('lht-switch-help')
         ]);
         await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
@@ -3024,11 +3024,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -1005,13 +1005,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
@@ -2196,11 +2196,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtHelpTextField);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtHelpSelect);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -1,42 +1,56 @@
 # lht-cmn
 
-`local-html-tools` 全体で共有する UI コンポーネント置き場です。
+`lht-cmn` は `local-html-tools` 全体で共有する UI コンポーネント基盤です。
 
-## 位置づけ
+## 目的
 
-- `lht-cmn` は `local-html-tools` の UI 抽象化レイヤーです
-- Material Web を使う場合でも、画面側で `md-*` を直接多用せず、原則 `lht-*` コンポーネントとして提供してから利用します
-- `lht-*` を画面側の公開APIとして扱い、内部実装（Material Web / 自前DOM）は `lht-cmn` 側に閉じ込めます
-- 目的:
-  - 画面ごとの重複実装を減らす
-  - 見た目と挙動を統一する
-  - 変更点を `lht-cmn` に集約して保守しやすくする
-  - 生成AIが扱いやすい構造にする
+`local-html-tools` では、入力・選択・ヘルプ・コピー・メニューなどの UI を複数ページで繰り返し実装してきました。  
+`lht-cmn` はこの重複を減らし、UI を `lht-*` Web Components として共通化するためのレイヤーです。
 
-## 実装方針（重要）
+## 基本方針
 
-- 優先順位:
-  - 1. Material Web が利用可能なら内部で活用する
-  - 2. 利用不可環境では `lht-cmn` 内フォールバック実装で同等操作を維持する
+- デザイン基準は Material Design 3
+- 実現手段として Material Web を優先利用する
+- Material Web に妥当な選択肢がない場合は、`lht-cmn` 側に自前実装（必要に応じて新規 Web Component）を追加し、`lht-*` として提供する
+- Material Web で直接実現できる要素も、画面側では一旦 `lht-*` でラップして利用する
+- 画面側で利用するのは原則 `lht-*` とし、`md-*` 直接利用は `lht-cmn` 内部実装に限定する
+
+## メリット
+
+- 画面ごとの重複実装を削減できる
+- 見た目と挙動（必須表示、ヘルプ表示、フォーカス時の挙動）を統一できる
+- 変更点を `lht-cmn` に集約でき、保守・レビューがしやすくなる
+- 単一HTML生成前提でも、開発時の部品再利用性を維持できる
+- 変更点が局所化され、生成AIが誤って別画面を壊す確率が下がる
+- UI規約が `lht-*` に集約され、提案が毎回同じ型で出せる
+- レビュー時に「画面の見た目差分」より「共通部品の差分」を見ればよくなり、判断が速くなる
+
+## 運用方針（重要）
+
 - 画面側（`docs/*-src.html`）は `lht-*` を利用し、`md-*` 直接実装の追加は原則避ける
-- 将来方針:
-  - `lht-cmn/css/components.css` を正本とし、`md3/` 依存を段階的に縮退する
-  - `md3/` はリファレンスとして扱い、実運用スタイルは `lht-cmn` に集約する
+- `lht-cmn/js/components.js` を共通コンポーネントの正本とする
+- `lht-cmn/css/components.css` を実運用スタイルの正本とする
+- `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約する
 
 ## 構成
 
 - `lht-cmn/js/components.js`
   - 共通 Web Components 定義
-  - `lht-help-tooltip`
-  - `lht-help-text-field`
-  - `lht-help-select`
-  - `lht-switch-help`
-  - `lht-command-block`
-  - `lht-page-menu`
-  - `lht-index-card-link`
-  - `lht-file-select`
 - `lht-cmn/css/components.css`
   - 上記コンポーネントの共通スタイル
+
+### コンポーネント一覧
+
+| コンポーネント | できること | 内部構造（概要） |
+|---|---|---|
+| `lht-help-tooltip` | `(i)` ヘルプアイコンとツールチップを1タグで配置できる | 内部で `md-icon-button` + `md-tooltip-content` を生成し、タグ内HTMLをツールチップ本文へ差し込む |
+| `lht-text-field-help` | ラベル付き入力（単一行/複数行）とフォーカス時ヘルプ表示を共通化できる | 内部で `md-outlined-text-field` を生成し、属性（`field-id`/`label`/`type`/`rows` など）を透過。`focus/blur` で `supportingText` を制御 |
+| `lht-select-help` | ラベル付きドロップダウンとヘルプ表示を共通化できる | 内部で `md-outlined-select` を生成し、`<script type="application/json" slot="options">` から `md-select-option` を構築 |
+| `lht-switch-help` | スイッチ + ラベル + ヘルプを1セットで配置できる | 内部で `md-switch` と `lht-help-tooltip` を組み合わせ、`on-change` 指定時はグローバル関数を呼び出す |
+| `lht-command-block` | コマンド表示枠とコピー操作（単一/二重ボタン）を共通化できる | 内部で `code` と `md-icon-button` を生成。クリック時に Clipboard API（不可時は `textarea` フォールバック）でコピー |
+| `lht-page-menu` | 右上メニュー（トップへ戻る等）を共通化できる | 内部でメニューボタン + パネル + リンクを生成。外側クリックで自動クローズ |
+| `lht-index-card-link` | `docs/index` のカードリンクを統一フォーマットで記述できる | 内部でカードDOM（`a` + タイトル + 説明 + 矢印/バッジ）を生成し、`variant`/`target`/外部リンク判定を吸収 |
+| `lht-file-select` | ファイル選択UI（Filledボタン + ファイル名表示）を共通化できる | 内部で hidden `input[type=file]` とトリガUIを生成。`md-filled-button` が使える環境ではそれを利用し、未定義時はフォールバックボタンで動作維持 |
 
 ## 利用方法
 
@@ -45,42 +59,27 @@ HTML から次を読み込みます。
 - `../../lht-cmn/css/components.css`
 - `../../lht-cmn/js/components.js`
 
+開発時は上記ファイルを参照し、最終的な配布物はビルド時に単一HTMLへインライン化します。
+
 ページ固有の見た目調整は各画面側の CSS で実施し、共通的な DOM 生成と振る舞いは `lht-cmn` 側で管理します。
 
 ## 適用ルール
 
-- `lht-help-text-field` を使う場合は、`label` と `help-text` の設定を「できない理由がない限り」行う
-- `lht-help-select` を使う場合も、`label` と `help-text` の設定を「できない理由がない限り」行う
+- `lht-text-field-help` を使う場合は、`label` と `help-text` の設定を「できない理由がない限り」行う
+- `lht-select-help` を使う場合も、`label` と `help-text` の設定を「できない理由がない限り」行う
 - `lht` 前提の形へ揃える:
-  - 外側の旧ラベル（`label + Required + (i) + :`）は整理する
-  - 入力系は `lht-help-text-field` / `lht-help-select` / `lht-switch-help` 側に `label` と `help-text` を集約する
-  - 必須指定は可能な限りコンポーネント側（`required` と `label` の `*`）へ寄せる
+  - 外側の旧ラベル（`label + Required + (i) + :`）は整理する（全画面で対応完了した時点で、この項目はREADMEから削除する）
+  - 入力系は `lht-text-field-help` / `lht-select-help` / `lht-switch-help` 側に `label` と `help-text` を集約する
+  - 必須指定は可能な限りコンポーネント側（`required`）へ寄せる
 - 例外にする場合は、対象画面側に理由を残す（表示密度・既存互換・重複説明の回避など）
 
-## ドロップダウン置換手順（`lht-help-select`）
+## ドロップダウン置換手順（`lht-select-help`）
 
-1. 基本は `lht-help-select` を使い、`field-id` / `label` / `help-text` を設定する
-2. 選択肢は `lht-help-select` に対して宣言する
-   - 推奨: 子要素の `<script type="application/json" slot="options">[...]</script>`
-   - 代替: 子要素の `<option>`（後方互換）
-3. 表示崩れや選択肢非表示が出る画面は、初期化時に JS で `md-select-option` を注入する方式へ切り替える
+1. 基本は `lht-select-help` を使い、`field-id` / `label` / `help-text` を設定する
+2. 選択肢は `lht-select-help` に対して宣言する
+   - `<script type="application/json" slot="options">[...]</script>` を使用する
+3. `lht-select-help` で `<option>` 子要素は使用しない（後方互換運用は終了）
 4. 既存JS互換のため、DOM参照ID（`document.getElementById(...)`）は変更しない
-
-### 静的定義で成立する事例
-
-- すべての画面で動的注入が必須ではない
-- 例: `docs/git/git-branch-diff-src.html` の「出力形式」は、`md-outlined-select` + `md-select-option` の静的定義で安定動作している
-- そのため方針は「まず静的定義を試す → 崩れが出る画面のみ動的注入へ切替」が基本
-
-### 崩れ対策の実装方針
-
-- `selectElement.tagName === "MD-OUTLINED-SELECT"` の場合:
-  - `md-select-option` を `createElement` で生成
-  - `option.value` を設定
-  - 表示文字列は `<div slot="headline">...</div>` で設定
-  - 既定値は `selected` 属性と `selectElement.value` を両方設定
-- ネイティブ `select` の場合:
-  - 従来どおり `<option>` を生成して設定
 
 ## カード共通化（`lht-index-card-link`）
 
@@ -114,3 +113,46 @@ HTML から次を読み込みます。
   desc-lines="3">
 </lht-index-card-link>
 ```
+
+## LHT リファレンス
+
+### `lht-help-tooltip`
+
+- 用途: `(i)` ヘルプ表示
+- 主な属性: `label`, `wide`
+
+### `lht-text-field-help`
+
+- 用途: テキスト/数値/複数行入力 + フォーカス時ヘルプ
+- 主な属性: `field-id`, `label`, `help-text`, `type`, `placeholder`, `value`, `rows`, `min`, `max`, `step`, `required`, `disabled`, `field-class`
+
+### `lht-select-help`
+
+- 用途: セレクト入力 + フォーカス時ヘルプ
+- 主な属性: `field-id`, `label`, `help-text`, `value`, `required`, `disabled`, `field-class`
+- 選択肢定義: `<script type="application/json" slot="options">[...]</script>`
+
+### `lht-switch-help`
+
+- 用途: スイッチ + ラベル + ヘルプ
+- 主な属性: `switch-id`, `label`, `help-label`, `help-wide`, `checked`, `on-change`
+
+### `lht-command-block`
+
+- 用途: コマンド表示 + コピーUI
+- 主な属性: `command-id`, `copy-buttons`（`single` / `dual`）
+
+### `lht-page-menu`
+
+- 用途: 右上メニュー（戻るリンク等）
+- 主な属性: `home-href`, `home-label`
+
+### `lht-index-card-link`
+
+- 用途: `docs/index` 用カードリンク
+- 主な属性: `href`, `title`, `desc`, `icon`, `variant`, `arrow`, `target`, `rel`, `badge`, `desc-lines`
+
+### `lht-file-select`
+
+- 用途: ファイル選択UI（ボタン + hidden file input + ファイル名表示）
+- 主な属性: `input-id`, `button-id`, `file-name-id`, `accept`, `button-label`, `placeholder`, `file-label`, `multiple`, `disabled`, `show-file-name`

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -7,13 +7,13 @@ lht-command-block {
   display: block;
 }
 
-lht-help-text-field {
+lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
 }
 
-lht-help-select {
+lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -27,7 +27,7 @@ class LhtHelpTooltip extends HTMLElement {
   }
 }
 
-class LhtHelpTextField extends HTMLElement {
+class LhtTextFieldHelp extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
@@ -92,7 +92,7 @@ class LhtHelpTextField extends HTMLElement {
   }
 }
 
-class LhtHelpSelect extends HTMLElement {
+class LhtSelectHelp extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
@@ -587,11 +587,11 @@ class LhtPageMenu extends HTMLElement {
 if (!customElements.get("lht-help-tooltip")) {
   customElements.define("lht-help-tooltip", LhtHelpTooltip);
 }
-if (!customElements.get("lht-help-text-field")) {
-  customElements.define("lht-help-text-field", LhtHelpTextField);
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
 }
-if (!customElements.get("lht-help-select")) {
-  customElements.define("lht-help-select", LhtHelpSelect);
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);


### PR DESCRIPTION
### 概要
`lht-cmn` のコンポーネント命名とドキュメント方針を整理し、リポジトリ全体の参照を新命名へ統一しました。 あわせて、`lht` 中心運用・Material Web利用方針・`md3/` 縮退方針をREADME/TODOへ明文化しています。

### 主な変更内容

1. コンポーネント命名変更（Breaking）
- `lht-help-text-field` → `lht-text-field-help`
- `lht-help-select` → `lht-select-help`
- 対象:
  - `lht-cmn/js/components.js`（クラス名 / `customElements.define`）
  - `lht-cmn/css/components.css`（タグセレクタ）

2. ドキュメント刷新（`lht-cmn/README.md`）
- 目的 / 基本方針 / メリット / 運用方針 を再構成
- 「Material Design 3 ベース + Material Web優先、ただし妥当な選択肢がない場合は `lht-cmn` で自前実装を追加」の方針を明記
- 画面側は原則 `lht-*` 利用、`md-*` 直接利用は `lht-cmn` 内部に限定する方針を明記
- コンポーネント一覧を表形式化（できること / 内部構造）
- `lht-select-help` の選択肢定義を JSON slot 方式に統一（`<option>` 後方互換運用終了を明示）
- LHTリファレンス節を追加

3. 全体参照更新
- `README.md`, `docs/git/README.md`, 各 `docs/*-src.html`, `docs/*.html`, `dist/docs/*` などを新タグ名へ更新

4. 方針の追記
- `TODO.md` に方針タスクを追加:
  - `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約

### 影響範囲
- 65 files changed / 586 insertions / 543 deletions
- 既存ページで旧タグ名を使用している場合は新タグ名への置換が必要です

### 移行メモ
- 置換:
  - `<lht-help-text-field ...>` → `<lht-text-field-help ...>`
  - `<lht-help-select ...>` → `<lht-select-help ...>`
- `lht-select-help` の選択肢は `<script type="application/json" slot="options">...</script>` 方式を使用