### PR TITLE
docs/music の `musicxml-to-midi` を LHT 化し、単一HTMLビルド破損対策と `lht-cmn` のライ…

### DIFF
--- a/docs/music/musicxml-to-midi-src.html
+++ b/docs/music/musicxml-to-midi-src.html
@@ -19,6 +19,7 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → MIDI 変換</title>
+    <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
     <link rel="stylesheet" href="src/musicxml-to-midi/css/app.css" />
 </head>
 <body>
@@ -110,18 +111,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -143,37 +141,51 @@ limitations under the License.
         <details class="md-disclosure">
           <summary class="md-disclosure-summary">詳細設定（既定タイトル / 既定作曲者 / 既定テンポ）</summary>
           <div class="md-grid md-grid--defaults">
-            <div>
-              <label class="md-label" for="defaultTitleInput">既定タイトル</label>
-              <input id="defaultTitleInput" class="md-input" type="text" value="Untitled" />
-            </div>
-            <div>
-              <label class="md-label" for="defaultComposerInput">既定作曲者</label>
-              <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
-            </div>
-            <div>
-              <label class="md-label" for="defaultTempoInput">既定テンポ (BPM)</label>
-              <input id="defaultTempoInput" class="md-input" type="number" min="20" max="300" step="1" value="120" />
-            </div>
+            <lht-text-field-help
+              field-id="defaultTitleInput"
+              label="既定タイトル"
+              value="Untitled">
+            </lht-text-field-help>
+            <lht-text-field-help
+              field-id="defaultComposerInput"
+              label="既定作曲者"
+              value="Unknown">
+            </lht-text-field-help>
+            <lht-text-field-help
+              field-id="defaultTempoInput"
+              label="既定テンポ (BPM)"
+              type="number"
+              min="20"
+              max="300"
+              step="1"
+              value="120">
+            </lht-text-field-help>
           </div>
         </details>
         <div class="md-grid">
-          <div>
-            <label class="md-label" for="instrumentOverrideSelect">音色上書き</label>
-            <select id="instrumentOverrideSelect" class="md-input">
-              <option value="">MusicXMLを使用</option>
-              <option value="fm_piano_1">FM Piano 1 (Electric Piano 1)</option>
-              <option value="fm_piano_2">FM Piano 2 (Electric Piano 2)</option>
-            </select>
-          </div>
-          <div>
-            <label class="md-label" for="synthWaveformSelect">内蔵シンセ波形</label>
-            <select id="synthWaveformSelect" class="md-input">
-              <option value="sine">sine (やわらかい音)</option>
-              <option value="square">square (明るく硬い音)</option>
-              <option value="triangle">triangle (中間の音)</option>
-            </select>
-          </div>
+          <lht-select-help
+            field-id="instrumentOverrideSelect"
+            label="音色上書き">
+            <script type="application/json" slot="options">
+              [
+                { "value": "", "label": "MusicXMLを使用", "selected": true },
+                { "value": "fm_piano_1", "label": "FM Piano 1 (Electric Piano 1)" },
+                { "value": "fm_piano_2", "label": "FM Piano 2 (Electric Piano 2)" }
+              ]
+            </script>
+          </lht-select-help>
+          <lht-select-help
+            field-id="synthWaveformSelect"
+            label="内蔵シンセ波形"
+            value="sine">
+            <script type="application/json" slot="options">
+              [
+                { "value": "sine", "label": "sine (やわらかい音)", "selected": true },
+                { "value": "square", "label": "square (明るく硬い音)" },
+                { "value": "triangle", "label": "triangle (中間の音)" }
+              ]
+            </script>
+          </lht-select-help>
         </div>
 
         <div class="md-actions">
@@ -232,6 +244,8 @@ limitations under the License.
 
   <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
 
+    <script src="../git/src/vendor/material-web-outlined-text-field.bundle.js"></script>
+    <script src="../../lht-cmn/js/components.js"></script>
     <script src="src/musicxml-to-midi/js/midi-writer.js"></script>
     <script src="src/common/js/musicxml-common.js"></script>
     <script src="src/common/js/music-synth-common.js"></script>

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -20,7 +20,279 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → MIDI 変換</title>
     
+    
   <style>
