### PR TITLE
feat(git): `lht-page-hero` を導入し、`docs/git` 全ページのヘッダを共通部品化

### DIFF
--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -43,15 +43,16 @@ limitations under the License.
     </defs>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🧰</span>
-      <span>Git ブランチ比較コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git ブランチ比較コマンドジェネレータの説明" wide>
-        2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git ブランチ比較コマンドジェネレータ"
+      subtitle="2つのブランチ差分を表示するコマンドを生成します。"
+      icon="🧰"
+      help-label="Git ブランチ比較コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。
+    </lht-page-hero>
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -36,6 +36,132 @@ lht-help-tooltip {
   align-items: center;
 }
 
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }
@@ -1359,15 +1485,16 @@ lht-index-card-link {
     </defs>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🧰</span>
-      <span>Git ブランチ比較コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git ブランチ比較コマンドジェネレータの説明" wide>
-        2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git ブランチ比較コマンドジェネレータ"
+      subtitle="2つのブランチ差分を表示するコマンドを生成します。"
+      icon="🧰"
+      help-label="Git ブランチ比較コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。
+    </lht-page-hero>
 
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
@@ -2496,6 +2623,78 @@ class LhtIndexCardLink extends HTMLElement {
   }
 }
 
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
 class LhtPageMenu extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -2557,6 +2756,9 @@ if (!customElements.get("lht-command-block")) {
 }
 if (!customElements.get("lht-index-card-link")) {
   customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
 }
 if (!customElements.get("lht-page-menu")) {
   customElements.define("lht-page-menu", LhtPageMenu);

--- a/docs/git/git-config-advanced-setup-src.html
+++ b/docs/git/git-config-advanced-setup-src.html
@@ -44,15 +44,16 @@ limitations under the License.
   </svg>
 
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🔧</span>
-      <span>Git 詳細設定コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git 詳細設定コマンドジェネレータの説明" wide>
-        core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git 詳細設定コマンドジェネレータ"
+      subtitle="Git の詳細設定を行うコマンドを生成します。"
+      icon="🔧"
+      help-label="Git 詳細設定コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
+    </lht-page-hero>
 
     <section id="checkSection" class="md-section md-stack-md">
       <div class="md-flow-row">

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -36,6 +36,132 @@ lht-help-tooltip {
   align-items: center;
 }
 
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }
@@ -1367,15 +1493,16 @@ lht-index-card-link {
   </svg>
 
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🔧</span>
-      <span>Git 詳細設定コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git 詳細設定コマンドジェネレータの説明" wide>
-        core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git 詳細設定コマンドジェネレータ"
+      subtitle="Git の詳細設定を行うコマンドを生成します。"
+      icon="🔧"
+      help-label="Git 詳細設定コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。
+    </lht-page-hero>
 
     <section id="checkSection" class="md-section md-stack-md">
       <div class="md-flow-row">
@@ -2581,6 +2708,78 @@ class LhtIndexCardLink extends HTMLElement {
   }
 }
 
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
 class LhtPageMenu extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -2642,6 +2841,9 @@ if (!customElements.get("lht-command-block")) {
 }
 if (!customElements.get("lht-index-card-link")) {
   customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
 }
 if (!customElements.get("lht-page-menu")) {
   customElements.define("lht-page-menu", LhtPageMenu);

--- a/docs/git/git-config-setup-src.html
+++ b/docs/git/git-config-setup-src.html
@@ -40,15 +40,16 @@ limitations under the License.
   </svg>
 
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">⚙️</span>
-      <span>Git ユーザー設定コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git ユーザー設定コマンドジェネレータの説明" wide>
-        グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git ユーザー設定コマンドジェネレータ"
+      subtitle="Gitユーザー名とメールアドレスを設定するコマンドを生成します。"
+      icon="⚙️"
+      help-label="Git ユーザー設定コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+    </lht-page-hero>
 
     <section id="checkSection" class="md-section md-stack-md">
       <div class="md-flow-row">

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -36,6 +36,132 @@ lht-help-tooltip {
   align-items: center;
 }
 
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }
@@ -1360,15 +1486,16 @@ lht-index-card-link {
   </svg>
 
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">⚙️</span>
-      <span>Git ユーザー設定コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git ユーザー設定コマンドジェネレータの説明" wide>
-        グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git ユーザー設定コマンドジェネレータ"
+      subtitle="Gitユーザー名とメールアドレスを設定するコマンドを生成します。"
+      icon="⚙️"
+      help-label="Git ユーザー設定コマンドジェネレータの説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。
+    </lht-page-hero>
 
     <section id="checkSection" class="md-section md-stack-md">
       <div class="md-flow-row">
@@ -2493,6 +2620,78 @@ class LhtIndexCardLink extends HTMLElement {
   }
 }
 
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
 class LhtPageMenu extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -2554,6 +2753,9 @@ if (!customElements.get("lht-command-block")) {
 }
 if (!customElements.get("lht-index-card-link")) {
   customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
 }
 if (!customElements.get("lht-page-menu")) {
   customElements.define("lht-page-menu", LhtPageMenu);

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -51,16 +51,17 @@ limitations under the License.
     </defs>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🧩</span>
-      <span>Git pseudo-squash コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git pseudo-squash の説明">
-        reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。
-        運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git pseudo-squash コマンドジェネレータ"
+      subtitle="履歴を1コミットにまとめるコマンドを生成します。"
+      icon="🧩"
+      help-label="Git pseudo-squash の説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。<br><br>
+      運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。
+    </lht-page-hero>
 
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -37,6 +37,132 @@ lht-help-tooltip {
   align-items: center;
 }
 
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }
@@ -1622,16 +1748,17 @@ lht-index-card-link {
     </defs>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-menu home-href="../index.html" home-label="トップへ戻る"></lht-page-menu>
-
-    <h1 class="md-headline">
-      <span aria-hidden="true" class="md-headline__icon">🧩</span>
-      <span>Git pseudo-squash コマンドジェネレータ</span>
-      <lht-help-tooltip label="Git pseudo-squash の説明">
-        reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。
-        運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。
-      </lht-help-tooltip>
-    </h1>
+    <lht-page-hero
+      title="Git pseudo-squash コマンドジェネレータ"
+      subtitle="履歴を1コミットにまとめるコマンドを生成します。"
+      icon="🧩"
+      help-label="Git pseudo-squash の説明"
+      help-wide
+      menu-home-href="../index.html"
+      menu-home-label="トップへ戻る">
+      reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。<br><br>
+      運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。
+    </lht-page-hero>
 
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">
@@ -2911,6 +3038,78 @@ class LhtIndexCardLink extends HTMLElement {
   }
 }
 
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
 class LhtPageMenu extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -2972,6 +3171,9 @@ if (!customElements.get("lht-command-block")) {
 }
 if (!customElements.get("lht-index-card-link")) {
   customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
 }
 if (!customElements.get("lht-page-menu")) {
   customElements.define("lht-page-menu", LhtPageMenu);

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -159,6 +159,12 @@ HTML から次を読み込みます。
 - 用途: 右上メニュー（戻るリンク等）
 - 主な属性: `home-href`, `home-label`
 
+### `lht-page-hero`
+
+- 用途: ページ先頭の見出しブロック（タイトル + 補助説明 + ヘルプ + メニュー）
+- 主な属性: `title`, `subtitle`, `icon`, `help-label`, `help-wide`, `menu-home-href`, `menu-home-label`, `no-menu`
+- 本文スロット: ヘルプポップアップに表示する説明HTML
+
 ### `lht-index-card-link`
 
 - 用途: `docs/index` 用カードリンク

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -10,6 +10,132 @@ lht-help-tooltip {
   align-items: center;
 }
 
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -604,6 +604,78 @@ class LhtIndexCardLink extends HTMLElement {
   }
 }
 
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
 class LhtPageMenu extends HTMLElement {
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
@@ -665,6 +737,9 @@ if (!customElements.get("lht-command-block")) {
 }
 if (!customElements.get("lht-index-card-link")) {
   customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
 }
 if (!customElements.get("lht-page-menu")) {
   customElements.define("lht-page-menu", LhtPageMenu);


### PR DESCRIPTION
# 概要
`5bea0efbad2a2b037bab97c6a5b9ea37830c31fa` では、`docs/git` 配下の各ツールページにあった個別実装のヘッダ（`h1` + `?` + 右上メニュー）を、共通コンポーネント `lht-page-hero` へ統一しました。 あわせて `lht-cmn` 側へ部品実装・スタイル・README 記載を追加し、生成HTMLも更新しています。

# 変更点
- `lht-cmn/js/components.js`
  - 新規コンポーネント `LhtPageHero` を追加
  - カスタム要素 `lht-page-hero` を登録
  - 主な属性:
    - `title`, `subtitle`, `icon`
    - `help-label`, `help-wide`
    - `menu-home-href`, `menu-home-label`
    - `no-menu`
  - 本文スロットをヘルプポップアップ内容として利用

- `lht-cmn/css/components.css`
  - `lht-page-hero` の共通スタイルを追加
  - タイトル行、サブタイトル、ヘルプ、メニュー位置、モバイル時レイアウトを定義
  - ツールチップの積層順（`z-index`）も部品側で吸収

- `lht-cmn/README.md`
  - `lht-page-hero` の用途・属性・本文スロット仕様を追記

- `docs/git/*-src.html`（4ページ）
  - 対象:
    - `docs/git/git-pseudo-squash-src.html`
    - `docs/git/git-config-setup-src.html`
    - `docs/git/git-config-advanced-setup-src.html`
    - `docs/git/git-branch-diff-src.html`
  - 変更:
    - 既存の `lht-page-menu` + `h1` + `lht-help-tooltip` を `lht-page-hero` へ置換
    - 各ページの説明文を `subtitle` とヘルプスロットに再配置

- `docs/git/*.html`（生成物）
  - 上記ソース変更を反映して再生成

# 影響
- `docs/git` 各ページのヘッダUIが統一され、見た目と挙動の一貫性が向上
- ヘッダ関連の修正が `lht-cmn` 側の1箇所で管理可能になり、保守性が向上
- 今後の Git系ページ追加時は `lht-page-hero` の再利用で実装コストを削減可能