### PR TITLE
`git-pseudo-squash` のPR整形/差分表示を改善し、運用ルールをドキュメント明確化

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - regex/sed/awk: 文字列変換テンプレの生成
 - [後まわし] docker/docker-compose: よくある起動・開発用コマンド生成
 - [方針] `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約する
+- [方針] 最優先: Material Web vendor バンドル（`material-web-outlined-text-field.bundle.js`）の配置場所を `lht-cmn` 基準へ適正化し、各 `*-src.html` / build script の参照を整理する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み
   - 未実装: 生成したMIDI実データ（SMF）のその場再生（MIDIパーサ/プレイヤー経由）

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -1416,13 +1416,26 @@ lht-index-card-link {
       padding: 0.6rem;
       max-height: 220px;
       overflow: auto;
-      white-space: pre-wrap;
-      word-break: break-word;
+      white-space: pre;
+      word-break: normal;
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size: 0.82rem;
       line-height: 1.45;
       color: #2c2736;
       background: #ffffff;
+    }
+    .md-diff-line {
+      display: block;
+      padding: 0 0.15rem;
+      border-radius: 4px;
+    }
+    .md-diff-line--before {
+      background: #ffe8ea;
+      color: #8a1f2b;
+    }
+    .md-diff-line--after {
+      background: #e7f8ed;
+      color: #1f6a36;
     }
 
     .md-step-icon { width: 3.5rem; height: 3.5rem; }
@@ -3741,7 +3754,7 @@ if (!customElements.get("lht-page-menu")) {
       return `${compactBefore} → ${compactAfter}`;
     }
 
-    function buildLineDiffOnly(beforeText, afterText) {
+    function buildLineDiffHighlightData(beforeText, afterText) {
       const beforeLines = String(beforeText || "").replace(/\r\n?/g, "\n").split("\n");
       const afterLines = String(afterText || "").replace(/\r\n?/g, "\n").split("\n");
       const n = beforeLines.length;
@@ -3758,37 +3771,59 @@ if (!customElements.get("lht-page-menu")) {
         }
       }
 
-      const beforeOnly = [];
-      const afterOnly = [];
+      const beforeHighlighted = [];
+      const afterHighlighted = [];
       let i = 0;
       let j = 0;
       while (i < n && j < m) {
         if (beforeLines[i] === afterLines[j]) {
+          beforeHighlighted.push({ text: beforeLines[i], changed: false });
+          afterHighlighted.push({ text: afterLines[j], changed: false });
           i += 1;
           j += 1;
           continue;
         }
         if (dp[i + 1][j] >= dp[i][j + 1]) {
-          beforeOnly.push(`- ${beforeLines[i]}`);
+          beforeHighlighted.push({ text: beforeLines[i], changed: true });
           i += 1;
         } else {
-          afterOnly.push(`+ ${afterLines[j]}`);
+          afterHighlighted.push({ text: afterLines[j], changed: true });
           j += 1;
         }
       }
       while (i < n) {
-        beforeOnly.push(`- ${beforeLines[i]}`);
+        beforeHighlighted.push({ text: beforeLines[i], changed: true });
         i += 1;
       }
       while (j < m) {
-        afterOnly.push(`+ ${afterLines[j]}`);
+        afterHighlighted.push({ text: afterLines[j], changed: true });
         j += 1;
       }
 
       return {
-        beforeOnly: beforeOnly.length > 0 ? beforeOnly.join("\n") : "(差分なし)",
-        afterOnly: afterOnly.length > 0 ? afterOnly.join("\n") : "(差分なし)"
+        beforeHighlighted,
+        afterHighlighted
       };
+    }
+
+    function escapeHtml(text) {
+      return String(text || "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    }
+
+    function renderDiffHighlightHtml(lines, changedClass) {
+      if (!lines || lines.length === 0) {
+        return '<span class="md-diff-line">(空)</span>';
+      }
+      return lines.map((line) => {
+        const cssClass = line.changed ? `md-diff-line ${changedClass}` : "md-diff-line";
+        const safeText = escapeHtml(line.text);
+        return `<span class="${cssClass}">${safeText || "&nbsp;"}</span>`;
+      }).join("");
     }
 
     function isPrTitleHeadingLine(line) {
@@ -3798,6 +3833,15 @@ if (!customElements.get("lht-page-menu")) {
       }
       const titleText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
       return /^(?:pr\s*タイトル|pr\s*title|タイトル|title)\s*[:：]?$/.test(titleText);
+    }
+
+    function isPrTextHeadingLine(line) {
+      const normalized = String(line || "").trim();
+      if (!/^#{1,6}\s*/.test(normalized)) {
+        return false;
+      }
+      const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
+      return /^(?:pr\s*テキスト|pr\s*text)\s*[:：]?$/.test(headingText);
     }
 
     function isFenceStartLine(line) {
@@ -3818,6 +3862,7 @@ if (!customElements.get("lht-page-menu")) {
       // 先頭は「空行 / PRタイトル見出し / 開始フェンス」が
       // 混在しやすいため、順不同で連続除去する。
       let changed = true;
+      let removedPrTitleHeading = false;
       while (changed) {
         changed = false;
         while (lines.length > 0 && lines[0].trim() === "") {
@@ -3829,6 +3874,7 @@ if (!customElements.get("lht-page-menu")) {
         }
         if (lines.length > 0 && isPrTitleHeadingLine(lines[0])) {
           lines.shift();
+          removedPrTitleHeading = true;
           changed = true;
           continue;
         }
@@ -3838,8 +3884,56 @@ if (!customElements.get("lht-page-menu")) {
         }
       }
 
-      if (lines.length > 0) {
-        lines[0] = lines[0].replace(/^`+/, "").replace(/`+$/, "");
+      if (removedPrTitleHeading) {
+        const firstNonEmptyIndex = lines.findIndex((line) => line.trim() !== "");
+        if (firstNonEmptyIndex >= 0) {
+          const line = lines[firstNonEmptyIndex];
+          if (/^\s*`.*`\s*$/.test(line)) {
+            lines[firstNonEmptyIndex] = line.replace(/^\s*`+/, "").replace(/`+\s*$/, "");
+          }
+        }
+      }
+
+      // 「## PRテキスト」セクションは、見出し自体を除去する。
+      // 直後が ```markdown で始まる場合はフェンスを外して本文だけ残す。
+      {
+        const rewritten = [];
+        let i = 0;
+        while (i < lines.length) {
+          if (!isPrTextHeadingLine(lines[i])) {
+            rewritten.push(lines[i]);
+            i += 1;
+            continue;
+          }
+
+          // 見出し行を除去し、直後の空行をスキップ。
+          i += 1;
+          while (i < lines.length && lines[i].trim() === "") {
+            i += 1;
+          }
+
+          // この条件の ```markdown だけを除去対象にする。
+          if (i < lines.length && /^```markdown\s*$/i.test(lines[i].trim())) {
+            i += 1;
+            const blockLines = [];
+            while (i < lines.length && !isFenceEndLine(lines[i])) {
+              blockLines.push(lines[i]);
+              i += 1;
+            }
+            if (i < lines.length && isFenceEndLine(lines[i])) {
+              i += 1;
+            }
+
+            while (blockLines.length > 0 && blockLines[0].trim() === "") {
+              blockLines.shift();
+            }
+            while (blockLines.length > 0 && blockLines[blockLines.length - 1].trim() === "") {
+              blockLines.pop();
+            }
+            rewritten.push(...blockLines);
+          }
+        }
+        lines = rewritten;
       }
 
       while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
@@ -3876,10 +3970,9 @@ if (!customElements.get("lht-page-menu")) {
       const currentValue = commitMessageField ? String(commitMessageField.value || "") : "";
       const beforeText = lastNormalizeBefore || currentValue;
       const afterText = lastNormalizeAfter || currentValue;
-      const diffOnly = buildLineDiffOnly(beforeText, afterText);
-
-      beforeNode.textContent = diffOnly.beforeOnly;
-      afterNode.textContent = diffOnly.afterOnly;
+      const diffData = buildLineDiffHighlightData(beforeText, afterText);
+      beforeNode.innerHTML = renderDiffHighlightHtml(diffData.beforeHighlighted, "md-diff-line--before");
+      afterNode.innerHTML = renderDiffHighlightHtml(diffData.afterHighlighted, "md-diff-line--after");
 
       if (!dialog.dataset.boundOutsideClose) {
         dialog.addEventListener("click", (event) => {

--- a/docs/git/src/git-pseudo-squash/css/app.css
+++ b/docs/git/src/git-pseudo-squash/css/app.css
@@ -966,13 +966,26 @@
       padding: 0.6rem;
       max-height: 220px;
       overflow: auto;
-      white-space: pre-wrap;
-      word-break: break-word;
+      white-space: pre;
+      word-break: normal;
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
       font-size: 0.82rem;
       line-height: 1.45;
       color: #2c2736;
       background: #ffffff;
+    }
+    .md-diff-line {
+      display: block;
+      padding: 0 0.15rem;
+      border-radius: 4px;
+    }
+    .md-diff-line--before {
+      background: #ffe8ea;
+      color: #8a1f2b;
+    }
+    .md-diff-line--after {
+      background: #e7f8ed;
+      color: #1f6a36;
     }
 
     .md-step-icon { width: 3.5rem; height: 3.5rem; }

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -413,7 +413,7 @@
       return `${compactBefore} → ${compactAfter}`;
     }
 
-    function buildLineDiffOnly(beforeText, afterText) {
+    function buildLineDiffHighlightData(beforeText, afterText) {
       const beforeLines = String(beforeText || "").replace(/\r\n?/g, "\n").split("\n");
       const afterLines = String(afterText || "").replace(/\r\n?/g, "\n").split("\n");
       const n = beforeLines.length;
@@ -430,37 +430,59 @@
         }
       }
 
-      const beforeOnly = [];
-      const afterOnly = [];
+      const beforeHighlighted = [];
+      const afterHighlighted = [];
       let i = 0;
       let j = 0;
       while (i < n && j < m) {
         if (beforeLines[i] === afterLines[j]) {
+          beforeHighlighted.push({ text: beforeLines[i], changed: false });
+          afterHighlighted.push({ text: afterLines[j], changed: false });
           i += 1;
           j += 1;
           continue;
         }
         if (dp[i + 1][j] >= dp[i][j + 1]) {
-          beforeOnly.push(`- ${beforeLines[i]}`);
+          beforeHighlighted.push({ text: beforeLines[i], changed: true });
           i += 1;
         } else {
-          afterOnly.push(`+ ${afterLines[j]}`);
+          afterHighlighted.push({ text: afterLines[j], changed: true });
           j += 1;
         }
       }
       while (i < n) {
-        beforeOnly.push(`- ${beforeLines[i]}`);
+        beforeHighlighted.push({ text: beforeLines[i], changed: true });
         i += 1;
       }
       while (j < m) {
-        afterOnly.push(`+ ${afterLines[j]}`);
+        afterHighlighted.push({ text: afterLines[j], changed: true });
         j += 1;
       }
 
       return {
-        beforeOnly: beforeOnly.length > 0 ? beforeOnly.join("\n") : "(差分なし)",
-        afterOnly: afterOnly.length > 0 ? afterOnly.join("\n") : "(差分なし)"
+        beforeHighlighted,
+        afterHighlighted
       };
+    }
+
+    function escapeHtml(text) {
+      return String(text || "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    }
+
+    function renderDiffHighlightHtml(lines, changedClass) {
+      if (!lines || lines.length === 0) {
+        return '<span class="md-diff-line">(空)</span>';
+      }
+      return lines.map((line) => {
+        const cssClass = line.changed ? `md-diff-line ${changedClass}` : "md-diff-line";
+        const safeText = escapeHtml(line.text);
+        return `<span class="${cssClass}">${safeText || "&nbsp;"}</span>`;
+      }).join("");
     }
 
     function isPrTitleHeadingLine(line) {
@@ -470,6 +492,15 @@
       }
       const titleText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
       return /^(?:pr\s*タイトル|pr\s*title|タイトル|title)\s*[:：]?$/.test(titleText);
+    }
+
+    function isPrTextHeadingLine(line) {
+      const normalized = String(line || "").trim();
+      if (!/^#{1,6}\s*/.test(normalized)) {
+        return false;
+      }
+      const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
+      return /^(?:pr\s*テキスト|pr\s*text)\s*[:：]?$/.test(headingText);
     }
 
     function isFenceStartLine(line) {
@@ -490,6 +521,7 @@
       // 先頭は「空行 / PRタイトル見出し / 開始フェンス」が
       // 混在しやすいため、順不同で連続除去する。
       let changed = true;
+      let removedPrTitleHeading = false;
       while (changed) {
         changed = false;
         while (lines.length > 0 && lines[0].trim() === "") {
@@ -501,6 +533,7 @@
         }
         if (lines.length > 0 && isPrTitleHeadingLine(lines[0])) {
           lines.shift();
+          removedPrTitleHeading = true;
           changed = true;
           continue;
         }
@@ -510,8 +543,56 @@
         }
       }
 
-      if (lines.length > 0) {
-        lines[0] = lines[0].replace(/^`+/, "").replace(/`+$/, "");
+      if (removedPrTitleHeading) {
+        const firstNonEmptyIndex = lines.findIndex((line) => line.trim() !== "");
+        if (firstNonEmptyIndex >= 0) {
+          const line = lines[firstNonEmptyIndex];
+          if (/^\s*`.*`\s*$/.test(line)) {
+            lines[firstNonEmptyIndex] = line.replace(/^\s*`+/, "").replace(/`+\s*$/, "");
+          }
+        }
+      }
+
+      // 「## PRテキスト」セクションは、見出し自体を除去する。
+      // 直後が ```markdown で始まる場合はフェンスを外して本文だけ残す。
+      {
+        const rewritten = [];
+        let i = 0;
+        while (i < lines.length) {
+          if (!isPrTextHeadingLine(lines[i])) {
+            rewritten.push(lines[i]);
+            i += 1;
+            continue;
+          }
+
+          // 見出し行を除去し、直後の空行をスキップ。
+          i += 1;
+          while (i < lines.length && lines[i].trim() === "") {
+            i += 1;
+          }
+
+          // この条件の ```markdown だけを除去対象にする。
+          if (i < lines.length && /^```markdown\s*$/i.test(lines[i].trim())) {
+            i += 1;
+            const blockLines = [];
+            while (i < lines.length && !isFenceEndLine(lines[i])) {
+              blockLines.push(lines[i]);
+              i += 1;
+            }
+            if (i < lines.length && isFenceEndLine(lines[i])) {
+              i += 1;
+            }
+
+            while (blockLines.length > 0 && blockLines[0].trim() === "") {
+              blockLines.shift();
+            }
+            while (blockLines.length > 0 && blockLines[blockLines.length - 1].trim() === "") {
+              blockLines.pop();
+            }
+            rewritten.push(...blockLines);
+          }
+        }
+        lines = rewritten;
       }
 
       while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
@@ -548,10 +629,9 @@
       const currentValue = commitMessageField ? String(commitMessageField.value || "") : "";
       const beforeText = lastNormalizeBefore || currentValue;
       const afterText = lastNormalizeAfter || currentValue;
-      const diffOnly = buildLineDiffOnly(beforeText, afterText);
-
-      beforeNode.textContent = diffOnly.beforeOnly;
-      afterNode.textContent = diffOnly.afterOnly;
+      const diffData = buildLineDiffHighlightData(beforeText, afterText);
+      beforeNode.innerHTML = renderDiffHighlightHtml(diffData.beforeHighlighted, "md-diff-line--before");
+      afterNode.innerHTML = renderDiffHighlightHtml(diffData.afterHighlighted, "md-diff-line--after");
 
       if (!dialog.dataset.boundOutsideClose) {
         dialog.addEventListener("click", (event) => {

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -42,6 +42,7 @@
 - 画面側（`docs/*-src.html`）は `lht-*` を利用し、`md-*` 直接実装の追加は原則避ける
 - `lht-cmn/js/components.js` を共通コンポーネントの正本とする
 - `lht-cmn/css/components.css` を実運用スタイルの正本とする
+- `lht-cmn/` 配下（特に `js/components.js` / `css/components.css`）の変更は、必ずユーザーの明示許可を得てから実施する
 - `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約する
 
 ## 構成


### PR DESCRIPTION
## 概要
`docs/git/git-pseudo-squash` のコミットメッセージ整形機能を改善し、整形差分の視認性を向上しました。 あわせて、`TODO.md` と `lht-cmn/README.md` に運用方針を追記しました。

## 変更内容
- `docs/git/src/git-pseudo-squash/js/main.js`
  - 差分表示ロジックを「差分行のみ表示」から「全文表示 + 変更行ハイライト」へ変更
  - `escapeHtml` / `renderDiffHighlightHtml` を追加し、表示安全性と可読性を向上
  - PR整形ルールを拡張
    - `## PRテキスト`（`PR text` 含む）見出しを除去
    - 直後が ````markdown` の場合のみフェンスを除去して本文抽出
    - `## PRタイトル` を除去した場合のみ、直後行の全体バッククオートを条件付きで除去

- `docs/git/src/git-pseudo-squash/css/app.css`
  - 差分ダイアログの表示スタイルを調整
  - 変更前行（赤系）/変更後行（緑系）のハイライトスタイルを追加

- `docs/git/git-pseudo-squash.html`
  - 上記変更のビルド反映

- `TODO.md`
  - Material Web vendor バンドル配置適正化（`lht-cmn` 基準）を「最優先」方針として追記

- `lht-cmn/README.md`
  - `lht-cmn/` 配下変更時は「ユーザーの明示許可必須」の運用ルールを追記

## 影響
- `git-pseudo-squash` のPR整形結果確認がしやすくなります
- 既存の整形処理に対し、誤変換しにくい条件付きルールへ改善されます
- 実装運用ルールが明確化され、`lht-cmn` への変更手順が統一されます

## テスト
- `npm run build:git` 実行済み
- 生成物 `docs/git/git-pseudo-squash.html` への反映確認済み