+/*
+ * lht-cmn components.css
+ * Version: v20260222
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-text-field-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+}
+
+lht-file-select {
+  display: block;
+}
+
+lht-file-select .lht-file-select {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+lht-file-select .lht-file-select__button {
+  --md-filled-button-container-color: var(--md-sys-color-primary, #6200ee);
+  --md-filled-button-label-text-color: #ffffff;
+  --md-filled-button-container-shape: 999px;
+  --md-filled-button-container-height: 54px;
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 24px;
+  --md-filled-button-icon-size: 20px;
+  --md-focus-ring-color: #6c3eea;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(98, 0, 238, 0.24);
+}
+
+lht-file-select .lht-file-select__button--fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.55rem;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--md-sys-color-primary, #6200ee);
+  cursor: pointer;
+}
+
+lht-file-select .lht-file-select__button-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  flex: 0 0 auto;
+}
+
+lht-file-select .lht-file-select__button-text {
+  white-space: nowrap;
+}
+
+lht-file-select .lht-file-select__file-name {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  word-break: break-all;
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
+lht-index-card-link {
+  display: block;
+}
+
+.lht-index-card-link__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.3rem;
+}
+
+.lht-index-card-link__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.45rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #534a64;
+  background: rgba(108, 62, 234, 0.13);
+}
+
+.lht-index-card-link__desc--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--lht-desc-lines, 3);
+  overflow: hidden;
+}
+
 :root {
       --md-danger: #b3261e;
       --md-sys-color-background: #f6f4f8;
@@ -486,18 +758,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -519,37 +788,51 @@ limitations under the License.
         <details class="md-disclosure">
           <summary class="md-disclosure-summary">詳細設定（既定タイトル / 既定作曲者 / 既定テンポ）</summary>
           <div class="md-grid md-grid--defaults">
-            <div>
-              <label class="md-label" for="defaultTitleInput">既定タイトル</label>
-              <input id="defaultTitleInput" class="md-input" type="text" value="Untitled" />
-            </div>
-            <div>
-              <label class="md-label" for="defaultComposerInput">既定作曲者</label>
-              <input id="defaultComposerInput" class="md-input" type="text" value="Unknown" />
-            </div>
-            <div>
-              <label class="md-label" for="defaultTempoInput">既定テンポ (BPM)</label>
-              <input id="defaultTempoInput" class="md-input" type="number" min="20" max="300" step="1" value="120" />
-            </div>
+            <lht-text-field-help
+              field-id="defaultTitleInput"
+              label="既定タイトル"
+              value="Untitled">
+            </lht-text-field-help>
+            <lht-text-field-help
+              field-id="defaultComposerInput"
+              label="既定作曲者"
+              value="Unknown">
+            </lht-text-field-help>
+            <lht-text-field-help
+              field-id="defaultTempoInput"
+              label="既定テンポ (BPM)"
+              type="number"
+              min="20"
+              max="300"
+              step="1"
+              value="120">
+            </lht-text-field-help>
           </div>
         </details>
         <div class="md-grid">
-          <div>
-            <label class="md-label" for="instrumentOverrideSelect">音色上書き</label>
-            <select id="instrumentOverrideSelect" class="md-input">
-              <option value="">MusicXMLを使用</option>
-              <option value="fm_piano_1">FM Piano 1 (Electric Piano 1)</option>
-              <option value="fm_piano_2">FM Piano 2 (Electric Piano 2)</option>
-            </select>
-          </div>
-          <div>
-            <label class="md-label" for="synthWaveformSelect">内蔵シンセ波形</label>
-            <select id="synthWaveformSelect" class="md-input">
-              <option value="sine">sine (やわらかい音)</option>
-              <option value="square">square (明るく硬い音)</option>
-              <option value="triangle">triangle (中間の音)</option>
-            </select>
-          </div>
+          <lht-select-help
+            field-id="instrumentOverrideSelect"
+            label="音色上書き">
+            <script type="application/json" slot="options">
+              [
+                { "value": "", "label": "MusicXMLを使用", "selected": true },
+                { "value": "fm_piano_1", "label": "FM Piano 1 (Electric Piano 1)" },
+                { "value": "fm_piano_2", "label": "FM Piano 2 (Electric Piano 2)" }
+              ]
+            </script>
+          </lht-select-help>
+          <lht-select-help
+            field-id="synthWaveformSelect"
+            label="内蔵シンセ波形"
+            value="sine">
+            <script type="application/json" slot="options">
+              [
+                { "value": "sine", "label": "sine (やわらかい音)", "selected": true },
+                { "value": "square", "label": "square (明るく硬い音)" },
+                { "value": "triangle", "label": "triangle (中間の音)" }
+              ]
+            </script>
+          </lht-select-help>
         </div>
 
         <div class="md-actions">
@@ -612,6 +895,1118 @@ limitations under the License.
     
     
     
+    
+    
+  <script>
+(()=>{function s(o,e,t,r){var i=arguments.length,n=i<3?e:r===null?r=Object.getOwnPropertyDescriptor(e,t):r,a;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")n=Reflect.decorate(o,e,t,r);else for(var d=o.length-1;d>=0;d--)(a=o[d])&&(n=(i<3?a(n):i>3?a(e,t,n):a(e,t))||n);return i>3&&n&&Object.defineProperty(e,t,n),n}var E=o=>(e,t)=>{t!==void 0?t.addInitializer(()=>{customElements.define(o,e)}):customElements.define(o,e)};var Qe=globalThis,et=Qe.ShadowRoot&&(Qe.ShadyCSS===void 0||Qe.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,Bt=Symbol(),$r=new WeakMap,Ne=class{constructor(e,t,r){if(this._$cssResult$=!0,r!==Bt)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o,t=this.t;if(et&&e===void 0){let r=t!==void 0&&t.length===1;r&&(e=$r.get(t)),e===void 0&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),r&&$r.set(t,e))}return e}toString(){return this.cssText}},Tr=o=>new Ne(typeof o=="string"?o:o+"",void 0,Bt),g=(o,...e)=>{let t=o.length===1?o[0]:e.reduce((r,i,n)=>r+(a=>{if(a._$cssResult$===!0)return a.cssText;if(typeof a=="number")return a;throw Error("Value passed to 'css' function must be a 'css' function result: "+a+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+o[n+1],o[0]);return new Ne(t,o,Bt)},Sr=(o,e)=>{if(et)o.adoptedStyleSheets=e.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(let t of e){let r=document.createElement("style"),i=Qe.litNonce;i!==void 0&&r.setAttribute("nonce",i),r.textContent=t.cssText,o.appendChild(r)}},Ft=et?o=>o:o=>o instanceof CSSStyleSheet?(e=>{let t="";for(let r of e.cssRules)t+=r.cssText;return Tr(t)})(o):o;var{is:Io,defineProperty:ko,getOwnPropertyDescriptor:Oo,getOwnPropertyNames:Ro,getOwnPropertySymbols:Po,getPrototypeOf:Lo}=Object,ce=globalThis,Ir=ce.trustedTypes,Do=Ir?Ir.emptyScript:"",zo=ce.reactiveElementPolyfillSupport,Be=(o,e)=>o,Fe={toAttribute(o,e){switch(e){case Boolean:o=o?Do:null;break;case Object:case Array:o=o==null?o:JSON.stringify(o)}return o},fromAttribute(o,e){let t=o;switch(e){case Boolean:t=o!==null;break;case Number:t=o===null?null:Number(o);break;case Object:case Array:try{t=JSON.parse(o)}catch{t=null}}return t}},tt=(o,e)=>!Io(o,e),kr={attribute:!0,type:String,converter:Fe,reflect:!1,useDefault:!1,hasChanged:tt};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),ce.litPropertyMetadata??(ce.litPropertyMetadata=new WeakMap);var re=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??(this.l=[])).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=kr){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){let r=Symbol(),i=this.getPropertyDescriptor(e,r,t);i!==void 0&&ko(this.prototype,e,i)}}static getPropertyDescriptor(e,t,r){let{get:i,set:n}=Oo(this.prototype,e)??{get(){return this[t]},set(a){this[t]=a}};return{get:i,set(a){let d=i?.call(this);n?.call(this,a),this.requestUpdate(e,d,r)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??kr}static _$Ei(){if(this.hasOwnProperty(Be("elementProperties")))return;let e=Lo(this);e.finalize(),e.l!==void 0&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(Be("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Be("properties"))){let t=this.properties,r=[...Ro(t),...Po(t)];for(let i of r)this.createProperty(i,t[i])}let e=this[Symbol.metadata];if(e!==null){let t=litPropertyMetadata.get(e);if(t!==void 0)for(let[r,i]of t)this.elementProperties.set(r,i)}this._$Eh=new Map;for(let[t,r]of this.elementProperties){let i=this._$Eu(t,r);i!==void 0&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){let t=[];if(Array.isArray(e)){let r=new Set(e.flat(1/0).reverse());for(let i of r)t.unshift(Ft(i))}else e!==void 0&&t.push(Ft(e));return t}static _$Eu(e,t){let r=t.attribute;return r===!1?void 0:typeof r=="string"?r:typeof e=="string"?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??(this._$EO=new Set)).add(e),this.renderRoot!==void 0&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){let e=new Map,t=this.constructor.elementProperties;for(let r of t.keys())this.hasOwnProperty(r)&&(e.set(r,this[r]),delete this[r]);e.size>0&&(this._$Ep=e)}createRenderRoot(){let e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return Sr(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,r){this._$AK(e,r)}_$ET(e,t){let r=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,r);if(i!==void 0&&r.reflect===!0){let n=(r.converter?.toAttribute!==void 0?r.converter:Fe).toAttribute(t,r.type);this._$Em=e,n==null?this.removeAttribute(i):this.setAttribute(i,n),this._$Em=null}}_$AK(e,t){let r=this.constructor,i=r._$Eh.get(e);if(i!==void 0&&this._$Em!==i){let n=r.getPropertyOptions(i),a=typeof n.converter=="function"?{fromAttribute:n.converter}:n.converter?.fromAttribute!==void 0?n.converter:Fe;this._$Em=i;let d=a.fromAttribute(t,n.type);this[i]=d??this._$Ej?.get(i)??d,this._$Em=null}}requestUpdate(e,t,r,i=!1,n){if(e!==void 0){let a=this.constructor;if(i===!1&&(n=this[e]),r??(r=a.getPropertyOptions(e)),!((r.hasChanged??tt)(n,t)||r.useDefault&&r.reflect&&n===this._$Ej?.get(e)&&!this.hasAttribute(a._$Eu(e,r))))return;this.C(e,t,r)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(e,t,{useDefault:r,reflect:i,wrapped:n},a){r&&!(this._$Ej??(this._$Ej=new Map)).has(e)&&(this._$Ej.set(e,a??t??this[e]),n!==!0||a!==void 0)||(this._$AL.has(e)||(this.hasUpdated||r||(t=void 0),this._$AL.set(e,t)),i===!0&&this._$Em!==e&&(this._$Eq??(this._$Eq=new Set)).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}let e=this.scheduleUpdate();return e!=null&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[i,n]of this._$Ep)this[i]=n;this._$Ep=void 0}let r=this.constructor.elementProperties;if(r.size>0)for(let[i,n]of r){let{wrapped:a}=n,d=this[i];a!==!0||this._$AL.has(i)||d===void 0||this.C(i,void 0,n,d)}}let e=!1,t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(r=>r.hostUpdate?.()),this.update(t)):this._$EM()}catch(r){throw e=!1,this._$EM(),r}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&(this._$Eq=this._$Eq.forEach(t=>this._$ET(t,this[t]))),this._$EM()}updated(e){}firstUpdated(e){}};re.elementStyles=[],re.shadowRootOptions={mode:"open"},re[Be("elementProperties")]=new Map,re[Be("finalized")]=new Map,zo?.({ReactiveElement:re}),(ce.reactiveElementVersions??(ce.reactiveElementVersions=[])).push("2.1.2");var Mo={attribute:!0,type:String,converter:Fe,reflect:!1,hasChanged:tt},No=(o=Mo,e,t)=>{let{kind:r,metadata:i}=t,n=globalThis.litPropertyMetadata.get(i);if(n===void 0&&globalThis.litPropertyMetadata.set(i,n=new Map),r==="setter"&&((o=Object.create(o)).wrapped=!0),n.set(t.name,o),r==="accessor"){let{name:a}=t;return{set(d){let c=e.get.call(this);e.set.call(this,d),this.requestUpdate(a,c,o,!0,d)},init(d){return d!==void 0&&this.C(a,void 0,o,d),d}}}if(r==="setter"){let{name:a}=t;return function(d){let c=this[a];e.call(this,d),this.requestUpdate(a,c,o,!0,d)}}throw Error("Unsupported decorator location: "+r)};function l(o){return(e,t)=>typeof t=="object"?No(o,e,t):((r,i,n)=>{let a=i.hasOwnProperty(n);return i.constructor.createProperty(n,r),a?Object.getOwnPropertyDescriptor(i,n):void 0})(o,e,t)}function k(o){return l({...o,state:!0,attribute:!1})}var Q=(o,e,t)=>(t.configurable=!0,t.enumerable=!0,Reflect.decorate&&typeof e!="object"&&Object.defineProperty(o,e,t),t);function S(o,e){return(t,r,i)=>{let n=a=>a.renderRoot?.querySelector(o)??null;if(e){let{get:a,set:d}=typeof r=="object"?t:i??(()=>{let c=Symbol();return{get(){return this[c]},set(h){this[c]=h}}})();return Q(t,r,{get(){let c=a.call(this);return c===void 0&&(c=n(this),(c!==null||this.hasUpdated)&&d.call(this,c)),c}})}return Q(t,r,{get(){return n(this)}})}}var Bo;function Or(o){return(e,t)=>Q(e,t,{get(){return(this.renderRoot??Bo??(Bo=document.createDocumentFragment())).querySelectorAll(o)}})}function N(o){return(e,t)=>{let{slot:r,selector:i}=o??{},n="slot"+(r?`[name=${r}]`:":not([name])");return Q(e,t,{get(){let a=this.renderRoot?.querySelector(n),d=a?.assignedElements(o)??[];return i===void 0?d:d.filter(c=>c.matches(i))}})}}function rt(o){return(e,t)=>{let{slot:r}=o??{},i="slot"+(r?`[name=${r}]`:":not([name])");return Q(e,t,{get(){return this.renderRoot?.querySelector(i)?.assignedNodes(o)??[]}})}}var qe=globalThis,Rr=o=>o,ot=qe.trustedTypes,Pr=ot?ot.createPolicy("lit-html",{createHTML:o=>o}):void 0,qt="$lit$",oe=`lit$${Math.random().toFixed(9).slice(2)}$`,Vt="?"+oe,Fo=`<${Vt}>`,_e=document,Ve=()=>_e.createComment(""),He=o=>o===null||typeof o!="object"&&typeof o!="function",Ht=Array.isArray,Br=o=>Ht(o)||typeof o?.[Symbol.iterator]=="function",Ut=`[ 	
+\f\r]`,Ue=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Lr=/-->/g,Dr=/>/g,ye=RegExp(`>|${Ut}(?:([^\\s"'>=/]+)(${Ut}*=${Ut}*(?:[^ 	
+\f\r"'\`<>=]|("|')|))|$)`,"g"),zr=/'/g,Mr=/"/g,Fr=/^(?:script|style|textarea|title)$/i,jt=o=>(e,...t)=>({_$litType$:o,strings:e,values:t}),u=jt(1),Ur=jt(2),qr=jt(3),U=Symbol.for("lit-noChange"),p=Symbol.for("lit-nothing"),Nr=new WeakMap,xe=_e.createTreeWalker(_e,129);function Vr(o,e){if(!Ht(o)||!o.hasOwnProperty("raw"))throw Error("invalid template strings array");return Pr!==void 0?Pr.createHTML(e):e}var Hr=(o,e)=>{let t=o.length-1,r=[],i,n=e===2?"<svg>":e===3?"<math>":"",a=Ue;for(let d=0;d<t;d++){let c=o[d],h,m,f=-1,x=0;for(;x<c.length&&(a.lastIndex=x,m=a.exec(c),m!==null);)x=a.lastIndex,a===Ue?m[1]==="!--"?a=Lr:m[1]!==void 0?a=Dr:m[2]!==void 0?(Fr.test(m[2])&&(i=RegExp("</"+m[2],"g")),a=ye):m[3]!==void 0&&(a=ye):a===ye?m[0]===">"?(a=i??Ue,f=-1):m[1]===void 0?f=-2:(f=a.lastIndex-m[2].length,h=m[1],a=m[3]===void 0?ye:m[3]==='"'?Mr:zr):a===Mr||a===zr?a=ye:a===Lr||a===Dr?a=Ue:(a=ye,i=void 0);let y=a===ye&&o[d+1].startsWith("/>")?" ":"";n+=a===Ue?c+Fo:f>=0?(r.push(h),c.slice(0,f)+qt+c.slice(f)+oe+y):c+oe+(f===-2?d:y)}return[Vr(o,n+(o[t]||"<?>")+(e===2?"</svg>":e===3?"</math>":"")),r]},je=class o{constructor({strings:e,_$litType$:t},r){let i;this.parts=[];let n=0,a=0,d=e.length-1,c=this.parts,[h,m]=Hr(e,t);if(this.el=o.createElement(h,r),xe.currentNode=this.el.content,t===2||t===3){let f=this.el.content.firstChild;f.replaceWith(...f.childNodes)}for(;(i=xe.nextNode())!==null&&c.length<d;){if(i.nodeType===1){if(i.hasAttributes())for(let f of i.getAttributeNames())if(f.endsWith(qt)){let x=m[a++],y=i.getAttribute(f).split(oe),I=/([.?@])?(.*)/.exec(x);c.push({type:1,index:n,name:I[2],strings:y,ctor:I[1]==="."?nt:I[1]==="?"?st:I[1]==="@"?at:Ee}),i.removeAttribute(f)}else f.startsWith(oe)&&(c.push({type:6,index:n}),i.removeAttribute(f));if(Fr.test(i.tagName)){let f=i.textContent.split(oe),x=f.length-1;if(x>0){i.textContent=ot?ot.emptyScript:"";for(let y=0;y<x;y++)i.append(f[y],Ve()),xe.nextNode(),c.push({type:2,index:++n});i.append(f[x],Ve())}}}else if(i.nodeType===8)if(i.data===Vt)c.push({type:2,index:n});else{let f=-1;for(;(f=i.data.indexOf(oe,f+1))!==-1;)c.push({type:7,index:n}),f+=oe.length-1}n++}}static createElement(e,t){let r=_e.createElement("template");return r.innerHTML=e,r}};function we(o,e,t=o,r){if(e===U)return e;let i=r!==void 0?t._$Co?.[r]:t._$Cl,n=He(e)?void 0:e._$litDirective$;return i?.constructor!==n&&(i?._$AO?.(!1),n===void 0?i=void 0:(i=new n(o),i._$AT(o,t,r)),r!==void 0?(t._$Co??(t._$Co=[]))[r]=i:t._$Cl=i),i!==void 0&&(e=we(o,i._$AS(o,e.values),i,r)),e}var it=class{constructor(e,t){this._$AV=[],this._$AN=void 0,this._$AD=e,this._$AM=t}get parentNode(){return this._$AM.parentNode}get _$AU(){return this._$AM._$AU}u(e){let{el:{content:t},parts:r}=this._$AD,i=(e?.creationScope??_e).importNode(t,!0);xe.currentNode=i;let n=xe.nextNode(),a=0,d=0,c=r[0];for(;c!==void 0;){if(a===c.index){let h;c.type===2?h=new Te(n,n.nextSibling,this,e):c.type===1?h=new c.ctor(n,c.name,c.strings,this,e):c.type===6&&(h=new lt(n,this,e)),this._$AV.push(h),c=r[++d]}a!==c?.index&&(n=xe.nextNode(),a++)}return xe.currentNode=_e,i}p(e){let t=0;for(let r of this._$AV)r!==void 0&&(r.strings!==void 0?(r._$AI(e,r,t),t+=r.strings.length-2):r._$AI(e[t])),t++}},Te=class o{get _$AU(){return this._$AM?._$AU??this._$Cv}constructor(e,t,r,i){this.type=2,this._$AH=p,this._$AN=void 0,this._$AA=e,this._$AB=t,this._$AM=r,this.options=i,this._$Cv=i?.isConnected??!0}get parentNode(){let e=this._$AA.parentNode,t=this._$AM;return t!==void 0&&e?.nodeType===11&&(e=t.parentNode),e}get startNode(){return this._$AA}get endNode(){return this._$AB}_$AI(e,t=this){e=we(this,e,t),He(e)?e===p||e==null||e===""?(this._$AH!==p&&this._$AR(),this._$AH=p):e!==this._$AH&&e!==U&&this._(e):e._$litType$!==void 0?this.$(e):e.nodeType!==void 0?this.T(e):Br(e)?this.k(e):this._(e)}O(e){return this._$AA.parentNode.insertBefore(e,this._$AB)}T(e){this._$AH!==e&&(this._$AR(),this._$AH=this.O(e))}_(e){this._$AH!==p&&He(this._$AH)?this._$AA.nextSibling.data=e:this.T(_e.createTextNode(e)),this._$AH=e}$(e){let{values:t,_$litType$:r}=e,i=typeof r=="number"?this._$AC(e):(r.el===void 0&&(r.el=je.createElement(Vr(r.h,r.h[0]),this.options)),r);if(this._$AH?._$AD===i)this._$AH.p(t);else{let n=new it(i,this),a=n.u(this.options);n.p(t),this.T(a),this._$AH=n}}_$AC(e){let t=Nr.get(e.strings);return t===void 0&&Nr.set(e.strings,t=new je(e)),t}k(e){Ht(this._$AH)||(this._$AH=[],this._$AR());let t=this._$AH,r,i=0;for(let n of e)i===t.length?t.push(r=new o(this.O(Ve()),this.O(Ve()),this,this.options)):r=t[i],r._$AI(n),i++;i<t.length&&(this._$AR(r&&r._$AB.nextSibling,i),t.length=i)}_$AR(e=this._$AA.nextSibling,t){for(this._$AP?.(!1,!0,t);e!==this._$AB;){let r=Rr(e).nextSibling;Rr(e).remove(),e=r}}setConnected(e){this._$AM===void 0&&(this._$Cv=e,this._$AP?.(e))}},Ee=class{get tagName(){return this.element.tagName}get _$AU(){return this._$AM._$AU}constructor(e,t,r,i,n){this.type=1,this._$AH=p,this._$AN=void 0,this.element=e,this.name=t,this._$AM=i,this.options=n,r.length>2||r[0]!==""||r[1]!==""?(this._$AH=Array(r.length-1).fill(new String),this.strings=r):this._$AH=p}_$AI(e,t=this,r,i){let n=this.strings,a=!1;if(n===void 0)e=we(this,e,t,0),a=!He(e)||e!==this._$AH&&e!==U,a&&(this._$AH=e);else{let d=e,c,h;for(e=n[0],c=0;c<n.length-1;c++)h=we(this,d[r+c],t,c),h===U&&(h=this._$AH[c]),a||(a=!He(h)||h!==this._$AH[c]),h===p?e=p:e!==p&&(e+=(h??"")+n[c+1]),this._$AH[c]=h}a&&!i&&this.j(e)}j(e){e===p?this.element.removeAttribute(this.name):this.element.setAttribute(this.name,e??"")}},nt=class extends Ee{constructor(){super(...arguments),this.type=3}j(e){this.element[this.name]=e===p?void 0:e}},st=class extends Ee{constructor(){super(...arguments),this.type=4}j(e){this.element.toggleAttribute(this.name,!!e&&e!==p)}},at=class extends Ee{constructor(e,t,r,i,n){super(e,t,r,i,n),this.type=5}_$AI(e,t=this){if((e=we(this,e,t,0)??p)===U)return;let r=this._$AH,i=e===p&&r!==p||e.capture!==r.capture||e.once!==r.once||e.passive!==r.passive,n=e!==p&&(r===p||i);i&&this.element.removeEventListener(this.name,this,r),n&&this.element.addEventListener(this.name,this,e),this._$AH=e}handleEvent(e){typeof this._$AH=="function"?this._$AH.call(this.options?.host??this.element,e):this._$AH.handleEvent(e)}},lt=class{constructor(e,t,r){this.element=e,this.type=6,this._$AN=void 0,this._$AM=t,this.options=r}get _$AU(){return this._$AM._$AU}_$AI(e){we(this,e)}},jr={M:qt,P:oe,A:Vt,C:1,L:Hr,R:it,D:Br,V:we,I:Te,H:Ee,N:st,U:at,B:nt,F:lt},Uo=qe.litHtmlPolyfillSupport;Uo?.(je,Te),(qe.litHtmlVersions??(qe.litHtmlVersions=[])).push("3.3.2");var Se=(o,e,t)=>{let r=t?.renderBefore??e,i=r._$litPart$;if(i===void 0){let n=t?.renderBefore??null;r._$litPart$=i=new Te(e.insertBefore(Ve(),n),n,void 0,t??{})}return i._$AI(o),i};var We=globalThis,b=class extends re{constructor(){super(...arguments),this.renderOptions={host:this},this._$Do=void 0}createRenderRoot(){var t;let e=super.createRenderRoot();return(t=this.renderOptions).renderBefore??(t.renderBefore=e.firstChild),e}update(e){let t=this.render();this.hasUpdated||(this.renderOptions.isConnected=this.isConnected),super.update(e),this._$Do=Se(t,this.renderRoot,this.renderOptions)}connectedCallback(){super.connectedCallback(),this._$Do?.setConnected(!0)}disconnectedCallback(){super.disconnectedCallback(),this._$Do?.setConnected(!1)}render(){return U}};b._$litElement$=!0,b.finalized=!0,We.litElementHydrateSupport?.({LitElement:b});var qo=We.litElementPolyfillSupport;qo?.({LitElement:b});(We.litElementVersions??(We.litElementVersions=[])).push("4.2.2");var X={ATTRIBUTE:1,CHILD:2,PROPERTY:3,BOOLEAN_ATTRIBUTE:4,EVENT:5,ELEMENT:6},Ie=o=>(...e)=>({_$litDirective$:o,values:e}),pe=class{constructor(e){}get _$AU(){return this._$AM._$AU}_$AT(e,t,r){this._$Ct=e,this._$AM=t,this._$Ci=r}_$AS(e,t){return this.update(e,t)}update(e,t){return this.render(...t)}};var R=Ie(class extends pe{constructor(o){if(super(o),o.type!==X.ATTRIBUTE||o.name!=="class"||o.strings?.length>2)throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.")}render(o){return" "+Object.keys(o).filter(e=>o[e]).join(" ")+" "}update(o,[e]){if(this.st===void 0){this.st=new Set,o.strings!==void 0&&(this.nt=new Set(o.strings.join(" ").split(/\s/).filter(r=>r!=="")));for(let r in e)e[r]&&!this.nt?.has(r)&&this.st.add(r);return this.render(e)}let t=o.element.classList;for(let r of this.st)r in e||(t.remove(r),this.st.delete(r));for(let r in e){let i=!!e[r];i===this.st.has(r)||this.nt?.has(r)||(i?(t.add(r),this.st.add(r)):(t.remove(r),this.st.delete(r)))}return U}});var ie={STANDARD:"cubic-bezier(0.2, 0, 0, 1)",STANDARD_ACCELERATE:"cubic-bezier(.3,0,1,1)",STANDARD_DECELERATE:"cubic-bezier(0,0,0,1)",EMPHASIZED:"cubic-bezier(.3,0,0,1)",EMPHASIZED_ACCELERATE:"cubic-bezier(.3,0,.8,.15)",EMPHASIZED_DECELERATE:"cubic-bezier(.05,.7,.1,1)"};function Wr(){let o=null;return{start(){return o?.abort(),o=new AbortController,o.signal},finish(){o=null}}}var $=class extends b{constructor(){super(...arguments),this.disabled=!1,this.error=!1,this.focused=!1,this.label="",this.noAsterisk=!1,this.populated=!1,this.required=!1,this.resizable=!1,this.supportingText="",this.errorText="",this.count=-1,this.max=-1,this.hasStart=!1,this.hasEnd=!1,this.isAnimating=!1,this.refreshErrorAlert=!1,this.disableTransitions=!1}get counterText(){let e=this.count??-1,t=this.max??-1;return e<0||t<=0?"":`${e} / ${t}`}get supportingOrErrorText(){return this.error&&this.errorText?this.errorText:this.supportingText}reannounceError(){this.refreshErrorAlert=!0}update(e){e.has("disabled")&&e.get("disabled")!==void 0&&(this.disableTransitions=!0),this.disabled&&this.focused&&(e.set("focused",!0),this.focused=!1),this.animateLabelIfNeeded({wasFocused:e.get("focused"),wasPopulated:e.get("populated")}),super.update(e)}render(){let e=this.renderLabel(!0),t=this.renderLabel(!1),r=this.renderOutline?.(e),i={disabled:this.disabled,"disable-transitions":this.disableTransitions,error:this.error&&!this.disabled,focused:this.focused,"with-start":this.hasStart,"with-end":this.hasEnd,populated:this.populated,resizable:this.resizable,required:this.required,"no-label":!this.label};return u`
+      <div class="field ${R(i)}">
+        <div class="container-overflow">
+          ${this.renderBackground?.()}
+          <slot name="container"></slot>
+          ${this.renderStateLayer?.()} ${this.renderIndicator?.()} ${r}
+          <div class="container">
+            <div class="start">
+              <slot name="start"></slot>
+            </div>
+            <div class="middle">
+              <div class="label-wrapper">
+                ${t} ${r?p:e}
+              </div>
+              <div class="content">
+                <slot></slot>
+              </div>
+            </div>
+            <div class="end">
+              <slot name="end"></slot>
+            </div>
+          </div>
+        </div>
+        ${this.renderSupportingText()}
+      </div>
+    `}updated(e){(e.has("supportingText")||e.has("errorText")||e.has("count")||e.has("max"))&&this.updateSlottedAriaDescribedBy(),this.refreshErrorAlert&&requestAnimationFrame(()=>{this.refreshErrorAlert=!1}),this.disableTransitions&&requestAnimationFrame(()=>{this.disableTransitions=!1})}renderSupportingText(){let{supportingOrErrorText:e,counterText:t}=this;if(!e&&!t)return p;let r=u`<span>${e}</span>`,i=t?u`<span class="counter">${t}</span>`:p,a=this.error&&this.errorText&&!this.refreshErrorAlert?"alert":p;return u`
+      <div class="supporting-text" role=${a}>${r}${i}</div>
+      <slot
+        name="aria-describedby"
+        @slotchange=${this.updateSlottedAriaDescribedBy}></slot>
+    `}updateSlottedAriaDescribedBy(){for(let e of this.slottedAriaDescribedBy)Se(u`${this.supportingOrErrorText} ${this.counterText}`,e),e.setAttribute("hidden","")}renderLabel(e){if(!this.label)return p;let t;e?t=this.focused||this.populated||this.isAnimating:t=!this.focused&&!this.populated&&!this.isAnimating;let r={hidden:!t,floating:e,resting:!e},i=`${this.label}${this.required&&!this.noAsterisk?"*":""}`;return u`
+      <span class="label ${R(r)}" aria-hidden=${!t}
+        >${i}</span
+      >
+    `}animateLabelIfNeeded({wasFocused:e,wasPopulated:t}){if(!this.label)return;e??(e=this.focused),t??(t=this.populated);let r=e||t,i=this.focused||this.populated;r!==i&&(this.isAnimating=!0,this.labelAnimation?.cancel(),this.labelAnimation=this.floatingLabelEl?.animate(this.getLabelKeyframes(),{duration:150,easing:ie.STANDARD}),this.labelAnimation?.addEventListener("finish",()=>{this.isAnimating=!1}))}getLabelKeyframes(){let{floatingLabelEl:e,restingLabelEl:t}=this;if(!e||!t)return[];let{x:r,y:i,height:n}=e.getBoundingClientRect(),{x:a,y:d,height:c}=t.getBoundingClientRect(),h=e.scrollWidth,m=t.scrollWidth,f=m/h,x=a-r,y=d-i+Math.round((c-n*f)/2),I=`translateX(${x}px) translateY(${y}px) scale(${f})`,w="translateX(0) translateY(0) scale(1)",O=t.clientWidth,C=m>O?`${O/f}px`:"";return this.focused||this.populated?[{transform:I,width:C},{transform:w,width:C}]:[{transform:w,width:C},{transform:I,width:C}]}getSurfacePositionClientRect(){return this.containerEl.getBoundingClientRect()}};s([l({type:Boolean})],$.prototype,"disabled",void 0);s([l({type:Boolean})],$.prototype,"error",void 0);s([l({type:Boolean})],$.prototype,"focused",void 0);s([l()],$.prototype,"label",void 0);s([l({type:Boolean,attribute:"no-asterisk"})],$.prototype,"noAsterisk",void 0);s([l({type:Boolean})],$.prototype,"populated",void 0);s([l({type:Boolean})],$.prototype,"required",void 0);s([l({type:Boolean})],$.prototype,"resizable",void 0);s([l({attribute:"supporting-text"})],$.prototype,"supportingText",void 0);s([l({attribute:"error-text"})],$.prototype,"errorText",void 0);s([l({type:Number})],$.prototype,"count",void 0);s([l({type:Number})],$.prototype,"max",void 0);s([l({type:Boolean,attribute:"has-start"})],$.prototype,"hasStart",void 0);s([l({type:Boolean,attribute:"has-end"})],$.prototype,"hasEnd",void 0);s([N({slot:"aria-describedby"})],$.prototype,"slottedAriaDescribedBy",void 0);s([k()],$.prototype,"isAnimating",void 0);s([k()],$.prototype,"refreshErrorAlert",void 0);s([k()],$.prototype,"disableTransitions",void 0);s([S(".label.floating")],$.prototype,"floatingLabelEl",void 0);s([S(".label.resting")],$.prototype,"restingLabelEl",void 0);s([S(".container")],$.prototype,"containerEl",void 0);var dt=class extends ${renderOutline(e){return u`
+      <div class="outline">
+        <div class="outline-start"></div>
+        <div class="outline-notch">
+          <div class="outline-panel-inactive"></div>
+          <div class="outline-panel-active"></div>
+          <div class="outline-label">${e}</div>
+        </div>
+        <div class="outline-end"></div>
+      </div>
+    `}};var Kr=g`@layer styles{:host{--_bottom-space: var(--md-outlined-field-bottom-space, 16px);--_content-color: var(--md-outlined-field-content-color, var(--md-sys-color-on-surface, #1d1b20));--_content-font: var(--md-outlined-field-content-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_content-line-height: var(--md-outlined-field-content-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_content-size: var(--md-outlined-field-content-size, var(--md-sys-typescale-body-large-size, 1rem));--_content-space: var(--md-outlined-field-content-space, 16px);--_content-weight: var(--md-outlined-field-content-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_disabled-content-color: var(--md-outlined-field-disabled-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-content-opacity: var(--md-outlined-field-disabled-content-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-field-disabled-label-text-opacity, 0.38);--_disabled-leading-content-color: var(--md-outlined-field-disabled-leading-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-content-opacity: var(--md-outlined-field-disabled-leading-content-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-content-color: var(--md-outlined-field-disabled-trailing-content-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-content-opacity: var(--md-outlined-field-disabled-trailing-content-opacity, 0.38);--_error-content-color: var(--md-outlined-field-error-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-content-color: var(--md-outlined-field-error-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-content-color: var(--md-outlined-field-error-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-content-color: var(--md-outlined-field-error-focus-trailing-content-color, var(--md-sys-color-error, #b3261e));--_error-hover-content-color: var(--md-outlined-field-error-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-content-color: var(--md-outlined-field-error-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-content-color: var(--md-outlined-field-error-hover-trailing-content-color, var(--md-sys-color-on-error-container, #410e0b));--_error-label-text-color: var(--md-outlined-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-content-color: var(--md-outlined-field-error-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-content-color: var(--md-outlined-field-error-trailing-content-color, var(--md-sys-color-error, #b3261e));--_focus-content-color: var(--md-outlined-field-focus-content-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-content-color: var(--md-outlined-field-focus-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-content-color: var(--md-outlined-field-focus-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-content-color: var(--md-outlined-field-hover-content-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-content-color: var(--md-outlined-field-hover-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-content-color: var(--md-outlined-field-hover-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-color: var(--md-outlined-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-padding-bottom: var(--md-outlined-field-label-text-padding-bottom, 8px);--_label-text-populated-line-height: var(--md-outlined-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-content-color: var(--md-outlined-field-leading-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-space: var(--md-outlined-field-leading-space, 16px);--_outline-color: var(--md-outlined-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-label-padding: var(--md-outlined-field-outline-label-padding, 4px);--_outline-width: var(--md-outlined-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-leading-space: var(--md-outlined-field-supporting-text-leading-space, 16px);--_supporting-text-line-height: var(--md-outlined-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-top-space: var(--md-outlined-field-supporting-text-top-space, 4px);--_supporting-text-trailing-space: var(--md-outlined-field-supporting-text-trailing-space, 16px);--_supporting-text-weight: var(--md-outlined-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_top-space: var(--md-outlined-field-top-space, 16px);--_trailing-content-color: var(--md-outlined-field-trailing-content-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-space: var(--md-outlined-field-trailing-space, 16px);--_with-leading-content-leading-space: var(--md-outlined-field-with-leading-content-leading-space, 12px);--_with-trailing-content-trailing-space: var(--md-outlined-field-with-trailing-content-trailing-space, 12px);--_container-shape-start-start: var(--md-outlined-field-container-shape-start-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-field-container-shape-start-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-field-container-shape-end-end, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-field-container-shape-end-start, var(--md-outlined-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)))}.outline{border-color:var(--_outline-color);border-radius:inherit;display:flex;pointer-events:none;height:100%;position:absolute;width:100%;z-index:1}.outline-start::before,.outline-start::after,.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after,.outline-end::before,.outline-end::after{border:inherit;content:"";inset:0;position:absolute}.outline-start,.outline-end{border:inherit;border-radius:inherit;box-sizing:border-box;position:relative}.outline-start::before,.outline-start::after,.outline-end::before,.outline-end::after{border-bottom-style:solid;border-top-style:solid}.outline-start::after,.outline-end::after{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-start::after,.focused .outline-end::after{opacity:1}.outline-start::before,.outline-start::after{border-inline-start-style:solid;border-inline-end-style:none;border-start-start-radius:inherit;border-start-end-radius:0;border-end-start-radius:inherit;border-end-end-radius:0;margin-inline-end:var(--_outline-label-padding)}.outline-end{flex-grow:1;margin-inline-start:calc(-1*var(--_outline-label-padding))}.outline-end::before,.outline-end::after{border-inline-start-style:none;border-inline-end-style:solid;border-start-start-radius:0;border-start-end-radius:inherit;border-end-start-radius:0;border-end-end-radius:inherit}.outline-notch{align-items:flex-start;border:inherit;display:flex;margin-inline-start:calc(-1*var(--_outline-label-padding));margin-inline-end:var(--_outline-label-padding);max-width:calc(100% - var(--_leading-space) - var(--_trailing-space));padding:0 var(--_outline-label-padding);position:relative}.no-label .outline-notch{display:none}.outline-panel-inactive,.outline-panel-active{border:inherit;border-bottom-style:solid;inset:0;position:absolute}.outline-panel-inactive::before,.outline-panel-inactive::after,.outline-panel-active::before,.outline-panel-active::after{border-top-style:solid;border-bottom:none;bottom:auto;transform:scaleX(1);transition:transform 150ms cubic-bezier(0.2, 0, 0, 1)}.outline-panel-inactive::before,.outline-panel-active::before{right:50%;transform-origin:top left}.outline-panel-inactive::after,.outline-panel-active::after{left:50%;transform-origin:top right}.populated .outline-panel-inactive::before,.populated .outline-panel-inactive::after,.populated .outline-panel-active::before,.populated .outline-panel-active::after,.focused .outline-panel-inactive::before,.focused .outline-panel-inactive::after,.focused .outline-panel-active::before,.focused .outline-panel-active::after{transform:scaleX(0)}.outline-panel-active{opacity:0;transition:opacity 150ms cubic-bezier(0.2, 0, 0, 1)}.focused .outline-panel-active{opacity:1}.outline-label{display:flex;max-width:100%;transform:translateY(calc(-100% + var(--_label-text-padding-bottom)))}.outline-start,.field:not(.with-start) .content ::slotted(*){padding-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-start) .label-wrapper{margin-inline-start:max(var(--_leading-space),max(var(--_container-shape-start-start),var(--_container-shape-end-start)) + var(--_outline-label-padding))}.field:not(.with-end) .content ::slotted(*){padding-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.field:not(.with-end) .label-wrapper{margin-inline-end:max(var(--_trailing-space),max(var(--_container-shape-start-end),var(--_container-shape-end-end)))}.outline-start::before,.outline-end::before,.outline-panel-inactive,.outline-panel-inactive::before,.outline-panel-inactive::after{border-width:var(--_outline-width)}:hover .outline{border-color:var(--_hover-outline-color);color:var(--_hover-outline-color)}:hover .outline-start::before,:hover .outline-end::before,:hover .outline-panel-inactive,:hover .outline-panel-inactive::before,:hover .outline-panel-inactive::after{border-width:var(--_hover-outline-width)}.focused .outline{border-color:var(--_focus-outline-color);color:var(--_focus-outline-color)}.outline-start::after,.outline-end::after,.outline-panel-active,.outline-panel-active::before,.outline-panel-active::after{border-width:var(--_focus-outline-width)}.disabled .outline{border-color:var(--_disabled-outline-color);color:var(--_disabled-outline-color)}.disabled .outline-start,.disabled .outline-end,.disabled .outline-panel-inactive{opacity:var(--_disabled-outline-opacity)}.disabled .outline-start::before,.disabled .outline-end::before,.disabled .outline-panel-inactive,.disabled .outline-panel-inactive::before,.disabled .outline-panel-inactive::after{border-width:var(--_disabled-outline-width)}.error .outline{border-color:var(--_error-outline-color);color:var(--_error-outline-color)}.error:hover .outline{border-color:var(--_error-hover-outline-color);color:var(--_error-hover-outline-color)}.error.focused .outline{border-color:var(--_error-focus-outline-color);color:var(--_error-focus-outline-color)}.resizable .container{bottom:var(--_focus-outline-width);inset-inline-end:var(--_focus-outline-width);clip-path:inset(var(--_focus-outline-width) 0 0 var(--_focus-outline-width))}.resizable .container>*{top:var(--_focus-outline-width);inset-inline-start:var(--_focus-outline-width)}.resizable .container:dir(rtl){clip-path:inset(var(--_focus-outline-width) var(--_focus-outline-width) 0 0)}}@layer hcm{@media(forced-colors: active){.disabled .outline{border-color:GrayText;color:GrayText}.disabled :is(.outline-start,.outline-end,.outline-panel-inactive){opacity:1}}}
+`;var Gr=g`:host{display:inline-flex;resize:both}.field{display:flex;flex:1;flex-direction:column;writing-mode:horizontal-tb;max-width:100%}.container-overflow{border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-end-radius:var(--_container-shape-end-end);border-end-start-radius:var(--_container-shape-end-start);display:flex;height:100%;position:relative}.container{align-items:center;border-radius:inherit;display:flex;flex:1;max-height:100%;min-height:100%;min-width:min-content;position:relative}.field,.container-overflow{resize:inherit}.resizable:not(.disabled) .container{resize:inherit;overflow:hidden}.disabled{pointer-events:none}slot[name=container]{border-radius:inherit}slot[name=container]::slotted(*){border-radius:inherit;inset:0;pointer-events:none;position:absolute}@layer styles{.start,.middle,.end{display:flex;box-sizing:border-box;height:100%;position:relative}.start{color:var(--_leading-content-color)}.end{color:var(--_trailing-content-color)}.start,.end{align-items:center;justify-content:center}.with-start .start{margin-inline:var(--_with-leading-content-leading-space) var(--_content-space)}.with-end .end{margin-inline:var(--_content-space) var(--_with-trailing-content-trailing-space)}.middle{align-items:stretch;align-self:baseline;flex:1}.content{color:var(--_content-color);display:flex;flex:1;opacity:0;transition:opacity 83ms cubic-bezier(0.2, 0, 0, 1)}.no-label .content,.focused .content,.populated .content{opacity:1;transition-delay:67ms}:is(.disabled,.disable-transitions) .content{transition:none}.content ::slotted(*){all:unset;color:currentColor;font-family:var(--_content-font);font-size:var(--_content-size);line-height:var(--_content-line-height);font-weight:var(--_content-weight);width:100%;overflow-wrap:revert;white-space:revert}.content ::slotted(:not(textarea)){padding-top:var(--_top-space);padding-bottom:var(--_bottom-space)}.content ::slotted(textarea){margin-top:var(--_top-space);margin-bottom:var(--_bottom-space)}:hover .content{color:var(--_hover-content-color)}:hover .start{color:var(--_hover-leading-content-color)}:hover .end{color:var(--_hover-trailing-content-color)}.focused .content{color:var(--_focus-content-color)}.focused .start{color:var(--_focus-leading-content-color)}.focused .end{color:var(--_focus-trailing-content-color)}.disabled .content{color:var(--_disabled-content-color)}.disabled.no-label .content,.disabled.focused .content,.disabled.populated .content{opacity:var(--_disabled-content-opacity)}.disabled .start{color:var(--_disabled-leading-content-color);opacity:var(--_disabled-leading-content-opacity)}.disabled .end{color:var(--_disabled-trailing-content-color);opacity:var(--_disabled-trailing-content-opacity)}.error .content{color:var(--_error-content-color)}.error .start{color:var(--_error-leading-content-color)}.error .end{color:var(--_error-trailing-content-color)}.error:hover .content{color:var(--_error-hover-content-color)}.error:hover .start{color:var(--_error-hover-leading-content-color)}.error:hover .end{color:var(--_error-hover-trailing-content-color)}.error.focused .content{color:var(--_error-focus-content-color)}.error.focused .start{color:var(--_error-focus-leading-content-color)}.error.focused .end{color:var(--_error-focus-trailing-content-color)}}@layer hcm{@media(forced-colors: active){.disabled :is(.start,.content,.end){color:GrayText;opacity:1}}}@layer styles{.label{box-sizing:border-box;color:var(--_label-text-color);overflow:hidden;max-width:100%;text-overflow:ellipsis;white-space:nowrap;z-index:1;font-family:var(--_label-text-font);font-size:var(--_label-text-size);line-height:var(--_label-text-line-height);font-weight:var(--_label-text-weight);width:min-content}.label-wrapper{inset:0;pointer-events:none;position:absolute}.label.resting{position:absolute;top:var(--_top-space)}.label.floating{font-size:var(--_label-text-populated-size);line-height:var(--_label-text-populated-line-height);transform-origin:top left}.label.hidden{opacity:0}.no-label .label{display:none}.label-wrapper{inset:0;position:absolute;text-align:initial}:hover .label{color:var(--_hover-label-text-color)}.focused .label{color:var(--_focus-label-text-color)}.disabled .label{color:var(--_disabled-label-text-color)}.disabled .label:not(.hidden){opacity:var(--_disabled-label-text-opacity)}.error .label{color:var(--_error-label-text-color)}.error:hover .label{color:var(--_error-hover-label-text-color)}.error.focused .label{color:var(--_error-focus-label-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .label:not(.hidden){color:GrayText;opacity:1}}}@layer styles{.supporting-text{color:var(--_supporting-text-color);display:flex;font-family:var(--_supporting-text-font);font-size:var(--_supporting-text-size);line-height:var(--_supporting-text-line-height);font-weight:var(--_supporting-text-weight);gap:16px;justify-content:space-between;padding-inline-start:var(--_supporting-text-leading-space);padding-inline-end:var(--_supporting-text-trailing-space);padding-top:var(--_supporting-text-top-space)}.supporting-text :nth-child(2){flex-shrink:0}:hover .supporting-text{color:var(--_hover-supporting-text-color)}.focus .supporting-text{color:var(--_focus-supporting-text-color)}.disabled .supporting-text{color:var(--_disabled-supporting-text-color);opacity:var(--_disabled-supporting-text-opacity)}.error .supporting-text{color:var(--_error-supporting-text-color)}.error:hover .supporting-text{color:var(--_error-hover-supporting-text-color)}.error.focus .supporting-text{color:var(--_error-focus-supporting-text-color)}}@layer hcm{@media(forced-colors: active){.disabled .supporting-text{color:GrayText;opacity:1}}}
+`;var Wt=class extends dt{};Wt.styles=[Gr,Kr];Wt=s([E("md-outlined-field")],Wt);var Xr=Symbol.for(""),Vo=o=>{if(o?.r===Xr)return o?._$litStatic$};var G=(o,...e)=>({_$litStatic$:e.reduce((t,r,i)=>t+(n=>{if(n._$litStatic$!==void 0)return n._$litStatic$;throw Error(`Value passed to 'literal' function must be a 'literal' result: ${n}. Use 'unsafeStatic' to pass non-literal values, but
+            take care to ensure page security.`)})(r)+o[i+1],o[0]),r:Xr}),Yr=new Map,Kt=o=>(e,...t)=>{let r=t.length,i,n,a=[],d=[],c,h=0,m=!1;for(;h<r;){for(c=e[h];h<r&&(n=t[h],(i=Vo(n))!==void 0);)c+=i+e[++h],m=!0;h!==r&&d.push(n),a.push(c),h++}if(h===r&&a.push(e[r]),m){let f=a.join("$$lit$$");(e=Yr.get(f))===void 0&&(a.raw=a,Yr.set(f,e=a)),t=d}return o(e,...t)},ue=Kt(u),Wn=Kt(Ur),Kn=Kt(qr);var Zr=g`:host{--_caret-color: var(--md-outlined-text-field-caret-color, var(--md-sys-color-primary, #6750a4));--_disabled-input-text-color: var(--md-outlined-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-input-text-opacity: var(--md-outlined-text-field-disabled-input-text-opacity, 0.38);--_disabled-label-text-color: var(--md-outlined-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-outlined-text-field-disabled-label-text-opacity, 0.38);--_disabled-leading-icon-color: var(--md-outlined-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-leading-icon-opacity: var(--md-outlined-text-field-disabled-leading-icon-opacity, 0.38);--_disabled-outline-color: var(--md-outlined-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-outline-opacity: var(--md-outlined-text-field-disabled-outline-opacity, 0.12);--_disabled-outline-width: var(--md-outlined-text-field-disabled-outline-width, 1px);--_disabled-supporting-text-color: var(--md-outlined-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-supporting-text-opacity: var(--md-outlined-text-field-disabled-supporting-text-opacity, 0.38);--_disabled-trailing-icon-color: var(--md-outlined-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-trailing-icon-opacity: var(--md-outlined-text-field-disabled-trailing-icon-opacity, 0.38);--_error-focus-caret-color: var(--md-outlined-text-field-error-focus-caret-color, var(--md-sys-color-error, #b3261e));--_error-focus-input-text-color: var(--md-outlined-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-focus-label-text-color: var(--md-outlined-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-leading-icon-color: var(--md-outlined-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-focus-outline-color: var(--md-outlined-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_error-focus-supporting-text-color: var(--md-outlined-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-focus-trailing-icon-color: var(--md-outlined-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_error-hover-input-text-color: var(--md-outlined-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-hover-label-text-color: var(--md-outlined-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-leading-icon-color: var(--md-outlined-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-hover-outline-color: var(--md-outlined-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_error-hover-supporting-text-color: var(--md-outlined-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-hover-trailing-icon-color: var(--md-outlined-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_error-input-text-color: var(--md-outlined-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_error-label-text-color: var(--md-outlined-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_error-leading-icon-color: var(--md-outlined-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_error-outline-color: var(--md-outlined-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_error-supporting-text-color: var(--md-outlined-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_error-trailing-icon-color: var(--md-outlined-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_focus-input-text-color: var(--md-outlined-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_focus-label-text-color: var(--md-outlined-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_focus-leading-icon-color: var(--md-outlined-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-outline-color: var(--md-outlined-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_focus-outline-width: var(--md-outlined-text-field-focus-outline-width, 3px);--_focus-supporting-text-color: var(--md-outlined-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_focus-trailing-icon-color: var(--md-outlined-text-field-focus-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-input-text-color: var(--md-outlined-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-label-text-color: var(--md-outlined-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-leading-icon-color: var(--md-outlined-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-outline-color: var(--md-outlined-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_hover-outline-width: var(--md-outlined-text-field-hover-outline-width, 1px);--_hover-supporting-text-color: var(--md-outlined-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-trailing-icon-color: var(--md-outlined-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-color: var(--md-outlined-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_input-text-font: var(--md-outlined-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_input-text-line-height: var(--md-outlined-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_input-text-placeholder-color: var(--md-outlined-text-field-input-text-placeholder-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-prefix-color: var(--md-outlined-text-field-input-text-prefix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-size: var(--md-outlined-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_input-text-suffix-color: var(--md-outlined-text-field-input-text-suffix-color, var(--md-sys-color-on-surface-variant, #49454f));--_input-text-weight: var(--md-outlined-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_label-text-color: var(--md-outlined-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_label-text-font: var(--md-outlined-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-outlined-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_label-text-populated-line-height: var(--md-outlined-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_label-text-populated-size: var(--md-outlined-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_label-text-size: var(--md-outlined-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_label-text-weight: var(--md-outlined-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_leading-icon-color: var(--md-outlined-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_leading-icon-size: var(--md-outlined-text-field-leading-icon-size, 24px);--_outline-color: var(--md-outlined-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_outline-width: var(--md-outlined-text-field-outline-width, 1px);--_supporting-text-color: var(--md-outlined-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_supporting-text-font: var(--md-outlined-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_supporting-text-line-height: var(--md-outlined-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_supporting-text-size: var(--md-outlined-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_supporting-text-weight: var(--md-outlined-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_trailing-icon-color: var(--md-outlined-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_trailing-icon-size: var(--md-outlined-text-field-trailing-icon-size, 24px);--_container-shape-start-start: var(--md-outlined-text-field-container-shape-start-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-start-end: var(--md-outlined-text-field-container-shape-start-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-end: var(--md-outlined-text-field-container-shape-end-end, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_container-shape-end-start: var(--md-outlined-text-field-container-shape-end-start, var(--md-outlined-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_icon-input-space: var(--md-outlined-text-field-icon-input-space, 16px);--_leading-space: var(--md-outlined-text-field-leading-space, 16px);--_trailing-space: var(--md-outlined-text-field-trailing-space, 16px);--_top-space: var(--md-outlined-text-field-top-space, 16px);--_bottom-space: var(--md-outlined-text-field-bottom-space, 16px);--_input-text-prefix-trailing-space: var(--md-outlined-text-field-input-text-prefix-trailing-space, 2px);--_input-text-suffix-leading-space: var(--md-outlined-text-field-input-text-suffix-leading-space, 2px);--_focus-caret-color: var(--md-outlined-text-field-focus-caret-color, var(--md-sys-color-primary, #6750a4));--_with-leading-icon-leading-space: var(--md-outlined-text-field-with-leading-icon-leading-space, 12px);--_with-trailing-icon-trailing-space: var(--md-outlined-text-field-with-trailing-icon-trailing-space, 12px);--md-outlined-field-bottom-space: var(--_bottom-space);--md-outlined-field-container-shape-end-end: var(--_container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_container-shape-start-start);--md-outlined-field-content-color: var(--_input-text-color);--md-outlined-field-content-font: var(--_input-text-font);--md-outlined-field-content-line-height: var(--_input-text-line-height);--md-outlined-field-content-size: var(--_input-text-size);--md-outlined-field-content-space: var(--_icon-input-space);--md-outlined-field-content-weight: var(--_input-text-weight);--md-outlined-field-disabled-content-color: var(--_disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_focus-outline-color);--md-outlined-field-focus-outline-width: var(--_focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_hover-outline-color);--md-outlined-field-hover-outline-width: var(--_hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_label-text-color);--md-outlined-field-label-text-font: var(--_label-text-font);--md-outlined-field-label-text-line-height: var(--_label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_label-text-populated-size);--md-outlined-field-label-text-size: var(--_label-text-size);--md-outlined-field-label-text-weight: var(--_label-text-weight);--md-outlined-field-leading-content-color: var(--_leading-icon-color);--md-outlined-field-leading-space: var(--_leading-space);--md-outlined-field-outline-color: var(--_outline-color);--md-outlined-field-outline-width: var(--_outline-width);--md-outlined-field-supporting-text-color: var(--_supporting-text-color);--md-outlined-field-supporting-text-font: var(--_supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_supporting-text-weight);--md-outlined-field-top-space: var(--_top-space);--md-outlined-field-trailing-content-color: var(--_trailing-icon-color);--md-outlined-field-trailing-space: var(--_trailing-space);--md-outlined-field-with-leading-content-leading-space: var(--_with-leading-icon-leading-space);--md-outlined-field-with-trailing-content-trailing-space: var(--_with-trailing-icon-trailing-space)}
+`;var{I:es}=jr;var Jr=o=>o.strings===void 0;var Ho={},Qr=(o,e=Ho)=>o._$AH=e;var Gt=Ie(class extends pe{constructor(o){if(super(o),o.type!==X.PROPERTY&&o.type!==X.ATTRIBUTE&&o.type!==X.BOOLEAN_ATTRIBUTE)throw Error("The `live` directive is not allowed on child or event bindings");if(!Jr(o))throw Error("`live` bindings can only contain a single expression")}render(o){return o}update(o,[e]){if(e===U||e===p)return e;let t=o.element,r=o.name;if(o.type===X.PROPERTY){if(e===t[r])return U}else if(o.type===X.BOOLEAN_ATTRIBUTE){if(!!e===t.hasAttribute(r))return U}else if(o.type===X.ATTRIBUTE&&t.getAttribute(r)===e+"")return U;return Qr(o),e}});var eo="important",jo=" !"+eo,Ae=Ie(class extends pe{constructor(o){if(super(o),o.type!==X.ATTRIBUTE||o.name!=="style"||o.strings?.length>2)throw Error("The `styleMap` directive must be used in the `style` attribute and must be the only part in the attribute.")}render(o){return Object.keys(o).reduce((e,t)=>{let r=o[t];return r==null?e:e+`${t=t.includes("-")?t:t.replace(/(?:^(webkit|moz|ms|o)|)(?=[A-Z])/g,"-$&").toLowerCase()}:${r};`},"")}update(o,[e]){let{style:t}=o.element;if(this.ft===void 0)return this.ft=new Set(Object.keys(e)),this.render(e);for(let r of this.ft)e[r]==null&&(this.ft.delete(r),r.includes("-")?t.removeProperty(r):t[r]=null);for(let r in e){let i=e[r];if(i!=null){this.ft.add(r);let n=typeof i=="string"&&i.endsWith(jo);r.includes("-")||n?t.setProperty(r,n?i.slice(0,-11):i,n?eo:""):t[r]=i}}return U}});var Yt=["role","ariaAtomic","ariaAutoComplete","ariaBusy","ariaChecked","ariaColCount","ariaColIndex","ariaColSpan","ariaCurrent","ariaDisabled","ariaExpanded","ariaHasPopup","ariaHidden","ariaInvalid","ariaKeyShortcuts","ariaLabel","ariaLevel","ariaLive","ariaModal","ariaMultiLine","ariaMultiSelectable","ariaOrientation","ariaPlaceholder","ariaPosInSet","ariaPressed","ariaReadOnly","ariaRequired","ariaRoleDescription","ariaRowCount","ariaRowIndex","ariaRowSpan","ariaSelected","ariaSetSize","ariaSort","ariaValueMax","ariaValueMin","ariaValueNow","ariaValueText"],Wo=Yt.map(Xt);function ct(o){return Wo.includes(o)}function Xt(o){return o.replace("aria","aria-").replace(/Elements?/g,"").toLowerCase()}var pt=Symbol("privateIgnoreAttributeChangesFor");function W(o){var e;if(!1)return o;class t extends o{constructor(){super(...arguments),this[e]=new Set}attributeChangedCallback(i,n,a){if(!ct(i)){super.attributeChangedCallback(i,n,a);return}if(this[pt].has(i))return;this[pt].add(i),this.removeAttribute(i),this[pt].delete(i);let d=Jt(i);a===null?delete this.dataset[d]:this.dataset[d]=a,this.requestUpdate(Jt(i),n)}getAttribute(i){return ct(i)?super.getAttribute(Zt(i)):super.getAttribute(i)}removeAttribute(i){super.removeAttribute(i),ct(i)&&(super.removeAttribute(Zt(i)),this.requestUpdate())}}return e=pt,Ko(t),t}function Ko(o){for(let e of Yt){let t=Xt(e),r=Zt(t),i=Jt(t);o.createProperty(e,{attribute:t,noAccessor:!0}),o.createProperty(Symbol(r),{attribute:r,noAccessor:!0}),Object.defineProperty(o.prototype,e,{configurable:!0,enumerable:!0,get(){return this.dataset[i]??null},set(n){let a=this.dataset[i]??null;n!==a&&(n===null?delete this.dataset[i]:this.dataset[i]=n,this.requestUpdate(e,a))}})}}function Zt(o){return`data-${o}`}function Jt(o){return o.replace(/-\w/,e=>e[1].toUpperCase())}var to={fromAttribute(o){return o??""},toAttribute(o){return o||null}};function ke(o,e){e.bubbles&&(!o.shadowRoot||e.composed)&&e.stopPropagation();let t=Reflect.construct(e.constructor,[e.type,e]),r=o.dispatchEvent(t);return r||e.preventDefault(),r}var P=Symbol("internals"),Qt=Symbol("privateInternals");function ee(o){class e extends o{get[P](){return this[Qt]||(this[Qt]=this.attachInternals()),this[Qt]}}return e}var he=Symbol("createValidator"),fe=Symbol("getValidityAnchor"),er=Symbol("privateValidator"),ne=Symbol("privateSyncValidity"),ut=Symbol("privateCustomValidationMessage");function Oe(o){var e;class t extends o{constructor(){super(...arguments),this[e]=""}get validity(){return this[ne](),this[P].validity}get validationMessage(){return this[ne](),this[P].validationMessage}get willValidate(){return this[ne](),this[P].willValidate}checkValidity(){return this[ne](),this[P].checkValidity()}reportValidity(){return this[ne](),this[P].reportValidity()}setCustomValidity(i){this[ut]=i,this[ne]()}requestUpdate(i,n,a){super.requestUpdate(i,n,a),this[ne]()}firstUpdated(i){super.firstUpdated(i),this[ne]()}[(e=ut,ne)](){if(!1)return;this[er]||(this[er]=this[he]());let{validity:i,validationMessage:n}=this[er].getValidity(),a=!!this[ut],d=this[ut]||n;this[P].setValidity({...i,customError:a},d,this[fe]()??void 0)}[he](){throw new Error("Implement [createValidator]")}[fe](){throw new Error("Implement [getValidityAnchor]")}}return t}var se=Symbol("getFormValue"),ht=Symbol("getFormState");function Re(o){class e extends o{get form(){return this[P].form}get labels(){return this[P].labels}get name(){return this.getAttribute("name")??""}set name(r){this.setAttribute("name",r)}get disabled(){return this.hasAttribute("disabled")}set disabled(r){this.toggleAttribute("disabled",r)}attributeChangedCallback(r,i,n){if(r==="name"||r==="disabled"){let a=r==="disabled"?i!==null:i;this.requestUpdate(r,a);return}super.attributeChangedCallback(r,i,n)}requestUpdate(r,i,n){super.requestUpdate(r,i,n),this[P].setFormValue(this[se](),this[ht]())}[se](){throw new Error("Implement [getFormValue]")}[ht](){return this[se]()}formDisabledCallback(r){this.disabled=r}}return e.formAssociated=!0,s([l({noAccessor:!0})],e.prototype,"name",null),s([l({type:Boolean,noAccessor:!0})],e.prototype,"disabled",null),e}var Pe=Symbol("onReportValidity"),ft=Symbol("privateCleanupFormListeners"),mt=Symbol("privateDoNotReportInvalid"),vt=Symbol("privateIsSelfReportingValidity"),gt=Symbol("privateCallOnReportValidity");function bt(o){var e,t,r;class i extends o{constructor(...a){super(...a),this[e]=new AbortController,this[t]=!1,this[r]=!1,!!1&&this.addEventListener("invalid",d=>{this[mt]||!d.isTrusted||this.addEventListener("invalid",()=>{this[gt](d)},{once:!0})},{capture:!0})}checkValidity(){this[mt]=!0;let a=super.checkValidity();return this[mt]=!1,a}reportValidity(){this[vt]=!0;let a=super.reportValidity();return a&&this[gt](null),this[vt]=!1,a}[(e=ft,t=mt,r=vt,gt)](a){let d=a?.defaultPrevented;d||(this[Pe](a),!(!d&&a?.defaultPrevented))||(this[vt]||Xo(this[P].form,this))&&this.focus()}[Pe](a){throw new Error("Implement [onReportValidity]")}formAssociatedCallback(a){super.formAssociatedCallback&&super.formAssociatedCallback(a),this[ft].abort(),a&&(this[ft]=new AbortController,Go(this,a,()=>{this[gt](null)},this[ft].signal))}}return i}function Go(o,e,t,r){let i=Yo(e),n=!1,a,d=!1;i.addEventListener("before",()=>{d=!0,a=new AbortController,n=!1,o.addEventListener("invalid",()=>{n=!0},{signal:a.signal})},{signal:r}),i.addEventListener("after",()=>{d=!1,a?.abort(),!n&&t()},{signal:r}),e.addEventListener("submit",()=>{d||t()},{signal:r})}var tr=new WeakMap;function Yo(o){if(!tr.has(o)){let e=new EventTarget;tr.set(o,e);for(let t of["reportValidity","requestSubmit"]){let r=o[t];o[t]=function(){e.dispatchEvent(new Event("before"));let i=Reflect.apply(r,this,arguments);return e.dispatchEvent(new Event("after")),i}}}return tr.get(o)}function Xo(o,e){if(!o)return!0;let t;for(let r of o.elements)if(r.matches(":invalid")){t=r;break}return t===e}var me=class{constructor(e){this.getCurrentState=e,this.currentValidity={validity:{},validationMessage:""}}getValidity(){let e=this.getCurrentState();if(!(!this.prevState||!this.equals(this.prevState,e)))return this.currentValidity;let{validity:r,validationMessage:i}=this.computeValidity(e);return this.prevState=this.copy(e),this.currentValidity={validationMessage:i,validity:{badInput:r.badInput,customError:r.customError,patternMismatch:r.patternMismatch,rangeOverflow:r.rangeOverflow,rangeUnderflow:r.rangeUnderflow,stepMismatch:r.stepMismatch,tooLong:r.tooLong,tooShort:r.tooShort,typeMismatch:r.typeMismatch,valueMissing:r.valueMissing}},this.currentValidity}};var yt=class extends me{computeValidity({state:e,renderedControl:t}){let r=t;Ke(e)&&!r?(r=this.inputControl||document.createElement("input"),this.inputControl=r):r||(r=this.textAreaControl||document.createElement("textarea"),this.textAreaControl=r);let i=Ke(e)?r:null;if(i&&(i.type=e.type),r.value!==e.value&&(r.value=e.value),r.required=e.required,i){let n=e;n.pattern?i.pattern=n.pattern:i.removeAttribute("pattern"),n.min?i.min=n.min:i.removeAttribute("min"),n.max?i.max=n.max:i.removeAttribute("max"),n.step?i.step=n.step:i.removeAttribute("step")}return(e.minLength??-1)>-1?r.setAttribute("minlength",String(e.minLength)):r.removeAttribute("minlength"),(e.maxLength??-1)>-1?r.setAttribute("maxlength",String(e.maxLength)):r.removeAttribute("maxlength"),{validity:r.validity,validationMessage:r.validationMessage}}equals({state:e},{state:t}){let r=e.type===t.type&&e.value===t.value&&e.required===t.required&&e.minLength===t.minLength&&e.maxLength===t.maxLength;return!Ke(e)||!Ke(t)?r:r&&e.pattern===t.pattern&&e.min===t.min&&e.max===t.max&&e.step===t.step}copy({state:e}){return{state:Ke(e)?this.copyInput(e):this.copyTextArea(e),renderedControl:null}}copyInput(e){let{type:t,pattern:r,min:i,max:n,step:a}=e;return{...this.copySharedState(e),type:t,pattern:r,min:i,max:n,step:a}}copyTextArea(e){return{...this.copySharedState(e),type:e.type}}copySharedState({value:e,required:t,minLength:r,maxLength:i}){return{value:e,required:t,minLength:r,maxLength:i}}};function Ke(o){return o.type!=="textarea"}var Zo=W(bt(Oe(Re(ee(b))))),v=class extends Zo{constructor(){super(...arguments),this.error=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.required=!1,this.value="",this.prefixText="",this.suffixText="",this.hasLeadingIcon=!1,this.hasTrailingIcon=!1,this.supportingText="",this.textDirection="",this.rows=2,this.cols=20,this.inputMode="",this.max="",this.maxLength=-1,this.min="",this.minLength=-1,this.noSpinner=!1,this.pattern="",this.placeholder="",this.readOnly=!1,this.multiple=!1,this.step="",this.type="text",this.autocomplete="",this.dirty=!1,this.focused=!1,this.nativeError=!1,this.nativeErrorText=""}get selectionDirection(){return this.getInputOrTextarea().selectionDirection}set selectionDirection(e){this.getInputOrTextarea().selectionDirection=e}get selectionEnd(){return this.getInputOrTextarea().selectionEnd}set selectionEnd(e){this.getInputOrTextarea().selectionEnd=e}get selectionStart(){return this.getInputOrTextarea().selectionStart}set selectionStart(e){this.getInputOrTextarea().selectionStart=e}get valueAsNumber(){let e=this.getInput();return e?e.valueAsNumber:NaN}set valueAsNumber(e){let t=this.getInput();t&&(t.valueAsNumber=e,this.value=t.value)}get valueAsDate(){let e=this.getInput();return e?e.valueAsDate:null}set valueAsDate(e){let t=this.getInput();t&&(t.valueAsDate=e,this.value=t.value)}get hasError(){return this.error||this.nativeError}select(){this.getInputOrTextarea().select()}setRangeText(...e){this.getInputOrTextarea().setRangeText(...e),this.value=this.getInputOrTextarea().value}setSelectionRange(e,t,r){this.getInputOrTextarea().setSelectionRange(e,t,r)}showPicker(){let e=this.getInput();e&&e.showPicker()}stepDown(e){let t=this.getInput();t&&(t.stepDown(e),this.value=t.value)}stepUp(e){let t=this.getInput();t&&(t.stepUp(e),this.value=t.value)}reset(){this.dirty=!1,this.value=this.getAttribute("value")??"",this.nativeError=!1,this.nativeErrorText=""}attributeChangedCallback(e,t,r){e==="value"&&this.dirty||super.attributeChangedCallback(e,t,r)}render(){let e={disabled:this.disabled,error:!this.disabled&&this.hasError,textarea:this.type==="textarea","no-spinner":this.noSpinner};return u`
+      <span class="text-field ${R(e)}">
+        ${this.renderField()}
+      </span>
+    `}updated(e){let t=this.getInputOrTextarea().value;this.value!==t&&(this.value=t)}renderField(){return ue`<${this.fieldTag}
+      class="field"
+      count=${this.value.length}
+      ?disabled=${this.disabled}
+      ?error=${this.hasError}
+      error-text=${this.getErrorText()}
+      ?focused=${this.focused}
+      ?has-end=${this.hasTrailingIcon}
+      ?has-start=${this.hasLeadingIcon}
+      label=${this.label}
+      ?no-asterisk=${this.noAsterisk}
+      max=${this.maxLength}
+      ?populated=${!!this.value}
+      ?required=${this.required}
+      ?resizable=${this.type==="textarea"}
+      supporting-text=${this.supportingText}
+    >
+      ${this.renderLeadingIcon()}
+      ${this.renderInputOrTextarea()}
+      ${this.renderTrailingIcon()}
+      <div id="description" slot="aria-describedby"></div>
+      <slot name="container" slot="container"></slot>
+    </${this.fieldTag}>`}renderLeadingIcon(){return u`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return u`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderInputOrTextarea(){let e={direction:this.textDirection},t=this.ariaLabel||this.label||p,r=this.autocomplete,i=(this.maxLength??-1)>-1,n=(this.minLength??-1)>-1;if(this.type==="textarea")return u`
+        <textarea
+          class="input"
+          style=${Ae(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||p}
+          name=${this.name||p}
+          ?disabled=${this.disabled}
+          maxlength=${i?this.maxLength:p}
+          minlength=${n?this.minLength:p}
+          placeholder=${this.placeholder||p}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          rows=${this.rows}
+          cols=${this.cols}
+          .value=${Gt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent}></textarea>
+      `;let a=this.renderPrefix(),d=this.renderSuffix(),c=this.inputMode;return u`
+      <div class="input-wrapper">
+        ${a}
+        <input
+          class="input"
+          style=${Ae(e)}
+          aria-describedby="description"
+          aria-invalid=${this.hasError}
+          aria-label=${t}
+          autocomplete=${r||p}
+          name=${this.name||p}
+          ?disabled=${this.disabled}
+          inputmode=${c||p}
+          max=${this.max||p}
+          maxlength=${i?this.maxLength:p}
+          min=${this.min||p}
+          minlength=${n?this.minLength:p}
+          pattern=${this.pattern||p}
+          placeholder=${this.placeholder||p}
+          ?readonly=${this.readOnly}
+          ?required=${this.required}
+          ?multiple=${this.multiple}
+          step=${this.step||p}
+          type=${this.type}
+          .value=${Gt(this.value)}
+          @change=${this.redispatchEvent}
+          @focus=${this.handleFocusChange}
+          @blur=${this.handleFocusChange}
+          @input=${this.handleInput}
+          @select=${this.redispatchEvent} />
+        ${d}
+      </div>
+    `}renderPrefix(){return this.renderAffix(this.prefixText,!1)}renderSuffix(){return this.renderAffix(this.suffixText,!0)}renderAffix(e,t){return e?u`<span class="${R({suffix:t,prefix:!t})}">${e}</span>`:p}getErrorText(){return this.error?this.errorText:this.nativeErrorText}handleFocusChange(){this.focused=this.inputOrTextarea?.matches(":focus")??!1}handleInput(e){this.dirty=!0,this.value=e.target.value}redispatchEvent(e){ke(this,e)}getInputOrTextarea(){return this.inputOrTextarea||(this.connectedCallback(),this.scheduleUpdate()),this.isUpdatePending&&this.scheduleUpdate(),this.inputOrTextarea}getInput(){return this.type==="textarea"?null:this.getInputOrTextarea()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0,this.hasTrailingIcon=this.trailingIcons.length>0}[se](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}focus(){this.getInputOrTextarea().focus()}[he](){return new yt(()=>({state:this,renderedControl:this.inputOrTextarea}))}[fe](){return this.inputOrTextarea}[Pe](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}};v.shadowRootOptions={...b.shadowRootOptions,delegatesFocus:!0};s([l({type:Boolean,reflect:!0})],v.prototype,"error",void 0);s([l({attribute:"error-text"})],v.prototype,"errorText",void 0);s([l()],v.prototype,"label",void 0);s([l({type:Boolean,attribute:"no-asterisk"})],v.prototype,"noAsterisk",void 0);s([l({type:Boolean,reflect:!0})],v.prototype,"required",void 0);s([l()],v.prototype,"value",void 0);s([l({attribute:"prefix-text"})],v.prototype,"prefixText",void 0);s([l({attribute:"suffix-text"})],v.prototype,"suffixText",void 0);s([l({type:Boolean,attribute:"has-leading-icon"})],v.prototype,"hasLeadingIcon",void 0);s([l({type:Boolean,attribute:"has-trailing-icon"})],v.prototype,"hasTrailingIcon",void 0);s([l({attribute:"supporting-text"})],v.prototype,"supportingText",void 0);s([l({attribute:"text-direction"})],v.prototype,"textDirection",void 0);s([l({type:Number})],v.prototype,"rows",void 0);s([l({type:Number})],v.prototype,"cols",void 0);s([l({reflect:!0})],v.prototype,"inputMode",void 0);s([l()],v.prototype,"max",void 0);s([l({type:Number})],v.prototype,"maxLength",void 0);s([l()],v.prototype,"min",void 0);s([l({type:Number})],v.prototype,"minLength",void 0);s([l({type:Boolean,attribute:"no-spinner"})],v.prototype,"noSpinner",void 0);s([l()],v.prototype,"pattern",void 0);s([l({reflect:!0,converter:to})],v.prototype,"placeholder",void 0);s([l({type:Boolean,reflect:!0})],v.prototype,"readOnly",void 0);s([l({type:Boolean,reflect:!0})],v.prototype,"multiple",void 0);s([l()],v.prototype,"step",void 0);s([l({reflect:!0})],v.prototype,"type",void 0);s([l({reflect:!0})],v.prototype,"autocomplete",void 0);s([k()],v.prototype,"dirty",void 0);s([k()],v.prototype,"focused",void 0);s([k()],v.prototype,"nativeError",void 0);s([k()],v.prototype,"nativeErrorText",void 0);s([S(".input")],v.prototype,"inputOrTextarea",void 0);s([S(".field")],v.prototype,"field",void 0);s([N({slot:"leading-icon"})],v.prototype,"leadingIcons",void 0);s([N({slot:"trailing-icon"})],v.prototype,"trailingIcons",void 0);var xt=class extends v{constructor(){super(...arguments),this.fieldTag=G`md-outlined-field`}};var ro=g`:host{display:inline-flex;outline:none;resize:both;text-align:start;-webkit-tap-highlight-color:rgba(0,0,0,0)}.text-field,.field{width:100%}.text-field{display:inline-flex}.field{cursor:text}.disabled .field{cursor:default}.text-field,.textarea .field{resize:inherit}slot[name=container]{border-radius:inherit}.icon{color:currentColor;display:flex;align-items:center;justify-content:center;fill:currentColor;position:relative}.icon ::slotted(*){display:flex;position:absolute}[has-start] .icon.leading{font-size:var(--_leading-icon-size);height:var(--_leading-icon-size);width:var(--_leading-icon-size)}[has-end] .icon.trailing{font-size:var(--_trailing-icon-size);height:var(--_trailing-icon-size);width:var(--_trailing-icon-size)}.input-wrapper{display:flex}.input-wrapper>*{all:inherit;padding:0}.input{caret-color:var(--_caret-color);overflow-x:hidden;text-align:inherit}.input::placeholder{color:currentColor;opacity:1}.input::-webkit-calendar-picker-indicator{display:none}.input::-webkit-search-decoration,.input::-webkit-search-cancel-button{display:none}@media(forced-colors: active){.input{background:none}}.no-spinner .input::-webkit-inner-spin-button,.no-spinner .input::-webkit-outer-spin-button{display:none}.no-spinner .input[type=number]{-moz-appearance:textfield}:focus-within .input{caret-color:var(--_focus-caret-color)}.error:focus-within .input{caret-color:var(--_error-focus-caret-color)}.text-field:not(.disabled) .prefix{color:var(--_input-text-prefix-color)}.text-field:not(.disabled) .suffix{color:var(--_input-text-suffix-color)}.text-field:not(.disabled) .input::placeholder{color:var(--_input-text-placeholder-color)}.prefix,.suffix{text-wrap:nowrap;width:min-content}.prefix{padding-inline-end:var(--_input-text-prefix-trailing-space)}.suffix{padding-inline-start:var(--_input-text-suffix-leading-space)}
+`;var rr=class extends xt{constructor(){super(...arguments),this.fieldTag=G`md-outlined-field`}};rr.styles=[ro,Zr];rr=s([E("md-outlined-text-field")],rr);var _t=class extends b{connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){return u`<span class="shadow"></span>`}};var oo=g`:host,.shadow,.shadow::before,.shadow::after{border-radius:inherit;inset:0;position:absolute;transition-duration:inherit;transition-property:inherit;transition-timing-function:inherit}:host{display:flex;pointer-events:none;transition-property:box-shadow,opacity}.shadow::before,.shadow::after{content:"";transition-property:box-shadow,opacity;--_level: var(--md-elevation-level, 0);--_shadow-color: var(--md-elevation-shadow-color, var(--md-sys-color-shadow, #000))}.shadow::before{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 3,1) + 2*clamp(0,var(--_level) - 4,1))) calc(1px*(2*clamp(0,var(--_level),1) + clamp(0,var(--_level) - 2,1) + clamp(0,var(--_level) - 4,1))) 0px var(--_shadow-color);opacity:.3}.shadow::after{box-shadow:0px calc(1px*(clamp(0,var(--_level),1) + clamp(0,var(--_level) - 1,1) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(3*clamp(0,var(--_level),2) + 2*clamp(0,var(--_level) - 2,3))) calc(1px*(clamp(0,var(--_level),4) + 2*clamp(0,var(--_level) - 4,1))) var(--_shadow-color);opacity:.15}
+`;var or=class extends _t{};or.styles=[oo];or=s([E("md-elevation")],or);var io=Symbol("attachableController"),no;no=new MutationObserver(o=>{for(let e of o)e.target[io]?.hostConnected()});var Le=class{get htmlFor(){return this.host.getAttribute("for")}set htmlFor(e){e===null?this.host.removeAttribute("for"):this.host.setAttribute("for",e)}get control(){return this.host.hasAttribute("for")?!this.htmlFor||!this.host.isConnected?null:this.host.getRootNode().querySelector(`#${this.htmlFor}`):this.currentControl||this.host.parentElement}set control(e){e?this.attach(e):this.detach()}constructor(e,t){this.host=e,this.onControlChange=t,this.currentControl=null,e.addController(this),e[io]=this,no?.observe(e,{attributeFilter:["for"]})}attach(e){e!==this.currentControl&&(this.setCurrentControl(e),this.host.removeAttribute("for"))}detach(){this.setCurrentControl(null),this.host.setAttribute("for","")}hostConnected(){this.setCurrentControl(this.control)}hostDisconnected(){this.setCurrentControl(null)}setCurrentControl(e){this.onControlChange(this.currentControl,e),this.currentControl=e}};var Jo=["focusin","focusout","pointerdown"],De=class extends b{constructor(){super(...arguments),this.visible=!1,this.inward=!1,this.attachableController=new Le(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}handleEvent(e){if(!e[so]){switch(e.type){default:return;case"focusin":this.visible=this.control?.matches(":focus-visible")??!1;break;case"focusout":case"pointerdown":this.visible=!1;break}e[so]=!0}}onControlChange(e,t){if(!!1)for(let r of Jo)e?.removeEventListener(r,this),t?.addEventListener(r,this)}update(e){e.has("visible")&&this.dispatchEvent(new Event("visibility-changed")),super.update(e)}};s([l({type:Boolean,reflect:!0})],De.prototype,"visible",void 0);s([l({type:Boolean,reflect:!0})],De.prototype,"inward",void 0);var so=Symbol("handledByFocusRing");var ao=g`:host{animation-delay:0s,calc(var(--md-focus-ring-duration, 600ms)*.25);animation-duration:calc(var(--md-focus-ring-duration, 600ms)*.25),calc(var(--md-focus-ring-duration, 600ms)*.75);animation-timing-function:cubic-bezier(0.2, 0, 0, 1);box-sizing:border-box;color:var(--md-focus-ring-color, var(--md-sys-color-secondary, #625b71));display:none;pointer-events:none;position:absolute}:host([visible]){display:flex}:host(:not([inward])){animation-name:outward-grow,outward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) + var(--md-focus-ring-outward-offset, 2px));inset:calc(-1*var(--md-focus-ring-outward-offset, 2px));outline:var(--md-focus-ring-width, 3px) solid currentColor}:host([inward]){animation-name:inward-grow,inward-shrink;border-end-end-radius:calc(var(--md-focus-ring-shape-end-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-end-start-radius:calc(var(--md-focus-ring-shape-end-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-end-radius:calc(var(--md-focus-ring-shape-start-end, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border-start-start-radius:calc(var(--md-focus-ring-shape-start-start, var(--md-focus-ring-shape, var(--md-sys-shape-corner-full, 9999px))) - var(--md-focus-ring-inward-offset, 0px));border:var(--md-focus-ring-width, 3px) solid currentColor;inset:var(--md-focus-ring-inward-offset, 0px)}@keyframes outward-grow{from{outline-width:0}to{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes outward-shrink{from{outline-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-grow{from{border-width:0}to{border-width:var(--md-focus-ring-active-width, 8px)}}@keyframes inward-shrink{from{border-width:var(--md-focus-ring-active-width, 8px)}}@media(prefers-reduced-motion){:host{animation:none}}
+`;var ir=class extends De{};ir.styles=[ao];ir=s([E("md-focus-ring")],ir);function nr(o,e=ae){let t=Ge(o,e);return t&&(t.tabIndex=0,t.focus()),t}function sr(o,e=ae){let t=ar(o,e);return t&&(t.tabIndex=0,t.focus()),t}function ve(o,e=ae){for(let t=0;t<o.length;t++){let r=o[t];if(r.tabIndex===0&&e(r))return{item:r,index:t}}return null}function Ge(o,e=ae){for(let t of o)if(e(t))return t;return null}function ar(o,e=ae){for(let t=o.length-1;t>=0;t--){let r=o[t];if(e(r))return r}return null}function Qo(o,e,t=ae,r=!0){for(let i=1;i<o.length;i++){let n=(i+e)%o.length;if(n<e&&!r)return null;let a=o[n];if(t(a))return a}return o[e]?o[e]:null}function ei(o,e,t=ae,r=!0){for(let i=1;i<o.length;i++){let n=(e-i+o.length)%o.length;if(n>e&&!r)return null;let a=o[n];if(t(a))return a}return o[e]?o[e]:null}function lr(o,e,t=ae,r=!0){if(e){let i=Qo(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return nr(o,t)}function dr(o,e,t=ae,r=!0){if(e){let i=ei(o,e.index,t,r);return i&&(i.tabIndex=0,i.focus()),i}else return sr(o,t)}function ae(o){return!o.disabled}var B={ArrowDown:"ArrowDown",ArrowLeft:"ArrowLeft",ArrowUp:"ArrowUp",ArrowRight:"ArrowRight",Home:"Home",End:"End"},wt=class{constructor(e){this.handleKeydown=m=>{let f=m.key;if(m.defaultPrevented||!this.isNavigableKey(f))return;let x=this.items;if(!x.length)return;let y=ve(x,this.isActivatable);m.preventDefault();let I=this.isRtl(),w=I?B.ArrowRight:B.ArrowLeft,O=I?B.ArrowLeft:B.ArrowRight,z=null;switch(f){case B.ArrowDown:case O:z=lr(x,y,this.isActivatable,this.wrapNavigation());break;case B.ArrowUp:case w:z=dr(x,y,this.isActivatable,this.wrapNavigation());break;case B.Home:z=nr(x,this.isActivatable);break;case B.End:z=sr(x,this.isActivatable);break;default:break}z&&y&&y.item!==z&&(y.item.tabIndex=-1)},this.onDeactivateItems=()=>{let m=this.items;for(let f of m)this.deactivateItem(f)},this.onRequestActivation=m=>{this.onDeactivateItems();let f=m.target;this.activateItem(f),f.focus()},this.onSlotchange=()=>{let m=this.items,f=!1;for(let y of m){if(!y.disabled&&y.tabIndex>-1&&!f){f=!0,y.tabIndex=0;continue}y.tabIndex=-1}if(f)return;let x=Ge(m,this.isActivatable);x&&(x.tabIndex=0)};let{isItem:t,getPossibleItems:r,isRtl:i,deactivateItem:n,activateItem:a,isNavigableKey:d,isActivatable:c,wrapNavigation:h}=e;this.isItem=t,this.getPossibleItems=r,this.isRtl=i,this.deactivateItem=n,this.activateItem=a,this.isNavigableKey=d,this.isActivatable=c,this.wrapNavigation=h??(()=>!0)}get items(){let e=this.getPossibleItems(),t=[];for(let r of e){if(this.isItem(r)){t.push(r);continue}let n=r.item;n&&this.isItem(n)&&t.push(n)}return t}activateNextItem(){let e=this.items,t=ve(e,this.isActivatable);return t&&(t.item.tabIndex=-1),lr(e,t,this.isActivatable,this.wrapNavigation())}activatePreviousItem(){let e=this.items,t=ve(e,this.isActivatable);return t&&(t.item.tabIndex=-1),dr(e,t,this.isActivatable,this.wrapNavigation())}};function ti(o,e){return new CustomEvent("close-menu",{bubbles:!0,composed:!0,detail:{initiator:o,reason:e,itemPath:[o]}})}var pr=ti;var cr={SPACE:"Space",ENTER:"Enter"},Et={CLICK_SELECTION:"click-selection",KEYDOWN:"keydown"},ri={ESCAPE:"Escape",SPACE:cr.SPACE,ENTER:cr.ENTER};function At(o){return Object.values(ri).some(e=>e===o)}function lo(o){return Object.values(cr).some(e=>e===o)}function Ye(o,e){let t=new Event("md-contains",{bubbles:!0,composed:!0}),r=[],i=a=>{r=a.composedPath()};return e.addEventListener("md-contains",i),o.dispatchEvent(t),e.removeEventListener("md-contains",i),r.length>0}var K={NONE:"none",LIST_ROOT:"list-root",FIRST_ITEM:"first-item",LAST_ITEM:"last-item"};var Xe={END_START:"end-start",END_END:"end-end",START_START:"start-start",START_END:"start-end"},Ct=class{constructor(e,t){this.host=e,this.getProperties=t,this.surfaceStylesInternal={display:"none"},this.lastValues={isOpen:!1},this.host.addController(this)}get surfaceStyles(){return this.surfaceStylesInternal}async position(){let{surfaceEl:e,anchorEl:t,anchorCorner:r,surfaceCorner:i,positioning:n,xOffset:a,yOffset:d,disableBlockFlip:c,disableInlineFlip:h,repositionStrategy:m}=this.getProperties(),f=r.toLowerCase().trim(),x=i.toLowerCase().trim();if(!e||!t)return;let y=window.innerWidth,I=window.innerHeight,w=document.createElement("div");w.style.opacity="0",w.style.position="fixed",w.style.display="block",w.style.inset="0",document.body.appendChild(w);let O=w.getBoundingClientRect();w.remove();let z=window.innerHeight-O.bottom,C=window.innerWidth-O.right;this.surfaceStylesInternal={display:"block",opacity:"0"},this.host.requestUpdate(),await this.host.updateComplete,e.popover&&e.isConnected&&e.showPopover();let V=e.getSurfacePositionClientRect?e.getSurfacePositionClientRect():e.getBoundingClientRect(),F=t.getSurfacePositionClientRect?t.getSurfacePositionClientRect():t.getBoundingClientRect(),[L,le]=x.split("-"),[de,be]=f.split("-"),Ze=getComputedStyle(e).direction==="ltr",{blockInset:Ce,blockOutOfBoundsCorrection:J,surfaceBlockProperty:Ar}=this.calculateBlock({surfaceRect:V,anchorRect:F,anchorBlock:de,surfaceBlock:L,yOffset:d,positioning:n,windowInnerHeight:I,blockScrollbarHeight:z});if(J&&!c){let Mt=L==="start"?"end":"start",Nt=de==="start"?"end":"start",te=this.calculateBlock({surfaceRect:V,anchorRect:F,anchorBlock:Nt,surfaceBlock:Mt,yOffset:d,positioning:n,windowInnerHeight:I,blockScrollbarHeight:z});J>te.blockOutOfBoundsCorrection&&(Ce=te.blockInset,J=te.blockOutOfBoundsCorrection,Ar=te.surfaceBlockProperty)}let{inlineInset:Je,inlineOutOfBoundsCorrection:$e,surfaceInlineProperty:Cr}=this.calculateInline({surfaceRect:V,anchorRect:F,anchorInline:be,surfaceInline:le,xOffset:a,positioning:n,isLTR:Ze,windowInnerWidth:y,inlineScrollbarWidth:C});if($e&&!h){let Mt=le==="start"?"end":"start",Nt=be==="start"?"end":"start",te=this.calculateInline({surfaceRect:V,anchorRect:F,anchorInline:Nt,surfaceInline:Mt,xOffset:a,positioning:n,isLTR:Ze,windowInnerWidth:y,inlineScrollbarWidth:C});Math.abs($e)>Math.abs(te.inlineOutOfBoundsCorrection)&&(Je=te.inlineInset,$e=te.inlineOutOfBoundsCorrection,Cr=te.surfaceInlineProperty)}m==="move"&&(Ce=Ce-J,Je=Je-$e),this.surfaceStylesInternal={display:"block",opacity:"1",[Ar]:`${Ce}px`,[Cr]:`${Je}px`},m==="resize"&&(J&&(this.surfaceStylesInternal.height=`${V.height-J}px`),$e&&(this.surfaceStylesInternal.width=`${V.width-$e}px`)),this.host.requestUpdate()}calculateBlock(e){let{surfaceRect:t,anchorRect:r,anchorBlock:i,surfaceBlock:n,yOffset:a,positioning:d,windowInnerHeight:c,blockScrollbarHeight:h}=e,m=d==="fixed"||d==="document"?1:0,f=d==="document"?1:0,x=n==="start"?1:0,y=n==="end"?1:0,w=(i!==n?1:0)*r.height+a,O=x*r.top+y*(c-r.bottom-h),z=x*window.scrollY-y*window.scrollY,C=Math.abs(Math.min(0,c-O-w-t.height));return{blockInset:m*O+f*z+w,blockOutOfBoundsCorrection:C,surfaceBlockProperty:n==="start"?"inset-block-start":"inset-block-end"}}calculateInline(e){let{isLTR:t,surfaceInline:r,anchorInline:i,anchorRect:n,surfaceRect:a,xOffset:d,positioning:c,windowInnerWidth:h,inlineScrollbarWidth:m}=e,f=c==="fixed"||c==="document"?1:0,x=c==="document"?1:0,y=t?1:0,I=t?0:1,w=r==="start"?1:0,O=r==="end"?1:0,C=(i!==r?1:0)*n.width+d,V=w*n.left+O*(h-n.right-m),F=w*(h-n.right-m)+O*n.left,L=y*V+I*F,le=w*window.scrollX-O*window.scrollX,de=O*window.scrollX-w*window.scrollX,be=y*le+I*de,Ze=Math.abs(Math.min(0,h-L-C-a.width)),Ce=f*L+C+x*be,J=r==="start"?"inset-inline-start":"inset-inline-end";return(c==="document"||c==="fixed")&&(r==="start"&&t||r==="end"&&!t?J="left":J="right"),{inlineInset:Ce,inlineOutOfBoundsCorrection:Ze,surfaceInlineProperty:J}}hostUpdate(){this.onUpdate()}hostUpdated(){this.onUpdate()}async onUpdate(){let e=this.getProperties(),t=!1;for(let[a,d]of Object.entries(e))if(t=t||d!==this.lastValues[a],t)break;let r=this.lastValues.isOpen!==e.isOpen,i=!!e.anchorEl,n=!!e.surfaceEl;t&&i&&n&&(this.lastValues.isOpen=e.isOpen,e.isOpen?(this.lastValues=e,await this.position(),e.onOpen()):r&&(await e.beforeClose(),this.close(),e.onClose()))}close(){this.surfaceStylesInternal={display:"none"},this.host.requestUpdate();let e=this.getProperties().surfaceEl;e?.popover&&e?.isConnected&&e.hidePopover()}};var Y={INDEX:0,ITEM:1,TEXT:2},$t=class{constructor(e){this.getProperties=e,this.typeaheadRecords=[],this.typaheadBuffer="",this.cancelTypeaheadTimeout=0,this.isTypingAhead=!1,this.lastActiveRecord=null,this.onKeydown=t=>{this.isTypingAhead?this.typeahead(t):this.beginTypeahead(t)},this.endTypeahead=()=>{this.isTypingAhead=!1,this.typaheadBuffer="",this.typeaheadRecords=[]}}get items(){return this.getProperties().getItems()}get active(){return this.getProperties().active}beginTypeahead(e){this.active&&(e.code==="Space"||e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"||(this.isTypingAhead=!0,this.typeaheadRecords=this.items.map((t,r)=>[r,t,t.typeaheadText.trim().toLowerCase()]),this.lastActiveRecord=this.typeaheadRecords.find(t=>t[Y.ITEM].tabIndex===0)??null,this.lastActiveRecord&&(this.lastActiveRecord[Y.ITEM].tabIndex=-1),this.typeahead(e)))}typeahead(e){if(e.defaultPrevented)return;if(clearTimeout(this.cancelTypeaheadTimeout),e.code==="Enter"||e.code.startsWith("Arrow")||e.code==="Escape"){this.endTypeahead(),this.lastActiveRecord&&(this.lastActiveRecord[Y.ITEM].tabIndex=-1);return}e.code==="Space"&&e.preventDefault(),this.cancelTypeaheadTimeout=setTimeout(this.endTypeahead,this.getProperties().typeaheadBufferTime),this.typaheadBuffer+=e.key.toLowerCase();let t=this.lastActiveRecord?this.lastActiveRecord[Y.INDEX]:-1,r=this.typeaheadRecords.length,i=c=>(c[Y.INDEX]+r-t)%r,n=this.typeaheadRecords.filter(c=>!c[Y.ITEM].disabled&&c[Y.TEXT].startsWith(this.typaheadBuffer)).sort((c,h)=>i(c)-i(h));if(n.length===0){clearTimeout(this.cancelTypeaheadTimeout),this.lastActiveRecord&&(this.lastActiveRecord[Y.ITEM].tabIndex=-1),this.endTypeahead();return}let a=this.typaheadBuffer.length===1,d;this.lastActiveRecord===n[0]&&a?d=n[1]??n[0]:d=n[0],this.lastActiveRecord&&(this.lastActiveRecord[Y.ITEM].tabIndex=-1),this.lastActiveRecord=d,d[Y.ITEM].tabIndex=0,d[Y.ITEM].focus()}};var ur=200,co=new Set([B.ArrowDown,B.ArrowUp,B.Home,B.End]),oi=new Set([B.ArrowLeft,B.ArrowRight,...co]);function ii(o=document){let e=o.activeElement;for(;e&&e?.shadowRoot?.activeElement;)e=e.shadowRoot.activeElement;return e}var T=class extends b{get openDirection(){return this.menuCorner.split("-")[0]==="start"?"DOWN":"UP"}get anchorElement(){return this.anchor?this.getRootNode().querySelector(`#${this.anchor}`):this.currentAnchorElement}set anchorElement(e){this.currentAnchorElement=e,this.requestUpdate("anchorElement")}constructor(){super(),this.anchor="",this.positioning="absolute",this.quick=!1,this.hasOverflow=!1,this.open=!1,this.xOffset=0,this.yOffset=0,this.noHorizontalFlip=!1,this.noVerticalFlip=!1,this.typeaheadDelay=ur,this.anchorCorner=Xe.END_START,this.menuCorner=Xe.START_START,this.stayOpenOnOutsideClick=!1,this.stayOpenOnFocusout=!1,this.skipRestoreFocus=!1,this.defaultFocus=K.FIRST_ITEM,this.noNavigationWrap=!1,this.typeaheadActive=!0,this.isSubmenu=!1,this.pointerPath=[],this.isRepositioning=!1,this.openCloseAnimationSignal=Wr(),this.listController=new wt({isItem:e=>e.hasAttribute("md-menu-item"),getPossibleItems:()=>this.slotItems,isRtl:()=>getComputedStyle(this).direction==="rtl",deactivateItem:e=>{e.selected=!1,e.tabIndex=-1},activateItem:e=>{e.selected=!0,e.tabIndex=0},isNavigableKey:e=>{if(!this.isSubmenu)return oi.has(e);let r=getComputedStyle(this).direction==="rtl"?B.ArrowLeft:B.ArrowRight;return e===r?!0:co.has(e)},wrapNavigation:()=>!this.noNavigationWrap}),this.lastFocusedElement=null,this.typeaheadController=new $t(()=>({getItems:()=>this.items,typeaheadBufferTime:this.typeaheadDelay,active:this.typeaheadActive})),this.currentAnchorElement=null,this.internals=this.attachInternals(),this.menuPositionController=new Ct(this,()=>({anchorCorner:this.anchorCorner,surfaceCorner:this.menuCorner,surfaceEl:this.surfaceEl,anchorEl:this.anchorElement,positioning:this.positioning==="popover"?"document":this.positioning,isOpen:this.open,xOffset:this.xOffset,yOffset:this.yOffset,disableBlockFlip:this.noVerticalFlip,disableInlineFlip:this.noHorizontalFlip,onOpen:this.onOpened,beforeClose:this.beforeClose,onClose:this.onClosed,repositionStrategy:this.hasOverflow&&this.positioning!=="popover"?"move":"resize"})),this.onWindowResize=()=>{this.isRepositioning||this.positioning!=="document"&&this.positioning!=="fixed"&&this.positioning!=="popover"||(this.isRepositioning=!0,this.reposition(),this.isRepositioning=!1)},this.handleFocusout=async e=>{let t=this.anchorElement;if(this.stayOpenOnFocusout||!this.open||this.pointerPath.includes(t))return;if(e.relatedTarget){if(Ye(e.relatedTarget,this)||this.pointerPath.length!==0&&Ye(e.relatedTarget,t))return}else if(this.pointerPath.includes(this))return;let r=this.skipRestoreFocus;this.skipRestoreFocus=!0,this.close(),await this.updateComplete,this.skipRestoreFocus=r},this.onOpened=async()=>{this.lastFocusedElement=ii();let e=this.items,t=ve(e);t&&this.defaultFocus!==K.NONE&&(t.item.tabIndex=-1);let r=!this.quick;switch(this.quick?this.dispatchEvent(new Event("opening")):r=!!await this.animateOpen(),this.defaultFocus){case K.FIRST_ITEM:let i=Ge(e);i&&(i.tabIndex=0,i.focus(),await i.updateComplete);break;case K.LAST_ITEM:let n=ar(e);n&&(n.tabIndex=0,n.focus(),await n.updateComplete);break;case K.LIST_ROOT:this.focus();break;default:case K.NONE:break}r||this.dispatchEvent(new Event("opened"))},this.beforeClose=async()=>{this.open=!1,this.skipRestoreFocus||this.lastFocusedElement?.focus?.(),this.quick||await this.animateClose()},this.onClosed=()=>{this.quick&&(this.dispatchEvent(new Event("closing")),this.dispatchEvent(new Event("closed")))},this.onWindowPointerdown=e=>{this.pointerPath=e.composedPath()},this.onDocumentClick=e=>{if(!this.open)return;let t=e.composedPath();!this.stayOpenOnOutsideClick&&!t.includes(this)&&!t.includes(this.anchorElement)&&(this.open=!1)},this.internals.role="menu",this.addEventListener("keydown",this.handleKeydown),this.addEventListener("keydown",this.captureKeydown,{capture:!0}),this.addEventListener("focusout",this.handleFocusout)}get items(){return this.listController.items}willUpdate(e){if(e.has("open")){if(this.open){this.removeAttribute("aria-hidden");return}this.setAttribute("aria-hidden","true")}}update(e){e.has("open")&&(this.open?this.setUpGlobalEventListeners():this.cleanUpGlobalEventListeners()),e.has("positioning")&&this.positioning==="popover"&&!this.showPopover&&(this.positioning="fixed"),super.update(e)}connectedCallback(){super.connectedCallback(),this.open&&this.setUpGlobalEventListeners()}disconnectedCallback(){super.disconnectedCallback(),this.cleanUpGlobalEventListeners()}getBoundingClientRect(){return this.surfaceEl?this.surfaceEl.getBoundingClientRect():super.getBoundingClientRect()}getClientRects(){return this.surfaceEl?this.surfaceEl.getClientRects():super.getClientRects()}render(){return this.renderSurface()}renderSurface(){return u`
+      <div
+        class="menu ${R(this.getSurfaceClasses())}"
+        style=${Ae(this.menuPositionController.surfaceStyles)}
+        popover=${this.positioning==="popover"?"manual":p}>
+        ${this.renderElevation()}
+        <div class="items">
+          <div class="item-padding"> ${this.renderMenuItems()} </div>
+        </div>
+      </div>
+    `}renderMenuItems(){return u`<slot
+      @close-menu=${this.onCloseMenu}
+      @deactivate-items=${this.onDeactivateItems}
+      @request-activation=${this.onRequestActivation}
+      @deactivate-typeahead=${this.handleDeactivateTypeahead}
+      @activate-typeahead=${this.handleActivateTypeahead}
+      @stay-open-on-focusout=${this.handleStayOpenOnFocusout}
+      @close-on-focusout=${this.handleCloseOnFocusout}
+      @slotchange=${this.listController.onSlotchange}></slot>`}renderElevation(){return u`<md-elevation part="elevation"></md-elevation>`}getSurfaceClasses(){return{open:this.open,fixed:this.positioning==="fixed","has-overflow":this.hasOverflow}}captureKeydown(e){e.target===this&&!e.defaultPrevented&&At(e.code)&&(e.preventDefault(),this.close()),this.typeaheadController.onKeydown(e)}async animateOpen(){let e=this.surfaceEl,t=this.slotEl;if(!e||!t)return!0;let r=this.openDirection;this.dispatchEvent(new Event("opening")),e.classList.toggle("animating",!0);let i=this.openCloseAnimationSignal.start(),n=e.offsetHeight,a=r==="UP",d=this.items,c=500,h=50,m=250,f=(c-m)/d.length,x=e.animate([{height:"0px"},{height:`${n}px`}],{duration:c,easing:ie.EMPHASIZED}),y=t.animate([{transform:a?`translateY(-${n}px)`:""},{transform:""}],{duration:c,easing:ie.EMPHASIZED}),I=e.animate([{opacity:0},{opacity:1}],h),w=[];for(let C=0;C<d.length;C++){let V=a?d.length-1-C:C,F=d[V],L=F.animate([{opacity:0},{opacity:1}],{duration:m,delay:f*C});F.classList.toggle("md-menu-hidden",!0),L.addEventListener("finish",()=>{F.classList.toggle("md-menu-hidden",!1)}),w.push([F,L])}let O=C=>{},z=new Promise(C=>{O=C});return i.addEventListener("abort",()=>{x.cancel(),y.cancel(),I.cancel(),w.forEach(([C,V])=>{C.classList.toggle("md-menu-hidden",!1),V.cancel()}),O(!0)}),x.addEventListener("finish",()=>{e.classList.toggle("animating",!1),this.openCloseAnimationSignal.finish(),O(!1)}),await z}animateClose(){let e,t=new Promise(L=>{e=L}),r=this.surfaceEl,i=this.slotEl;if(!r||!i)return e(!1),t;let a=this.openDirection==="UP";this.dispatchEvent(new Event("closing")),r.classList.toggle("animating",!0);let d=this.openCloseAnimationSignal.start(),c=r.offsetHeight,h=this.items,m=150,f=50,x=m-f,y=50,I=50,w=.35,O=(m-I-y)/h.length,z=r.animate([{height:`${c}px`},{height:`${c*w}px`}],{duration:m,easing:ie.EMPHASIZED_ACCELERATE}),C=i.animate([{transform:""},{transform:a?`translateY(-${c*(1-w)}px)`:""}],{duration:m,easing:ie.EMPHASIZED_ACCELERATE}),V=r.animate([{opacity:1},{opacity:0}],{duration:f,delay:x}),F=[];for(let L=0;L<h.length;L++){let le=a?L:h.length-1-L,de=h[le],be=de.animate([{opacity:1},{opacity:0}],{duration:y,delay:I+O*L});be.addEventListener("finish",()=>{de.classList.toggle("md-menu-hidden",!0)}),F.push([de,be])}return d.addEventListener("abort",()=>{z.cancel(),C.cancel(),V.cancel(),F.forEach(([L,le])=>{le.cancel(),L.classList.toggle("md-menu-hidden",!1)}),e(!1)}),z.addEventListener("finish",()=>{r.classList.toggle("animating",!1),F.forEach(([L])=>{L.classList.toggle("md-menu-hidden",!1)}),this.openCloseAnimationSignal.finish(),this.dispatchEvent(new Event("closed")),e(!0)}),t}handleKeydown(e){this.pointerPath=[],this.listController.handleKeydown(e)}setUpGlobalEventListeners(){document.addEventListener("click",this.onDocumentClick,{capture:!0}),window.addEventListener("pointerdown",this.onWindowPointerdown),document.addEventListener("resize",this.onWindowResize,{passive:!0}),window.addEventListener("resize",this.onWindowResize,{passive:!0})}cleanUpGlobalEventListeners(){document.removeEventListener("click",this.onDocumentClick,{capture:!0}),window.removeEventListener("pointerdown",this.onWindowPointerdown),document.removeEventListener("resize",this.onWindowResize),window.removeEventListener("resize",this.onWindowResize)}onCloseMenu(){this.close()}onDeactivateItems(e){e.stopPropagation(),this.listController.onDeactivateItems()}onRequestActivation(e){e.stopPropagation(),this.listController.onRequestActivation(e)}handleDeactivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!1}handleActivateTypeahead(e){e.stopPropagation(),this.typeaheadActive=!0}handleStayOpenOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!0}handleCloseOnFocusout(e){e.stopPropagation(),this.stayOpenOnFocusout=!1}close(){this.open=!1,this.slotItems.forEach(t=>{t.close?.()})}show(){this.open=!0}activateNextItem(){return this.listController.activateNextItem()??null}activatePreviousItem(){return this.listController.activatePreviousItem()??null}reposition(){this.open&&this.menuPositionController.position()}};s([S(".menu")],T.prototype,"surfaceEl",void 0);s([S("slot")],T.prototype,"slotEl",void 0);s([l()],T.prototype,"anchor",void 0);s([l()],T.prototype,"positioning",void 0);s([l({type:Boolean})],T.prototype,"quick",void 0);s([l({type:Boolean,attribute:"has-overflow"})],T.prototype,"hasOverflow",void 0);s([l({type:Boolean,reflect:!0})],T.prototype,"open",void 0);s([l({type:Number,attribute:"x-offset"})],T.prototype,"xOffset",void 0);s([l({type:Number,attribute:"y-offset"})],T.prototype,"yOffset",void 0);s([l({type:Boolean,attribute:"no-horizontal-flip"})],T.prototype,"noHorizontalFlip",void 0);s([l({type:Boolean,attribute:"no-vertical-flip"})],T.prototype,"noVerticalFlip",void 0);s([l({type:Number,attribute:"typeahead-delay"})],T.prototype,"typeaheadDelay",void 0);s([l({attribute:"anchor-corner"})],T.prototype,"anchorCorner",void 0);s([l({attribute:"menu-corner"})],T.prototype,"menuCorner",void 0);s([l({type:Boolean,attribute:"stay-open-on-outside-click"})],T.prototype,"stayOpenOnOutsideClick",void 0);s([l({type:Boolean,attribute:"stay-open-on-focusout"})],T.prototype,"stayOpenOnFocusout",void 0);s([l({type:Boolean,attribute:"skip-restore-focus"})],T.prototype,"skipRestoreFocus",void 0);s([l({attribute:"default-focus"})],T.prototype,"defaultFocus",void 0);s([l({type:Boolean,attribute:"no-navigation-wrap"})],T.prototype,"noNavigationWrap",void 0);s([N({flatten:!0})],T.prototype,"slotItems",void 0);s([k()],T.prototype,"typeaheadActive",void 0);var po=g`:host{--md-elevation-level: var(--md-menu-container-elevation, 2);--md-elevation-shadow-color: var(--md-menu-container-shadow-color, var(--md-sys-color-shadow, #000));min-width:112px;color:unset;display:contents}md-focus-ring{--md-focus-ring-shape: var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px))}.menu{border-radius:var(--md-menu-container-shape, var(--md-sys-shape-corner-extra-small, 4px));display:none;inset:auto;border:none;padding:0px;overflow:visible;background-color:rgba(0,0,0,0);color:inherit;opacity:0;z-index:20;position:absolute;user-select:none;max-height:inherit;height:inherit;min-width:inherit;max-width:inherit;scrollbar-width:inherit}.menu::backdrop{display:none}.fixed{position:fixed}.items{display:block;list-style-type:none;margin:0;outline:none;box-sizing:border-box;background-color:var(--md-menu-container-color, var(--md-sys-color-surface-container, #f3edf7));height:inherit;max-height:inherit;overflow:auto;min-width:inherit;max-width:inherit;border-radius:inherit;scrollbar-width:inherit}.item-padding{padding-block:var(--md-menu-top-space, 8px) var(--md-menu-bottom-space, 8px)}.has-overflow:not([popover]) .items{overflow:visible}.has-overflow.animating .items,.animating .items{overflow:hidden}.has-overflow.animating .items{pointer-events:none}.animating ::slotted(.md-menu-hidden){opacity:0}slot{display:block;height:inherit;max-height:inherit}::slotted(:is(md-divider,[role=separator])){margin:8px 0}@media(forced-colors: active){.menu{border-style:solid;border-color:CanvasText;border-width:1px}}
+`;var hr=class extends T{};hr.styles=[po];hr=s([E("md-menu")],hr);var Tt=class extends me{computeValidity(e){return this.selectControl||(this.selectControl=document.createElement("select")),Se(u`<option value=${e.value}></option>`,this.selectControl),this.selectControl.value=e.value,this.selectControl.required=e.required,{validity:this.selectControl.validity,validationMessage:this.selectControl.validationMessage}}equals(e,t){return e.value===t.value&&e.required===t.required}copy({value:e,required:t}){return{value:e,required:t}}};function uo(o){let e=[];for(let t=0;t<o.length;t++){let r=o[t];r.selected&&e.push([r,t])}return e}var ho,St=Symbol("value"),ni=W(bt(Oe(Re(ee(b))))),_=class extends ni{get value(){return this[St]}set value(e){this.lastUserSetValue=e,this.select(e)}get options(){return this.menu?.items??[]}get selectedIndex(){let[e,t]=(this.getSelectedOptions()??[])[0]??[];return t??-1}set selectedIndex(e){this.lastUserSetSelectedIndex=e,this.selectIndex(e)}get selectedOptions(){return(this.getSelectedOptions()??[]).map(([e])=>e)}get hasError(){return this.error||this.nativeError}constructor(){super(),this.quick=!1,this.required=!1,this.errorText="",this.label="",this.noAsterisk=!1,this.supportingText="",this.error=!1,this.menuPositioning="popover",this.clampMenuWidth=!1,this.typeaheadDelay=ur,this.hasLeadingIcon=!1,this.displayText="",this.menuAlign="start",this[ho]="",this.lastUserSetValue=null,this.lastUserSetSelectedIndex=null,this.lastSelectedOption=null,this.lastSelectedOptionRecords=[],this.nativeError=!1,this.nativeErrorText="",this.focused=!1,this.open=!1,this.defaultFocus=K.NONE,this.prevOpen=this.open,this.selectWidth=0,!!1&&(this.addEventListener("focus",this.handleFocus.bind(this)),this.addEventListener("blur",this.handleBlur.bind(this)))}select(e){let t=this.options.find(r=>r.value===e);t&&this.selectItem(t)}selectIndex(e){let t=this.options[e];t&&this.selectItem(t)}reset(){for(let e of this.options)e.selected=e.hasAttribute("selected");this.updateValueAndDisplayText(),this.nativeError=!1,this.nativeErrorText=""}showPicker(){this.open=!0}[(ho=St,Pe)](e){e?.preventDefault();let t=this.getErrorText();this.nativeError=!!e,this.nativeErrorText=this.validationMessage,t===this.getErrorText()&&this.field?.reannounceError()}update(e){if(this.hasUpdated||this.initUserSelection(),this.prevOpen!==this.open&&this.open){let t=this.getBoundingClientRect();this.selectWidth=t.width}this.prevOpen=this.open,super.update(e)}render(){return u`
+      <span
+        class="select ${R(this.getRenderClasses())}"
+        @focusout=${this.handleFocusout}>
+        ${this.renderField()} ${this.renderMenu()}
+      </span>
+    `}async firstUpdated(e){await this.menu?.updateComplete,this.lastSelectedOptionRecords.length||this.initUserSelection(),!this.lastSelectedOptionRecords.length&&!!1&&!this.options.length&&setTimeout(()=>{this.updateValueAndDisplayText()}),super.firstUpdated(e)}getRenderClasses(){return{disabled:this.disabled,error:this.error,open:this.open}}renderField(){let e=this.ariaLabel||this.label;return ue`
+      <${this.fieldTag}
+          aria-haspopup="listbox"
+          role="combobox"
+          part="field"
+          id="field"
+          tabindex=${this.disabled?"-1":"0"}
+          aria-label=${e||p}
+          aria-describedby="description"
+          aria-expanded=${this.open?"true":"false"}
+          aria-controls="listbox"
+          class="field"
+          label=${this.label}
+          ?no-asterisk=${this.noAsterisk}
+          .focused=${this.focused||this.open}
+          .populated=${!!this.displayText}
+          .disabled=${this.disabled}
+          .required=${this.required}
+          .error=${this.hasError}
+          ?has-start=${this.hasLeadingIcon}
+          has-end
+          supporting-text=${this.supportingText}
+          error-text=${this.getErrorText()}
+          @keydown=${this.handleKeydown}
+          @click=${this.handleClick}>
+         ${this.renderFieldContent()}
+         <div id="description" slot="aria-describedby"></div>
+      </${this.fieldTag}>`}renderFieldContent(){return[this.renderLeadingIcon(),this.renderLabel(),this.renderTrailingIcon()]}renderLeadingIcon(){return u`
+      <span class="icon leading" slot="start">
+        <slot name="leading-icon" @slotchange=${this.handleIconChange}></slot>
+      </span>
+    `}renderTrailingIcon(){return u`
+      <span class="icon trailing" slot="end">
+        <slot name="trailing-icon" @slotchange=${this.handleIconChange}>
+          <svg height="5" viewBox="7 10 10 5" focusable="false">
+            <polygon
+              class="down"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 10 12 15 17 10"></polygon>
+            <polygon
+              class="up"
+              stroke="none"
+              fill-rule="evenodd"
+              points="7 15 12 10 17 15"></polygon>
+          </svg>
+        </slot>
+      </span>
+    `}renderLabel(){return u`<div id="label">${this.displayText||u`&nbsp;`}</div>`}renderMenu(){let e=this.label||this.ariaLabel;return u`<div class="menu-wrapper">
+      <md-menu
+        id="listbox"
+        .defaultFocus=${this.defaultFocus}
+        role="listbox"
+        tabindex="-1"
+        aria-label=${e||p}
+        stay-open-on-focusout
+        part="menu"
+        exportparts="focus-ring: menu-focus-ring"
+        anchor="field"
+        style=${Ae({"--__menu-min-width":`${this.selectWidth}px`,"--__menu-max-width":this.clampMenuWidth?`${this.selectWidth}px`:void 0})}
+        no-navigation-wrap
+        .open=${this.open}
+        .quick=${this.quick}
+        .positioning=${this.menuPositioning}
+        .typeaheadDelay=${this.typeaheadDelay}
+        .anchorCorner=${this.menuAlign==="start"?"end-start":"end-end"}
+        .menuCorner=${this.menuAlign==="start"?"start-start":"start-end"}
+        @opening=${this.handleOpening}
+        @opened=${this.redispatchEvent}
+        @closing=${this.redispatchEvent}
+        @closed=${this.handleClosed}
+        @close-menu=${this.handleCloseMenu}
+        @request-selection=${this.handleRequestSelection}
+        @request-deselection=${this.handleRequestDeselection}>
+        ${this.renderMenuContent()}
+      </md-menu>
+    </div>`}renderMenuContent(){return u`<slot></slot>`}handleKeydown(e){if(this.open||this.disabled||!this.menu)return;let t=this.menu.typeaheadController,r=e.code==="Space"||e.code==="ArrowDown"||e.code==="ArrowUp"||e.code==="End"||e.code==="Home"||e.code==="Enter";if(!t.isTypingAhead&&r){switch(e.preventDefault(),this.open=!0,e.code){case"Space":case"ArrowDown":case"Enter":this.defaultFocus=K.NONE;break;case"End":this.defaultFocus=K.LAST_ITEM;break;case"ArrowUp":case"Home":this.defaultFocus=K.FIRST_ITEM;break;default:break}return}if(e.key.length===1){t.onKeydown(e),e.preventDefault();let{lastActiveRecord:n}=t;if(!n)return;this.labelEl?.setAttribute?.("aria-live","polite"),this.selectItem(n[Y.ITEM])&&this.dispatchInteractionEvents()}}handleClick(){this.open=!this.open}handleFocus(){this.focused=!0}handleBlur(){this.focused=!1}handleFocusout(e){e.relatedTarget&&Ye(e.relatedTarget,this)||(this.open=!1)}getSelectedOptions(){if(!this.menu)return this.lastSelectedOptionRecords=[],null;let e=this.menu.items;return this.lastSelectedOptionRecords=uo(e),this.lastSelectedOptionRecords}async getUpdateComplete(){return await this.menu?.updateComplete,super.getUpdateComplete()}updateValueAndDisplayText(){let e=this.getSelectedOptions()??[],t=!1;if(e.length){let[r]=e[0];t=this.lastSelectedOption!==r,this.lastSelectedOption=r,this[St]=r.value,this.displayText=r.displayText}else t=this.lastSelectedOption!==null,this.lastSelectedOption=null,this[St]="",this.displayText="";return t}async handleOpening(e){if(this.labelEl?.removeAttribute?.("aria-live"),this.redispatchEvent(e),this.defaultFocus!==K.NONE)return;let t=this.menu.items,r=ve(t)?.item,[i]=this.lastSelectedOptionRecords[0]??[null];r&&r!==i&&(r.tabIndex=-1),i=i??t[0],i&&(i.tabIndex=0,i.focus())}redispatchEvent(e){ke(this,e)}handleClosed(e){this.open=!1,this.redispatchEvent(e)}handleCloseMenu(e){let t=e.detail.reason,r=e.detail.itemPath[0];this.open=!1;let i=!1;t.kind==="click-selection"?i=this.selectItem(r):t.kind==="keydown"&&lo(t.key)?i=this.selectItem(r):(r.tabIndex=-1,r.blur()),i&&this.dispatchInteractionEvents()}selectItem(e){return(this.getSelectedOptions()??[]).forEach(([r])=>{e!==r&&(r.selected=!1)}),e.selected=!0,this.updateValueAndDisplayText()}handleRequestSelection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)||this.selectItem(t)}handleRequestDeselection(e){let t=e.target;this.lastSelectedOptionRecords.some(([r])=>r===t)&&this.updateValueAndDisplayText()}initUserSelection(){this.lastUserSetValue&&!this.lastSelectedOptionRecords.length?this.select(this.lastUserSetValue):this.lastUserSetSelectedIndex!==null&&!this.lastSelectedOptionRecords.length?this.selectIndex(this.lastUserSetSelectedIndex):this.updateValueAndDisplayText()}handleIconChange(){this.hasLeadingIcon=this.leadingIcons.length>0}dispatchInteractionEvents(){this.dispatchEvent(new Event("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0}))}getErrorText(){return this.error?this.errorText:this.nativeErrorText}[se](){return this.value}formResetCallback(){this.reset()}formStateRestoreCallback(e){this.value=e}click(){this.field?.click()}[he](){return new Tt(()=>this)}[fe](){return this.field}};_.shadowRootOptions={...b.shadowRootOptions,delegatesFocus:!0};s([l({type:Boolean})],_.prototype,"quick",void 0);s([l({type:Boolean})],_.prototype,"required",void 0);s([l({type:String,attribute:"error-text"})],_.prototype,"errorText",void 0);s([l()],_.prototype,"label",void 0);s([l({type:Boolean,attribute:"no-asterisk"})],_.prototype,"noAsterisk",void 0);s([l({type:String,attribute:"supporting-text"})],_.prototype,"supportingText",void 0);s([l({type:Boolean,reflect:!0})],_.prototype,"error",void 0);s([l({attribute:"menu-positioning"})],_.prototype,"menuPositioning",void 0);s([l({type:Boolean,attribute:"clamp-menu-width"})],_.prototype,"clampMenuWidth",void 0);s([l({type:Number,attribute:"typeahead-delay"})],_.prototype,"typeaheadDelay",void 0);s([l({type:Boolean,attribute:"has-leading-icon"})],_.prototype,"hasLeadingIcon",void 0);s([l({attribute:"display-text"})],_.prototype,"displayText",void 0);s([l({attribute:"menu-align"})],_.prototype,"menuAlign",void 0);s([l()],_.prototype,"value",null);s([l({type:Number,attribute:"selected-index"})],_.prototype,"selectedIndex",null);s([k()],_.prototype,"nativeError",void 0);s([k()],_.prototype,"nativeErrorText",void 0);s([k()],_.prototype,"focused",void 0);s([k()],_.prototype,"open",void 0);s([k()],_.prototype,"defaultFocus",void 0);s([S(".field")],_.prototype,"field",void 0);s([S("md-menu")],_.prototype,"menu",void 0);s([S("#label")],_.prototype,"labelEl",void 0);s([N({slot:"leading-icon",flatten:!0})],_.prototype,"leadingIcons",void 0);var It=class extends _{constructor(){super(...arguments),this.fieldTag=G`md-outlined-field`}};var fo=g`:host{--_text-field-disabled-input-text-color: var(--md-outlined-select-text-field-disabled-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-input-text-opacity: var(--md-outlined-select-text-field-disabled-input-text-opacity, 0.38);--_text-field-disabled-label-text-color: var(--md-outlined-select-text-field-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-label-text-opacity: var(--md-outlined-select-text-field-disabled-label-text-opacity, 0.38);--_text-field-disabled-leading-icon-color: var(--md-outlined-select-text-field-disabled-leading-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-leading-icon-opacity: var(--md-outlined-select-text-field-disabled-leading-icon-opacity, 0.38);--_text-field-disabled-outline-color: var(--md-outlined-select-text-field-disabled-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-outline-opacity: var(--md-outlined-select-text-field-disabled-outline-opacity, 0.12);--_text-field-disabled-outline-width: var(--md-outlined-select-text-field-disabled-outline-width, 1px);--_text-field-disabled-supporting-text-color: var(--md-outlined-select-text-field-disabled-supporting-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-supporting-text-opacity: var(--md-outlined-select-text-field-disabled-supporting-text-opacity, 0.38);--_text-field-disabled-trailing-icon-color: var(--md-outlined-select-text-field-disabled-trailing-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-disabled-trailing-icon-opacity: var(--md-outlined-select-text-field-disabled-trailing-icon-opacity, 0.38);--_text-field-error-focus-input-text-color: var(--md-outlined-select-text-field-error-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-focus-label-text-color: var(--md-outlined-select-text-field-error-focus-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-leading-icon-color: var(--md-outlined-select-text-field-error-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-focus-outline-color: var(--md-outlined-select-text-field-error-focus-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-supporting-text-color: var(--md-outlined-select-text-field-error-focus-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-focus-trailing-icon-color: var(--md-outlined-select-text-field-error-focus-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-input-text-color: var(--md-outlined-select-text-field-error-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-hover-label-text-color: var(--md-outlined-select-text-field-error-hover-label-text-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-leading-icon-color: var(--md-outlined-select-text-field-error-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-hover-outline-color: var(--md-outlined-select-text-field-error-hover-outline-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-hover-supporting-text-color: var(--md-outlined-select-text-field-error-hover-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-hover-trailing-icon-color: var(--md-outlined-select-text-field-error-hover-trailing-icon-color, var(--md-sys-color-on-error-container, #410e0b));--_text-field-error-input-text-color: var(--md-outlined-select-text-field-error-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-error-label-text-color: var(--md-outlined-select-text-field-error-label-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-leading-icon-color: var(--md-outlined-select-text-field-error-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-error-outline-color: var(--md-outlined-select-text-field-error-outline-color, var(--md-sys-color-error, #b3261e));--_text-field-error-supporting-text-color: var(--md-outlined-select-text-field-error-supporting-text-color, var(--md-sys-color-error, #b3261e));--_text-field-error-trailing-icon-color: var(--md-outlined-select-text-field-error-trailing-icon-color, var(--md-sys-color-error, #b3261e));--_text-field-focus-input-text-color: var(--md-outlined-select-text-field-focus-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-focus-label-text-color: var(--md-outlined-select-text-field-focus-label-text-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-leading-icon-color: var(--md-outlined-select-text-field-focus-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-outline-color: var(--md-outlined-select-text-field-focus-outline-color, var(--md-sys-color-primary, #6750a4));--_text-field-focus-outline-width: var(--md-outlined-select-text-field-focus-outline-width, 3px);--_text-field-focus-supporting-text-color: var(--md-outlined-select-text-field-focus-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-focus-trailing-icon-color: var(--md-outlined-select-text-field-focus-trailing-icon-color, var(--md-sys-color-primary, #6750a4));--_text-field-hover-input-text-color: var(--md-outlined-select-text-field-hover-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-label-text-color: var(--md-outlined-select-text-field-hover-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-leading-icon-color: var(--md-outlined-select-text-field-hover-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-outline-color: var(--md-outlined-select-text-field-hover-outline-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-hover-outline-width: var(--md-outlined-select-text-field-hover-outline-width, 1px);--_text-field-hover-supporting-text-color: var(--md-outlined-select-text-field-hover-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-hover-trailing-icon-color: var(--md-outlined-select-text-field-hover-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-input-text-color: var(--md-outlined-select-text-field-input-text-color, var(--md-sys-color-on-surface, #1d1b20));--_text-field-input-text-font: var(--md-outlined-select-text-field-input-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-input-text-line-height: var(--md-outlined-select-text-field-input-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-input-text-size: var(--md-outlined-select-text-field-input-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-input-text-weight: var(--md-outlined-select-text-field-input-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-label-text-color: var(--md-outlined-select-text-field-label-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-label-text-font: var(--md-outlined-select-text-field-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-label-text-line-height: var(--md-outlined-select-text-field-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));--_text-field-label-text-populated-line-height: var(--md-outlined-select-text-field-label-text-populated-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-label-text-populated-size: var(--md-outlined-select-text-field-label-text-populated-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-label-text-size: var(--md-outlined-select-text-field-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));--_text-field-label-text-weight: var(--md-outlined-select-text-field-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-leading-icon-color: var(--md-outlined-select-text-field-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-leading-icon-size: var(--md-outlined-select-text-field-leading-icon-size, 24px);--_text-field-outline-color: var(--md-outlined-select-text-field-outline-color, var(--md-sys-color-outline, #79747e));--_text-field-outline-width: var(--md-outlined-select-text-field-outline-width, 1px);--_text-field-supporting-text-color: var(--md-outlined-select-text-field-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-supporting-text-font: var(--md-outlined-select-text-field-supporting-text-font, var(--md-sys-typescale-body-small-font, var(--md-ref-typeface-plain, Roboto)));--_text-field-supporting-text-line-height: var(--md-outlined-select-text-field-supporting-text-line-height, var(--md-sys-typescale-body-small-line-height, 1rem));--_text-field-supporting-text-size: var(--md-outlined-select-text-field-supporting-text-size, var(--md-sys-typescale-body-small-size, 0.75rem));--_text-field-supporting-text-weight: var(--md-outlined-select-text-field-supporting-text-weight, var(--md-sys-typescale-body-small-weight, var(--md-ref-typeface-weight-regular, 400)));--_text-field-trailing-icon-color: var(--md-outlined-select-text-field-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_text-field-trailing-icon-size: var(--md-outlined-select-text-field-trailing-icon-size, 24px);--_text-field-container-shape-start-start: var(--md-outlined-select-text-field-container-shape-start-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-start-end: var(--md-outlined-select-text-field-container-shape-start-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-end: var(--md-outlined-select-text-field-container-shape-end-end, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--_text-field-container-shape-end-start: var(--md-outlined-select-text-field-container-shape-end-start, var(--md-outlined-select-text-field-container-shape, var(--md-sys-shape-corner-extra-small, 4px)));--md-outlined-field-container-shape-end-end: var(--_text-field-container-shape-end-end);--md-outlined-field-container-shape-end-start: var(--_text-field-container-shape-end-start);--md-outlined-field-container-shape-start-end: var(--_text-field-container-shape-start-end);--md-outlined-field-container-shape-start-start: var(--_text-field-container-shape-start-start);--md-outlined-field-content-color: var(--_text-field-input-text-color);--md-outlined-field-content-font: var(--_text-field-input-text-font);--md-outlined-field-content-line-height: var(--_text-field-input-text-line-height);--md-outlined-field-content-size: var(--_text-field-input-text-size);--md-outlined-field-content-weight: var(--_text-field-input-text-weight);--md-outlined-field-disabled-content-color: var(--_text-field-disabled-input-text-color);--md-outlined-field-disabled-content-opacity: var(--_text-field-disabled-input-text-opacity);--md-outlined-field-disabled-label-text-color: var(--_text-field-disabled-label-text-color);--md-outlined-field-disabled-label-text-opacity: var(--_text-field-disabled-label-text-opacity);--md-outlined-field-disabled-leading-content-color: var(--_text-field-disabled-leading-icon-color);--md-outlined-field-disabled-leading-content-opacity: var(--_text-field-disabled-leading-icon-opacity);--md-outlined-field-disabled-outline-color: var(--_text-field-disabled-outline-color);--md-outlined-field-disabled-outline-opacity: var(--_text-field-disabled-outline-opacity);--md-outlined-field-disabled-outline-width: var(--_text-field-disabled-outline-width);--md-outlined-field-disabled-supporting-text-color: var(--_text-field-disabled-supporting-text-color);--md-outlined-field-disabled-supporting-text-opacity: var(--_text-field-disabled-supporting-text-opacity);--md-outlined-field-disabled-trailing-content-color: var(--_text-field-disabled-trailing-icon-color);--md-outlined-field-disabled-trailing-content-opacity: var(--_text-field-disabled-trailing-icon-opacity);--md-outlined-field-error-content-color: var(--_text-field-error-input-text-color);--md-outlined-field-error-focus-content-color: var(--_text-field-error-focus-input-text-color);--md-outlined-field-error-focus-label-text-color: var(--_text-field-error-focus-label-text-color);--md-outlined-field-error-focus-leading-content-color: var(--_text-field-error-focus-leading-icon-color);--md-outlined-field-error-focus-outline-color: var(--_text-field-error-focus-outline-color);--md-outlined-field-error-focus-supporting-text-color: var(--_text-field-error-focus-supporting-text-color);--md-outlined-field-error-focus-trailing-content-color: var(--_text-field-error-focus-trailing-icon-color);--md-outlined-field-error-hover-content-color: var(--_text-field-error-hover-input-text-color);--md-outlined-field-error-hover-label-text-color: var(--_text-field-error-hover-label-text-color);--md-outlined-field-error-hover-leading-content-color: var(--_text-field-error-hover-leading-icon-color);--md-outlined-field-error-hover-outline-color: var(--_text-field-error-hover-outline-color);--md-outlined-field-error-hover-supporting-text-color: var(--_text-field-error-hover-supporting-text-color);--md-outlined-field-error-hover-trailing-content-color: var(--_text-field-error-hover-trailing-icon-color);--md-outlined-field-error-label-text-color: var(--_text-field-error-label-text-color);--md-outlined-field-error-leading-content-color: var(--_text-field-error-leading-icon-color);--md-outlined-field-error-outline-color: var(--_text-field-error-outline-color);--md-outlined-field-error-supporting-text-color: var(--_text-field-error-supporting-text-color);--md-outlined-field-error-trailing-content-color: var(--_text-field-error-trailing-icon-color);--md-outlined-field-focus-content-color: var(--_text-field-focus-input-text-color);--md-outlined-field-focus-label-text-color: var(--_text-field-focus-label-text-color);--md-outlined-field-focus-leading-content-color: var(--_text-field-focus-leading-icon-color);--md-outlined-field-focus-outline-color: var(--_text-field-focus-outline-color);--md-outlined-field-focus-outline-width: var(--_text-field-focus-outline-width);--md-outlined-field-focus-supporting-text-color: var(--_text-field-focus-supporting-text-color);--md-outlined-field-focus-trailing-content-color: var(--_text-field-focus-trailing-icon-color);--md-outlined-field-hover-content-color: var(--_text-field-hover-input-text-color);--md-outlined-field-hover-label-text-color: var(--_text-field-hover-label-text-color);--md-outlined-field-hover-leading-content-color: var(--_text-field-hover-leading-icon-color);--md-outlined-field-hover-outline-color: var(--_text-field-hover-outline-color);--md-outlined-field-hover-outline-width: var(--_text-field-hover-outline-width);--md-outlined-field-hover-supporting-text-color: var(--_text-field-hover-supporting-text-color);--md-outlined-field-hover-trailing-content-color: var(--_text-field-hover-trailing-icon-color);--md-outlined-field-label-text-color: var(--_text-field-label-text-color);--md-outlined-field-label-text-font: var(--_text-field-label-text-font);--md-outlined-field-label-text-line-height: var(--_text-field-label-text-line-height);--md-outlined-field-label-text-populated-line-height: var(--_text-field-label-text-populated-line-height);--md-outlined-field-label-text-populated-size: var(--_text-field-label-text-populated-size);--md-outlined-field-label-text-size: var(--_text-field-label-text-size);--md-outlined-field-label-text-weight: var(--_text-field-label-text-weight);--md-outlined-field-leading-content-color: var(--_text-field-leading-icon-color);--md-outlined-field-outline-color: var(--_text-field-outline-color);--md-outlined-field-outline-width: var(--_text-field-outline-width);--md-outlined-field-supporting-text-color: var(--_text-field-supporting-text-color);--md-outlined-field-supporting-text-font: var(--_text-field-supporting-text-font);--md-outlined-field-supporting-text-line-height: var(--_text-field-supporting-text-line-height);--md-outlined-field-supporting-text-size: var(--_text-field-supporting-text-size);--md-outlined-field-supporting-text-weight: var(--_text-field-supporting-text-weight);--md-outlined-field-trailing-content-color: var(--_text-field-trailing-icon-color)}[has-start] .icon.leading{font-size:var(--_text-field-leading-icon-size);height:var(--_text-field-leading-icon-size);width:var(--_text-field-leading-icon-size)}.icon.trailing{font-size:var(--_text-field-trailing-icon-size);height:var(--_text-field-trailing-icon-size);width:var(--_text-field-trailing-icon-size)}
+`;var mo=g`:host{color:unset;min-width:210px;display:flex}.field{cursor:default;outline:none}.select{position:relative;flex-direction:column}.icon.trailing svg,.icon ::slotted(*){fill:currentColor}.icon ::slotted(*){width:inherit;height:inherit;font-size:inherit}.icon slot{display:flex;height:100%;width:100%;align-items:center;justify-content:center}.icon.trailing :is(.up,.down){opacity:0;transition:opacity 75ms linear 75ms}.select:not(.open) .down,.select.open .up{opacity:1}.field,.select,md-menu{min-width:inherit;width:inherit;max-width:inherit;display:flex}md-menu{min-width:var(--__menu-min-width);max-width:var(--__menu-max-width, inherit)}.menu-wrapper{width:0px;height:0px;max-width:inherit}md-menu ::slotted(:not[disabled]){cursor:pointer}.field,.select{width:100%}:host{display:inline-flex}:host([disabled]){pointer-events:none}
+`;var fr=class extends It{};fr.styles=[mo,fo];fr=s([E("md-outlined-select")],fr);var kt=g`:host{display:flex;--md-ripple-hover-color: var(--md-menu-item-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-menu-item-hover-state-layer-opacity, 0.08);--md-ripple-pressed-color: var(--md-menu-item-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-opacity: var(--md-menu-item-pressed-state-layer-opacity, 0.12)}:host([disabled]){opacity:var(--md-menu-item-disabled-opacity, 0.3);pointer-events:none}md-focus-ring{z-index:1;--md-focus-ring-shape: 8px}a,button,li{background:none;border:none;padding:0;margin:0;text-align:unset;text-decoration:none}.list-item{border-radius:inherit;display:flex;flex:1;max-width:inherit;min-width:inherit;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}.list-item:not(.disabled){cursor:pointer}[slot=container]{pointer-events:none}md-ripple{border-radius:inherit}md-item{border-radius:inherit;flex:1;color:var(--md-menu-item-label-text-color, var(--md-sys-color-on-surface, #1d1b20));font-family:var(--md-menu-item-label-text-font, var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-label-text-size, var(--md-sys-typescale-body-large-size, 1rem));line-height:var(--md-menu-item-label-text-line-height, var(--md-sys-typescale-body-large-line-height, 1.5rem));font-weight:var(--md-menu-item-label-text-weight, var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400)));min-height:var(--md-menu-item-one-line-container-height, 56px);padding-top:var(--md-menu-item-top-space, 12px);padding-bottom:var(--md-menu-item-bottom-space, 12px);padding-inline-start:var(--md-menu-item-leading-space, 16px);padding-inline-end:var(--md-menu-item-trailing-space, 16px)}md-item[multiline]{min-height:var(--md-menu-item-two-line-container-height, 72px)}[slot=supporting-text]{color:var(--md-menu-item-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-supporting-text-font, var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-supporting-text-size, var(--md-sys-typescale-body-medium-size, 0.875rem));line-height:var(--md-menu-item-supporting-text-line-height, var(--md-sys-typescale-body-medium-line-height, 1.25rem));font-weight:var(--md-menu-item-supporting-text-weight, var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400)))}[slot=trailing-supporting-text]{color:var(--md-menu-item-trailing-supporting-text-color, var(--md-sys-color-on-surface-variant, #49454f));font-family:var(--md-menu-item-trailing-supporting-text-font, var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto)));font-size:var(--md-menu-item-trailing-supporting-text-size, var(--md-sys-typescale-label-small-size, 0.6875rem));line-height:var(--md-menu-item-trailing-supporting-text-line-height, var(--md-sys-typescale-label-small-line-height, 1rem));font-weight:var(--md-menu-item-trailing-supporting-text-weight, var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500)))}:is([slot=start],[slot=end])::slotted(*){fill:currentColor}[slot=start]{color:var(--md-menu-item-leading-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}[slot=end]{color:var(--md-menu-item-trailing-icon-color, var(--md-sys-color-on-surface-variant, #49454f))}.list-item{background-color:var(--md-menu-item-container-color, transparent)}.list-item.selected{background-color:var(--md-menu-item-selected-container-color, var(--md-sys-color-secondary-container, #e8def8))}.selected:not(.disabled) ::slotted(*){color:var(--md-menu-item-selected-label-text-color, var(--md-sys-color-on-secondary-container, #1d192b))}@media(forced-colors: active){:host([disabled]),:host([disabled]) slot{color:GrayText;opacity:1}.list-item{position:relative}.list-item.selected::before{content:"";position:absolute;inset:0;box-sizing:border-box;border-radius:inherit;pointer-events:none;border:3px double CanvasText}}
+`;var ze=class extends b{constructor(){super(...arguments),this.multiline=!1}render(){return u`
+      <slot name="container"></slot>
+      <slot class="non-text" name="start"></slot>
+      <div class="text">
+        <slot name="overline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          class="default-slot"
+          @slotchange=${this.handleTextSlotChange}></slot>
+        <slot name="headline" @slotchange=${this.handleTextSlotChange}></slot>
+        <slot
+          name="supporting-text"
+          @slotchange=${this.handleTextSlotChange}></slot>
+      </div>
+      <slot class="non-text" name="trailing-supporting-text"></slot>
+      <slot class="non-text" name="end"></slot>
+    `}handleTextSlotChange(){let e=!1,t=0;for(let r of this.textSlots)if(si(r)&&(t+=1),t>1){e=!0;break}this.multiline=e}};s([l({type:Boolean,reflect:!0})],ze.prototype,"multiline",void 0);s([Or(".text slot")],ze.prototype,"textSlots",void 0);function si(o){for(let e of o.assignedNodes({flatten:!0})){let t=e.nodeType===Node.ELEMENT_NODE,r=e.nodeType===Node.TEXT_NODE&&e.textContent?.match(/\S/);if(t||r)return!0}return!1}var vo=g`:host{color:var(--md-sys-color-on-surface, #1d1b20);font-family:var(--md-sys-typescale-body-large-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-large-size, 1rem);font-weight:var(--md-sys-typescale-body-large-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-large-line-height, 1.5rem);align-items:center;box-sizing:border-box;display:flex;gap:16px;min-height:56px;overflow:hidden;padding:12px 16px;position:relative;text-overflow:ellipsis}:host([multiline]){min-height:72px}[name=overline]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-body-medium-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-body-medium-size, 0.875rem);font-weight:var(--md-sys-typescale-body-medium-weight, var(--md-ref-typeface-weight-regular, 400));line-height:var(--md-sys-typescale-body-medium-line-height, 1.25rem)}[name=trailing-supporting-text]{color:var(--md-sys-color-on-surface-variant, #49454f);font-family:var(--md-sys-typescale-label-small-font, var(--md-ref-typeface-plain, Roboto));font-size:var(--md-sys-typescale-label-small-size, 0.6875rem);font-weight:var(--md-sys-typescale-label-small-weight, var(--md-ref-typeface-weight-medium, 500));line-height:var(--md-sys-typescale-label-small-line-height, 1rem)}[name=container]::slotted(*){inset:0;position:absolute}.default-slot{display:inline}.default-slot,.text ::slotted(*){overflow:hidden;text-overflow:ellipsis}.text{display:flex;flex:1;flex-direction:column;overflow:hidden}
+`;var mr=class extends ze{};mr.styles=[vo];mr=s([E("md-item")],mr);var ai=450,go=225,li=.2,di=10,ci=75,pi=.35,ui="::after",hi="forwards",H;(function(o){o[o.INACTIVE=0]="INACTIVE",o[o.TOUCH_DELAY=1]="TOUCH_DELAY",o[o.HOLDING=2]="HOLDING",o[o.WAITING_FOR_CLICK=3]="WAITING_FOR_CLICK"})(H||(H={}));var fi=["click","contextmenu","pointercancel","pointerdown","pointerenter","pointerleave","pointerup"],mi=150,vi=window.matchMedia("(forced-colors: active)"),ge=class extends b{constructor(){super(...arguments),this.disabled=!1,this.hovered=!1,this.pressed=!1,this.rippleSize="",this.rippleScale="",this.initialSize=0,this.state=H.INACTIVE,this.attachableController=new Le(this,this.onControlChange.bind(this))}get htmlFor(){return this.attachableController.htmlFor}set htmlFor(e){this.attachableController.htmlFor=e}get control(){return this.attachableController.control}set control(e){this.attachableController.control=e}attach(e){this.attachableController.attach(e)}detach(){this.attachableController.detach()}connectedCallback(){super.connectedCallback(),this.setAttribute("aria-hidden","true")}render(){let e={hovered:this.hovered,pressed:this.pressed};return u`<div class="surface ${R(e)}"></div>`}update(e){e.has("disabled")&&this.disabled&&(this.hovered=!1,this.pressed=!1),super.update(e)}handlePointerenter(e){this.shouldReactToEvent(e)&&(this.hovered=!0)}handlePointerleave(e){this.shouldReactToEvent(e)&&(this.hovered=!1,this.state!==H.INACTIVE&&this.endPressAnimation())}handlePointerup(e){if(this.shouldReactToEvent(e)){if(this.state===H.HOLDING){this.state=H.WAITING_FOR_CLICK;return}if(this.state===H.TOUCH_DELAY){this.state=H.WAITING_FOR_CLICK,this.startPressAnimation(this.rippleStartEvent);return}}}async handlePointerdown(e){if(this.shouldReactToEvent(e)){if(this.rippleStartEvent=e,!this.isTouch(e)){this.state=H.WAITING_FOR_CLICK,this.startPressAnimation(e);return}this.state=H.TOUCH_DELAY,await new Promise(t=>{setTimeout(t,mi)}),this.state===H.TOUCH_DELAY&&(this.state=H.HOLDING,this.startPressAnimation(e))}}handleClick(){if(!this.disabled){if(this.state===H.WAITING_FOR_CLICK){this.endPressAnimation();return}this.state===H.INACTIVE&&(this.startPressAnimation(),this.endPressAnimation())}}handlePointercancel(e){this.shouldReactToEvent(e)&&this.endPressAnimation()}handleContextmenu(){this.disabled||this.endPressAnimation()}determineRippleSize(){let{height:e,width:t}=this.getBoundingClientRect(),r=Math.max(e,t),i=Math.max(pi*r,ci),n=this.currentCSSZoom??1,a=Math.floor(r*li/n),c=Math.sqrt(t**2+e**2)+di;this.initialSize=a;let h=(c+i)/a;this.rippleScale=`${h/n}`,this.rippleSize=`${a}px`}getNormalizedPointerEventCoords(e){let{scrollX:t,scrollY:r}=window,{left:i,top:n}=this.getBoundingClientRect(),a=t+i,d=r+n,{pageX:c,pageY:h}=e,m=this.currentCSSZoom??1;return{x:(c-a)/m,y:(h-d)/m}}getTranslationCoordinates(e){let{height:t,width:r}=this.getBoundingClientRect(),i=this.currentCSSZoom??1,n={x:(r/i-this.initialSize)/2,y:(t/i-this.initialSize)/2},a;return e instanceof PointerEvent?a=this.getNormalizedPointerEventCoords(e):a={x:r/i/2,y:t/i/2},a={x:a.x-this.initialSize/2,y:a.y-this.initialSize/2},{startPoint:a,endPoint:n}}startPressAnimation(e){if(!this.mdRoot)return;this.pressed=!0,this.growAnimation?.cancel(),this.determineRippleSize();let{startPoint:t,endPoint:r}=this.getTranslationCoordinates(e),i=`${t.x}px, ${t.y}px`,n=`${r.x}px, ${r.y}px`;this.growAnimation=this.mdRoot.animate({top:[0,0],left:[0,0],height:[this.rippleSize,this.rippleSize],width:[this.rippleSize,this.rippleSize],transform:[`translate(${i}) scale(1)`,`translate(${n}) scale(${this.rippleScale})`]},{pseudoElement:ui,duration:ai,easing:ie.STANDARD,fill:hi})}async endPressAnimation(){this.rippleStartEvent=void 0,this.state=H.INACTIVE;let e=this.growAnimation,t=1/0;if(typeof e?.currentTime=="number"?t=e.currentTime:e?.currentTime&&(t=e.currentTime.to("ms").value),t>=go){this.pressed=!1;return}await new Promise(r=>{setTimeout(r,go-t)}),this.growAnimation===e&&(this.pressed=!1)}shouldReactToEvent(e){if(this.disabled||!e.isPrimary||this.rippleStartEvent&&this.rippleStartEvent.pointerId!==e.pointerId)return!1;if(e.type==="pointerenter"||e.type==="pointerleave")return!this.isTouch(e);let t=e.buttons===1;return this.isTouch(e)||t}isTouch({pointerType:e}){return e==="touch"}async handleEvent(e){if(!vi?.matches)switch(e.type){case"click":this.handleClick();break;case"contextmenu":this.handleContextmenu();break;case"pointercancel":this.handlePointercancel(e);break;case"pointerdown":await this.handlePointerdown(e);break;case"pointerenter":this.handlePointerenter(e);break;case"pointerleave":this.handlePointerleave(e);break;case"pointerup":this.handlePointerup(e);break;default:break}}onControlChange(e,t){if(!!1)for(let r of fi)e?.removeEventListener(r,this),t?.addEventListener(r,this)}};s([l({type:Boolean,reflect:!0})],ge.prototype,"disabled",void 0);s([k()],ge.prototype,"hovered",void 0);s([k()],ge.prototype,"pressed",void 0);s([S(".surface")],ge.prototype,"mdRoot",void 0);var bo=g`:host{display:flex;margin:auto;pointer-events:none}:host([disabled]){display:none}@media(forced-colors: active){:host{display:none}}:host,.surface{border-radius:inherit;position:absolute;inset:0;overflow:hidden}.surface{-webkit-tap-highlight-color:rgba(0,0,0,0)}.surface::before,.surface::after{content:"";opacity:0;position:absolute}.surface::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));inset:0;transition:opacity 15ms linear,background-color 15ms linear}.surface::after{background:radial-gradient(closest-side, var(--md-ripple-pressed-color, var(--md-sys-color-on-surface, #1d1b20)) max(100% - 70px, 65%), transparent 100%);transform-origin:center center;transition:opacity 375ms linear}.hovered::before{background-color:var(--md-ripple-hover-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-ripple-hover-opacity, 0.08)}.pressed::after{opacity:var(--md-ripple-pressed-opacity, 0.12);transition-duration:105ms}
+`;var vr=class extends ge{};vr.styles=[bo];vr=s([E("md-ripple")],vr);var Me=class{constructor(e,t){this.host=e,this.internalTypeaheadText=null,this.onClick=()=>{this.host.keepOpen||this.host.dispatchEvent(pr(this.host,{kind:Et.CLICK_SELECTION}))},this.onKeydown=r=>{if(this.host.href&&r.code==="Enter"){let n=this.getInteractiveElement();n instanceof HTMLAnchorElement&&n.click()}if(r.defaultPrevented)return;let i=r.code;this.host.keepOpen&&i!=="Escape"||At(i)&&(r.preventDefault(),this.host.dispatchEvent(pr(this.host,{kind:Et.KEYDOWN,key:i})))},this.getHeadlineElements=t.getHeadlineElements,this.getSupportingTextElements=t.getSupportingTextElements,this.getDefaultElements=t.getDefaultElements,this.getInteractiveElement=t.getInteractiveElement,this.host.addController(this)}get typeaheadText(){if(this.internalTypeaheadText!==null)return this.internalTypeaheadText;let e=this.getHeadlineElements(),t=[];return e.forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getDefaultElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.length===0&&this.getSupportingTextElements().forEach(r=>{r.textContent&&r.textContent.trim()&&t.push(r.textContent.trim())}),t.join(" ")}get tagName(){switch(this.host.type){case"link":return"a";case"button":return"button";default:case"menuitem":case"option":return"li"}}get role(){return this.host.type==="option"?"option":"menuitem"}hostConnected(){this.host.toggleAttribute("md-menu-item",!0)}hostUpdate(){this.host.href&&(this.host.type="link")}setTypeaheadText(e){this.internalTypeaheadText=e}};function gi(){return new Event("request-selection",{bubbles:!0,composed:!0})}function bi(){return new Event("request-deselection",{bubbles:!0,composed:!0})}var Ot=class{get role(){return this.menuItemController.role}get typeaheadText(){return this.menuItemController.typeaheadText}setTypeaheadText(e){this.menuItemController.setTypeaheadText(e)}get displayText(){return this.internalDisplayText!==null?this.internalDisplayText:this.menuItemController.typeaheadText}setDisplayText(e){this.internalDisplayText=e}constructor(e,t){this.host=e,this.internalDisplayText=null,this.firstUpdate=!0,this.onClick=()=>{this.menuItemController.onClick()},this.onKeydown=r=>{this.menuItemController.onKeydown(r)},this.lastSelected=this.host.selected,this.menuItemController=new Me(e,t),e.addController(this)}hostUpdate(){this.lastSelected!==this.host.selected&&(this.host.ariaSelected=this.host.selected?"true":"false")}hostUpdated(){this.lastSelected!==this.host.selected&&!this.firstUpdate&&(this.host.selected?this.host.dispatchEvent(gi()):this.host.dispatchEvent(bi())),this.lastSelected=this.host.selected,this.firstUpdate=!1}};var yi=W(b),j=class extends yi{constructor(){super(...arguments),this.disabled=!1,this.isMenuItem=!0,this.selected=!1,this.value="",this.type="option",this.selectOptionController=new Ot(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.selectOptionController.typeaheadText}set typeaheadText(e){this.selectOptionController.setTypeaheadText(e)}get displayText(){return this.selectOptionController.displayText}set displayText(e){this.selectOptionController.setDisplayText(e)}render(){return this.renderListItem(u`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){return u`
+      <li
+        id="item"
+        tabindex=${this.disabled?-1:0}
+        role=${this.selectOptionController.role}
+        aria-label=${this.ariaLabel||p}
+        aria-selected=${this.ariaSelected||p}
+        aria-checked=${this.ariaChecked||p}
+        aria-expanded=${this.ariaExpanded||p}
+        aria-haspopup=${this.ariaHasPopup||p}
+        class="list-item ${R(this.getRenderClasses())}"
+        @click=${this.selectOptionController.onClick}
+        @keydown=${this.selectOptionController.onKeydown}
+        >${e}</li
+      >
+    `}renderRipple(){return u` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return u` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return u`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};j.shadowRootOptions={...b.shadowRootOptions,delegatesFocus:!0};s([l({type:Boolean,reflect:!0})],j.prototype,"disabled",void 0);s([l({type:Boolean,attribute:"md-menu-item",reflect:!0})],j.prototype,"isMenuItem",void 0);s([l({type:Boolean})],j.prototype,"selected",void 0);s([l()],j.prototype,"value",void 0);s([S(".list-item")],j.prototype,"listItemRoot",void 0);s([N({slot:"headline"})],j.prototype,"headlineElements",void 0);s([N({slot:"supporting-text"})],j.prototype,"supportingTextElements",void 0);s([rt({slot:""})],j.prototype,"defaultElements",void 0);s([l({attribute:"typeahead-text"})],j.prototype,"typeaheadText",null);s([l({attribute:"display-text"})],j.prototype,"displayText",null);var gr=class extends j{};gr.styles=[kt];gr=s([E("md-select-option")],gr);var xi=W(b),q=class extends xi{constructor(){super(...arguments),this.disabled=!1,this.type="menuitem",this.href="",this.target="",this.keepOpen=!1,this.selected=!1,this.menuItemController=new Me(this,{getHeadlineElements:()=>this.headlineElements,getSupportingTextElements:()=>this.supportingTextElements,getDefaultElements:()=>this.defaultElements,getInteractiveElement:()=>this.listItemRoot})}get typeaheadText(){return this.menuItemController.typeaheadText}set typeaheadText(e){this.menuItemController.setTypeaheadText(e)}render(){return this.renderListItem(u`
+      <md-item>
+        <div slot="container">
+          ${this.renderRipple()} ${this.renderFocusRing()}
+        </div>
+        <slot name="start" slot="start"></slot>
+        <slot name="end" slot="end"></slot>
+        ${this.renderBody()}
+      </md-item>
+    `)}renderListItem(e){let t=this.type==="link",r;switch(this.menuItemController.tagName){case"a":r=G`a`;break;case"button":r=G`button`;break;default:case"li":r=G`li`;break}let i=t&&this.target?this.target:p;return ue`
+      <${r}
+        id="item"
+        tabindex=${this.disabled&&!t?-1:0}
+        role=${this.menuItemController.role}
+        aria-label=${this.ariaLabel||p}
+        aria-selected=${this.ariaSelected||p}
+        aria-checked=${this.ariaChecked||p}
+        aria-expanded=${this.ariaExpanded||p}
+        aria-haspopup=${this.ariaHasPopup||p}
+        class="list-item ${R(this.getRenderClasses())}"
+        href=${this.href||p}
+        target=${i}
+        @click=${this.menuItemController.onClick}
+        @keydown=${this.menuItemController.onKeydown}
+      >${e}</${r}>
+    `}renderRipple(){return u` <md-ripple
+      part="ripple"
+      for="item"
+      ?disabled=${this.disabled}></md-ripple>`}renderFocusRing(){return u` <md-focus-ring
+      part="focus-ring"
+      for="item"
+      inward></md-focus-ring>`}getRenderClasses(){return{disabled:this.disabled,selected:this.selected}}renderBody(){return u`
+      <slot></slot>
+      <slot name="overline" slot="overline"></slot>
+      <slot name="headline" slot="headline"></slot>
+      <slot name="supporting-text" slot="supporting-text"></slot>
+      <slot
+        name="trailing-supporting-text"
+        slot="trailing-supporting-text"></slot>
+    `}focus(){this.listItemRoot?.focus()}};q.shadowRootOptions={...b.shadowRootOptions,delegatesFocus:!0};s([l({type:Boolean,reflect:!0})],q.prototype,"disabled",void 0);s([l()],q.prototype,"type",void 0);s([l()],q.prototype,"href",void 0);s([l()],q.prototype,"target",void 0);s([l({type:Boolean,attribute:"keep-open"})],q.prototype,"keepOpen",void 0);s([l({type:Boolean})],q.prototype,"selected",void 0);s([S(".list-item")],q.prototype,"listItemRoot",void 0);s([N({slot:"headline"})],q.prototype,"headlineElements",void 0);s([N({slot:"supporting-text"})],q.prototype,"supportingTextElements",void 0);s([rt({slot:""})],q.prototype,"defaultElements",void 0);s([l({attribute:"typeahead-text"})],q.prototype,"typeaheadText",null);var br=class extends q{};br.styles=[kt];br=s([E("md-menu-item")],br);function Rt(o){o.addInitializer(e=>{let t=e;t.addEventListener("click",async r=>{let{type:i,[P]:n}=t,{form:a}=n;if(!(!a||i==="button")&&(await new Promise(d=>{setTimeout(d)}),!r.defaultPrevented)){if(i==="reset"){a.reset();return}a.addEventListener("submit",d=>{Object.defineProperty(d,"submitter",{configurable:!0,enumerable:!0,get:()=>t})},{capture:!0,once:!0}),n.setFormValue(t.value),a.requestSubmit()}})})}function yr(o,e=!0){return e&&getComputedStyle(o).getPropertyValue("direction").trim()==="rtl"}var _i=W(ee(b)),D=class extends _i{get name(){return this.getAttribute("name")??""}set name(e){this.setAttribute("name",e)}get form(){return this[P].form}get labels(){return this[P].labels}constructor(){super(),this.disabled=!1,this.softDisabled=!1,this.flipIconInRtl=!1,this.href="",this.download="",this.target="",this.ariaLabelSelected="",this.toggle=!1,this.selected=!1,this.type="submit",this.value="",this.flipIcon=yr(this,this.flipIconInRtl),this.addEventListener("click",this.handleClick.bind(this))}willUpdate(){this.href&&(this.disabled=!1,this.softDisabled=!1)}render(){let e=this.href?G`div`:G`button`,{ariaLabel:t,ariaHasPopup:r,ariaExpanded:i}=this,n=t&&this.ariaLabelSelected,a=this.toggle?this.selected:p,d=p;return this.href||(d=n&&this.selected?this.ariaLabelSelected:t),ue`<${e}
+        class="icon-button ${R(this.getRenderClasses())}"
+        id="button"
+        aria-label="${d||p}"
+        aria-haspopup="${!this.href&&r||p}"
+        aria-expanded="${!this.href&&i||p}"
+        aria-pressed="${a}"
+        aria-disabled=${!this.href&&this.softDisabled||p}
+        ?disabled="${!this.href&&this.disabled}"
+        @click="${this.handleClickOnChild}">
+        ${this.renderFocusRing()}
+        ${this.renderRipple()}
+        ${this.selected?p:this.renderIcon()}
+        ${this.selected?this.renderSelectedIcon():p}
+        ${this.href?this.renderLink():this.renderTouchTarget()}
+  </${e}>`}renderLink(){let{ariaLabel:e}=this;return u`
+      <a
+        class="link"
+        id="link"
+        href="${this.href}"
+        download="${this.download||p}"
+        target="${this.target||p}"
+        aria-label="${e||p}">
+        ${this.renderTouchTarget()}
+      </a>
+    `}getRenderClasses(){return{"flip-icon":this.flipIcon,selected:this.toggle&&this.selected}}renderIcon(){return u`<span class="icon"><slot></slot></span>`}renderSelectedIcon(){return u`<span class="icon icon--selected"
+      ><slot name="selected"><slot></slot></slot
+    ></span>`}renderTouchTarget(){return u`<span class="touch"></span>`}renderFocusRing(){return u`<md-focus-ring
+      part="focus-ring"
+      for=${this.href?"link":"button"}></md-focus-ring>`}renderRipple(){let e=!this.href&&(this.disabled||this.softDisabled);return u`<md-ripple
+      for=${this.href?"link":p}
+      ?disabled="${e}"></md-ripple>`}connectedCallback(){this.flipIcon=yr(this,this.flipIconInRtl),super.connectedCallback()}handleClick(e){if(!this.href&&this.softDisabled){e.stopImmediatePropagation(),e.preventDefault();return}}async handleClickOnChild(e){await 0,!(!this.toggle||this.disabled||this.softDisabled||e.defaultPrevented)&&(this.selected=!this.selected,this.dispatchEvent(new InputEvent("input",{bubbles:!0,composed:!0})),this.dispatchEvent(new Event("change",{bubbles:!0})))}};Rt(D);D.formAssociated=!0;D.shadowRootOptions={mode:"open",delegatesFocus:!0};s([l({type:Boolean,reflect:!0})],D.prototype,"disabled",void 0);s([l({type:Boolean,attribute:"soft-disabled",reflect:!0})],D.prototype,"softDisabled",void 0);s([l({type:Boolean,attribute:"flip-icon-in-rtl"})],D.prototype,"flipIconInRtl",void 0);s([l()],D.prototype,"href",void 0);s([l()],D.prototype,"download",void 0);s([l()],D.prototype,"target",void 0);s([l({attribute:"aria-label-selected"})],D.prototype,"ariaLabelSelected",void 0);s([l({type:Boolean})],D.prototype,"toggle",void 0);s([l({type:Boolean,reflect:!0})],D.prototype,"selected",void 0);s([l()],D.prototype,"type",void 0);s([l({reflect:!0})],D.prototype,"value",void 0);s([k()],D.prototype,"flipIcon",void 0);var yo=g`:host{display:inline-flex;outline:none;-webkit-tap-highlight-color:rgba(0,0,0,0);height:var(--_container-height);width:var(--_container-width);justify-content:center}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_container-height))/2) max(0px,(48px - var(--_container-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_container-shape-start-start);--md-focus-ring-shape-start-end: var(--_container-shape-start-end);--md-focus-ring-shape-end-end: var(--_container-shape-end-end);--md-focus-ring-shape-end-start: var(--_container-shape-end-start)}:host(:is([disabled],[soft-disabled])){pointer-events:none}.icon-button{place-items:center;background:none;border:none;box-sizing:border-box;cursor:pointer;display:flex;place-content:center;outline:none;padding:0;position:relative;text-decoration:none;user-select:none;z-index:0;flex:1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.icon ::slotted(*){font-size:var(--_icon-size);height:var(--_icon-size);width:var(--_icon-size);font-weight:inherit}md-ripple{z-index:-1;border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end)}.flip-icon .icon{transform:scaleX(-1)}.icon{display:inline-flex}.link{display:grid;height:100%;outline:none;place-items:center;position:absolute;width:100%}.touch{position:absolute;height:max(48px,100%);width:max(48px,100%)}:host([touch-target=none]) .touch{display:none}@media(forced-colors: active){:host(:is([disabled],[soft-disabled])){--_disabled-icon-color: GrayText;--_disabled-icon-opacity: 1}}
+`;var xo=g`:host{--_disabled-icon-color: var(--md-icon-button-disabled-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-icon-opacity: var(--md-icon-button-disabled-icon-opacity, 0.38);--_icon-size: var(--md-icon-button-icon-size, 24px);--_selected-focus-icon-color: var(--md-icon-button-selected-focus-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-icon-color: var(--md-icon-button-selected-hover-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-color: var(--md-icon-button-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-hover-state-layer-opacity: var(--md-icon-button-selected-hover-state-layer-opacity, 0.08);--_selected-icon-color: var(--md-icon-button-selected-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-icon-color: var(--md-icon-button-selected-pressed-icon-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-color: var(--md-icon-button-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--_selected-pressed-state-layer-opacity: var(--md-icon-button-selected-pressed-state-layer-opacity, 0.12);--_state-layer-height: var(--md-icon-button-state-layer-height, 40px);--_state-layer-shape: var(--md-icon-button-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));--_state-layer-width: var(--md-icon-button-state-layer-width, 40px);--_focus-icon-color: var(--md-icon-button-focus-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-icon-color: var(--md-icon-button-hover-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-color: var(--md-icon-button-hover-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_hover-state-layer-opacity: var(--md-icon-button-hover-state-layer-opacity, 0.08);--_icon-color: var(--md-icon-button-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-icon-color: var(--md-icon-button-pressed-icon-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-color: var(--md-icon-button-pressed-state-layer-color, var(--md-sys-color-on-surface-variant, #49454f));--_pressed-state-layer-opacity: var(--md-icon-button-pressed-state-layer-opacity, 0.12);--_container-shape-start-start: 0;--_container-shape-start-end: 0;--_container-shape-end-end: 0;--_container-shape-end-start: 0;--_container-height: 0;--_container-width: 0;height:var(--_state-layer-height);width:var(--_state-layer-width)}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_state-layer-height))/2) max(0px,(48px - var(--_state-layer-width))/2)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_state-layer-shape);--md-focus-ring-shape-start-end: var(--_state-layer-shape);--md-focus-ring-shape-end-end: var(--_state-layer-shape);--md-focus-ring-shape-end-start: var(--_state-layer-shape)}.standard{background-color:rgba(0,0,0,0);color:var(--_icon-color);--md-ripple-hover-color: var(--_hover-state-layer-color);--md-ripple-hover-opacity: var(--_hover-state-layer-opacity);--md-ripple-pressed-color: var(--_pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_pressed-state-layer-opacity)}.standard:hover{color:var(--_hover-icon-color)}.standard:focus{color:var(--_focus-icon-color)}.standard:active{color:var(--_pressed-icon-color)}.standard:is(:disabled,[aria-disabled=true]){color:var(--_disabled-icon-color)}md-ripple{border-radius:var(--_state-layer-shape)}.standard:is(:disabled,[aria-disabled=true]){opacity:var(--_disabled-icon-opacity)}.selected:not(:disabled,[aria-disabled=true]){color:var(--_selected-icon-color)}.selected:not(:disabled,[aria-disabled=true]):hover{color:var(--_selected-hover-icon-color)}.selected:not(:disabled,[aria-disabled=true]):focus{color:var(--_selected-focus-icon-color)}.selected:not(:disabled,[aria-disabled=true]):active{color:var(--_selected-pressed-icon-color)}.selected{--md-ripple-hover-color: var(--_selected-hover-state-layer-color);--md-ripple-hover-opacity: var(--_selected-hover-state-layer-opacity);--md-ripple-pressed-color: var(--_selected-pressed-state-layer-color);--md-ripple-pressed-opacity: var(--_selected-pressed-state-layer-opacity)}
+`;var xr=class extends D{getRenderClasses(){return{...super.getRenderClasses(),standard:!0}}};xr.styles=[yo,xo];xr=s([E("md-icon-button")],xr);function Pt(o){let e=new MouseEvent("click",{bubbles:!0});return o.dispatchEvent(e),e}function Lt(o){return o.currentTarget!==o.target||o.composedPath()[0]!==o.target||o.target.disabled?!1:!wi(o)}function wi(o){let e=_r;return e&&(o.preventDefault(),o.stopImmediatePropagation()),Ei(),e}var _r=!1;async function Ei(){_r=!0,await null,_r=!1}var Ai=W(ee(b)),M=class extends Ai{get name(){return this.getAttribute("name")??""}set name(e){this.setAttribute("name",e)}get form(){return this[P].form}constructor(){super(),this.disabled=!1,this.softDisabled=!1,this.href="",this.download="",this.target="",this.trailingIcon=!1,this.hasIcon=!1,this.type="submit",this.value="",this.addEventListener("click",this.handleClick.bind(this))}focus(){this.buttonElement?.focus()}blur(){this.buttonElement?.blur()}render(){let e=this.disabled||this.softDisabled,t=this.href?this.renderLink():this.renderButton(),r=this.href?"link":"button";return u`
+      ${this.renderElevationOrOutline?.()}
+      <div class="background"></div>
+      <md-focus-ring part="focus-ring" for=${r}></md-focus-ring>
+      <md-ripple
+        part="ripple"
+        for=${r}
+        ?disabled="${e}"></md-ripple>
+      ${t}
+    `}renderButton(){let{ariaLabel:e,ariaHasPopup:t,ariaExpanded:r}=this;return u`<button
+      id="button"
+      class="button"
+      ?disabled=${this.disabled}
+      aria-disabled=${this.softDisabled||p}
+      aria-label="${e||p}"
+      aria-haspopup="${t||p}"
+      aria-expanded="${r||p}">
+      ${this.renderContent()}
+    </button>`}renderLink(){let{ariaLabel:e,ariaHasPopup:t,ariaExpanded:r}=this;return u`<a
+      id="link"
+      class="button"
+      aria-label="${e||p}"
+      aria-haspopup="${t||p}"
+      aria-expanded="${r||p}"
+      aria-disabled=${this.disabled||this.softDisabled||p}
+      tabindex="${this.disabled&&!this.softDisabled?-1:p}"
+      href=${this.href}
+      download=${this.download||p}
+      target=${this.target||p}
+      >${this.renderContent()}
+    </a>`}renderContent(){let e=u`<slot
+      name="icon"
+      @slotchange="${this.handleSlotChange}"></slot>`;return u`
+      <span class="touch"></span>
+      ${this.trailingIcon?p:e}
+      <span class="label"><slot></slot></span>
+      ${this.trailingIcon?e:p}
+    `}handleClick(e){if(this.softDisabled||this.disabled&&this.href){e.stopImmediatePropagation(),e.preventDefault();return}!Lt(e)||!this.buttonElement||(this.focus(),Pt(this.buttonElement))}handleSlotChange(){this.hasIcon=this.assignedIcons.length>0}};Rt(M);M.formAssociated=!0;M.shadowRootOptions={mode:"open",delegatesFocus:!0};s([l({type:Boolean,reflect:!0})],M.prototype,"disabled",void 0);s([l({type:Boolean,attribute:"soft-disabled",reflect:!0})],M.prototype,"softDisabled",void 0);s([l()],M.prototype,"href",void 0);s([l()],M.prototype,"download",void 0);s([l()],M.prototype,"target",void 0);s([l({type:Boolean,attribute:"trailing-icon",reflect:!0})],M.prototype,"trailingIcon",void 0);s([l({type:Boolean,attribute:"has-icon",reflect:!0})],M.prototype,"hasIcon",void 0);s([l()],M.prototype,"type",void 0);s([l({reflect:!0})],M.prototype,"value",void 0);s([S(".button")],M.prototype,"buttonElement",void 0);s([N({slot:"icon",flatten:!0})],M.prototype,"assignedIcons",void 0);var Dt=class extends M{renderElevationOrOutline(){return u`<md-elevation part="elevation"></md-elevation>`}};var _o=g`:host{--_container-color: var(--md-filled-button-container-color, var(--md-sys-color-primary, #6750a4));--_container-elevation: var(--md-filled-button-container-elevation, 0);--_container-height: var(--md-filled-button-container-height, 40px);--_container-shadow-color: var(--md-filled-button-container-shadow-color, var(--md-sys-color-shadow, #000));--_disabled-container-color: var(--md-filled-button-disabled-container-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-container-elevation: var(--md-filled-button-disabled-container-elevation, 0);--_disabled-container-opacity: var(--md-filled-button-disabled-container-opacity, 0.12);--_disabled-label-text-color: var(--md-filled-button-disabled-label-text-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-label-text-opacity: var(--md-filled-button-disabled-label-text-opacity, 0.38);--_focus-container-elevation: var(--md-filled-button-focus-container-elevation, 0);--_focus-label-text-color: var(--md-filled-button-focus-label-text-color, var(--md-sys-color-on-primary, #fff));--_hover-container-elevation: var(--md-filled-button-hover-container-elevation, 1);--_hover-label-text-color: var(--md-filled-button-hover-label-text-color, var(--md-sys-color-on-primary, #fff));--_hover-state-layer-color: var(--md-filled-button-hover-state-layer-color, var(--md-sys-color-on-primary, #fff));--_hover-state-layer-opacity: var(--md-filled-button-hover-state-layer-opacity, 0.08);--_label-text-color: var(--md-filled-button-label-text-color, var(--md-sys-color-on-primary, #fff));--_label-text-font: var(--md-filled-button-label-text-font, var(--md-sys-typescale-label-large-font, var(--md-ref-typeface-plain, Roboto)));--_label-text-line-height: var(--md-filled-button-label-text-line-height, var(--md-sys-typescale-label-large-line-height, 1.25rem));--_label-text-size: var(--md-filled-button-label-text-size, var(--md-sys-typescale-label-large-size, 0.875rem));--_label-text-weight: var(--md-filled-button-label-text-weight, var(--md-sys-typescale-label-large-weight, var(--md-ref-typeface-weight-medium, 500)));--_pressed-container-elevation: var(--md-filled-button-pressed-container-elevation, 0);--_pressed-label-text-color: var(--md-filled-button-pressed-label-text-color, var(--md-sys-color-on-primary, #fff));--_pressed-state-layer-color: var(--md-filled-button-pressed-state-layer-color, var(--md-sys-color-on-primary, #fff));--_pressed-state-layer-opacity: var(--md-filled-button-pressed-state-layer-opacity, 0.12);--_disabled-icon-color: var(--md-filled-button-disabled-icon-color, var(--md-sys-color-on-surface, #1d1b20));--_disabled-icon-opacity: var(--md-filled-button-disabled-icon-opacity, 0.38);--_focus-icon-color: var(--md-filled-button-focus-icon-color, var(--md-sys-color-on-primary, #fff));--_hover-icon-color: var(--md-filled-button-hover-icon-color, var(--md-sys-color-on-primary, #fff));--_icon-color: var(--md-filled-button-icon-color, var(--md-sys-color-on-primary, #fff));--_icon-size: var(--md-filled-button-icon-size, 18px);--_pressed-icon-color: var(--md-filled-button-pressed-icon-color, var(--md-sys-color-on-primary, #fff));--_container-shape-start-start: var(--md-filled-button-container-shape-start-start, var(--md-filled-button-container-shape, var(--md-sys-shape-corner-full, 9999px)));--_container-shape-start-end: var(--md-filled-button-container-shape-start-end, var(--md-filled-button-container-shape, var(--md-sys-shape-corner-full, 9999px)));--_container-shape-end-end: var(--md-filled-button-container-shape-end-end, var(--md-filled-button-container-shape, var(--md-sys-shape-corner-full, 9999px)));--_container-shape-end-start: var(--md-filled-button-container-shape-end-start, var(--md-filled-button-container-shape, var(--md-sys-shape-corner-full, 9999px)));--_leading-space: var(--md-filled-button-leading-space, 24px);--_trailing-space: var(--md-filled-button-trailing-space, 24px);--_with-leading-icon-leading-space: var(--md-filled-button-with-leading-icon-leading-space, 16px);--_with-leading-icon-trailing-space: var(--md-filled-button-with-leading-icon-trailing-space, 24px);--_with-trailing-icon-leading-space: var(--md-filled-button-with-trailing-icon-leading-space, 24px);--_with-trailing-icon-trailing-space: var(--md-filled-button-with-trailing-icon-trailing-space, 16px)}
+`;var wo=g`md-elevation{transition-duration:280ms}:host(:is([disabled],[soft-disabled])) md-elevation{transition:none}md-elevation{--md-elevation-level: var(--_container-elevation);--md-elevation-shadow-color: var(--_container-shadow-color)}:host(:focus-within) md-elevation{--md-elevation-level: var(--_focus-container-elevation)}:host(:hover) md-elevation{--md-elevation-level: var(--_hover-container-elevation)}:host(:active) md-elevation{--md-elevation-level: var(--_pressed-container-elevation)}:host(:is([disabled],[soft-disabled])) md-elevation{--md-elevation-level: var(--_disabled-container-elevation)}
+`;var Eo=g`:host{border-start-start-radius:var(--_container-shape-start-start);border-start-end-radius:var(--_container-shape-start-end);border-end-start-radius:var(--_container-shape-end-start);border-end-end-radius:var(--_container-shape-end-end);box-sizing:border-box;cursor:pointer;display:inline-flex;gap:8px;min-height:var(--_container-height);outline:none;padding-block:calc((var(--_container-height) - max(var(--_label-text-line-height),var(--_icon-size)))/2);padding-inline-start:var(--_leading-space);padding-inline-end:var(--_trailing-space);place-content:center;place-items:center;position:relative;font-family:var(--_label-text-font);font-size:var(--_label-text-size);line-height:var(--_label-text-line-height);font-weight:var(--_label-text-weight);text-overflow:ellipsis;text-wrap:nowrap;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);vertical-align:top;--md-ripple-hover-color: var(--_hover-state-layer-color);--md-ripple-pressed-color: var(--_pressed-state-layer-color);--md-ripple-hover-opacity: var(--_hover-state-layer-opacity);--md-ripple-pressed-opacity: var(--_pressed-state-layer-opacity)}md-focus-ring{--md-focus-ring-shape-start-start: var(--_container-shape-start-start);--md-focus-ring-shape-start-end: var(--_container-shape-start-end);--md-focus-ring-shape-end-end: var(--_container-shape-end-end);--md-focus-ring-shape-end-start: var(--_container-shape-end-start)}:host(:is([disabled],[soft-disabled])){cursor:default;pointer-events:none}.button{border-radius:inherit;cursor:inherit;display:inline-flex;align-items:center;justify-content:center;border:none;outline:none;-webkit-appearance:none;vertical-align:middle;background:rgba(0,0,0,0);text-decoration:none;min-width:calc(64px - var(--_leading-space) - var(--_trailing-space));width:100%;z-index:0;height:100%;font:inherit;color:var(--_label-text-color);padding:0;gap:inherit;text-transform:inherit}.button::-moz-focus-inner{padding:0;border:0}:host(:hover) .button{color:var(--_hover-label-text-color)}:host(:focus-within) .button{color:var(--_focus-label-text-color)}:host(:active) .button{color:var(--_pressed-label-text-color)}.background{background:var(--_container-color);border-radius:inherit;inset:0;position:absolute}.label{overflow:hidden}:is(.button,.label,.label slot),.label ::slotted(*){text-overflow:inherit}:host(:is([disabled],[soft-disabled])) .label{color:var(--_disabled-label-text-color);opacity:var(--_disabled-label-text-opacity)}:host(:is([disabled],[soft-disabled])) .background{background:var(--_disabled-container-color);opacity:var(--_disabled-container-opacity)}@media(forced-colors: active){.background{border:1px solid CanvasText}:host(:is([disabled],[soft-disabled])){--_disabled-icon-color: GrayText;--_disabled-icon-opacity: 1;--_disabled-container-opacity: 1;--_disabled-label-text-color: GrayText;--_disabled-label-text-opacity: 1}}:host([has-icon]:not([trailing-icon])){padding-inline-start:var(--_with-leading-icon-leading-space);padding-inline-end:var(--_with-leading-icon-trailing-space)}:host([has-icon][trailing-icon]){padding-inline-start:var(--_with-trailing-icon-leading-space);padding-inline-end:var(--_with-trailing-icon-trailing-space)}::slotted([slot=icon]){display:inline-flex;position:relative;writing-mode:horizontal-tb;fill:currentColor;flex-shrink:0;color:var(--_icon-color);font-size:var(--_icon-size);inline-size:var(--_icon-size);block-size:var(--_icon-size)}:host(:hover) ::slotted([slot=icon]){color:var(--_hover-icon-color)}:host(:focus-within) ::slotted([slot=icon]){color:var(--_focus-icon-color)}:host(:active) ::slotted([slot=icon]){color:var(--_pressed-icon-color)}:host(:is([disabled],[soft-disabled])) ::slotted([slot=icon]){color:var(--_disabled-icon-color);opacity:var(--_disabled-icon-opacity)}.touch{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%)}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--_container-height))/2) 0}:host([touch-target=none]) .touch{display:none}
+`;var wr=class extends Dt{};wr.styles=[Eo,wo,_o];wr=s([E("md-filled-button")],wr);var Co=Symbol("dispatchHooks");function $o(o,e){let t=o[Co];if(!t)throw new Error(`'${o.type}' event needs setupDispatchHooks().`);t.addEventListener("after",e)}var Ao=new WeakMap;function To(o,...e){let t=Ao.get(o);t||(t=new Set,Ao.set(o,t));for(let r of e){if(t.has(r))continue;let i=!1;o.addEventListener(r,n=>{if(i)return;n.stopImmediatePropagation();let a=Reflect.construct(n.constructor,[n.type,n]),d=new EventTarget;a[Co]=d,i=!0;let c=o.dispatchEvent(a);i=!1,c||n.preventDefault(),d.dispatchEvent(new Event("after"))},{capture:!0}),t.add(r)}}var zt=class extends me{computeValidity(e){return this.checkboxControl||(this.checkboxControl=document.createElement("input"),this.checkboxControl.type="checkbox"),this.checkboxControl.checked=e.checked,this.checkboxControl.required=e.required,{validity:this.checkboxControl.validity,validationMessage:this.checkboxControl.validationMessage}}equals(e,t){return e.checked===t.checked&&e.required===t.required}copy({checked:e,required:t}){return{checked:e,required:t}}};var Ci=W(Oe(Re(ee(b)))),Z=class extends Ci{constructor(){super(),this.selected=!1,this.icons=!1,this.showOnlySelectedIcon=!1,this.required=!1,this.value="on",!!1&&(this.addEventListener("click",e=>{!Lt(e)||!this.input||(this.focus(),Pt(this.input))}),To(this,"keydown"),this.addEventListener("keydown",e=>{$o(e,()=>{e.defaultPrevented||e.key!=="Enter"||this.disabled||!this.input||this.input.click()})}))}render(){return u`
+      <div class="switch ${R(this.getRenderClasses())}">
+        <input
+          id="switch"
+          class="touch"
+          type="checkbox"
+          role="switch"
+          aria-label=${this.ariaLabel||p}
+          ?checked=${this.selected}
+          ?disabled=${this.disabled}
+          ?required=${this.required}
+          @input=${this.handleInput}
+          @change=${this.handleChange} />
+
+        <md-focus-ring part="focus-ring" for="switch"></md-focus-ring>
+        <span class="track"> ${this.renderHandle()} </span>
+      </div>
+    `}getRenderClasses(){return{selected:this.selected,unselected:!this.selected,disabled:this.disabled}}renderHandle(){let e={"with-icon":this.showOnlySelectedIcon?this.selected:this.icons};return u`
+      ${this.renderTouchTarget()}
+      <span class="handle-container">
+        <md-ripple for="switch" ?disabled="${this.disabled}"></md-ripple>
+        <span class="handle ${R(e)}">
+          ${this.shouldShowIcons()?this.renderIcons():u``}
+        </span>
+      </span>
+    `}renderIcons(){return u`
+      <div class="icons">
+        ${this.renderOnIcon()}
+        ${this.showOnlySelectedIcon?u``:this.renderOffIcon()}
+      </div>
+    `}renderOnIcon(){return u`
+      <slot class="icon icon--on" name="on-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M9.55 18.2 3.65 12.3 5.275 10.675 9.55 14.95 18.725 5.775 20.35 7.4Z" />
+        </svg>
+      </slot>
+    `}renderOffIcon(){return u`
+      <slot class="icon icon--off" name="off-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M6.4 19.2 4.8 17.6 10.4 12 4.8 6.4 6.4 4.8 12 10.4 17.6 4.8 19.2 6.4 13.6 12 19.2 17.6 17.6 19.2 12 13.6Z" />
+        </svg>
+      </slot>
+    `}renderTouchTarget(){return u`<span class="touch"></span>`}shouldShowIcons(){return this.icons||this.showOnlySelectedIcon}handleInput(e){let t=e.target;this.selected=t.checked}handleChange(e){ke(this,e)}[se](){return this.selected?this.value:null}[ht](){return String(this.selected)}formResetCallback(){this.selected=this.hasAttribute("selected")}formStateRestoreCallback(e){this.selected=e==="true"}[he](){return new zt(()=>({checked:this.selected,required:this.required}))}[fe](){return this.input}};Z.shadowRootOptions={mode:"open",delegatesFocus:!0};s([l({type:Boolean})],Z.prototype,"selected",void 0);s([l({type:Boolean})],Z.prototype,"icons",void 0);s([l({type:Boolean,attribute:"show-only-selected-icon"})],Z.prototype,"showOnlySelectedIcon",void 0);s([l({type:Boolean})],Z.prototype,"required",void 0);s([l()],Z.prototype,"value",void 0);s([S("input")],Z.prototype,"input",void 0);var So=g`@layer styles, hcm;@layer styles{:host{display:inline-flex;outline:none;vertical-align:top;-webkit-tap-highlight-color:rgba(0,0,0,0);cursor:pointer}:host([disabled]){cursor:default}:host([touch-target=wrapper]){margin:max(0px,(48px - var(--md-switch-track-height, 32px))/2) 0px}md-focus-ring{--md-focus-ring-shape-start-start: var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-start-end: var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-end: var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));--md-focus-ring-shape-end-start: var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}.switch{align-items:center;display:inline-flex;flex-shrink:0;position:relative;width:var(--md-switch-track-width, 52px);height:var(--md-switch-track-height, 32px);border-start-start-radius:var(--md-switch-track-shape-start-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-track-shape-start-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-track-shape-end-end, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-track-shape-end-start, var(--md-switch-track-shape, var(--md-sys-shape-corner-full, 9999px)))}input{appearance:none;height:max(100%,var(--md-switch-touch-target-size, 48px));outline:none;margin:0;position:absolute;width:max(100%,var(--md-switch-touch-target-size, 48px));z-index:1;cursor:inherit;top:50%;left:50%;transform:translate(-50%, -50%)}:host([touch-target=none]) input{display:none}}@layer styles{.track{position:absolute;width:100%;height:100%;box-sizing:border-box;border-radius:inherit;display:flex;justify-content:center;align-items:center}.track::before{content:"";display:flex;position:absolute;height:100%;width:100%;border-radius:inherit;box-sizing:border-box;transition-property:opacity,background-color;transition-timing-function:linear;transition-duration:67ms}.disabled .track{background-color:rgba(0,0,0,0);border-color:rgba(0,0,0,0)}.disabled .track::before,.disabled .track::after{transition:none;opacity:var(--md-switch-disabled-track-opacity, 0.12)}.disabled .track::before{background-clip:content-box}.selected .track::before{background-color:var(--md-switch-selected-track-color, var(--md-sys-color-primary, #6750a4))}.selected:hover .track::before{background-color:var(--md-switch-selected-hover-track-color, var(--md-sys-color-primary, #6750a4))}.selected:focus-within .track::before{background-color:var(--md-switch-selected-focus-track-color, var(--md-sys-color-primary, #6750a4))}.selected:active .track::before{background-color:var(--md-switch-selected-pressed-track-color, var(--md-sys-color-primary, #6750a4))}.selected.disabled .track{background-clip:border-box}.selected.disabled .track::before{background-color:var(--md-switch-disabled-selected-track-color, var(--md-sys-color-on-surface, #1d1b20))}.unselected .track::before{background-color:var(--md-switch-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-track-outline-color, var(--md-sys-color-outline, #79747e));border-style:solid;border-width:var(--md-switch-track-outline-width, 2px)}.unselected:hover .track::before{background-color:var(--md-switch-hover-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-hover-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:focus-visible .track::before{background-color:var(--md-switch-focus-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-focus-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected:active .track::before{background-color:var(--md-switch-pressed-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-pressed-track-outline-color, var(--md-sys-color-outline, #79747e))}.unselected.disabled .track::before{background-color:var(--md-switch-disabled-track-color, var(--md-sys-color-surface-container-highest, #e6e0e9));border-color:var(--md-switch-disabled-track-outline-color, var(--md-sys-color-on-surface, #1d1b20))}}@layer hcm{@media(forced-colors: active){.selected .track::before{background:ButtonText;border-color:ButtonText}.disabled .track::before{border-color:GrayText;opacity:1}.disabled.selected .track::before{background:GrayText}}}@layer styles{.handle-container{display:flex;place-content:center;place-items:center;position:relative;transition:margin 300ms cubic-bezier(0.175, 0.885, 0.32, 1.275)}.selected .handle-container{margin-inline-start:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.unselected .handle-container{margin-inline-end:calc(var(--md-switch-track-width, 52px) - var(--md-switch-track-height, 32px))}.disabled .handle-container{transition:none}.handle{border-start-start-radius:var(--md-switch-handle-shape-start-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-start-end-radius:var(--md-switch-handle-shape-start-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-end-radius:var(--md-switch-handle-shape-end-end, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));border-end-start-radius:var(--md-switch-handle-shape-end-start, var(--md-switch-handle-shape, var(--md-sys-shape-corner-full, 9999px)));height:var(--md-switch-handle-height, 16px);width:var(--md-switch-handle-width, 16px);transform-origin:center;transition-property:height,width;transition-duration:250ms,250ms;transition-timing-function:cubic-bezier(0.2, 0, 0, 1),cubic-bezier(0.2, 0, 0, 1);z-index:0}.handle::before{content:"";display:flex;inset:0;position:absolute;border-radius:inherit;box-sizing:border-box;transition:background-color 67ms linear}.disabled .handle,.disabled .handle::before{transition:none}.selected .handle{height:var(--md-switch-selected-handle-height, 24px);width:var(--md-switch-selected-handle-width, 24px)}.handle.with-icon{height:var(--md-switch-with-icon-handle-height, 24px);width:var(--md-switch-with-icon-handle-width, 24px)}.selected:not(.disabled):active .handle,.unselected:not(.disabled):active .handle{height:var(--md-switch-pressed-handle-height, 28px);width:var(--md-switch-pressed-handle-width, 28px);transition-timing-function:linear;transition-duration:100ms}.selected .handle::before{background-color:var(--md-switch-selected-handle-color, var(--md-sys-color-on-primary, #fff))}.selected:hover .handle::before{background-color:var(--md-switch-selected-hover-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:focus-within .handle::before{background-color:var(--md-switch-selected-focus-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected:active .handle::before{background-color:var(--md-switch-selected-pressed-handle-color, var(--md-sys-color-primary-container, #eaddff))}.selected.disabled .handle::before{background-color:var(--md-switch-disabled-selected-handle-color, var(--md-sys-color-surface, #fef7ff));opacity:var(--md-switch-disabled-selected-handle-opacity, 1)}.unselected .handle::before{background-color:var(--md-switch-handle-color, var(--md-sys-color-outline, #79747e))}.unselected:hover .handle::before{background-color:var(--md-switch-hover-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:focus-within .handle::before{background-color:var(--md-switch-focus-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected:active .handle::before{background-color:var(--md-switch-pressed-handle-color, var(--md-sys-color-on-surface-variant, #49454f))}.unselected.disabled .handle::before{background-color:var(--md-switch-disabled-handle-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-handle-opacity, 0.38)}md-ripple{border-radius:var(--md-switch-state-layer-shape, var(--md-sys-shape-corner-full, 9999px));height:var(--md-switch-state-layer-size, 40px);inset:unset;width:var(--md-switch-state-layer-size, 40px)}.selected md-ripple{--md-ripple-hover-color: var(--md-switch-selected-hover-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-pressed-color: var(--md-switch-selected-pressed-state-layer-color, var(--md-sys-color-primary, #6750a4));--md-ripple-hover-opacity: var(--md-switch-selected-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-selected-pressed-state-layer-opacity, 0.12)}.unselected md-ripple{--md-ripple-hover-color: var(--md-switch-hover-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-pressed-color: var(--md-switch-pressed-state-layer-color, var(--md-sys-color-on-surface, #1d1b20));--md-ripple-hover-opacity: var(--md-switch-hover-state-layer-opacity, 0.08);--md-ripple-pressed-opacity: var(--md-switch-pressed-state-layer-opacity, 0.12)}}@layer hcm{@media(forced-colors: active){.unselected .handle::before{background:ButtonText}.disabled .handle::before{opacity:1}.disabled.unselected .handle::before{background:GrayText}}}@layer styles{.icons{position:relative;height:100%;width:100%}.icon{position:absolute;inset:0;margin:auto;display:flex;align-items:center;justify-content:center;fill:currentColor;transition:fill 67ms linear,opacity 33ms linear,transform 167ms cubic-bezier(0.2, 0, 0, 1);opacity:0}.disabled .icon{transition:none}.selected .icon--on,.unselected .icon--off{opacity:1}.unselected .handle:not(.with-icon) .icon--on{transform:rotate(-45deg)}.icon--off{width:var(--md-switch-icon-size, 16px);height:var(--md-switch-icon-size, 16px);color:var(--md-switch-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:hover .icon--off{color:var(--md-switch-hover-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:focus-within .icon--off{color:var(--md-switch-focus-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected:active .icon--off{color:var(--md-switch-pressed-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9))}.unselected.disabled .icon--off{color:var(--md-switch-disabled-icon-color, var(--md-sys-color-surface-container-highest, #e6e0e9));opacity:var(--md-switch-disabled-icon-opacity, 0.38)}.icon--on{width:var(--md-switch-selected-icon-size, 16px);height:var(--md-switch-selected-icon-size, 16px);color:var(--md-switch-selected-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:hover .icon--on{color:var(--md-switch-selected-hover-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:focus-within .icon--on{color:var(--md-switch-selected-focus-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected:active .icon--on{color:var(--md-switch-selected-pressed-icon-color, var(--md-sys-color-on-primary-container, #21005d))}.selected.disabled .icon--on{color:var(--md-switch-disabled-selected-icon-color, var(--md-sys-color-on-surface, #1d1b20));opacity:var(--md-switch-disabled-selected-icon-opacity, 0.38)}}@layer hcm{@media(forced-colors: active){.icon--off{fill:Canvas}.icon--on{fill:ButtonText}.disabled.unselected .icon--off,.disabled.selected .icon--on{opacity:1}.disabled .icon--on{fill:GrayText}}}
+`;var Er=class extends Z{};Er.styles=[So];Er=s([E("md-switch")],Er);})();
+  </script>
+
+  <script>
+/*
+ * lht-cmn components.js
+ * Version: v20260222
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtTextFieldHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const type = this.getAttribute("type");
+    if (type != null) field.setAttribute("type", type);
+
+    const min = this.getAttribute("min");
+    if (min != null) field.setAttribute("min", min);
+
+    const max = this.getAttribute("max");
+    if (max != null) field.setAttribute("max", max);
+
+    const step = this.getAttribute("step");
+    if (step != null) field.setAttribute("step", step);
+
+    const rows = this.getAttribute("rows");
+    if (rows != null) field.setAttribute("rows", rows);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    if (helpText) {
+      field.addEventListener("focus", () => {
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        field.supportingText = "";
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSelectHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
+    field.id = fieldId;
+    this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
+
+    const value = this.getAttribute("value");
+    if (value != null) field.value = value;
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    if (helpText) {
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        field.addEventListener("focus", () => {
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          field.supportingText = "";
+        });
+      }
+    }
+
+    this.appendChild(field);
+    this.hydrateOptions();
+
+    if (!this._hasDeclarativeOptions()) {
+      this._optionsObserver = new MutationObserver(() => {
+        this.hydrateOptions();
+      });
+      this._optionsObserver.observe(this, { childList: true, subtree: true });
+      requestAnimationFrame(() => this.hydrateOptions());
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+
+  _hasDeclarativeOptions() {
+    return this.hasAttribute("options") || !!this.querySelector("script[type='application/json'][slot='options']");
+  }
+
+  _normalizeOptions(rawOptions) {
+    return rawOptions
+      .map((entry) => {
+        const value = String(entry?.value ?? entry?.label ?? "");
+        const label = String(entry?.label ?? entry?.text ?? entry?.value ?? "");
+        return {
+          value,
+          label,
+          selected: !!entry?.selected,
+          disabled: !!entry?.disabled
+        };
+      })
+      .filter((entry) => entry.value || entry.label);
+  }
+
+  _readDeclarativeOptions() {
+    const optionsJson = (this.getAttribute("options") || "").trim();
+    if (optionsJson) {
+      try {
+        const parsed = JSON.parse(optionsJson);
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は次の入力ソースへフォールバック
+      }
+    }
+
+    const script = this.querySelector("script[type='application/json'][slot='options']");
+    if (script) {
+      try {
+        const parsed = JSON.parse(script.textContent || "[]");
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は空扱い
+      }
+      return [];
+    }
+
+    return null;
+  }
+
+  _readChildOptionElements() {
+    const sourceOptions = Array.from(this.querySelectorAll("option"));
+    if (sourceOptions.length === 0) return [];
+    return sourceOptions.map((sourceOption) => ({
+      value: sourceOption.getAttribute("value") ?? sourceOption.textContent ?? "",
+      label: sourceOption.textContent ?? "",
+      selected: sourceOption.hasAttribute("selected"),
+      disabled: sourceOption.hasAttribute("disabled")
+    }));
+  }
+
+  _setFieldOptions(options) {
+    const field = this._lhtField;
+    if (!field) return;
+    field.innerHTML = "";
+
+    for (const entry of options) {
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
+      }
+    }
+  }
+
+  hydrateOptions() {
+    const declarativeOptions = this._readDeclarativeOptions();
+    if (Array.isArray(declarativeOptions)) {
+      this._setFieldOptions(declarativeOptions);
+      const jsonScript = this.querySelector("script[type='application/json'][slot='options']");
+      if (jsonScript) jsonScript.remove();
+      if (this._optionsObserver) {
+        this._optionsObserver.disconnect();
+        this._optionsObserver = null;
+      }
+      return;
+    }
+
+    const optionsFromChildren = this._readChildOptionElements();
+    if (optionsFromChildren.length === 0) return;
+    this._setFieldOptions(optionsFromChildren);
+    this.querySelectorAll("option").forEach((option) => option.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtFileSelect extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const inputId = (this.getAttribute("input-id") || "fileInput").trim();
+    const buttonId = (this.getAttribute("button-id") || "fileSelectBtn").trim();
+    const fileNameId = (this.getAttribute("file-name-id") || "fileNameText").trim();
+    const accept = (this.getAttribute("accept") || "").trim();
+    const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
+    const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
+    const showFileName = this.hasAttribute("show-file-name");
+
+    this.textContent = "";
+
+    const root = document.createElement("div");
+    root.className = "lht-file-select";
+
+    const hasMdFilledButton = !!(window.customElements && window.customElements.get("md-filled-button"));
+    const triggerButton = document.createElement(hasMdFilledButton ? "md-filled-button" : "button");
+    if (!hasMdFilledButton) {
+      triggerButton.type = "button";
+    }
+    triggerButton.id = buttonId;
+    triggerButton.className = `lht-file-select__button${hasMdFilledButton ? "" : " lht-file-select__button--fallback"}`;
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("slot", "icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("class", "lht-file-select__button-icon");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "1.9");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.innerHTML = '<path d="M4 7h7l2 2h7v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path><path d="M12 10v6"></path><path d="M9 13l3 3 3-3"></path>';
+
+    const labelNode = document.createElement("span");
+    labelNode.className = "lht-file-select__button-text";
+    labelNode.textContent = buttonLabel;
+    triggerButton.appendChild(icon);
+    triggerButton.appendChild(labelNode);
+
+    const input = document.createElement("input");
+    input.id = inputId;
+    input.type = "file";
+    input.className = "md-file";
+    input.hidden = true;
+    if (accept) input.setAttribute("accept", accept);
+    if (this.hasAttribute("multiple")) input.multiple = true;
+
+    const fileName = document.createElement("span");
+    fileName.id = fileNameId;
+    fileName.className = "lht-file-select__file-name";
+    fileName.textContent = placeholder;
+    if (!showFileName) fileName.hidden = true;
+
+    if (this.hasAttribute("disabled")) {
+      input.disabled = true;
+      triggerButton.disabled = true;
+    }
+
+    triggerButton.addEventListener("click", () => input.click());
+    input.addEventListener("change", () => {
+      const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
+      fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+    });
+
+    root.appendChild(triggerButton);
+    root.appendChild(fileName);
+    this.appendChild(root);
+    this.appendChild(input);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
+
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
+    }
+  }
+}
+
+class LhtIndexCardLink extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const href = (this.getAttribute("href") || "").trim();
+    if (!href) return;
+
+    const title = (this.getAttribute("title") || "").trim();
+    const descAttr = (this.getAttribute("desc") || "").trim();
+    const iconAttr = (this.getAttribute("icon") || "").trim();
+    const target = (this.getAttribute("target") || "").trim();
+    const relAttr = (this.getAttribute("rel") || "").trim();
+    const variant = (this.getAttribute("variant") || "default").trim().toLowerCase();
+    const arrowMode = (this.getAttribute("arrow") || "auto").trim().toLowerCase();
+    const badgeText = (this.getAttribute("badge") || "").trim();
+    const descLines = (this.getAttribute("desc-lines") || "").trim();
+
+    if (!title || !descAttr) {
+      const missing = [];
+      if (!title) missing.push("title");
+      if (!descAttr) missing.push("desc");
+      // Fail fast for authoring mistakes in index cards.
+      console.warn(`[lht-index-card-link] Missing required attribute(s): ${missing.join(", ")}`, this);
+      return;
+    }
+
+    this.textContent = "";
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "md-link-card";
+    const isExternalHref = /^(https?:)?\/\//i.test(href);
+    const isExternal = variant === "external" || isExternalHref || target === "_blank";
+    const effectiveTarget = target || (isExternal ? "_blank" : "");
+    if (effectiveTarget) link.target = effectiveTarget;
+    if (effectiveTarget === "_blank") {
+      link.rel = relAttr || "noopener noreferrer";
+    } else if (relAttr) {
+      link.rel = relAttr;
+    }
+    if (variant === "simple") link.classList.add("lht-index-card-link--simple");
+    if (isExternal) link.classList.add("lht-index-card-link--external");
+
+    const head = document.createElement("div");
+    head.className = "md-card-head";
+
+    const h3 = document.createElement("h3");
+    h3.className = "md-card-title";
+    if (iconAttr) {
+      const iconContainer = document.createElement("span");
+      iconContainer.className = "lht-index-card-link__icon";
+      iconContainer.textContent = iconAttr;
+      h3.appendChild(iconContainer);
+    }
+    const titleContainer = document.createElement("span");
+    titleContainer.className = "lht-index-card-link__title";
+    titleContainer.textContent = title;
+    h3.appendChild(titleContainer);
+    if (badgeText) {
+      const badge = document.createElement("span");
+      badge.className = "lht-index-card-link__badge";
+      badge.textContent = badgeText;
+      h3.appendChild(badge);
+    }
+
+    const arrow = document.createElement("span");
+    arrow.className = "md-card-arrow";
+    const showArrow = arrowMode === "auto" ? variant !== "simple" : arrowMode !== "none";
+    arrow.textContent = isExternal ? "↗" : "→";
+    if (!showArrow) arrow.hidden = true;
+
+    const desc = document.createElement("p");
+    desc.className = "md-card-desc";
+    desc.textContent = descAttr;
+    if (descLines && /^\d+$/.test(descLines)) {
+      desc.classList.add("lht-index-card-link__desc--clamp");
+      desc.style.setProperty("--lht-desc-lines", descLines);
+    }
+
+    head.appendChild(h3);
+    head.appendChild(arrow);
+    link.appendChild(head);
+    link.appendChild(desc);
+    this.appendChild(link);
+  }
+}
+
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
+      panel.classList.toggle("md-hidden");
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
+}
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
+}
+if (!customElements.get("lht-file-select")) {
+  customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-index-card-link")) {
+  customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
   <script>
 /**
  * MIDI file format constants.
@@ -2496,212 +3891,184 @@ window.MidiWriter = main;
 
   <script>
 const MusicXmlCommon = (() => {
-  function readTextFileUtf8(file, onLoad, onError) {
-    const reader = new FileReader();
-    reader.onload = () => {
-      onLoad(String(reader.result || ""));
+    function readTextFileUtf8(file, onLoad, onError) {
+        const reader = new FileReader();
+        reader.onload = () => {
+            onLoad(String(reader.result || ""));
+        };
+        reader.onerror = () => {
+            if (typeof onError === "function") {
+                onError(reader.error || new Error("file read failed"));
+            }
+        };
+        reader.readAsText(file, "utf-8");
+    }
+    function normalizeMusicXmlSource(rawText) {
+        if (!rawText) {
+            return "";
+        }
+        const lines = String(rawText).split("\n");
+        let first = 0;
+        let last = lines.length - 1;
+        while (first <= last && lines[first].trim() === "") {
+            first += 1;
+        }
+        while (last >= first && lines[last].trim() === "") {
+            last -= 1;
+        }
+        if (first > last) {
+            return "";
+        }
+        const firstLine = lines[first].trim();
+        const lastLine = lines[last].trim();
+        const hasCodeFencePair = /^```.*$/.test(firstLine) && /^```\s*$/.test(lastLine);
+        if (hasCodeFencePair) {
+            return lines.slice(first + 1, last).join("\n").trim();
+        }
+        return lines.slice(first, last + 1).join("\n").trim();
+    }
+    function parseScorePartwiseXml(source) {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(source, "application/xml");
+        const parseErr = xmlDoc.querySelector("parsererror");
+        if (parseErr) {
+            throw new Error("XMLの構文解釈に失敗しました。");
+        }
+        const root = xmlDoc.documentElement;
+        if (!root || root.nodeName !== "score-partwise") {
+            throw new Error("score-partwise 形式のMusicXMLに対応しています。");
+        }
+        return xmlDoc;
+    }
+    return {
+        readTextFileUtf8,
+        normalizeMusicXmlSource,
+        parseScorePartwiseXml
     };
-    reader.onerror = () => {
-      if (typeof onError === "function") {
-        onError(reader.error || new Error("file read failed"));
-      }
-    };
-    reader.readAsText(file, "utf-8");
-  }
-
-  function normalizeMusicXmlSource(rawText) {
-    if (!rawText) {
-      return "";
-    }
-
-    const lines = String(rawText).split("\n");
-    let first = 0;
-    let last = lines.length - 1;
-
-    while (first <= last && lines[first].trim() === "") {
-      first += 1;
-    }
-    while (last >= first && lines[last].trim() === "") {
-      last -= 1;
-    }
-    if (first > last) {
-      return "";
-    }
-
-    const firstLine = lines[first].trim();
-    const lastLine = lines[last].trim();
-    const hasCodeFencePair = /^```.*$/.test(firstLine) && /^```\s*$/.test(lastLine);
-    if (hasCodeFencePair) {
-      return lines.slice(first + 1, last).join("\n").trim();
-    }
-
-    return lines.slice(first, last + 1).join("\n").trim();
-  }
-
-  function parseScorePartwiseXml(source) {
-    const parser = new DOMParser();
-    const xmlDoc = parser.parseFromString(source, "application/xml");
-    const parseErr = xmlDoc.querySelector("parsererror");
-    if (parseErr) {
-      throw new Error("XMLの構文解釈に失敗しました。");
-    }
-
-    const root = xmlDoc.documentElement;
-    if (!root || root.nodeName !== "score-partwise") {
-      throw new Error("score-partwise 形式のMusicXMLに対応しています。");
-    }
-
-    return xmlDoc;
-  }
-
-  return {
-    readTextFileUtf8,
-    normalizeMusicXmlSource,
-    parseScorePartwiseXml
-  };
 })();
-
 if (typeof window !== "undefined") {
-  window["MusicXmlCommon"] = MusicXmlCommon;
+    window["MusicXmlCommon"] = MusicXmlCommon;
 }
   </script>
 
   <script>
 const MusicSynthCommon = (() => {
-  function normalizeWaveform(value) {
-    if (value === "square" || value === "triangle") {
-      return value;
-    }
-    return "sine";
-  }
-
-  function midiNumberToFrequency(midiNumber) {
-    return 440 * Math.pow(2, (Number(midiNumber) - 69) / 12);
-  }
-
-  function createBasicWaveSynthEngine(options = {}) {
-    const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
-      ? Math.max(1, Math.round(options.ticksPerQuarter))
-      : 128;
-
-    let audioContext = null;
-    let activeSynthNodes = [];
-    let synthStopTimer = null;
-
-    async function playSchedule(schedule, waveform, onEnded) {
-      if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
-        throw new Error("先に変換してください。");
-      }
-
-      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
-      if (!AudioContextCtor) {
-        throw new Error("このブラウザはWebAudioに対応していません。");
-      }
-
-      if (!audioContext) {
-        audioContext = new AudioContextCtor();
-      }
-
-      stop();
-      await audioContext.resume();
-
-      const normalizedWaveform = normalizeWaveform(waveform);
-      const secPerTick = 60 / (Math.max(1, Number(schedule.tempo) || 120) * ticksPerQuarter);
-      const baseTime = audioContext.currentTime + 0.04;
-      let latestEndTime = baseTime;
-
-      for (const event of schedule.events) {
-        const startAt = baseTime + (event.start * secPerTick);
-        const bodyDuration = Math.max(0.04, event.ticks * secPerTick);
-        latestEndTime = Math.max(
-          latestEndTime,
-          scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform)
-        );
-      }
-
-      if (synthStopTimer) {
-        clearTimeout(synthStopTimer);
-      }
-      const waitMs = Math.max(0, Math.ceil((latestEndTime - audioContext.currentTime) * 1000));
-      synthStopTimer = setTimeout(() => {
-        activeSynthNodes = [];
-        if (typeof onEnded === "function") {
-          onEnded();
+    function normalizeWaveform(value) {
+        if (value === "square" || value === "triangle") {
+            return value;
         }
-      }, waitMs);
+        return "sine";
     }
-
-    function stop() {
-      if (synthStopTimer) {
-        clearTimeout(synthStopTimer);
-        synthStopTimer = null;
-      }
-      for (const node of activeSynthNodes) {
-        try {
-          node.oscillator.stop();
-        } catch (_error) {
-          // ignore already-stopped nodes
+    function midiNumberToFrequency(midiNumber) {
+        return 440 * Math.pow(2, (Number(midiNumber) - 69) / 12);
+    }
+    function createBasicWaveSynthEngine(options = {}) {
+        const ticksPerQuarter = Number.isFinite(options.ticksPerQuarter)
+            ? Math.max(1, Math.round(options.ticksPerQuarter))
+            : 128;
+        let audioContext = null;
+        let activeSynthNodes = [];
+        let synthStopTimer = null;
+        async function playSchedule(schedule, waveform, onEnded) {
+            if (!schedule || !Array.isArray(schedule.events) || schedule.events.length === 0) {
+                throw new Error("先に変換してください。");
+            }
+            const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+            if (!AudioContextCtor) {
+                throw new Error("このブラウザはWebAudioに対応していません。");
+            }
+            if (!audioContext) {
+                audioContext = new AudioContextCtor();
+            }
+            stop();
+            await audioContext.resume();
+            const normalizedWaveform = normalizeWaveform(waveform);
+            const secPerTick = 60 / (Math.max(1, Number(schedule.tempo) || 120) * ticksPerQuarter);
+            const baseTime = audioContext.currentTime + 0.04;
+            let latestEndTime = baseTime;
+            for (const event of schedule.events) {
+                const startAt = baseTime + (event.start * secPerTick);
+                const bodyDuration = Math.max(0.04, event.ticks * secPerTick);
+                latestEndTime = Math.max(latestEndTime, scheduleBasicWaveNote(event, startAt, bodyDuration, normalizedWaveform));
+            }
+            if (synthStopTimer) {
+                clearTimeout(synthStopTimer);
+            }
+            const waitMs = Math.max(0, Math.ceil((latestEndTime - audioContext.currentTime) * 1000));
+            synthStopTimer = setTimeout(() => {
+                activeSynthNodes = [];
+                if (typeof onEnded === "function") {
+                    onEnded();
+                }
+            }, waitMs);
         }
-        try {
-          node.oscillator.disconnect();
-          node.gainNode.disconnect();
-        } catch (_error) {
-          // ignore disconnect error
+        function stop() {
+            if (synthStopTimer) {
+                clearTimeout(synthStopTimer);
+                synthStopTimer = null;
+            }
+            for (const node of activeSynthNodes) {
+                try {
+                    node.oscillator.stop();
+                }
+                catch (_error) {
+                    // ignore already-stopped nodes
+                }
+                try {
+                    node.oscillator.disconnect();
+                    node.gainNode.disconnect();
+                }
+                catch (_error) {
+                    // ignore disconnect error
+                }
+            }
+            activeSynthNodes = [];
         }
-      }
-      activeSynthNodes = [];
-    }
-
-    function scheduleBasicWaveNote(event, startAt, bodyDuration, waveform) {
-      const attack = 0.005;
-      const release = 0.03;
-      const endAt = startAt + bodyDuration;
-      const oscillator = audioContext.createOscillator();
-      oscillator.type = waveform;
-      oscillator.frequency.setValueAtTime(midiNumberToFrequency(event.midiNumber), startAt);
-
-      const gainNode = audioContext.createGain();
-      const gainLevel = event.channel === 10 ? 0.06 : 0.1;
-      gainNode.gain.setValueAtTime(0.0001, startAt);
-      gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
-      gainNode.gain.setValueAtTime(gainLevel, endAt);
-      gainNode.gain.linearRampToValueAtTime(0.0001, endAt + release);
-
-      oscillator.connect(gainNode);
-      gainNode.connect(audioContext.destination);
-      oscillator.start(startAt);
-      oscillator.stop(endAt + release + 0.01);
-      registerSynthNode(oscillator, gainNode);
-      return endAt + release + 0.02;
-    }
-
-    function registerSynthNode(oscillator, gainNode) {
-      oscillator.onended = () => {
-        try {
-          oscillator.disconnect();
-          gainNode.disconnect();
-        } catch (_error) {
-          // ignore cleanup failure
+        function scheduleBasicWaveNote(event, startAt, bodyDuration, waveform) {
+            const attack = 0.005;
+            const release = 0.03;
+            const endAt = startAt + bodyDuration;
+            const oscillator = audioContext.createOscillator();
+            oscillator.type = waveform;
+            oscillator.frequency.setValueAtTime(midiNumberToFrequency(event.midiNumber), startAt);
+            const gainNode = audioContext.createGain();
+            const gainLevel = event.channel === 10 ? 0.06 : 0.1;
+            gainNode.gain.setValueAtTime(0.0001, startAt);
+            gainNode.gain.linearRampToValueAtTime(gainLevel, startAt + attack);
+            gainNode.gain.setValueAtTime(gainLevel, endAt);
+            gainNode.gain.linearRampToValueAtTime(0.0001, endAt + release);
+            oscillator.connect(gainNode);
+            gainNode.connect(audioContext.destination);
+            oscillator.start(startAt);
+            oscillator.stop(endAt + release + 0.01);
+            registerSynthNode(oscillator, gainNode);
+            return endAt + release + 0.02;
         }
-      };
-      activeSynthNodes.push({ oscillator, gainNode });
+        function registerSynthNode(oscillator, gainNode) {
+            oscillator.onended = () => {
+                try {
+                    oscillator.disconnect();
+                    gainNode.disconnect();
+                }
+                catch (_error) {
+                    // ignore cleanup failure
+                }
+            };
+            activeSynthNodes.push({ oscillator, gainNode });
+        }
+        return {
+            playSchedule,
+            stop
+        };
     }
-
     return {
-      playSchedule,
-      stop
+        normalizeWaveform,
+        midiNumberToFrequency,
+        createBasicWaveSynthEngine
     };
-  }
-
-  return {
-    normalizeWaveform,
-    midiNumberToFrequency,
-    createBasicWaveSynthEngine
-  };
 })();
-
 if (typeof window !== "undefined") {
-  window["MusicSynthCommon"] = MusicSynthCommon;
+    window["MusicSynthCommon"] = MusicSynthCommon;
 }
   </script>
 
@@ -2709,217 +4076,185 @@ if (typeof window !== "undefined") {
 const musicXmlCommon = window["MusicXmlCommon"] || (typeof MusicXmlCommon !== "undefined" ? MusicXmlCommon : null);
 const musicSynthCommon = window["MusicSynthCommon"] || (typeof MusicSynthCommon !== "undefined" ? MusicSynthCommon : null);
 if (!musicXmlCommon || !musicSynthCommon) {
-  throw new Error("Common scripts are not loaded.");
+    throw new Error("Common scripts are not loaded.");
 }
 const xmlInput = document.getElementById("xmlInput");
-    const fileInput = document.getElementById("fileInput");
-    const inputModeSourceRadio = document.getElementById("inputModeSource");
-    const inputModeFileRadio = document.getElementById("inputModeFile");
-    const sourceInputBlock = document.getElementById("sourceInputBlock");
-    const fileInputBlock = document.getElementById("fileInputBlock");
-    const fileSelectBtn = document.getElementById("fileSelectBtn");
-    const fileNameText = document.getElementById("fileNameText");
-    const defaultTitleInput = document.getElementById("defaultTitleInput");
-    const defaultComposerInput = document.getElementById("defaultComposerInput");
-    const defaultTempoInput = document.getElementById("defaultTempoInput");
-    const instrumentOverrideSelect = document.getElementById("instrumentOverrideSelect");
-    const synthWaveformSelect = document.getElementById("synthWaveformSelect");
-    const convertBtn = document.getElementById("convertBtn");
-    const downloadBtn = document.getElementById("downloadBtn");
-    const playBtn = document.getElementById("playBtn");
-    const stopBtn = document.getElementById("stopBtn");
-    const previewText = document.getElementById("previewText");
-    const errorText = document.getElementById("errorText");
-    const warningText = document.getElementById("warningText");
-    const toast = document.getElementById("toast");
-    const menuPanel = document.getElementById("menuPanel");
-
-    const SETTINGS_KEY = "musicxml-to-midi-settings";
-    const MIDI_TICKS_PER_QUARTER = 128;
-
-    let lastMidiBytes = null;
-    let lastSynthSchedule = null;
-    const synthEngine = musicSynthCommon.createBasicWaveSynthEngine({
-      ticksPerQuarter: MIDI_TICKS_PER_QUARTER
-    });
-
-    restoreSettings();
-
-    convertBtn.addEventListener("click", convertMusicXml);
-    downloadBtn.addEventListener("click", downloadMidi);
-    playBtn.addEventListener("click", playMidi);
-    stopBtn.addEventListener("click", stopMidi);
-    fileInput.addEventListener("change", loadXmlFile);
-    fileSelectBtn.addEventListener("click", () => fileInput.click());
-    inputModeSourceRadio.addEventListener("change", applyInputMode);
-    inputModeFileRadio.addEventListener("change", applyInputMode);
-    defaultTitleInput.addEventListener("change", persistSettings);
-    defaultComposerInput.addEventListener("change", persistSettings);
-    defaultTempoInput.addEventListener("change", persistSettings);
-    instrumentOverrideSelect.addEventListener("change", persistSettings);
-    synthWaveformSelect.addEventListener("change", persistSettings);
-    document.addEventListener("click", handleDocumentClick);
-
-    applyInputMode();
-    convertMusicXml();
-
-    function loadXmlFile(event) {
-      const file = event.target.files && event.target.files[0];
-      if (!file) {
+const fileInput = document.getElementById("fileInput");
+const inputModeSourceRadio = document.getElementById("inputModeSource");
+const inputModeFileRadio = document.getElementById("inputModeFile");
+const sourceInputBlock = document.getElementById("sourceInputBlock");
+const fileInputBlock = document.getElementById("fileInputBlock");
+const fileSelectBtn = document.getElementById("fileSelectBtn");
+const fileNameText = document.getElementById("fileNameText");
+const defaultTitleInput = document.getElementById("defaultTitleInput");
+const defaultComposerInput = document.getElementById("defaultComposerInput");
+const defaultTempoInput = document.getElementById("defaultTempoInput");
+const instrumentOverrideSelect = document.getElementById("instrumentOverrideSelect");
+const synthWaveformSelect = document.getElementById("synthWaveformSelect");
+const convertBtn = document.getElementById("convertBtn");
+const downloadBtn = document.getElementById("downloadBtn");
+const playBtn = document.getElementById("playBtn");
+const stopBtn = document.getElementById("stopBtn");
+const previewText = document.getElementById("previewText");
+const errorText = document.getElementById("errorText");
+const warningText = document.getElementById("warningText");
+const toast = document.getElementById("toast");
+const menuPanel = document.getElementById("menuPanel");
+const SETTINGS_KEY = "musicxml-to-midi-settings";
+const MIDI_TICKS_PER_QUARTER = 128;
+let lastMidiBytes = null;
+let lastSynthSchedule = null;
+const synthEngine = musicSynthCommon.createBasicWaveSynthEngine({
+    ticksPerQuarter: MIDI_TICKS_PER_QUARTER
+});
+restoreSettings();
+convertBtn.addEventListener("click", convertMusicXml);
+downloadBtn.addEventListener("click", downloadMidi);
+playBtn.addEventListener("click", playMidi);
+stopBtn.addEventListener("click", stopMidi);
+fileInput.addEventListener("change", loadXmlFile);
+fileSelectBtn.addEventListener("click", () => fileInput.click());
+inputModeSourceRadio.addEventListener("change", applyInputMode);
+inputModeFileRadio.addEventListener("change", applyInputMode);
+defaultTitleInput.addEventListener("change", persistSettings);
+defaultComposerInput.addEventListener("change", persistSettings);
+defaultTempoInput.addEventListener("change", persistSettings);
+instrumentOverrideSelect.addEventListener("change", persistSettings);
+synthWaveformSelect.addEventListener("change", persistSettings);
+document.addEventListener("click", handleDocumentClick);
+applyInputMode();
+convertMusicXml();
+function loadXmlFile(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) {
         updateFileName("");
         return;
-      }
-      inputModeFileRadio.checked = true;
-      applyInputMode();
-      updateFileName(file.name);
-      musicXmlCommon.readTextFileUtf8(file, (text) => {
+    }
+    inputModeFileRadio.checked = true;
+    applyInputMode();
+    updateFileName(file.name);
+    musicXmlCommon.readTextFileUtf8(file, (text) => {
         xmlInput.value = text;
         showToast("MusicXMLを読み込みました。");
-      }, () => {
+    }, () => {
         setError("ファイルの読み込みに失敗しました。");
-      });
-    }
-
-    function updateFileName(name) {
-      fileNameText.textContent = name || "未選択";
-    }
-
-    function convertMusicXml() {
-      const source = normalizeSource(xmlInput.value);
-      if (!source) {
+    });
+}
+function updateFileName(name) {
+    fileNameText.textContent = name || "未選択";
+}
+function convertMusicXml() {
+    const source = normalizeSource(xmlInput.value);
+    if (!source) {
         setError("MusicXMLソースを入力してください。");
         resetOutput();
         return;
-      }
-
-      clearError();
-      clearWarning();
-
-      try {
+    }
+    clearError();
+    clearWarning();
+    try {
         const result = parseMusicXml(source, {
-          defaultTitle: defaultTitleInput.value.trim() || "Untitled",
-          defaultComposer: defaultComposerInput.value.trim() || "Unknown",
-          defaultTempo: clampTempo(defaultTempoInput.value)
+            defaultTitle: defaultTitleInput.value.trim() || "Untitled",
+            defaultComposer: defaultComposerInput.value.trim() || "Unknown",
+            defaultTempo: clampTempo(defaultTempoInput.value)
         });
         const instrumentOverride = parseInstrumentOverride(instrumentOverrideSelect.value);
-
         const voiceIds = Object.keys(result.voiceTracksById).sort(compareTrackIds);
         const tracks = [];
-
         for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
-          const voiceId = voiceIds[trackIndex];
-          const voiceTrack = result.voiceTracksById[voiceId];
-          const voiceEvents = voiceTrack.events;
-          const channelToUse = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
-          const track = new MidiWriter.Track();
-          track.addTrackName(voiceTrack.trackName);
-          track.addInstrumentName(voiceTrack.trackName);
-          track.addText("composer:" + result.meta.composer);
-          track.setTempo(result.meta.tempo);
-          track.setTimeSignature(result.meta.meter.beats, result.meta.meter.beatType);
-          const programToUse = resolveProgram(voiceTrack.program, instrumentOverride);
-          if (programToUse !== null) {
-            track.addEvent(
-              new MidiWriter.ProgramChangeEvent({
-                instrument: programToUse,
-                channel: channelToUse
-              })
-            );
-          }
-
-          let cursor = 0;
-          for (const event of voiceEvents) {
-            const waitTicks = Math.max(0, event.start - cursor);
-            const fields = {
-              pitch: [event.pitch],
-              duration: "T" + event.ticks,
-              velocity: 80,
-              channel: channelToUse
-            };
-            if (waitTicks > 0) {
-              fields.wait = "T" + waitTicks;
+            const voiceId = voiceIds[trackIndex];
+            const voiceTrack = result.voiceTracksById[voiceId];
+            const voiceEvents = voiceTrack.events;
+            const channelToUse = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
+            const track = new MidiWriter.Track();
+            track.addTrackName(voiceTrack.trackName);
+            track.addInstrumentName(voiceTrack.trackName);
+            track.addText("composer:" + result.meta.composer);
+            track.setTempo(result.meta.tempo);
+            track.setTimeSignature(result.meta.meter.beats, result.meta.meter.beatType);
+            const programToUse = resolveProgram(voiceTrack.program, instrumentOverride);
+            if (programToUse !== null) {
+                track.addEvent(new MidiWriter.ProgramChangeEvent({
+                    instrument: programToUse,
+                    channel: channelToUse
+                }));
             }
-            track.addEvent(new MidiWriter.NoteEvent(fields));
-            cursor = Math.max(cursor, event.start + event.ticks);
-          }
-          tracks.push(track);
+            let cursor = 0;
+            for (const event of voiceEvents) {
+                const waitTicks = Math.max(0, event.start - cursor);
+                const fields = {
+                    pitch: [event.pitch],
+                    duration: "T" + event.ticks,
+                    velocity: 80,
+                    channel: channelToUse
+                };
+                if (waitTicks > 0) {
+                    fields.wait = "T" + waitTicks;
+                }
+                track.addEvent(new MidiWriter.NoteEvent(fields));
+                cursor = Math.max(cursor, event.start + event.ticks);
+            }
+            tracks.push(track);
         }
-
         const writer = new MidiWriter.Writer(tracks);
         const built = writer.buildFile();
         lastMidiBytes = built instanceof Uint8Array ? built : Uint8Array.from(built || []);
         lastSynthSchedule = buildSynthSchedule(result.meta.tempo, voiceIds, result.voiceTracksById, instrumentOverride);
-
         downloadBtn.disabled = lastMidiBytes.length === 0;
         playBtn.disabled = !lastSynthSchedule || lastSynthSchedule.events.length === 0;
         stopBtn.disabled = true;
         previewText.textContent = [
-          "title: " + result.meta.title,
-          "composer: " + result.meta.composer,
-          "tempo: " + result.meta.tempo,
-          "instrument override: " + instrumentOverrideLabel(instrumentOverride),
-          "synth waveform: " + musicSynthCommon.normalizeWaveform(synthWaveformSelect.value),
-          "meter: " + result.meta.meter.beats + "/" + result.meta.meter.beatType,
-          "parts: " + result.meta.partCount,
-          "voices: " + result.meta.voiceCount,
-          "measures: " + result.meta.measureCount,
-          "notes: " + result.meta.noteCount,
-          "rests: " + result.meta.restCount,
-          "tracks: " + tracks.length,
-          "midi bytes: " + lastMidiBytes.length
+            "title: " + result.meta.title,
+            "composer: " + result.meta.composer,
+            "tempo: " + result.meta.tempo,
+            "instrument override: " + instrumentOverrideLabel(instrumentOverride),
+            "synth waveform: " + musicSynthCommon.normalizeWaveform(synthWaveformSelect.value),
+            "meter: " + result.meta.meter.beats + "/" + result.meta.meter.beatType,
+            "parts: " + result.meta.partCount,
+            "voices: " + result.meta.voiceCount,
+            "measures: " + result.meta.measureCount,
+            "notes: " + result.meta.noteCount,
+            "rests: " + result.meta.restCount,
+            "tracks: " + tracks.length,
+            "midi bytes: " + lastMidiBytes.length
         ].join("\n");
-
         if (result.warnings.length > 0) {
-          warningText.textContent = "警告:\n" + result.warnings.join("\n");
-          warningText.classList.remove("md-hidden");
+            warningText.textContent = "警告:\n" + result.warnings.join("\n");
+            warningText.classList.remove("md-hidden");
         }
-
         showToast("MIDIを生成しました。");
-      } catch (error) {
+    }
+    catch (error) {
         resetOutput();
         const message = error && error.message ? error.message : String(error);
         setError("変換に失敗しました: " + message);
-      }
     }
-
-    function parseMusicXml(source, settings) {
-      const xmlDoc = musicXmlCommon.parseScorePartwiseXml(source);
-      const root = xmlDoc.documentElement;
-
-      const warnings = [];
-      const partNodes = Array.from(root.children).filter(
-        (node) => node.nodeType === 1 && node.nodeName === "part"
-      );
-      if (partNodes.length === 0) {
+}
+function parseMusicXml(source, settings) {
+    const xmlDoc = musicXmlCommon.parseScorePartwiseXml(source);
+    const root = xmlDoc.documentElement;
+    const warnings = [];
+    const partNodes = Array.from(root.children).filter((node) => node.nodeType === 1 && node.nodeName === "part");
+    if (partNodes.length === 0) {
         throw new Error("part が見つかりません。");
-      }
-
-      const title = textOrFallback(
-        root.querySelector("work > work-title") || root.querySelector("movement-title"),
-        settings.defaultTitle
-      );
-      const composer = textOrFallback(
-        root.querySelector('identification > creator[type="composer"]') || root.querySelector("identification > creator"),
-        settings.defaultComposer
-      );
-
-      const partNameById = buildPartNameMap(root);
-      const partPlaybackById = buildPartPlaybackMap(root);
-      let globalMeter = { beats: 4, beatType: 4 };
-      let meterFixed = false;
-      let meter = { beats: 4, beatType: 4 };
-      let tempo = settings.defaultTempo;
-      let tempoDetected = false;
-      let noteCount = 0;
-      let restCount = 0;
-      let measureCount = 0;
-      const voiceTracksById = {};
-      const logLines = [];
-
-      let warnedChord = false;
-      let warnedTie = false;
-
-      for (let partIndex = 0; partIndex < partNodes.length; partIndex += 1) {
+    }
+    const title = textOrFallback(root.querySelector("work > work-title") || root.querySelector("movement-title"), settings.defaultTitle);
+    const composer = textOrFallback(root.querySelector('identification > creator[type="composer"]') || root.querySelector("identification > creator"), settings.defaultComposer);
+    const partNameById = buildPartNameMap(root);
+    const partPlaybackById = buildPartPlaybackMap(root);
+    let globalMeter = { beats: 4, beatType: 4 };
+    let meterFixed = false;
+    let meter = { beats: 4, beatType: 4 };
+    let tempo = settings.defaultTempo;
+    let tempoDetected = false;
+    let noteCount = 0;
+    let restCount = 0;
+    let measureCount = 0;
+    const voiceTracksById = {};
+    const logLines = [];
+    let warnedChord = false;
+    let warnedTie = false;
+    for (let partIndex = 0; partIndex < partNodes.length; partIndex += 1) {
         const part = partNodes[partIndex];
         const partId = part.getAttribute("id") || "P" + String(partIndex + 1);
         const partName = partNameById[partId] || partId;
@@ -2928,224 +4263,200 @@ const xmlInput = document.getElementById("xmlInput");
         meter = meterFixed ? globalMeter : meter;
         let timelineTick = 0;
         let currentTranspose = 0;
-
-        const measureNodes = Array.from(part.children).filter(
-          (node) => node.nodeType === 1 && node.nodeName === "measure"
-        );
+        const measureNodes = Array.from(part.children).filter((node) => node.nodeType === 1 && node.nodeName === "measure");
         if (measureNodes.length === 0) {
-          warnings.push("part " + partName + ": measure が見つからないためスキップしました。");
-          continue;
+            warnings.push("part " + partName + ": measure が見つからないためスキップしました。");
+            continue;
         }
-
         for (const measureNode of measureNodes) {
-          measureCount += 1;
-          const measureNo = measureNode.getAttribute("number") || String(logLines.length + 1);
-
-          const attrNode = firstDirectChild(measureNode, "attributes");
-          if (attrNode) {
-            const divText = getChildText(attrNode, "divisions");
-            if (divText) {
-              const divVal = Number.parseInt(divText, 10);
-              if (Number.isFinite(divVal) && divVal > 0) {
-                divisions = divVal;
-              }
-            }
-
-            const timeNode = firstDirectChild(attrNode, "time");
-            const beatsText = getChildText(timeNode, "beats");
-            const beatTypeText = getChildText(timeNode, "beat-type");
-            if (beatsText && beatTypeText) {
-              const beatsVal = Number.parseInt(beatsText, 10);
-              const beatTypeVal = Number.parseInt(beatTypeText, 10);
-              if (beatsVal > 0 && beatTypeVal > 0) {
-                meter = { beats: beatsVal, beatType: beatTypeVal };
-                if (!meterFixed) {
-                  globalMeter = meter;
-                  meterFixed = true;
+            measureCount += 1;
+            const measureNo = measureNode.getAttribute("number") || String(logLines.length + 1);
+            const attrNode = firstDirectChild(measureNode, "attributes");
+            if (attrNode) {
+                const divText = getChildText(attrNode, "divisions");
+                if (divText) {
+                    const divVal = Number.parseInt(divText, 10);
+                    if (Number.isFinite(divVal) && divVal > 0) {
+                        divisions = divVal;
+                    }
                 }
-              }
+                const timeNode = firstDirectChild(attrNode, "time");
+                const beatsText = getChildText(timeNode, "beats");
+                const beatTypeText = getChildText(timeNode, "beat-type");
+                if (beatsText && beatTypeText) {
+                    const beatsVal = Number.parseInt(beatsText, 10);
+                    const beatTypeVal = Number.parseInt(beatTypeText, 10);
+                    if (beatsVal > 0 && beatTypeVal > 0) {
+                        meter = { beats: beatsVal, beatType: beatTypeVal };
+                        if (!meterFixed) {
+                            globalMeter = meter;
+                            meterFixed = true;
+                        }
+                    }
+                }
+                const transposeNode = firstDirectChild(attrNode, "transpose");
+                if (transposeNode) {
+                    const chromaticText = getChildText(transposeNode, "chromatic");
+                    const octaveChangeText = getChildText(transposeNode, "octave-change");
+                    const chromatic = chromaticText ? Number.parseInt(chromaticText, 10) : 0;
+                    const octaveChange = octaveChangeText ? Number.parseInt(octaveChangeText, 10) : 0;
+                    const transposeSemitones = (Number.isFinite(chromatic) ? chromatic : 0) +
+                        ((Number.isFinite(octaveChange) ? octaveChange : 0) * 12);
+                    // Apply MusicXML transpose directly to move written pitch to sounding pitch.
+                    currentTranspose = transposeSemitones;
+                }
             }
-
-            const transposeNode = firstDirectChild(attrNode, "transpose");
-            if (transposeNode) {
-              const chromaticText = getChildText(transposeNode, "chromatic");
-              const octaveChangeText = getChildText(transposeNode, "octave-change");
-              const chromatic = chromaticText ? Number.parseInt(chromaticText, 10) : 0;
-              const octaveChange = octaveChangeText ? Number.parseInt(octaveChangeText, 10) : 0;
-              const transposeSemitones =
-                (Number.isFinite(chromatic) ? chromatic : 0) +
-                ((Number.isFinite(octaveChange) ? octaveChange : 0) * 12);
-              // Apply MusicXML transpose directly to move written pitch to sounding pitch.
-              currentTranspose = transposeSemitones;
+            if (!tempoDetected) {
+                for (const child of Array.from(measureNode.children)) {
+                    if (child.nodeName !== "direction") {
+                        continue;
+                    }
+                    const sound = firstDirectChild(child, "sound");
+                    const tempoText = sound ? sound.getAttribute("tempo") : "";
+                    if (tempoText) {
+                        const tempoValue = Number.parseFloat(tempoText);
+                        if (Number.isFinite(tempoValue) && tempoValue > 0) {
+                            tempo = clampTempo(Math.round(tempoValue));
+                            tempoDetected = true;
+                            break;
+                        }
+                    }
+                }
             }
-          }
-
-          if (!tempoDetected) {
+            let cursorTick = 0;
+            let measureMaxTick = 0;
             for (const child of Array.from(measureNode.children)) {
-              if (child.nodeName !== "direction") {
-                continue;
-              }
-              const sound = firstDirectChild(child, "sound");
-              const tempoText = sound ? sound.getAttribute("tempo") : "";
-              if (tempoText) {
-                const tempoValue = Number.parseFloat(tempoText);
-                if (Number.isFinite(tempoValue) && tempoValue > 0) {
-                  tempo = clampTempo(Math.round(tempoValue));
-                  tempoDetected = true;
-                  break;
+                const name = child.nodeName;
+                if (name === "note") {
+                    const event = noteToEvent(child, divisions, measureNo, warnings);
+                    if (!event) {
+                        continue;
+                    }
+                    if (event.kind === "chord") {
+                        if (!warnedChord) {
+                            warnings.push("和音（<chord/>）はMVPではスキップしています。");
+                            warnedChord = true;
+                        }
+                        continue;
+                    }
+                    if (event.kind === "rest") {
+                        restCount += 1;
+                        logLines.push("part=" + partName + " m" + measureNo + " v" + event.voice + " rest T" + event.ticks);
+                        cursorTick += event.ticks;
+                        measureMaxTick = Math.max(measureMaxTick, cursorTick);
+                        continue;
+                    }
+                    if (event.kind === "note") {
+                        if (event.tied && !warnedTie) {
+                            warnings.push("タイ/スラーはMVPでは厳密再現していません。");
+                            warnedTie = true;
+                        }
+                        noteCount += 1;
+                        const trackId = partId + ":" + event.voice;
+                        if (!Object.prototype.hasOwnProperty.call(voiceTracksById, trackId)) {
+                            const fallbackChannel = defaultChannelForPartIndex(partIndex);
+                            voiceTracksById[trackId] = {
+                                trackName: partName + " voice " + event.voice,
+                                channel: normalizeMidiChannel(partPlayback.channel, fallbackChannel),
+                                program: normalizeMidiProgram(partPlayback.program),
+                                events: []
+                            };
+                        }
+                        const soundingMidi = event.midiNumber + currentTranspose;
+                        if (soundingMidi < 0 || soundingMidi > 127) {
+                            warnings.push("part " + partName + " measure " + measureNo + ": 音高がMIDI範囲外のためスキップしました。");
+                            continue;
+                        }
+                        const soundingPitch = midiNumberToMidiWriterPitch(soundingMidi);
+                        voiceTracksById[trackId].events.push({
+                            pitch: soundingPitch,
+                            midiNumber: soundingMidi,
+                            ticks: event.ticks,
+                            start: timelineTick + cursorTick
+                        });
+                        logLines.push("part=" + partName + " m" + measureNo + " v" + event.voice + " " + soundingPitch + " T" + event.ticks + " @" + (timelineTick + cursorTick));
+                        cursorTick += event.ticks;
+                        measureMaxTick = Math.max(measureMaxTick, cursorTick);
+                    }
                 }
-              }
+                else if (name === "backup") {
+                    const ticks = parseDurationTicks(child, divisions, measureNo, warnings, "backup");
+                    if (ticks > cursorTick) {
+                        warnings.push("part " + partName + " measure " + measureNo + ": backup が小節開始を越えるため補正しました。");
+                        cursorTick = 0;
+                    }
+                    else {
+                        cursorTick -= ticks;
+                    }
+                }
+                else if (name === "forward") {
+                    const ticks = parseDurationTicks(child, divisions, measureNo, warnings, "forward");
+                    cursorTick += ticks;
+                    measureMaxTick = Math.max(measureMaxTick, cursorTick);
+                }
             }
-          }
-
-          let cursorTick = 0;
-          let measureMaxTick = 0;
-
-          for (const child of Array.from(measureNode.children)) {
-            const name = child.nodeName;
-            if (name === "note") {
-              const event = noteToEvent(child, divisions, measureNo, warnings);
-              if (!event) {
-                continue;
-              }
-              if (event.kind === "chord") {
-                if (!warnedChord) {
-                  warnings.push("和音（<chord/>）はMVPではスキップしています。");
-                  warnedChord = true;
-                }
-                continue;
-              }
-              if (event.kind === "rest") {
-                restCount += 1;
-                logLines.push(
-                  "part=" + partName + " m" + measureNo + " v" + event.voice + " rest T" + event.ticks
-                );
-                cursorTick += event.ticks;
-                measureMaxTick = Math.max(measureMaxTick, cursorTick);
-                continue;
-              }
-              if (event.kind === "note") {
-                if (event.tied && !warnedTie) {
-                  warnings.push("タイ/スラーはMVPでは厳密再現していません。");
-                  warnedTie = true;
-                }
-                noteCount += 1;
-                const trackId = partId + ":" + event.voice;
-                if (!Object.prototype.hasOwnProperty.call(voiceTracksById, trackId)) {
-                  const fallbackChannel = defaultChannelForPartIndex(partIndex);
-                  voiceTracksById[trackId] = {
-                    trackName: partName + " voice " + event.voice,
-                    channel: normalizeMidiChannel(partPlayback.channel, fallbackChannel),
-                    program: normalizeMidiProgram(partPlayback.program),
-                    events: []
-                  };
-                }
-                const soundingMidi = event.midiNumber + currentTranspose;
-                if (soundingMidi < 0 || soundingMidi > 127) {
-                  warnings.push(
-                    "part " + partName + " measure " + measureNo + ": 音高がMIDI範囲外のためスキップしました。"
-                  );
-                  continue;
-                }
-                const soundingPitch = midiNumberToMidiWriterPitch(soundingMidi);
-                voiceTracksById[trackId].events.push({
-                  pitch: soundingPitch,
-                  midiNumber: soundingMidi,
-                  ticks: event.ticks,
-                  start: timelineTick + cursorTick
-                });
-                logLines.push(
-                  "part=" + partName + " m" + measureNo + " v" + event.voice + " " + soundingPitch + " T" + event.ticks + " @" + (timelineTick + cursorTick)
-                );
-                cursorTick += event.ticks;
-                measureMaxTick = Math.max(measureMaxTick, cursorTick);
-              }
-            } else if (name === "backup") {
-              const ticks = parseDurationTicks(child, divisions, measureNo, warnings, "backup");
-              if (ticks > cursorTick) {
-                warnings.push(
-                  "part " + partName + " measure " + measureNo + ": backup が小節開始を越えるため補正しました。"
-                );
-                cursorTick = 0;
-              } else {
-                cursorTick -= ticks;
-              }
-            } else if (name === "forward") {
-              const ticks = parseDurationTicks(child, divisions, measureNo, warnings, "forward");
-              cursorTick += ticks;
-              measureMaxTick = Math.max(measureMaxTick, cursorTick);
+            if (measureMaxTick <= 0) {
+                measureMaxTick = Math.max(1, Math.round((MIDI_TICKS_PER_QUARTER * 4 * meter.beats) / meter.beatType));
             }
-          }
-
-          if (measureMaxTick <= 0) {
-            measureMaxTick = Math.max(
-              1,
-              Math.round((MIDI_TICKS_PER_QUARTER * 4 * meter.beats) / meter.beatType)
-            );
-          }
-          timelineTick += measureMaxTick;
+            timelineTick += measureMaxTick;
         }
-      }
-
-      if (noteCount === 0 && restCount === 0) {
+    }
+    if (noteCount === 0 && restCount === 0) {
         throw new Error("変換対象の note/rest が見つかりませんでした。");
-      }
-
-      return {
+    }
+    return {
         meta: {
-          title,
-          composer,
-          tempo,
-          meter: globalMeter,
-          partCount: partNodes.length,
-          voiceCount: Object.keys(voiceTracksById).length,
-          measureCount,
-          noteCount,
-          restCount
+            title,
+            composer,
+            tempo,
+            meter: globalMeter,
+            partCount: partNodes.length,
+            voiceCount: Object.keys(voiceTracksById).length,
+            measureCount,
+            noteCount,
+            restCount
         },
         voiceTracksById,
         warnings,
         logLines
-      };
-    }
-
-    function buildPartNameMap(root) {
-      const map = {};
-      const partList = firstDirectChild(root, "part-list");
-      if (!partList) {
+    };
+}
+function buildPartNameMap(root) {
+    const map = {};
+    const partList = firstDirectChild(root, "part-list");
+    if (!partList) {
         return map;
-      }
-      for (const child of Array.from(partList.children)) {
+    }
+    for (const child of Array.from(partList.children)) {
         if (child.nodeName !== "score-part") {
-          continue;
+            continue;
         }
         const id = child.getAttribute("id");
         if (!id) {
-          continue;
+            continue;
         }
         const name = getChildText(child, "part-name");
         map[id] = name || id;
-      }
-      return map;
     }
-
-    function buildPartPlaybackMap(root) {
-      const map = {};
-      const partList = firstDirectChild(root, "part-list");
-      if (!partList) {
+    return map;
+}
+function buildPartPlaybackMap(root) {
+    const map = {};
+    const partList = firstDirectChild(root, "part-list");
+    if (!partList) {
         return map;
-      }
-      for (const child of Array.from(partList.children)) {
+    }
+    for (const child of Array.from(partList.children)) {
         if (child.nodeName !== "score-part") {
-          continue;
+            continue;
         }
         const id = child.getAttribute("id");
         if (!id) {
-          continue;
+            continue;
         }
         const midiInstrument = firstDirectChild(child, "midi-instrument");
         if (!midiInstrument) {
-          continue;
+            continue;
         }
         const channelText = getChildText(midiInstrument, "midi-channel");
         const programText = getChildText(midiInstrument, "midi-program");
@@ -3153,82 +4464,74 @@ const xmlInput = document.getElementById("xmlInput");
         // MusicXML midi-program is 1-based. midi-writer-js expects 0-based.
         const program = programText ? Number.parseInt(programText, 10) - 1 : null;
         map[id] = {
-          channel: Number.isFinite(channel) ? channel : null,
-          program: Number.isFinite(program) ? program : null
+            channel: Number.isFinite(channel) ? channel : null,
+            program: Number.isFinite(program) ? program : null
         };
-      }
-      return map;
     }
-
-    function noteToEvent(noteNode, divisions, measureNo, warnings) {
-      if (firstDirectChild(noteNode, "grace")) {
+    return map;
+}
+function noteToEvent(noteNode, divisions, measureNo, warnings) {
+    if (firstDirectChild(noteNode, "grace")) {
         warnings.push("measure " + measureNo + ": grace note はスキップしました。");
         return null;
-      }
-      if (firstDirectChild(noteNode, "chord")) {
+    }
+    if (firstDirectChild(noteNode, "chord")) {
         return { kind: "chord" };
-      }
-
-      const durationText = getChildText(noteNode, "duration");
-      if (!durationText) {
+    }
+    const durationText = getChildText(noteNode, "duration");
+    if (!durationText) {
         warnings.push("measure " + measureNo + ": duration が無い note をスキップしました。");
         return null;
-      }
-      const durationVal = Number.parseInt(durationText, 10);
-      if (!Number.isFinite(durationVal) || durationVal <= 0) {
+    }
+    const durationVal = Number.parseInt(durationText, 10);
+    if (!Number.isFinite(durationVal) || durationVal <= 0) {
         warnings.push("measure " + measureNo + ": duration が不正な note をスキップしました。");
         return null;
-      }
-
-      const ticks = Math.max(1, Math.round((durationVal / divisions) * MIDI_TICKS_PER_QUARTER));
-      const voice = getChildText(noteNode, "voice") || "1";
-      if (firstDirectChild(noteNode, "rest")) {
+    }
+    const ticks = Math.max(1, Math.round((durationVal / divisions) * MIDI_TICKS_PER_QUARTER));
+    const voice = getChildText(noteNode, "voice") || "1";
+    if (firstDirectChild(noteNode, "rest")) {
         return { kind: "rest", ticks, voice };
-      }
-
-      const pitchNode = firstDirectChild(noteNode, "pitch");
-      const step = getChildText(pitchNode, "step");
-      const octaveText = getChildText(pitchNode, "octave");
-      if (!step || !octaveText) {
+    }
+    const pitchNode = firstDirectChild(noteNode, "pitch");
+    const step = getChildText(pitchNode, "step");
+    const octaveText = getChildText(pitchNode, "octave");
+    if (!step || !octaveText) {
         warnings.push("measure " + measureNo + ": pitch 情報が不完全な note をスキップしました。");
         return null;
-      }
-      const octave = Number.parseInt(octaveText, 10);
-      if (!Number.isFinite(octave)) {
+    }
+    const octave = Number.parseInt(octaveText, 10);
+    if (!Number.isFinite(octave)) {
         warnings.push("measure " + measureNo + ": octave が不正な note をスキップしました。");
         return null;
-      }
-
-      const alterText = getChildText(pitchNode, "alter");
-      const alter = alterText === "" ? 0 : Number.parseInt(alterText, 10);
-      const tied = Boolean(firstDirectChild(noteNode, "tie") || firstDirectChild(firstDirectChild(noteNode, "notations"), "tied"));
-
-      return {
+    }
+    const alterText = getChildText(pitchNode, "alter");
+    const alter = alterText === "" ? 0 : Number.parseInt(alterText, 10);
+    const tied = Boolean(firstDirectChild(noteNode, "tie") || firstDirectChild(firstDirectChild(noteNode, "notations"), "tied"));
+    return {
         kind: "note",
         midiNumber: pitchToMidiNumber(step, Number.isFinite(alter) ? alter : 0, octave),
         ticks,
         voice,
         tied
-      };
-    }
-
-    function parseDurationTicks(node, divisions, measureNo, warnings, elementName) {
-      const durationText = getChildText(node, "duration");
-      if (!durationText) {
+    };
+}
+function parseDurationTicks(node, divisions, measureNo, warnings, elementName) {
+    const durationText = getChildText(node, "duration");
+    if (!durationText) {
         warnings.push("measure " + measureNo + ": " + elementName + " の duration が無いため 0 扱いにしました。");
         return 0;
-      }
-      const durationVal = Number.parseInt(durationText, 10);
-      if (!Number.isFinite(durationVal) || durationVal < 0) {
+    }
+    const durationVal = Number.parseInt(durationText, 10);
+    if (!Number.isFinite(durationVal) || durationVal < 0) {
         warnings.push("measure " + measureNo + ": " + elementName + " の duration が不正なため 0 扱いにしました。");
         return 0;
-      }
-      return Math.max(0, Math.round((durationVal / divisions) * MIDI_TICKS_PER_QUARTER));
     }
-
-    function pitchToMidiNumber(step, alter, octave) {
-      const s = String(step || "C").toUpperCase();
-      const base = {
+    return Math.max(0, Math.round((durationVal / divisions) * MIDI_TICKS_PER_QUARTER));
+}
+function pitchToMidiNumber(step, alter, octave) {
+    const s = String(step || "C").toUpperCase();
+    const base = {
         C: 0,
         D: 2,
         E: 4,
@@ -3236,324 +4539,295 @@ const xmlInput = document.getElementById("xmlInput");
         G: 7,
         A: 9,
         B: 11
-      };
-      if (!Object.prototype.hasOwnProperty.call(base, s)) {
+    };
+    if (!Object.prototype.hasOwnProperty.call(base, s)) {
         return 60;
-      }
-      const semitone = base[s] + alter;
-      return (octave + 1) * 12 + semitone;
     }
-
-    function midiNumberToMidiWriterPitch(midiNumber) {
-      const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-      const n = Math.max(0, Math.min(127, Math.round(midiNumber)));
-      const octave = Math.floor(n / 12) - 1;
-      const note = names[n % 12];
-      return note + String(octave);
-    }
-
-    function firstDirectChild(parent, tagName) {
-      if (!parent) {
+    const semitone = base[s] + alter;
+    return (octave + 1) * 12 + semitone;
+}
+function midiNumberToMidiWriterPitch(midiNumber) {
+    const names = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+    const n = Math.max(0, Math.min(127, Math.round(midiNumber)));
+    const octave = Math.floor(n / 12) - 1;
+    const note = names[n % 12];
+    return note + String(octave);
+}
+function firstDirectChild(parent, tagName) {
+    if (!parent) {
         return null;
-      }
-      for (const child of Array.from(parent.children)) {
+    }
+    for (const child of Array.from(parent.children)) {
         if (child.nodeName === tagName) {
-          return child;
+            return child;
         }
-      }
-      return null;
     }
-
-    function getChildText(parent, tagName) {
-      const node = firstDirectChild(parent, tagName);
-      return node ? node.textContent.trim() : "";
-    }
-
-    function textOrFallback(node, fallback) {
-      if (!node) {
+    return null;
+}
+function getChildText(parent, tagName) {
+    const node = firstDirectChild(parent, tagName);
+    return node ? node.textContent.trim() : "";
+}
+function textOrFallback(node, fallback) {
+    if (!node) {
         return fallback;
-      }
-      const text = node.textContent ? node.textContent.trim() : "";
-      return text || fallback;
     }
-
-    function normalizeSource(rawText) {
-      return musicXmlCommon.normalizeMusicXmlSource(rawText);
-    }
-
-    function clampTempo(value) {
-      const num = Number.parseInt(String(value || ""), 10);
-      if (!Number.isFinite(num)) {
+    const text = node.textContent ? node.textContent.trim() : "";
+    return text || fallback;
+}
+function normalizeSource(rawText) {
+    return musicXmlCommon.normalizeMusicXmlSource(rawText);
+}
+function clampTempo(value) {
+    const num = Number.parseInt(String(value || ""), 10);
+    if (!Number.isFinite(num)) {
         return 120;
-      }
-      return Math.min(300, Math.max(20, num));
     }
-
-    function compareTrackIds(a, b) {
-      const [aPart, aVoice] = String(a).split(":");
-      const [bPart, bVoice] = String(b).split(":");
-      if (aPart !== bPart) {
+    return Math.min(300, Math.max(20, num));
+}
+function compareTrackIds(a, b) {
+    const [aPart, aVoice] = String(a).split(":");
+    const [bPart, bVoice] = String(b).split(":");
+    if (aPart !== bPart) {
         return String(aPart).localeCompare(String(bPart));
-      }
-      const aNum = Number.parseInt(aVoice, 10);
-      const bNum = Number.parseInt(bVoice, 10);
-      const aIsNum = Number.isFinite(aNum);
-      const bIsNum = Number.isFinite(bNum);
-      if (aIsNum && bIsNum) {
+    }
+    const aNum = Number.parseInt(aVoice, 10);
+    const bNum = Number.parseInt(bVoice, 10);
+    const aIsNum = Number.isFinite(aNum);
+    const bIsNum = Number.isFinite(bNum);
+    if (aIsNum && bIsNum) {
         return aNum - bNum;
-      }
-      if (aIsNum) {
+    }
+    if (aIsNum) {
         return -1;
-      }
-      if (bIsNum) {
+    }
+    if (bIsNum) {
         return 1;
-      }
-      return String(aVoice).localeCompare(String(bVoice));
     }
-
-    function parseInstrumentOverride(value) {
-      if (value === "fm_piano_1") {
+    return String(aVoice).localeCompare(String(bVoice));
+}
+function parseInstrumentOverride(value) {
+    if (value === "fm_piano_1") {
         return { key: value, program: 4 };
-      }
-      if (value === "fm_piano_2") {
+    }
+    if (value === "fm_piano_2") {
         return { key: value, program: 5 };
-      }
-      return { key: "", program: null };
     }
-
-    function resolveProgram(originalProgram, override) {
-      if (override && Number.isFinite(override.program)) {
+    return { key: "", program: null };
+}
+function resolveProgram(originalProgram, override) {
+    if (override && Number.isFinite(override.program)) {
         return override.program;
-      }
-      return originalProgram;
     }
-
-    function resolveChannel(originalChannel, override, trackIndex) {
-      if (override && Number.isFinite(override.program)) {
+    return originalProgram;
+}
+function resolveChannel(originalChannel, override, trackIndex) {
+    if (override && Number.isFinite(override.program)) {
         return defaultChannelForTrackIndex(trackIndex);
-      }
-      return normalizeMidiChannel(originalChannel, defaultChannelForPartIndex(trackIndex));
     }
-
-    function instrumentOverrideLabel(override) {
-      if (!override || !override.key) {
+    return normalizeMidiChannel(originalChannel, defaultChannelForPartIndex(trackIndex));
+}
+function instrumentOverrideLabel(override) {
+    if (!override || !override.key) {
         return "MusicXML";
-      }
-      if (override.key === "fm_piano_1") {
+    }
+    if (override.key === "fm_piano_1") {
         return "FM Piano 1";
-      }
-      if (override.key === "fm_piano_2") {
+    }
+    if (override.key === "fm_piano_2") {
         return "FM Piano 2";
-      }
-      return "MusicXML";
     }
-
-    function defaultChannelForPartIndex(partIndex) {
-      const oneBased = (partIndex % 16) + 1;
-      // Keep channel 10 free by default.
-      if (oneBased === 10) {
+    return "MusicXML";
+}
+function defaultChannelForPartIndex(partIndex) {
+    const oneBased = (partIndex % 16) + 1;
+    // Keep channel 10 free by default.
+    if (oneBased === 10) {
         return 11;
-      }
-      return oneBased;
     }
-
-    function defaultChannelForTrackIndex(trackIndex) {
-      return defaultChannelForPartIndex(trackIndex);
-    }
-
-    function normalizeMidiChannel(channel, fallback) {
-      if (Number.isFinite(channel) && channel >= 1 && channel <= 16) {
+    return oneBased;
+}
+function defaultChannelForTrackIndex(trackIndex) {
+    return defaultChannelForPartIndex(trackIndex);
+}
+function normalizeMidiChannel(channel, fallback) {
+    if (Number.isFinite(channel) && channel >= 1 && channel <= 16) {
         return channel;
-      }
-      return fallback;
     }
-
-    function normalizeMidiProgram(program) {
-      if (!Number.isFinite(program)) {
+    return fallback;
+}
+function normalizeMidiProgram(program) {
+    if (!Number.isFinite(program)) {
         return null;
-      }
-      return Math.max(0, Math.min(127, Math.round(program)));
     }
-
-    function buildSynthSchedule(tempo, voiceIds, voiceTracksById, instrumentOverride) {
-      const events = [];
-      for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
+    return Math.max(0, Math.min(127, Math.round(program)));
+}
+function buildSynthSchedule(tempo, voiceIds, voiceTracksById, instrumentOverride) {
+    const events = [];
+    for (let trackIndex = 0; trackIndex < voiceIds.length; trackIndex += 1) {
         const voiceId = voiceIds[trackIndex];
         const voiceTrack = voiceTracksById[voiceId];
         if (!voiceTrack || !Array.isArray(voiceTrack.events)) {
-          continue;
+            continue;
         }
         const channel = resolveChannel(voiceTrack.channel, instrumentOverride, trackIndex);
         for (const event of voiceTrack.events) {
-          if (!event || !Number.isFinite(event.midiNumber) || !Number.isFinite(event.start) || !Number.isFinite(event.ticks)) {
-            continue;
-          }
-          events.push({
-            midiNumber: Math.max(0, Math.min(127, Math.round(event.midiNumber))),
-            start: Math.max(0, Math.round(event.start)),
-            ticks: Math.max(1, Math.round(event.ticks)),
-            channel
-          });
+            if (!event || !Number.isFinite(event.midiNumber) || !Number.isFinite(event.start) || !Number.isFinite(event.ticks)) {
+                continue;
+            }
+            events.push({
+                midiNumber: Math.max(0, Math.min(127, Math.round(event.midiNumber))),
+                start: Math.max(0, Math.round(event.start)),
+                ticks: Math.max(1, Math.round(event.ticks)),
+                channel
+            });
         }
-      }
-      events.sort((a, b) => {
+    }
+    events.sort((a, b) => {
         if (a.start !== b.start) {
-          return a.start - b.start;
+            return a.start - b.start;
         }
         return a.midiNumber - b.midiNumber;
-      });
-      return {
+    });
+    return {
         tempo: clampTempo(tempo),
         events
-      };
-    }
-
-    function resetOutput() {
-      stopMidi(false);
-      lastMidiBytes = null;
-      lastSynthSchedule = null;
-      previewText.textContent = "未変換";
-      downloadBtn.disabled = true;
-      playBtn.disabled = true;
-      stopBtn.disabled = true;
-    }
-
-    function applyInputMode() {
-      const sourceMode = inputModeSourceRadio.checked;
-      sourceInputBlock.classList.toggle("md-hidden", !sourceMode);
-      fileInputBlock.classList.toggle("md-hidden", sourceMode);
-      if (sourceMode) {
+    };
+}
+function resetOutput() {
+    stopMidi(false);
+    lastMidiBytes = null;
+    lastSynthSchedule = null;
+    previewText.textContent = "未変換";
+    downloadBtn.disabled = true;
+    playBtn.disabled = true;
+    stopBtn.disabled = true;
+}
+function applyInputMode() {
+    const sourceMode = inputModeSourceRadio.checked;
+    sourceInputBlock.classList.toggle("md-hidden", !sourceMode);
+    fileInputBlock.classList.toggle("md-hidden", sourceMode);
+    if (sourceMode) {
         fileInput.value = "";
         updateFileName("");
-      }
     }
-
-    function downloadMidi() {
-      if (!lastMidiBytes || lastMidiBytes.length === 0) {
+}
+function downloadMidi() {
+    if (!lastMidiBytes || lastMidiBytes.length === 0) {
         setError("先に変換してください。");
         return;
-      }
-      const blob = new Blob([lastMidiBytes], { type: "audio/midi" });
-      downloadBlob(blob, "score.mid");
-      showToast("MIDIを保存しました。");
     }
-
-    function playMidi() {
-      if (!lastSynthSchedule || lastSynthSchedule.events.length === 0) {
+    const blob = new Blob([lastMidiBytes], { type: "audio/midi" });
+    downloadBlob(blob, "score.mid");
+    showToast("MIDIを保存しました。");
+}
+function playMidi() {
+    if (!lastSynthSchedule || lastSynthSchedule.events.length === 0) {
         setError("先に変換してください。");
         return;
-      }
-      const waveform = musicSynthCommon.normalizeWaveform(synthWaveformSelect.value);
-      synthEngine.playSchedule(lastSynthSchedule, waveform, () => {
+    }
+    const waveform = musicSynthCommon.normalizeWaveform(synthWaveformSelect.value);
+    synthEngine.playSchedule(lastSynthSchedule, waveform, () => {
         stopBtn.disabled = true;
-      }).then(() => {
+    }).then(() => {
         clearError();
         stopBtn.disabled = false;
         showToast("内蔵シンセ再生を開始しました。");
-      }).catch((error) => {
+    }).catch((error) => {
         stopBtn.disabled = true;
         setError("内蔵シンセ再生に失敗しました: " + (error && error.message ? error.message : String(error)));
-      });
-    }
-
-    function stopMidi(showMessage = true) {
-      synthEngine.stop();
-      stopBtn.disabled = true;
-      if (showMessage) {
+    });
+}
+function stopMidi(showMessage = true) {
+    synthEngine.stop();
+    stopBtn.disabled = true;
+    if (showMessage) {
         showToast("内蔵シンセ再生を停止しました。");
-      }
     }
-
-    function setError(message) {
-      errorText.textContent = message;
-      errorText.classList.remove("md-hidden");
-    }
-
-    function clearError() {
-      errorText.textContent = "";
-      errorText.classList.add("md-hidden");
-    }
-
-    function clearWarning() {
-      warningText.textContent = "";
-      warningText.classList.add("md-hidden");
-    }
-
-    function showToast(message) {
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => {
+}
+function setError(message) {
+    errorText.textContent = message;
+    errorText.classList.remove("md-hidden");
+}
+function clearError() {
+    errorText.textContent = "";
+    errorText.classList.add("md-hidden");
+}
+function clearWarning() {
+    warningText.textContent = "";
+    warningText.classList.add("md-hidden");
+}
+function showToast(message) {
+    toast.textContent = message;
+    toast.classList.remove("md-hidden");
+    toast.classList.add("md-visible");
+    clearTimeout(showToast.timer);
+    showToast.timer = setTimeout(() => {
         toast.classList.remove("md-visible");
         toast.classList.add("md-hidden");
-      }, 1400);
-    }
-
-    function toggleMenu() {
-      menuPanel.classList.toggle("md-hidden");
-    }
-
-    function handleDocumentClick(event) {
-      const menuButton = event.target.closest(".md-menu-button");
-      if (menuButton) {
+    }, 1400);
+}
+function toggleMenu() {
+    menuPanel.classList.toggle("md-hidden");
+}
+function handleDocumentClick(event) {
+    const menuButton = event.target.closest(".md-menu-button");
+    if (menuButton) {
         return;
-      }
-      if (!event.target.closest("#menuPanel")) {
+    }
+    if (!event.target.closest("#menuPanel")) {
         menuPanel.classList.add("md-hidden");
-      }
     }
-
-    function downloadBlob(blob, filename) {
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = url;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
-    }
-
-    function persistSettings() {
-      const payload = {
+}
+function downloadBlob(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+function persistSettings() {
+    const payload = {
         defaultTitle: defaultTitleInput.value,
         defaultComposer: defaultComposerInput.value,
         defaultTempo: defaultTempoInput.value,
         instrumentOverride: instrumentOverrideSelect.value,
         synthWaveform: synthWaveformSelect.value
-      };
-      localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
-    }
-
-    function restoreSettings() {
-      const raw = localStorage.getItem(SETTINGS_KEY);
-      if (!raw) {
+    };
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(payload));
+}
+function restoreSettings() {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) {
         return;
-      }
-      try {
+    }
+    try {
         const data = JSON.parse(raw);
         if (data && typeof data === "object") {
-          if (typeof data.defaultTitle === "string") {
-            defaultTitleInput.value = data.defaultTitle;
-          }
-          if (typeof data.defaultComposer === "string") {
-            defaultComposerInput.value = data.defaultComposer;
-          }
-          if (typeof data.defaultTempo === "string" || typeof data.defaultTempo === "number") {
-            defaultTempoInput.value = String(data.defaultTempo);
-          }
-          if (typeof data.instrumentOverride === "string") {
-            instrumentOverrideSelect.value = data.instrumentOverride;
-          }
-          if (typeof data.synthWaveform === "string") {
-            synthWaveformSelect.value = musicSynthCommon.normalizeWaveform(data.synthWaveform);
-          }
+            if (typeof data.defaultTitle === "string") {
+                defaultTitleInput.value = data.defaultTitle;
+            }
+            if (typeof data.defaultComposer === "string") {
+                defaultComposerInput.value = data.defaultComposer;
+            }
+            if (typeof data.defaultTempo === "string" || typeof data.defaultTempo === "number") {
+                defaultTempoInput.value = String(data.defaultTempo);
+            }
+            if (typeof data.instrumentOverride === "string") {
+                instrumentOverrideSelect.value = data.instrumentOverride;
+            }
+            if (typeof data.synthWaveform === "string") {
+                synthWaveformSelect.value = musicSynthCommon.normalizeWaveform(data.synthWaveform);
+            }
         }
-      } catch (_error) {
-        // ignore broken localStorage
-      }
     }
+    catch (_error) {
+        // ignore broken localStorage
+    }
+}
   </script>
 </body>
 </html>

--- a/lht-cmn/LICENSE
+++ b/lht-cmn/LICENSE
@@ -1,0 +1,197 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+      as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with the Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)
+
+      Copyright [yyyy] [name of copyright owner]
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/lht-cmn/NOTICE
+++ b/lht-cmn/NOTICE
@@ -1,0 +1,11 @@
+Copyright 2026 Toshiki Iga
+
+This product includes software developed by Toshiki Iga.
+
+Design direction:
+- 本プロジェクトは Material Design 3 の設計原則を参照しています。
+
+Third-party component implementation:
+- `lht-cmn` の内部実装では、必要に応じて Material Web（`@material/web`）を優先利用します。
+- Material Web のライセンスは Apache License, Version 2.0 です。
+- Source: https://github.com/material-components/material-web

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -2,6 +2,18 @@
 
 `lht-cmn` は `local-html-tools` 全体で共有する UI コンポーネント基盤です。
 
+- Version: `v20260222`
+- License: Apache License 2.0 (`lht-cmn/LICENSE`)
+- Copyright: Toshiki Iga
+
+## ライセンスと帰属
+
+- `lht-cmn` 自体は Apache License 2.0 で配布します。
+- デザイン方針は Material Design 3 の設計原則を参照します。
+- 実装技術として、`lht-cmn` は必要に応じて Material Web（`@material/web`）を優先利用します。
+- Material Web のライセンスは Apache License 2.0 です。
+- 帰属情報の詳細は `lht-cmn/NOTICE` に記載します。
+
 ## 目的
 
 `local-html-tools` では、入力・選択・ヘルプ・コピー・メニューなどの UI を複数ページで繰り返し実装してきました。  
@@ -192,3 +204,44 @@ HTML から次を読み込みます。
 ### Appendix D: tooltip 実装制約メモ
 
 - `@material/web@2.4.1` では `md-tooltip` が同梱されないため、`lht-help-tooltip` は `md-tooltip-group` + `md-tooltip-content` ベースで運用する
+
+### Appendix E: ドロップダウンでよくあるミスと回避方法
+
+`lht-select-help` は `md-outlined-select` を内部利用するため、単一HTML化や依存読込順の影響を受けやすいです。  
+以下のミスが、ドロップダウン崩れ（選択肢がただのテキストになる等）を起こしやすいです。
+
+1. `md-outlined-select` が未定義のまま初期化される
+- 症状:
+  - 選択UIが表示されず、選択肢テキストだけが並ぶ
+- 回避:
+  - Material Web バンドル読込を `lht-cmn/js/components.js` より前に配置する
+  - `lht-cmn` 側のフォールバック（ネイティブ `select`）が効く実装を維持する
+
+2. `lht-select-help` の選択肢定義が不正
+- 症状:
+  - 選択肢が空になる / 既定値が反映されない
+- 回避:
+  - `<script type="application/json" slot="options">[...]</script>` の JSON を必ず配列で定義する
+  - `value` と `label` を明示する
+  - 既定値は `selected: true` と `value` の整合を取る
+
+3. `field-id` を変えて既存JS参照が壊れる
+- 症状:
+  - `document.getElementById(...)` が `null` になり、初期化やイベント登録で失敗する
+- 回避:
+  - 置換時も DOM 参照ID（`field-id`）は既存IDを維持する
+
+4. 単一HTML化でインラインスクリプトが壊れる
+- 症状:
+  - `Unexpected end of input`
+  - バンドル内文字列が壊れ、`popover` などの警告が連鎖する
+- 回避:
+  - ビルド時に `</script>` を `<\\/script>` へエスケープする
+  - 文字列置換でJSを差し込む場合は `replace` の関数置換を使い、`$` 展開事故を避ける
+
+5. CSSの責務が混在して見た目が崩れる
+- 症状:
+  - ドロップダウンの幅・余白・フォーカス装飾がページごとに不揃い
+- 回避:
+  - 基本スタイルは `lht-cmn/css/components.css` に集約する
+  - 画面側CSSはレイアウト差分（余白・配置）に限定する

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -1,3 +1,10 @@
+/*
+ * lht-cmn components.css
+ * Version: v20260222
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
 lht-help-tooltip {
   display: inline-flex;
   align-items: center;
@@ -17,6 +24,17 @@ lht-select-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
 }
 
 lht-file-select {

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -1,3 +1,10 @@
+/*
+ * lht-cmn components.js
+ * Version: v20260222
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
 class LhtHelpTooltip extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -100,12 +107,20 @@ class LhtSelectHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-select");
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
     field.id = fieldId;
     this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const value = this.getAttribute("value");
     if (value != null) field.value = value;
@@ -114,7 +129,11 @@ class LhtSelectHelp extends HTMLElement {
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -124,12 +143,16 @@ class LhtSelectHelp extends HTMLElement {
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     if (helpText) {
-      field.addEventListener("focus", () => {
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        field.supportingText = "";
-      });
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        field.addEventListener("focus", () => {
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          field.supportingText = "";
+        });
+      }
     }
 
     this.appendChild(field);
@@ -212,19 +235,31 @@ class LhtSelectHelp extends HTMLElement {
     field.innerHTML = "";
 
     for (const entry of options) {
-      const option = document.createElement("md-select-option");
-      option.value = entry.value;
-      if (entry.disabled) option.disabled = true;
-      if (entry.selected) {
-        option.selected = true;
-        option.setAttribute("selected", "");
-        field.value = entry.value;
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
       }
-      const headline = document.createElement("div");
-      headline.slot = "headline";
-      headline.textContent = entry.label;
-      option.appendChild(headline);
-      field.appendChild(option);
     }
   }
 

--- a/scripts/build-music.mjs
+++ b/scripts/build-music.mjs
@@ -7,8 +7,13 @@ const TARGETS = [
     id: "musicxml-to-midi",
     srcHtml: "docs/music/musicxml-to-midi-src.html",
     outHtml: "docs/music/musicxml-to-midi.html",
-    cssOrder: ["src/musicxml-to-midi/css/app.css"],
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/musicxml-to-midi/css/app.css"
+    ],
     jsOrder: [
+      "../git/src/vendor/material-web-outlined-text-field.bundle.js",
+      "../../lht-cmn/js/components.js",
       "src/musicxml-to-midi/js/midi-writer.js",
       "src/common/js/musicxml-common.js",
       "src/common/js/music-synth-common.js",
@@ -173,12 +178,16 @@ function buildTarget(target) {
   assertExactOrder(`${target.id} js`, jsRefs, target.jsOrder);
 
   const cssText = target.cssOrder
-    .map((relPath) => fs.readFileSync(path.resolve(ROOT, "docs/music", relPath), "utf8").trimEnd())
+    .map((relPath) => {
+      const css = fs.readFileSync(path.resolve(ROOT, "docs/music", relPath), "utf8").trimEnd();
+      return escapeInlineStyleText(css);
+    })
     .join("\n\n");
 
   const jsBlocks = target.jsOrder.map((relPath) => {
     const scriptText = fs.readFileSync(path.resolve(ROOT, "docs/music", relPath), "utf8").trimEnd();
-    return `  <script>\n${scriptText}\n  </script>`;
+    const safeScriptText = escapeInlineScriptText(scriptText);
+    return `  <script>\n${safeScriptText}\n  </script>`;
   });
 
   let output = sourceHtml;
@@ -195,10 +204,10 @@ function buildTarget(target) {
 
   output = output.replace(
     /<\/head>/,
-    `  <style>\n${cssText}\n  </style>\n</head>`
+    () => `  <style>\n${cssText}\n  </style>\n</head>`
   );
 
-  output = output.replace(/<\/body>/, `${jsBlocks.join("\n\n")}\n</body>`);
+  output = output.replace(/<\/body>/, () => `${jsBlocks.join("\n\n")}\n</body>`);
 
   fs.writeFileSync(outHtmlPath, output, "utf8");
 }
@@ -215,4 +224,12 @@ function assertExactOrder(label, actual, expected) {
       );
     }
   }
+}
+
+function escapeInlineScriptText(text) {
+  return text.replace(/<\/script/gi, "<\\/script");
+}
+
+function escapeInlineStyleText(text) {
+  return text.replace(/<\/style/gi, "<\\/style");
 }


### PR DESCRIPTION
…センス/バージョン表記を追加

### 概要
`docs/music/musicxml-to-midi` を `lht-*` コンポーネント中心へ移行し、 あわせて単一HTMLビルド時に発生していたスクリプト破損（`Unexpected end of input`）を防ぐためのビルド修正を実施しました。 また、`lht-cmn` を単独利用しやすくするため、ライセンス・NOTICE・バージョン表記を整備しています。

### 変更内容

1. `musicxml-to-midi` の LHT 化
- `docs/music/musicxml-to-midi-src.html`
  - ファイル選択UIを `lht-file-select` へ置換
  - 既定値入力を `lht-text-field-help` へ置換
  - ドロップダウンを `lht-select-help` + JSON options へ置換
  - `lht-cmn/css/components.css` と `lht-cmn/js/components.js` を読み込み
  - Material Web バンドルを先行読み込み

2. `lht-select-help` の堅牢化（フォールバック）
- `lht-cmn/js/components.js`
  - `md-outlined-select` 未定義時にネイティブ `<select>` へフォールバック
  - ラベル/ヘルプ/選択肢生成をフォールバック対応
- `lht-cmn/css/components.css`
  - `.lht-select-help__fallback` スタイルを追加

3. `build:music` の単一HTML生成安定化
- `scripts/build-music.mjs`
  - CSS/JSインライン化対象に `lht-cmn` と Material Web バンドルを追加
  - `</script>` / `</style>` のエスケープ処理を追加
  - `replace` の文字列置換を関数置換へ変更し、`$` 展開によるJS破損を防止

4. `lht-cmn` のライセンス・帰属整備
- 追加: `lht-cmn/LICENSE`（Apache License 2.0）
- 追加: `lht-cmn/NOTICE`
  - 著作権者（Toshiki Iga）
  - Material Design 3 方針の参照
  - Material Web（Apache-2.0）の帰属情報
- `lht-cmn/README.md`
  - バージョン `v20260222` を明記
  - ライセンス/帰属セクションを追加
  - Appendix E（ドロップダウンでよくあるミスと回避方法）を追加

5. 生成物更新
- `docs/music/musicxml-to-midi.html` を上記変更に合わせて再生成

### 影響範囲
- 8 files changed
- 2566 insertions / 947 deletions

### 期待効果
- `musicxml-to-midi` で LHT 統一方針に沿ったUI運用が可能
- Material Web読込状態に依存しすぎないドロップダウン動作
- 単一HTML化時のスクリプト破損リスク低減
- `lht-cmn` 単体配布時のライセンス/帰属明確化