### PR TITLE
git-branch-diff: `--stat` 選択時に `--stat=200` 切替を追加し、初期化タイミングを安定化

### DIFF
--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -104,6 +104,16 @@ limitations under the License.
       </md-outlined-select>
     </div>
 
+    <div id="statWidthBlock" class="md-section md-form-row md-form-row--nowrap md-hidden">
+      <lht-switch-help
+        switch-id="useStat200"
+        label="長いファイル名向けに --stat=200 を使う"
+        help-label="--stat=200 の説明">
+        オフ: `git diff --stat`（デフォルト）<br>
+        オン: `git diff --stat=200`
+      </lht-switch-help>
+    </div>
+
     <lht-command-block command-id="diffCmd"></lht-command-block>
 
     <div id="toast" class="md-snackbar-host md-snackbar">

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -1572,6 +1572,16 @@ lht-index-card-link {
       </md-outlined-select>
     </div>
 
+    <div id="statWidthBlock" class="md-section md-form-row md-form-row--nowrap md-hidden">
+      <lht-switch-help
+        switch-id="useStat200"
+        label="長いファイル名向けに --stat=200 を使う"
+        help-label="--stat=200 の説明">
+        オフ: `git diff --stat`（デフォルト）<br>
+        オン: `git diff --stat=200`
+      </lht-switch-help>
+    </div>
+
     <lht-command-block command-id="diffCmd"></lht-command-block>
 
     <div id="toast" class="md-snackbar-host md-snackbar">
@@ -2812,10 +2822,9 @@ if (!customElements.get("lht-page-menu")) {
 
     function updateRemoteState() {
       const lockOrigin = getToggleSelected("lockOrigin", true);
-      const scopeA = document.getElementById("scopeA").checked;
-      const scopeB = document.getElementById("scopeB").checked;
       const remoteInput = document.getElementById("remoteName");
       const remoteBlock = document.getElementById("remoteNameBlock");
+      if (!remoteInput || !remoteBlock) return;
       remoteBlock.classList.toggle("md-hidden", lockOrigin);
       remoteInput.disabled = lockOrigin;
       if (lockOrigin) {
@@ -2823,14 +2832,26 @@ if (!customElements.get("lht-page-menu")) {
       }
     }
 
+    function updateStatWidthState() {
+      const diffMode = document.getElementById("diffMode")?.value || "";
+      const statWidthBlock = document.getElementById("statWidthBlock");
+      const show = diffMode === "--stat";
+      if (statWidthBlock) {
+        statWidthBlock.classList.toggle("md-hidden", !show);
+      }
+    }
+
     function generateCommands({ silent = false } = {}) {
+      updateStatWidthState();
       const branchA = document.getElementById("branchA").value.trim();
       const branchB = document.getElementById("branchB").value.trim();
       const scopeA = document.getElementById("scopeA").checked;
       const scopeB = document.getElementById("scopeB").checked;
       const lockOrigin = getToggleSelected("lockOrigin", true);
-      const remoteName = lockOrigin ? "origin" : document.getElementById("remoteName").value.trim();
+      const remoteInput = document.getElementById("remoteName");
+      const remoteName = lockOrigin ? "origin" : (remoteInput ? remoteInput.value.trim() : "");
       const diffMode = document.getElementById("diffMode").value;
+      const useStat200 = getToggleSelected("useStat200", false);
       const useTripleDot = getToggleSelected("useTripleDot", false);
       const output = document.getElementById("diffCmd");
 
@@ -2848,7 +2869,12 @@ if (!customElements.get("lht-page-menu")) {
 
       const refA = scopeA ? `${remoteName}/${branchA}` : branchA;
       const refB = scopeB ? `${remoteName}/${branchB}` : branchB;
-      const diffOption = diffMode ? ` ${diffMode}` : "";
+      let diffOption = "";
+      if (diffMode === "--stat") {
+        diffOption = useStat200 ? " --stat=200" : " --stat";
+      } else if (diffMode) {
+        diffOption = ` ${diffMode}`;
+      }
       const rangeSeparator = useTripleDot ? "..." : "..";
       const commands = [];
       if (useRemote) {
@@ -2861,7 +2887,7 @@ if (!customElements.get("lht-page-menu")) {
     function setupAutoUpdate() {
       const handler = () => generateCommands({ silent: true });
       const inputIds = ["branchA", "branchB", "remoteName"];
-      const changeIds = ["scopeA", "scopeB", "lockOrigin", "diffMode", "useTripleDot"];
+      const changeIds = ["scopeA", "scopeB", "lockOrigin", "diffMode", "useTripleDot", "useStat200"];
       inputIds.forEach((id) => {
         const el = document.getElementById(id);
         if (!el) return;
@@ -2884,9 +2910,18 @@ if (!customElements.get("lht-page-menu")) {
       }, 2000);
     }
 
-    updateRemoteState();
-    setupAutoUpdate();
-    generateCommands({ silent: true });
+    function bootstrap() {
+      updateRemoteState();
+      updateStatWidthState();
+      setupAutoUpdate();
+      generateCommands({ silent: true });
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", bootstrap);
+    } else {
+      bootstrap();
+    }
   </script>
 </body>
 </html>

--- a/docs/git/src/git-branch-diff/js/main.js
+++ b/docs/git/src/git-branch-diff/js/main.js
@@ -18,10 +18,9 @@
 
     function updateRemoteState() {
       const lockOrigin = getToggleSelected("lockOrigin", true);
-      const scopeA = document.getElementById("scopeA").checked;
-      const scopeB = document.getElementById("scopeB").checked;
       const remoteInput = document.getElementById("remoteName");
       const remoteBlock = document.getElementById("remoteNameBlock");
+      if (!remoteInput || !remoteBlock) return;
       remoteBlock.classList.toggle("md-hidden", lockOrigin);
       remoteInput.disabled = lockOrigin;
       if (lockOrigin) {
@@ -29,14 +28,26 @@
       }
     }
 
+    function updateStatWidthState() {
+      const diffMode = document.getElementById("diffMode")?.value || "";
+      const statWidthBlock = document.getElementById("statWidthBlock");
+      const show = diffMode === "--stat";
+      if (statWidthBlock) {
+        statWidthBlock.classList.toggle("md-hidden", !show);
+      }
+    }
+
     function generateCommands({ silent = false } = {}) {
+      updateStatWidthState();
       const branchA = document.getElementById("branchA").value.trim();
       const branchB = document.getElementById("branchB").value.trim();
       const scopeA = document.getElementById("scopeA").checked;
       const scopeB = document.getElementById("scopeB").checked;
       const lockOrigin = getToggleSelected("lockOrigin", true);
-      const remoteName = lockOrigin ? "origin" : document.getElementById("remoteName").value.trim();
+      const remoteInput = document.getElementById("remoteName");
+      const remoteName = lockOrigin ? "origin" : (remoteInput ? remoteInput.value.trim() : "");
       const diffMode = document.getElementById("diffMode").value;
+      const useStat200 = getToggleSelected("useStat200", false);
       const useTripleDot = getToggleSelected("useTripleDot", false);
       const output = document.getElementById("diffCmd");
 
@@ -54,7 +65,12 @@
 
       const refA = scopeA ? `${remoteName}/${branchA}` : branchA;
       const refB = scopeB ? `${remoteName}/${branchB}` : branchB;
-      const diffOption = diffMode ? ` ${diffMode}` : "";
+      let diffOption = "";
+      if (diffMode === "--stat") {
+        diffOption = useStat200 ? " --stat=200" : " --stat";
+      } else if (diffMode) {
+        diffOption = ` ${diffMode}`;
+      }
       const rangeSeparator = useTripleDot ? "..." : "..";
       const commands = [];
       if (useRemote) {
@@ -67,7 +83,7 @@
     function setupAutoUpdate() {
       const handler = () => generateCommands({ silent: true });
       const inputIds = ["branchA", "branchB", "remoteName"];
-      const changeIds = ["scopeA", "scopeB", "lockOrigin", "diffMode", "useTripleDot"];
+      const changeIds = ["scopeA", "scopeB", "lockOrigin", "diffMode", "useTripleDot", "useStat200"];
       inputIds.forEach((id) => {
         const el = document.getElementById(id);
         if (!el) return;
@@ -90,6 +106,15 @@
       }, 2000);
     }
 
-    updateRemoteState();
-    setupAutoUpdate();
-    generateCommands({ silent: true });
+    function bootstrap() {
+      updateRemoteState();
+      updateStatWidthState();
+      setupAutoUpdate();
+      generateCommands({ silent: true });
+    }
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", bootstrap);
+    } else {
+      bootstrap();
+    }


### PR DESCRIPTION
### 概要
`docs/git/git-branch-diff` に、`git diff --stat` 利用時のみ表示される `--stat=200` 切替オプションを追加しました。 あわせて、初期化処理を `DOMContentLoaded` ベースの `bootstrap()` に整理し、要素取得時の安全性を高めています。

### 変更点
- `git-branch-diff` の入力UIに `useStat200` スイッチを追加
  - 表示条件: `diffMode === "--stat"` のときのみ
  - オフ: `git diff --stat`
  - オン: `git diff --stat=200`
- コマンド生成ロジックを更新
  - `diffMode` が `--stat` の場合のみ `useStat200` を反映
  - それ以外の diff オプションは従来どおり
- 初期化処理を `bootstrap()` に集約し、`DOMContentLoaded` 後に実行
- `remoteName` 入力要素・ブロック取得にガードを追加し、要素未取得時の例外を防止
- `useStat200` の変更を自動再生成トリガーに追加
- 生成物 `docs/git/git-branch-diff.html` をソース変更に合わせて更新

### 影響
- `--stat` で長いファイル名が見切れやすいケースに対して、UIから簡単に `--stat=200` を選択可能
- 既存の `--name-only` / `--name-status` / 3点比較などの挙動には影響なし
- 初期化順序に起因する不安定さ（要素未取得）を回避し、画面起動時の安定性が向上