### PR TITLE
lht-cmn拡張（Loading/Toast/Error/InputMode/Preview）と music・git への適用、表示制御…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,19 @@
 - [後まわし] docker/docker-compose: よくある起動・開発用コマンド生成
 - [方針] `md3/` は段階的にリファレンス用途へ縮退し、実運用スタイルは `lht-cmn` に集約する
 - [方針] 最優先: Material Web vendor バンドル（`material-web-outlined-text-field.bundle.js`）の配置場所を `lht-cmn` 基準へ適正化し、各 `*-src.html` / build script の参照を整理する
+- [lht-cmn] `lht-toast` を追加し、`toast + showToast()` の重複実装を共通化する（`role="status"` / `aria-live="polite"` を標準化）
+- [横展開] music/git 以外の全アプリでも `lht-toast` 統一を適用し、`showToast` の旧フォールバック（`md-visible` / `md-hidden` 手動制御）を削除する
+- [横展開] music/git 以外の全アプリでも `lht-error-alert`（エラー表示）を適用し、エラー表示の重複実装を共通化する
+- [横展開] music/git 以外の全アプリでも `lht-input-mode-toggle`（source/file 切替）を適用し、切替UIの重複実装を共通化する
+- [横展開] music/git 以外の全アプリでも `lht-file-select`（ファイル選択UI）を適用し、選択ボタン＋ファイル名表示を共通化する
+- [横展開] music/git 以外の全アプリでも `lht-preview-output`（プレビュー表示＋コピー導線）を適用し、表示領域の重複実装を共通化する
+- [横展開] music/git 以外の全アプリでも `lht-command-block`（コマンド表示ブロック）を適用し、コマンド表示・コピー導線を共通化する
+- [ルール横展開] 表示制御属性は `active` に統一し、既存の `md-hidden` / `md-visible` 依存を段階的に削減する
+- [ルール横展開] API命名規約を統一する（表示系は `show/hide`、内容消去系は `show/clear`）
+- [運用スタイル] 新規実装は上記 `lht-cmn` コンポーネント + ルール準拠を必須とし、既存画面は「触るタイミングで順次置換」を原則に進める
+- [lht-cmn] `lht-error-alert` を追加し、`errorText` の表示/非表示と `role="alert"` 運用を共通化する
+- [lht-cmn] `lht-input-mode-toggle`（file/source 切替）を追加し、music系で反復しているラジオUIを共通化する
+- [lht-cmn] `lht-preview-output`（プレビュー + コピー導線）を追加し、`previewText` 周辺の反復UIを共通化する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み
   - 未実装: 生成したMIDI実データ（SMF）のその場再生（MIDIパーサ/プレイヤー経由）

--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1790,7 +1962,7 @@ if (typeof global.Viz !== 'undefined') {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2099,6 +2271,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2518,6 +3116,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -3475,7 +3647,7 @@ Expecting `+Qe.join(", ")+", got '"+(this.terminals_[Ne]||Ne)+"'":Dt="Parse erro
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -3784,6 +3956,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -4203,6 +4801,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2198,7 +2370,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2507,6 +2679,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2926,6 +3524,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1952,7 +2124,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2261,6 +2433,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2680,6 +3278,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -12,7 +12,7 @@ Licensed under the Apache License, Version 2.0
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -253,6 +253,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2223,7 +2395,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2532,6 +2704,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2951,6 +3549,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2067,7 +2239,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2376,6 +2548,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2795,6 +3393,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2218,7 +2390,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2527,6 +2699,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2946,6 +3544,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -12,7 +12,7 @@ Licensed under the Apache License, Version 2.0
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -253,6 +253,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1965,7 +2137,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2274,6 +2446,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2693,6 +3291,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1975,7 +2147,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2284,6 +2456,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2703,6 +3301,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -22,7 +22,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -263,6 +263,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1958,7 +2130,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2267,6 +2439,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2686,6 +3284,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -116,9 +116,7 @@ limitations under the License.
 
     <lht-command-block command-id="diffCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">
-      コピーしました
-    </div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
     <script src="src/git-branch-diff/js/main.js"></script>

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -26,7 +26,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -267,6 +267,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1584,9 +1756,7 @@ lht-index-card-link {
 
     <lht-command-block command-id="diffCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">
-      コピーしました
-    </div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
     
@@ -2055,7 +2225,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2364,6 +2534,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2784,6 +3380,21 @@ if (!customElements.get("lht-select-help")) {
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
 }
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);
 }
@@ -2903,11 +3514,8 @@ if (!customElements.get("lht-page-menu")) {
 
     function showToast(message) {
       const toast = document.getElementById("toast");
-      toast.textContent = message;
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-      }, 2000);
+      if (!toast || typeof toast.show !== "function") return;
+      toast.show(message, 2200);
     }
 
     function bootstrap() {

--- a/docs/git/git-config-advanced-setup-src.html
+++ b/docs/git/git-config-advanced-setup-src.html
@@ -186,7 +186,7 @@ limitations under the License.
     <button type="button" onclick="generateConfigCommand()" class="md-button md-button--primary">設定コマンド生成</button>
     <lht-command-block command-id="configCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
   <script src="src/git-config-advanced-setup/js/main.js"></script>

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -26,7 +26,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -267,6 +267,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1661,7 +1833,7 @@ lht-index-card-link {
     <button type="button" onclick="generateConfigCommand()" class="md-button md-button--primary">設定コマンド生成</button>
     <lht-command-block command-id="configCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
   
@@ -2130,7 +2302,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2439,6 +2611,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2859,6 +3457,21 @@ if (!customElements.get("lht-select-help")) {
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
 }
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);
 }
@@ -2941,12 +3554,8 @@ function generateConfigCommand({ silent = false } = {}) {
 
 function showToast(message) {
   const toast = document.getElementById("toast");
-  if (!toast) return;
-  toast.textContent = message;
-  toast.classList.add("md-visible");
-  setTimeout(() => {
-    toast.classList.remove("md-visible");
-  }, 2000);
+  if (!toast || typeof toast.show !== "function") return;
+  toast.show(message, 2200);
 }
 
 function setupAutoUpdate() {

--- a/docs/git/git-config-setup-src.html
+++ b/docs/git/git-config-setup-src.html
@@ -101,7 +101,7 @@ limitations under the License.
     <button type="button" onclick="generateSetupCommand()" class="md-button md-button--primary">設定コマンド生成</button>
     <lht-command-block command-id="setupCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
   <script src="src/git-config-setup/js/main.js"></script>

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -26,7 +26,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -267,6 +267,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1573,7 +1745,7 @@ lht-index-card-link {
     <button type="button" onclick="generateSetupCommand()" class="md-button md-button--primary">設定コマンド生成</button>
     <lht-command-block command-id="setupCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar">コピーしました</div>
+    <lht-toast id="toast"></lht-toast>
   </div>
 
   
@@ -2042,7 +2214,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2351,6 +2523,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2771,6 +3369,21 @@ if (!customElements.get("lht-select-help")) {
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
 }
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);
 }
@@ -2830,12 +3443,8 @@ function generateSetupCommand({ silent = false } = {}) {
 
 function showToast(message) {
   const toast = document.getElementById("toast");
-  if (!toast) return;
-  toast.textContent = message;
-  toast.classList.add("md-visible");
-  setTimeout(() => {
-    toast.classList.remove("md-visible");
-  }, 2000);
+  if (!toast || typeof toast.show !== "function") return;
+  toast.show(message, 2200);
 }
 
 function setupAutoUpdate() {

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -274,9 +274,7 @@ limitations under the License.
     </div>
     <lht-command-block command-id="plannedDiffCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar md-hidden">
-      コピーしました
-    </div>
+    <lht-toast id="toast"></lht-toast>
 
     <dialog id="normalizeDiffDialog" class="md-diff-dialog">
       <div class="md-diff-dialog__head">

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -27,7 +27,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -268,6 +268,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1665,10 +1837,6 @@ lht-index-card-link {
     }
     .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
     #toast {
-      position: fixed;
-      right: 1.25rem;
-      bottom: 1.25rem;
-      z-index: 120;
       --md-snackbar-container-color: #2b2831;
       --md-snackbar-supporting-text-color: #ffffff;
       --md-snackbar-supporting-text-size: 0.85rem;
@@ -2099,9 +2267,7 @@ lht-index-card-link {
     </div>
     <lht-command-block command-id="plannedDiffCmd"></lht-command-block>
 
-    <div id="toast" class="md-snackbar-host md-snackbar md-hidden">
-      コピーしました
-    </div>
+    <lht-toast id="toast"></lht-toast>
 
     <dialog id="normalizeDiffDialog" class="md-diff-dialog">
       <div class="md-diff-dialog__head">
@@ -2592,7 +2758,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2901,6 +3067,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -3321,6 +3913,21 @@ if (!customElements.get("lht-select-help")) {
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
 }
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);
 }
@@ -3710,14 +4317,8 @@ if (!customElements.get("lht-page-menu")) {
 
     function showToast(message) {
       const toast = document.getElementById("toast");
-      if (!toast) return;
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 2000);
+      if (!toast || typeof toast.show !== "function") return;
+      toast.show(message, 2200);
     }
 
     function summarizeTextDiffForToast(beforeText, afterText) {

--- a/docs/git/src/git-branch-diff/js/main.js
+++ b/docs/git/src/git-branch-diff/js/main.js
@@ -99,11 +99,8 @@
 
     function showToast(message) {
       const toast = document.getElementById("toast");
-      toast.textContent = message;
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-      }, 2000);
+      if (!toast || typeof toast.show !== "function") return;
+      toast.show(message, 2200);
     }
 
     function bootstrap() {

--- a/docs/git/src/git-config-advanced-setup/js/main.js
+++ b/docs/git/src/git-config-advanced-setup/js/main.js
@@ -62,12 +62,8 @@ function generateConfigCommand({ silent = false } = {}) {
 
 function showToast(message) {
   const toast = document.getElementById("toast");
-  if (!toast) return;
-  toast.textContent = message;
-  toast.classList.add("md-visible");
-  setTimeout(() => {
-    toast.classList.remove("md-visible");
-  }, 2000);
+  if (!toast || typeof toast.show !== "function") return;
+  toast.show(message, 2200);
 }
 
 function setupAutoUpdate() {

--- a/docs/git/src/git-config-setup/js/main.js
+++ b/docs/git/src/git-config-setup/js/main.js
@@ -39,12 +39,8 @@ function generateSetupCommand({ silent = false } = {}) {
 
 function showToast(message) {
   const toast = document.getElementById("toast");
-  if (!toast) return;
-  toast.textContent = message;
-  toast.classList.add("md-visible");
-  setTimeout(() => {
-    toast.classList.remove("md-visible");
-  }, 2000);
+  if (!toast || typeof toast.show !== "function") return;
+  toast.show(message, 2200);
 }
 
 function setupAutoUpdate() {

--- a/docs/git/src/git-pseudo-squash/css/app.css
+++ b/docs/git/src/git-pseudo-squash/css/app.css
@@ -1215,10 +1215,6 @@
     }
     .md-snackbar-host.md-visible { opacity: 1; pointer-events: auto; }
     #toast {
-      position: fixed;
-      right: 1.25rem;
-      bottom: 1.25rem;
-      z-index: 120;
       --md-snackbar-container-color: #2b2831;
       --md-snackbar-supporting-text-color: #ffffff;
       --md-snackbar-supporting-text-size: 0.85rem;

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -369,14 +369,8 @@
 
     function showToast(message) {
       const toast = document.getElementById("toast");
-      if (!toast) return;
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 2000);
+      if (!toast || typeof toast.show !== "function") return;
+      toast.show(message, 2200);
     }
 
     function summarizeTextDiffForToast(beforeText, afterText) {

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -26,7 +26,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -267,6 +267,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2062,7 +2234,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2371,6 +2543,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2790,6 +3388,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1030,7 +1030,7 @@
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1271,6 +1271,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -3460,7 +3632,7 @@ if(typeof define === 'function' && define.amd){
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -3769,6 +3941,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -4188,6 +4786,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1039,7 +1039,7 @@
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1282,6 +1282,178 @@ lht-file-select .lht-file-select__file-name {
   word-break: break-all;
 }
 
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 md-outlined-text-field.md-outlined-field {
   flex: 1 1 16rem;
   min-width: 12rem;
@@ -1494,7 +1666,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-02-24</div>
+        <div class="md-app-meta">更新日: 2026-03-07</div>
       </div>
     </header>
 
@@ -2174,7 +2346,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2483,6 +2655,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2902,6 +3500,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -939,7 +939,7 @@
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1180,6 +1180,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1563,7 +1735,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1872,6 +2044,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2291,6 +2889,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -964,7 +964,7 @@
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1205,6 +1205,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2226,7 +2398,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2535,6 +2707,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2954,6 +3552,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1024,7 +1024,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1265,6 +1265,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2052,7 +2224,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2361,6 +2533,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2780,6 +3378,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1024,7 +1024,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1265,6 +1265,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1993,7 +2165,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2302,6 +2474,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2721,6 +3319,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1054,7 +1054,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1295,6 +1295,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2051,7 +2223,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2360,6 +2532,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2779,6 +3377,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1025,7 +1025,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1266,6 +1266,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1997,7 +2169,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2306,6 +2478,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2725,6 +3323,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1024,7 +1024,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1265,6 +1265,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1992,7 +2164,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2301,6 +2473,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2720,6 +3318,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/music/abc-to-musicxml-src.html
+++ b/docs/music/abc-to-musicxml-src.html
@@ -19,6 +19,7 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ABC → MusicXML 変換</title>
+    <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
     <link rel="stylesheet" href="src/abc-to-musicxml/css/app.css" />
 </head>
 <body>
@@ -77,16 +78,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="abcInput" class="md-textarea" spellcheck="false">X:1
@@ -99,18 +100,15 @@ C D E F | G A B c |</textarea>
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".abc,.txt,text/plain"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -159,7 +157,7 @@ C D E F | G A B c |</textarea>
             <span>sine再生</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -206,8 +204,9 @@ C D E F | G A B c |</textarea>
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
+    <script src="../../lht-cmn/js/components.js"></script>
     <script src="src/common/js/abc-common.js"></script>
     <script src="src/common/js/musicxml-common.js"></script>
     <script src="src/common/js/musicxml-synth-schedule-common.js"></script>

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -20,7 +20,603 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>ABC → MusicXML 変換</title>
     
+    
   <style>
+/*
+ * lht-cmn components.css
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
+.md-page {
+  overflow-x: clip;
+}
+
+/* Tooltip defaults are centralized in lht to avoid per-page overflow regressions. */
+lht-help-tooltip .md-tooltip-content {
+  display: none;
+  max-width: min(24rem, calc(100vw - 2rem));
+}
+
+lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
+lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  lht-help-tooltip .md-tooltip-content {
+    left: auto;
+    right: 0;
+    transform: none;
+    width: min(24rem, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-text-field-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+}
+
+lht-file-select {
+  display: block;
+}
+
+lht-file-select .lht-file-select {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+lht-file-select .lht-file-select__button {
+  --md-filled-button-container-color: var(--md-sys-color-primary, #6200ee);
+  --md-filled-button-label-text-color: #ffffff;
+  --md-filled-button-container-shape: 999px;
+  --md-filled-button-container-height: 54px;
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 24px;
+  --md-filled-button-icon-size: 20px;
+  --md-focus-ring-color: #6c3eea;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(98, 0, 238, 0.24);
+}
+
+lht-file-select .lht-file-select__button--fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.55rem;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--md-sys-color-primary, #6200ee);
+  cursor: pointer;
+}
+
+lht-file-select .lht-file-select__button-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  flex: 0 0 auto;
+}
+
+lht-file-select .lht-file-select__button-text {
+  white-space: nowrap;
+}
+
+lht-file-select .lht-file-select__file-name {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
+lht-index-card-link {
+  display: block;
+}
+
+.lht-index-card-link__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.3rem;
+}
+
+.lht-index-card-link__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.45rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #534a64;
+  background: rgba(108, 62, 234, 0.13);
+}
+
+.lht-index-card-link__desc--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--lht-desc-lines, 3);
+  overflow: hidden;
+}
+
 :root {
       --md-danger: #b3261e;
       --md-sys-color-background: #f6f4f8;
@@ -486,16 +1082,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="abcInput" class="md-textarea" spellcheck="false">X:1
@@ -508,18 +1104,15 @@ C D E F | G A B c |</textarea>
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".abc,.txt,text/plain" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".abc,.txt,text/plain"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -568,7 +1161,7 @@ C D E F | G A B c |</textarea>
             <span>sine再生</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -615,7 +1208,7 @@ C D E F | G A B c |</textarea>
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     
     
@@ -624,6 +1217,1197 @@ C D E F | G A B c |</textarea>
     
     
     
+    
+  <script>
+/*
+ * lht-cmn components.js
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtTextFieldHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const type = this.getAttribute("type");
+    if (type != null) field.setAttribute("type", type);
+
+    const min = this.getAttribute("min");
+    if (min != null) field.setAttribute("min", min);
+
+    const max = this.getAttribute("max");
+    if (max != null) field.setAttribute("max", max);
+
+    const step = this.getAttribute("step");
+    if (step != null) field.setAttribute("step", step);
+
+    const rows = this.getAttribute("rows");
+    if (rows != null) field.setAttribute("rows", rows);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      let blurHideTimer = null;
+      field.addEventListener("focus", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+          blurHideTimer = null;
+        }
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+        }
+        blurHideTimer = setTimeout(() => {
+          field.supportingText = "";
+          blurHideTimer = null;
+        }, hideDelayMs);
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSelectHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
+    field.id = fieldId;
+    this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
+
+    const value = this.getAttribute("value");
+    if (value != null) field.value = value;
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
+    }
+
+    this.appendChild(field);
+    this.hydrateOptions();
+
+    if (!this._hasDeclarativeOptions()) {
+      this._optionsObserver = new MutationObserver(() => {
+        this.hydrateOptions();
+      });
+      this._optionsObserver.observe(this, { childList: true, subtree: true });
+      requestAnimationFrame(() => this.hydrateOptions());
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+
+  _hasDeclarativeOptions() {
+    return this.hasAttribute("options") || !!this.querySelector("script[type='application/json'][slot='options']");
+  }
+
+  _normalizeOptions(rawOptions) {
+    return rawOptions
+      .map((entry) => {
+        const value = String(entry?.value ?? entry?.label ?? "");
+        const label = String(entry?.label ?? entry?.text ?? entry?.value ?? "");
+        return {
+          value,
+          label,
+          selected: !!entry?.selected,
+          disabled: !!entry?.disabled
+        };
+      })
+      .filter((entry) => entry.value || entry.label);
+  }
+
+  _readDeclarativeOptions() {
+    const optionsJson = (this.getAttribute("options") || "").trim();
+    if (optionsJson) {
+      try {
+        const parsed = JSON.parse(optionsJson);
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は次の入力ソースへフォールバック
+      }
+    }
+
+    const script = this.querySelector("script[type='application/json'][slot='options']");
+    if (script) {
+      try {
+        const parsed = JSON.parse(script.textContent || "[]");
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は空扱い
+      }
+      return [];
+    }
+
+    return null;
+  }
+
+  _readChildOptionElements() {
+    const sourceOptions = Array.from(this.querySelectorAll("option"));
+    if (sourceOptions.length === 0) return [];
+    return sourceOptions.map((sourceOption) => ({
+      value: sourceOption.getAttribute("value") ?? sourceOption.textContent ?? "",
+      label: sourceOption.textContent ?? "",
+      selected: sourceOption.hasAttribute("selected"),
+      disabled: sourceOption.hasAttribute("disabled")
+    }));
+  }
+
+  _setFieldOptions(options) {
+    const field = this._lhtField;
+    if (!field) return;
+    field.innerHTML = "";
+
+    for (const entry of options) {
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
+      }
+    }
+  }
+
+  hydrateOptions() {
+    const declarativeOptions = this._readDeclarativeOptions();
+    if (Array.isArray(declarativeOptions)) {
+      this._setFieldOptions(declarativeOptions);
+      const jsonScript = this.querySelector("script[type='application/json'][slot='options']");
+      if (jsonScript) jsonScript.remove();
+      if (this._optionsObserver) {
+        this._optionsObserver.disconnect();
+        this._optionsObserver = null;
+      }
+      return;
+    }
+
+    const optionsFromChildren = this._readChildOptionElements();
+    if (optionsFromChildren.length === 0) return;
+    this._setFieldOptions(optionsFromChildren);
+    this.querySelectorAll("option").forEach((option) => option.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
+    }
+  }
+}
+
+class LhtFileSelect extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const inputId = (this.getAttribute("input-id") || "fileInput").trim();
+    const buttonId = (this.getAttribute("button-id") || "fileSelectBtn").trim();
+    const fileNameId = (this.getAttribute("file-name-id") || "fileNameText").trim();
+    const accept = (this.getAttribute("accept") || "").trim();
+    const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
+    const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
+    const showFileName = this.hasAttribute("show-file-name");
+
+    this.textContent = "";
+
+    const root = document.createElement("div");
+    root.className = "lht-file-select";
+
+    const hasMdFilledButton = !!(window.customElements && window.customElements.get("md-filled-button"));
+    const triggerButton = document.createElement(hasMdFilledButton ? "md-filled-button" : "button");
+    if (!hasMdFilledButton) {
+      triggerButton.type = "button";
+    }
+    triggerButton.id = buttonId;
+    triggerButton.className = `lht-file-select__button${hasMdFilledButton ? "" : " lht-file-select__button--fallback"}`;
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("slot", "icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("class", "lht-file-select__button-icon");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "1.9");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.innerHTML = '<path d="M4 7h7l2 2h7v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path><path d="M12 10v6"></path><path d="M9 13l3 3 3-3"></path>';
+
+    const labelNode = document.createElement("span");
+    labelNode.className = "lht-file-select__button-text";
+    labelNode.textContent = buttonLabel;
+    triggerButton.appendChild(icon);
+    triggerButton.appendChild(labelNode);
+
+    const input = document.createElement("input");
+    input.id = inputId;
+    input.type = "file";
+    input.className = "md-file";
+    input.hidden = true;
+    if (accept) input.setAttribute("accept", accept);
+    if (this.hasAttribute("multiple")) input.multiple = true;
+
+    const fileName = document.createElement("span");
+    fileName.id = fileNameId;
+    fileName.className = "lht-file-select__file-name";
+    fileName.textContent = placeholder;
+    if (!showFileName) fileName.hidden = true;
+
+    if (this.hasAttribute("disabled")) {
+      input.disabled = true;
+      triggerButton.disabled = true;
+    }
+
+    triggerButton.addEventListener("click", () => input.click());
+    input.addEventListener("change", () => {
+      const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
+      fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+    });
+
+    root.appendChild(triggerButton);
+    root.appendChild(fileName);
+    this.appendChild(root);
+    this.appendChild(input);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
+
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
+    }
+  }
+}
+
+class LhtIndexCardLink extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const href = (this.getAttribute("href") || "").trim();
+    if (!href) return;
+
+    const title = (this.getAttribute("title") || "").trim();
+    const descAttr = (this.getAttribute("desc") || "").trim();
+    const iconAttr = (this.getAttribute("icon") || "").trim();
+    const target = (this.getAttribute("target") || "").trim();
+    const relAttr = (this.getAttribute("rel") || "").trim();
+    const variant = (this.getAttribute("variant") || "default").trim().toLowerCase();
+    const arrowMode = (this.getAttribute("arrow") || "auto").trim().toLowerCase();
+    const badgeText = (this.getAttribute("badge") || "").trim();
+    const descLines = (this.getAttribute("desc-lines") || "").trim();
+
+    if (!title || !descAttr) {
+      const missing = [];
+      if (!title) missing.push("title");
+      if (!descAttr) missing.push("desc");
+      // Fail fast for authoring mistakes in index cards.
+      console.warn(`[lht-index-card-link] Missing required attribute(s): ${missing.join(", ")}`, this);
+      return;
+    }
+
+    this.textContent = "";
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "md-link-card";
+    const isExternalHref = /^(https?:)?\/\//i.test(href);
+    const isExternal = variant === "external" || isExternalHref || target === "_blank";
+    const effectiveTarget = target || (isExternal ? "_blank" : "");
+    if (effectiveTarget) link.target = effectiveTarget;
+    if (effectiveTarget === "_blank") {
+      link.rel = relAttr || "noopener noreferrer";
+    } else if (relAttr) {
+      link.rel = relAttr;
+    }
+    if (variant === "simple") link.classList.add("lht-index-card-link--simple");
+    if (isExternal) link.classList.add("lht-index-card-link--external");
+
+    const head = document.createElement("div");
+    head.className = "md-card-head";
+
+    const h3 = document.createElement("h3");
+    h3.className = "md-card-title";
+    if (iconAttr) {
+      const iconContainer = document.createElement("span");
+      iconContainer.className = "lht-index-card-link__icon";
+      iconContainer.textContent = iconAttr;
+      h3.appendChild(iconContainer);
+    }
+    const titleContainer = document.createElement("span");
+    titleContainer.className = "lht-index-card-link__title";
+    titleContainer.textContent = title;
+    h3.appendChild(titleContainer);
+    if (badgeText) {
+      const badge = document.createElement("span");
+      badge.className = "lht-index-card-link__badge";
+      badge.textContent = badgeText;
+      h3.appendChild(badge);
+    }
+
+    const arrow = document.createElement("span");
+    arrow.className = "md-card-arrow";
+    const showArrow = arrowMode === "auto" ? variant !== "simple" : arrowMode !== "none";
+    arrow.textContent = isExternal ? "↗" : "→";
+    if (!showArrow) arrow.hidden = true;
+
+    const desc = document.createElement("p");
+    desc.className = "md-card-desc";
+    desc.textContent = descAttr;
+    if (descLines && /^\d+$/.test(descLines)) {
+      desc.classList.add("lht-index-card-link__desc--clamp");
+      desc.style.setProperty("--lht-desc-lines", descLines);
+    }
+
+    head.appendChild(h3);
+    head.appendChild(arrow);
+    link.appendChild(head);
+    link.appendChild(desc);
+    this.appendChild(link);
+  }
+}
+
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
+      panel.classList.toggle("md-hidden");
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
+}
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
+}
+if (!customElements.get("lht-file-select")) {
+  customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-index-card-link")) {
+  customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
   <script>
 const AbcCommon = (() => {
     function gcd(a, b) {
@@ -2153,7 +3937,9 @@ downloadBtn.addEventListener("click", downloadMusicXml);
 playSineBtn.addEventListener("click", playSine);
 copyBtn.addEventListener("click", copyMusicXml);
 fileInput.addEventListener("change", loadAbcFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -2312,29 +4098,35 @@ function playSine() {
     });
 }
 function setError(message, lineNumber) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
     if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusLine(lineNumber);
     }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/midi-to-musicxml-src.html
+++ b/docs/music/midi-to-musicxml-src.html
@@ -19,6 +19,7 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MIDI → MusicXML 変換</title>
+    <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
     <link rel="stylesheet" href="src/midi-to-musicxml/css/app.css" />
 </head>
 <body>
@@ -67,25 +68,27 @@ limitations under the License.
           <h2 class="md-section-title">MIDI入力</h2>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>16進ソース入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="16進ソース入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="fileInputBlock">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
 
         <div id="sourceInputBlock" class="md-hidden">
@@ -186,7 +189,7 @@ limitations under the License.
             <span>コピー</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -202,8 +205,9 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
+    <script src="../../lht-cmn/js/components.js"></script>
     <script src="src/common/js/musicxml-writer-common.js"></script>
     <script src="src/midi-to-musicxml/js/main.js"></script>
 </body>

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -20,7 +20,603 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MIDI → MusicXML 変換</title>
     
+    
   <style>
+/*
+ * lht-cmn components.css
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
+.md-page {
+  overflow-x: clip;
+}
+
+/* Tooltip defaults are centralized in lht to avoid per-page overflow regressions. */
+lht-help-tooltip .md-tooltip-content {
+  display: none;
+  max-width: min(24rem, calc(100vw - 2rem));
+}
+
+lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
+lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  lht-help-tooltip .md-tooltip-content {
+    left: auto;
+    right: 0;
+    transform: none;
+    width: min(24rem, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-text-field-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+}
+
+lht-file-select {
+  display: block;
+}
+
+lht-file-select .lht-file-select {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+lht-file-select .lht-file-select__button {
+  --md-filled-button-container-color: var(--md-sys-color-primary, #6200ee);
+  --md-filled-button-label-text-color: #ffffff;
+  --md-filled-button-container-shape: 999px;
+  --md-filled-button-container-height: 54px;
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 24px;
+  --md-filled-button-icon-size: 20px;
+  --md-focus-ring-color: #6c3eea;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(98, 0, 238, 0.24);
+}
+
+lht-file-select .lht-file-select__button--fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.55rem;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--md-sys-color-primary, #6200ee);
+  cursor: pointer;
+}
+
+lht-file-select .lht-file-select__button-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  flex: 0 0 auto;
+}
+
+lht-file-select .lht-file-select__button-text {
+  white-space: nowrap;
+}
+
+lht-file-select .lht-file-select__file-name {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
+lht-index-card-link {
+  display: block;
+}
+
+.lht-index-card-link__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.3rem;
+}
+
+.lht-index-card-link__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.45rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #534a64;
+  background: rgba(108, 62, 234, 0.13);
+}
+
+.lht-index-card-link__desc--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--lht-desc-lines, 3);
+  overflow: hidden;
+}
+
 :root {
       --md-danger: #b3261e;
       --md-sys-color-background: #f6f4f8;
@@ -443,25 +1039,27 @@ limitations under the License.
           <h2 class="md-section-title">MIDI入力</h2>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>16進ソース入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="16進ソース入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="fileInputBlock">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".mid,.midi,audio/midi,audio/x-midi,application/octet-stream"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
 
         <div id="sourceInputBlock" class="md-hidden">
@@ -562,7 +1160,7 @@ limitations under the License.
             <span>コピー</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -578,10 +1176,1201 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     
     
+    
+  <script>
+/*
+ * lht-cmn components.js
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtTextFieldHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const type = this.getAttribute("type");
+    if (type != null) field.setAttribute("type", type);
+
+    const min = this.getAttribute("min");
+    if (min != null) field.setAttribute("min", min);
+
+    const max = this.getAttribute("max");
+    if (max != null) field.setAttribute("max", max);
+
+    const step = this.getAttribute("step");
+    if (step != null) field.setAttribute("step", step);
+
+    const rows = this.getAttribute("rows");
+    if (rows != null) field.setAttribute("rows", rows);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      let blurHideTimer = null;
+      field.addEventListener("focus", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+          blurHideTimer = null;
+        }
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+        }
+        blurHideTimer = setTimeout(() => {
+          field.supportingText = "";
+          blurHideTimer = null;
+        }, hideDelayMs);
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSelectHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
+    field.id = fieldId;
+    this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
+
+    const value = this.getAttribute("value");
+    if (value != null) field.value = value;
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
+    }
+
+    this.appendChild(field);
+    this.hydrateOptions();
+
+    if (!this._hasDeclarativeOptions()) {
+      this._optionsObserver = new MutationObserver(() => {
+        this.hydrateOptions();
+      });
+      this._optionsObserver.observe(this, { childList: true, subtree: true });
+      requestAnimationFrame(() => this.hydrateOptions());
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+
+  _hasDeclarativeOptions() {
+    return this.hasAttribute("options") || !!this.querySelector("script[type='application/json'][slot='options']");
+  }
+
+  _normalizeOptions(rawOptions) {
+    return rawOptions
+      .map((entry) => {
+        const value = String(entry?.value ?? entry?.label ?? "");
+        const label = String(entry?.label ?? entry?.text ?? entry?.value ?? "");
+        return {
+          value,
+          label,
+          selected: !!entry?.selected,
+          disabled: !!entry?.disabled
+        };
+      })
+      .filter((entry) => entry.value || entry.label);
+  }
+
+  _readDeclarativeOptions() {
+    const optionsJson = (this.getAttribute("options") || "").trim();
+    if (optionsJson) {
+      try {
+        const parsed = JSON.parse(optionsJson);
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は次の入力ソースへフォールバック
+      }
+    }
+
+    const script = this.querySelector("script[type='application/json'][slot='options']");
+    if (script) {
+      try {
+        const parsed = JSON.parse(script.textContent || "[]");
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は空扱い
+      }
+      return [];
+    }
+
+    return null;
+  }
+
+  _readChildOptionElements() {
+    const sourceOptions = Array.from(this.querySelectorAll("option"));
+    if (sourceOptions.length === 0) return [];
+    return sourceOptions.map((sourceOption) => ({
+      value: sourceOption.getAttribute("value") ?? sourceOption.textContent ?? "",
+      label: sourceOption.textContent ?? "",
+      selected: sourceOption.hasAttribute("selected"),
+      disabled: sourceOption.hasAttribute("disabled")
+    }));
+  }
+
+  _setFieldOptions(options) {
+    const field = this._lhtField;
+    if (!field) return;
+    field.innerHTML = "";
+
+    for (const entry of options) {
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
+      }
+    }
+  }
+
+  hydrateOptions() {
+    const declarativeOptions = this._readDeclarativeOptions();
+    if (Array.isArray(declarativeOptions)) {
+      this._setFieldOptions(declarativeOptions);
+      const jsonScript = this.querySelector("script[type='application/json'][slot='options']");
+      if (jsonScript) jsonScript.remove();
+      if (this._optionsObserver) {
+        this._optionsObserver.disconnect();
+        this._optionsObserver = null;
+      }
+      return;
+    }
+
+    const optionsFromChildren = this._readChildOptionElements();
+    if (optionsFromChildren.length === 0) return;
+    this._setFieldOptions(optionsFromChildren);
+    this.querySelectorAll("option").forEach((option) => option.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
+    }
+  }
+}
+
+class LhtFileSelect extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const inputId = (this.getAttribute("input-id") || "fileInput").trim();
+    const buttonId = (this.getAttribute("button-id") || "fileSelectBtn").trim();
+    const fileNameId = (this.getAttribute("file-name-id") || "fileNameText").trim();
+    const accept = (this.getAttribute("accept") || "").trim();
+    const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
+    const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
+    const showFileName = this.hasAttribute("show-file-name");
+
+    this.textContent = "";
+
+    const root = document.createElement("div");
+    root.className = "lht-file-select";
+
+    const hasMdFilledButton = !!(window.customElements && window.customElements.get("md-filled-button"));
+    const triggerButton = document.createElement(hasMdFilledButton ? "md-filled-button" : "button");
+    if (!hasMdFilledButton) {
+      triggerButton.type = "button";
+    }
+    triggerButton.id = buttonId;
+    triggerButton.className = `lht-file-select__button${hasMdFilledButton ? "" : " lht-file-select__button--fallback"}`;
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("slot", "icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("class", "lht-file-select__button-icon");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "1.9");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.innerHTML = '<path d="M4 7h7l2 2h7v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path><path d="M12 10v6"></path><path d="M9 13l3 3 3-3"></path>';
+
+    const labelNode = document.createElement("span");
+    labelNode.className = "lht-file-select__button-text";
+    labelNode.textContent = buttonLabel;
+    triggerButton.appendChild(icon);
+    triggerButton.appendChild(labelNode);
+
+    const input = document.createElement("input");
+    input.id = inputId;
+    input.type = "file";
+    input.className = "md-file";
+    input.hidden = true;
+    if (accept) input.setAttribute("accept", accept);
+    if (this.hasAttribute("multiple")) input.multiple = true;
+
+    const fileName = document.createElement("span");
+    fileName.id = fileNameId;
+    fileName.className = "lht-file-select__file-name";
+    fileName.textContent = placeholder;
+    if (!showFileName) fileName.hidden = true;
+
+    if (this.hasAttribute("disabled")) {
+      input.disabled = true;
+      triggerButton.disabled = true;
+    }
+
+    triggerButton.addEventListener("click", () => input.click());
+    input.addEventListener("change", () => {
+      const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
+      fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+    });
+
+    root.appendChild(triggerButton);
+    root.appendChild(fileName);
+    this.appendChild(root);
+    this.appendChild(input);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
+
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
+    }
+  }
+}
+
+class LhtIndexCardLink extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const href = (this.getAttribute("href") || "").trim();
+    if (!href) return;
+
+    const title = (this.getAttribute("title") || "").trim();
+    const descAttr = (this.getAttribute("desc") || "").trim();
+    const iconAttr = (this.getAttribute("icon") || "").trim();
+    const target = (this.getAttribute("target") || "").trim();
+    const relAttr = (this.getAttribute("rel") || "").trim();
+    const variant = (this.getAttribute("variant") || "default").trim().toLowerCase();
+    const arrowMode = (this.getAttribute("arrow") || "auto").trim().toLowerCase();
+    const badgeText = (this.getAttribute("badge") || "").trim();
+    const descLines = (this.getAttribute("desc-lines") || "").trim();
+
+    if (!title || !descAttr) {
+      const missing = [];
+      if (!title) missing.push("title");
+      if (!descAttr) missing.push("desc");
+      // Fail fast for authoring mistakes in index cards.
+      console.warn(`[lht-index-card-link] Missing required attribute(s): ${missing.join(", ")}`, this);
+      return;
+    }
+
+    this.textContent = "";
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "md-link-card";
+    const isExternalHref = /^(https?:)?\/\//i.test(href);
+    const isExternal = variant === "external" || isExternalHref || target === "_blank";
+    const effectiveTarget = target || (isExternal ? "_blank" : "");
+    if (effectiveTarget) link.target = effectiveTarget;
+    if (effectiveTarget === "_blank") {
+      link.rel = relAttr || "noopener noreferrer";
+    } else if (relAttr) {
+      link.rel = relAttr;
+    }
+    if (variant === "simple") link.classList.add("lht-index-card-link--simple");
+    if (isExternal) link.classList.add("lht-index-card-link--external");
+
+    const head = document.createElement("div");
+    head.className = "md-card-head";
+
+    const h3 = document.createElement("h3");
+    h3.className = "md-card-title";
+    if (iconAttr) {
+      const iconContainer = document.createElement("span");
+      iconContainer.className = "lht-index-card-link__icon";
+      iconContainer.textContent = iconAttr;
+      h3.appendChild(iconContainer);
+    }
+    const titleContainer = document.createElement("span");
+    titleContainer.className = "lht-index-card-link__title";
+    titleContainer.textContent = title;
+    h3.appendChild(titleContainer);
+    if (badgeText) {
+      const badge = document.createElement("span");
+      badge.className = "lht-index-card-link__badge";
+      badge.textContent = badgeText;
+      h3.appendChild(badge);
+    }
+
+    const arrow = document.createElement("span");
+    arrow.className = "md-card-arrow";
+    const showArrow = arrowMode === "auto" ? variant !== "simple" : arrowMode !== "none";
+    arrow.textContent = isExternal ? "↗" : "→";
+    if (!showArrow) arrow.hidden = true;
+
+    const desc = document.createElement("p");
+    desc.className = "md-card-desc";
+    desc.textContent = descAttr;
+    if (descLines && /^\d+$/.test(descLines)) {
+      desc.classList.add("lht-index-card-link__desc--clamp");
+      desc.style.setProperty("--lht-desc-lines", descLines);
+    }
+
+    head.appendChild(h3);
+    head.appendChild(arrow);
+    link.appendChild(head);
+    link.appendChild(desc);
+    this.appendChild(link);
+  }
+}
+
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
+      panel.classList.toggle("md-hidden");
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
+}
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
+}
+if (!customElements.get("lht-file-select")) {
+  customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-index-card-link")) {
+  customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
   <script>
 const MusicXmlWriterCommon = (() => {
     function escapeXml(value) {
@@ -890,7 +2679,9 @@ let loadedMidiName = "";
 let lastXmlText = "";
 restoreSettings();
 fileInput.addEventListener("change", onFileChange);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -1929,12 +3720,22 @@ function resetOutput() {
     copyBtn.disabled = true;
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
@@ -2024,18 +3825,11 @@ async function copyMusicXml() {
         showToast("コピーに失敗しました。");
     }
 }
-let toastTimer = 0;
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    if (toastTimer) {
-        clearTimeout(toastTimer);
+    if (!toast || typeof toast.show !== "function") {
+        return;
     }
-    toastTimer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1600);
+    toast.show(message, 1600);
 }
 window["toggleMenu"] = function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/musicxml-to-abc-src.html
+++ b/docs/music/musicxml-to-abc-src.html
@@ -19,6 +19,7 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → ABC 変換</title>
+    <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
     <link rel="stylesheet" href="src/musicxml-to-abc/css/app.css" />
 </head>
 <body>
@@ -77,16 +78,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="xmlInput" class="md-textarea" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -114,18 +115,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -176,7 +174,7 @@ limitations under the License.
             <span>sine再生</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -223,8 +221,9 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
+    <script src="../../lht-cmn/js/components.js"></script>
     <script src="src/common/js/musicxml-common.js"></script>
     <script src="src/common/js/musicxml-synth-schedule-common.js"></script>
     <script src="src/common/js/music-synth-common.js"></script>

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -20,7 +20,603 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → ABC 変換</title>
     
+    
   <style>
+/*
+ * lht-cmn components.css
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
+.md-page {
+  overflow-x: clip;
+}
+
+/* Tooltip defaults are centralized in lht to avoid per-page overflow regressions. */
+lht-help-tooltip .md-tooltip-content {
+  display: none;
+  max-width: min(24rem, calc(100vw - 2rem));
+}
+
+lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
+lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  lht-help-tooltip .md-tooltip-content {
+    left: auto;
+    right: 0;
+    transform: none;
+    width: min(24rem, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-text-field-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+}
+
+lht-file-select {
+  display: block;
+}
+
+lht-file-select .lht-file-select {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+lht-file-select .lht-file-select__button {
+  --md-filled-button-container-color: var(--md-sys-color-primary, #6200ee);
+  --md-filled-button-label-text-color: #ffffff;
+  --md-filled-button-container-shape: 999px;
+  --md-filled-button-container-height: 54px;
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 24px;
+  --md-filled-button-icon-size: 20px;
+  --md-focus-ring-color: #6c3eea;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(98, 0, 238, 0.24);
+}
+
+lht-file-select .lht-file-select__button--fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.55rem;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--md-sys-color-primary, #6200ee);
+  cursor: pointer;
+}
+
+lht-file-select .lht-file-select__button-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  flex: 0 0 auto;
+}
+
+lht-file-select .lht-file-select__button-text {
+  white-space: nowrap;
+}
+
+lht-file-select .lht-file-select__file-name {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
+lht-index-card-link {
+  display: block;
+}
+
+.lht-index-card-link__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.3rem;
+}
+
+.lht-index-card-link__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.45rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #534a64;
+  background: rgba(108, 62, 234, 0.13);
+}
+
+.lht-index-card-link__desc--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--lht-desc-lines, 3);
+  overflow: hidden;
+}
+
 :root {
       --md-danger: #b3261e;
       --md-sys-color-background: #f6f4f8;
@@ -488,16 +1084,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="xmlInput" class="md-textarea" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -525,18 +1121,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -587,7 +1180,7 @@ limitations under the License.
             <span>sine再生</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -634,13 +1227,1204 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     
     
     
     
     
+    
+  <script>
+/*
+ * lht-cmn components.js
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtTextFieldHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const type = this.getAttribute("type");
+    if (type != null) field.setAttribute("type", type);
+
+    const min = this.getAttribute("min");
+    if (min != null) field.setAttribute("min", min);
+
+    const max = this.getAttribute("max");
+    if (max != null) field.setAttribute("max", max);
+
+    const step = this.getAttribute("step");
+    if (step != null) field.setAttribute("step", step);
+
+    const rows = this.getAttribute("rows");
+    if (rows != null) field.setAttribute("rows", rows);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      let blurHideTimer = null;
+      field.addEventListener("focus", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+          blurHideTimer = null;
+        }
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+        }
+        blurHideTimer = setTimeout(() => {
+          field.supportingText = "";
+          blurHideTimer = null;
+        }, hideDelayMs);
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSelectHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
+    field.id = fieldId;
+    this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
+
+    const value = this.getAttribute("value");
+    if (value != null) field.value = value;
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
+    }
+
+    this.appendChild(field);
+    this.hydrateOptions();
+
+    if (!this._hasDeclarativeOptions()) {
+      this._optionsObserver = new MutationObserver(() => {
+        this.hydrateOptions();
+      });
+      this._optionsObserver.observe(this, { childList: true, subtree: true });
+      requestAnimationFrame(() => this.hydrateOptions());
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+
+  _hasDeclarativeOptions() {
+    return this.hasAttribute("options") || !!this.querySelector("script[type='application/json'][slot='options']");
+  }
+
+  _normalizeOptions(rawOptions) {
+    return rawOptions
+      .map((entry) => {
+        const value = String(entry?.value ?? entry?.label ?? "");
+        const label = String(entry?.label ?? entry?.text ?? entry?.value ?? "");
+        return {
+          value,
+          label,
+          selected: !!entry?.selected,
+          disabled: !!entry?.disabled
+        };
+      })
+      .filter((entry) => entry.value || entry.label);
+  }
+
+  _readDeclarativeOptions() {
+    const optionsJson = (this.getAttribute("options") || "").trim();
+    if (optionsJson) {
+      try {
+        const parsed = JSON.parse(optionsJson);
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は次の入力ソースへフォールバック
+      }
+    }
+
+    const script = this.querySelector("script[type='application/json'][slot='options']");
+    if (script) {
+      try {
+        const parsed = JSON.parse(script.textContent || "[]");
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は空扱い
+      }
+      return [];
+    }
+
+    return null;
+  }
+
+  _readChildOptionElements() {
+    const sourceOptions = Array.from(this.querySelectorAll("option"));
+    if (sourceOptions.length === 0) return [];
+    return sourceOptions.map((sourceOption) => ({
+      value: sourceOption.getAttribute("value") ?? sourceOption.textContent ?? "",
+      label: sourceOption.textContent ?? "",
+      selected: sourceOption.hasAttribute("selected"),
+      disabled: sourceOption.hasAttribute("disabled")
+    }));
+  }
+
+  _setFieldOptions(options) {
+    const field = this._lhtField;
+    if (!field) return;
+    field.innerHTML = "";
+
+    for (const entry of options) {
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
+      }
+    }
+  }
+
+  hydrateOptions() {
+    const declarativeOptions = this._readDeclarativeOptions();
+    if (Array.isArray(declarativeOptions)) {
+      this._setFieldOptions(declarativeOptions);
+      const jsonScript = this.querySelector("script[type='application/json'][slot='options']");
+      if (jsonScript) jsonScript.remove();
+      if (this._optionsObserver) {
+        this._optionsObserver.disconnect();
+        this._optionsObserver = null;
+      }
+      return;
+    }
+
+    const optionsFromChildren = this._readChildOptionElements();
+    if (optionsFromChildren.length === 0) return;
+    this._setFieldOptions(optionsFromChildren);
+    this.querySelectorAll("option").forEach((option) => option.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
+    }
+  }
+}
+
+class LhtFileSelect extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const inputId = (this.getAttribute("input-id") || "fileInput").trim();
+    const buttonId = (this.getAttribute("button-id") || "fileSelectBtn").trim();
+    const fileNameId = (this.getAttribute("file-name-id") || "fileNameText").trim();
+    const accept = (this.getAttribute("accept") || "").trim();
+    const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
+    const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
+    const showFileName = this.hasAttribute("show-file-name");
+
+    this.textContent = "";
+
+    const root = document.createElement("div");
+    root.className = "lht-file-select";
+
+    const hasMdFilledButton = !!(window.customElements && window.customElements.get("md-filled-button"));
+    const triggerButton = document.createElement(hasMdFilledButton ? "md-filled-button" : "button");
+    if (!hasMdFilledButton) {
+      triggerButton.type = "button";
+    }
+    triggerButton.id = buttonId;
+    triggerButton.className = `lht-file-select__button${hasMdFilledButton ? "" : " lht-file-select__button--fallback"}`;
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("slot", "icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("class", "lht-file-select__button-icon");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "1.9");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.innerHTML = '<path d="M4 7h7l2 2h7v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path><path d="M12 10v6"></path><path d="M9 13l3 3 3-3"></path>';
+
+    const labelNode = document.createElement("span");
+    labelNode.className = "lht-file-select__button-text";
+    labelNode.textContent = buttonLabel;
+    triggerButton.appendChild(icon);
+    triggerButton.appendChild(labelNode);
+
+    const input = document.createElement("input");
+    input.id = inputId;
+    input.type = "file";
+    input.className = "md-file";
+    input.hidden = true;
+    if (accept) input.setAttribute("accept", accept);
+    if (this.hasAttribute("multiple")) input.multiple = true;
+
+    const fileName = document.createElement("span");
+    fileName.id = fileNameId;
+    fileName.className = "lht-file-select__file-name";
+    fileName.textContent = placeholder;
+    if (!showFileName) fileName.hidden = true;
+
+    if (this.hasAttribute("disabled")) {
+      input.disabled = true;
+      triggerButton.disabled = true;
+    }
+
+    triggerButton.addEventListener("click", () => input.click());
+    input.addEventListener("change", () => {
+      const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
+      fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+    });
+
+    root.appendChild(triggerButton);
+    root.appendChild(fileName);
+    this.appendChild(root);
+    this.appendChild(input);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
+
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
+    }
+  }
+}
+
+class LhtIndexCardLink extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const href = (this.getAttribute("href") || "").trim();
+    if (!href) return;
+
+    const title = (this.getAttribute("title") || "").trim();
+    const descAttr = (this.getAttribute("desc") || "").trim();
+    const iconAttr = (this.getAttribute("icon") || "").trim();
+    const target = (this.getAttribute("target") || "").trim();
+    const relAttr = (this.getAttribute("rel") || "").trim();
+    const variant = (this.getAttribute("variant") || "default").trim().toLowerCase();
+    const arrowMode = (this.getAttribute("arrow") || "auto").trim().toLowerCase();
+    const badgeText = (this.getAttribute("badge") || "").trim();
+    const descLines = (this.getAttribute("desc-lines") || "").trim();
+
+    if (!title || !descAttr) {
+      const missing = [];
+      if (!title) missing.push("title");
+      if (!descAttr) missing.push("desc");
+      // Fail fast for authoring mistakes in index cards.
+      console.warn(`[lht-index-card-link] Missing required attribute(s): ${missing.join(", ")}`, this);
+      return;
+    }
+
+    this.textContent = "";
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "md-link-card";
+    const isExternalHref = /^(https?:)?\/\//i.test(href);
+    const isExternal = variant === "external" || isExternalHref || target === "_blank";
+    const effectiveTarget = target || (isExternal ? "_blank" : "");
+    if (effectiveTarget) link.target = effectiveTarget;
+    if (effectiveTarget === "_blank") {
+      link.rel = relAttr || "noopener noreferrer";
+    } else if (relAttr) {
+      link.rel = relAttr;
+    }
+    if (variant === "simple") link.classList.add("lht-index-card-link--simple");
+    if (isExternal) link.classList.add("lht-index-card-link--external");
+
+    const head = document.createElement("div");
+    head.className = "md-card-head";
+
+    const h3 = document.createElement("h3");
+    h3.className = "md-card-title";
+    if (iconAttr) {
+      const iconContainer = document.createElement("span");
+      iconContainer.className = "lht-index-card-link__icon";
+      iconContainer.textContent = iconAttr;
+      h3.appendChild(iconContainer);
+    }
+    const titleContainer = document.createElement("span");
+    titleContainer.className = "lht-index-card-link__title";
+    titleContainer.textContent = title;
+    h3.appendChild(titleContainer);
+    if (badgeText) {
+      const badge = document.createElement("span");
+      badge.className = "lht-index-card-link__badge";
+      badge.textContent = badgeText;
+      h3.appendChild(badge);
+    }
+
+    const arrow = document.createElement("span");
+    arrow.className = "md-card-arrow";
+    const showArrow = arrowMode === "auto" ? variant !== "simple" : arrowMode !== "none";
+    arrow.textContent = isExternal ? "↗" : "→";
+    if (!showArrow) arrow.hidden = true;
+
+    const desc = document.createElement("p");
+    desc.className = "md-card-desc";
+    desc.textContent = descAttr;
+    if (descLines && /^\d+$/.test(descLines)) {
+      desc.classList.add("lht-index-card-link__desc--clamp");
+      desc.style.setProperty("--lht-desc-lines", descLines);
+    }
+
+    head.appendChild(h3);
+    head.appendChild(arrow);
+    link.appendChild(head);
+    link.appendChild(desc);
+    this.appendChild(link);
+  }
+}
+
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
+      panel.classList.toggle("md-hidden");
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
+}
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
+}
+if (!customElements.get("lht-file-select")) {
+  customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-index-card-link")) {
+  customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
   <script>
 const MusicXmlCommon = (() => {
     function readTextFileUtf8(file, onLoad, onError) {
@@ -1217,7 +3001,9 @@ downloadBtn.addEventListener("click", downloadAbc);
 playSineBtn.addEventListener("click", playSine);
 copyBtn.addEventListener("click", copyAbc);
 fileInput.addEventListener("change", loadXmlFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -1801,26 +3587,32 @@ function playSine() {
     });
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/musicxml-to-midi-src.html
+++ b/docs/music/musicxml-to-midi-src.html
@@ -74,16 +74,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="xmlInput" class="md-textarea md-textarea--compact" rows="10" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -219,7 +219,7 @@ limitations under the License.
             <span>停止</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -242,7 +242,7 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     <script src="../git/src/vendor/material-web-outlined-text-field.bundle.js"></script>
     <script src="../../lht-cmn/js/components.js"></script>

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -24,7 +24,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -265,6 +265,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -873,16 +1045,16 @@ lht-index-card-link {
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="xmlInput" class="md-textarea md-textarea--compact" rows="10" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -1018,7 +1190,7 @@ lht-index-card-link {
             <span>停止</span>
           </button>
         </div>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
         <p id="warningText" class="md-warning md-hidden"></p>
       </section>
 
@@ -1041,7 +1213,7 @@ lht-index-card-link {
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     
     
@@ -1514,7 +1686,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1823,6 +1995,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2242,6 +2840,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);
@@ -4366,7 +4979,9 @@ downloadBtn.addEventListener("click", downloadMidi);
 playBtn.addEventListener("click", playMidi);
 stopBtn.addEventListener("click", stopMidi);
 fileInput.addEventListener("change", loadXmlFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -4999,26 +5614,32 @@ function stopMidi(showMessage = true) {
     }
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/musicxml-to-svg-src.html
+++ b/docs/music/musicxml-to-svg-src.html
@@ -19,6 +19,7 @@ limitations under the License.
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → SVG 変換</title>
+    <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
     <link rel="stylesheet" href="src/musicxml-to-svg/css/app.css" />
 </head>
 <body>
@@ -77,16 +78,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="musicxmlInput" class="md-textarea" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -117,18 +118,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -193,7 +191,7 @@ limitations under the License.
           </button>
         </div>
         <p class="md-note" id="statusText">Verovio初期化中...</p>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
       </section>
 
       <section class="md-section">
@@ -246,8 +244,9 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
+    <script src="../../lht-cmn/js/components.js"></script>
     <script src="src/musicxml-to-svg/js/verovio.js"></script>
     <script src="src/musicxml-to-svg/js/jszip.js"></script>
     <script src="src/common/js/musicxml-common.js"></script>

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -20,7 +20,603 @@ limitations under the License.
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MusicXML → SVG 変換</title>
     
+    
   <style>
+/*
+ * lht-cmn components.css
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
+.md-page {
+  overflow-x: clip;
+}
+
+/* Tooltip defaults are centralized in lht to avoid per-page overflow regressions. */
+lht-help-tooltip .md-tooltip-content {
+  display: none;
+  max-width: min(24rem, calc(100vw - 2rem));
+}
+
+lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
+lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  lht-help-tooltip .md-tooltip-content {
+    left: auto;
+    right: 0;
+    transform: none;
+    width: min(24rem, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+lht-page-hero {
+  display: block;
+  margin-bottom: 1.2rem;
+  padding: 1rem 1rem 0.9rem;
+  position: relative;
+  z-index: 40;
+  overflow: visible;
+  border-radius: 20px;
+  background: linear-gradient(180deg, #f6f1ff 0%, #fbf8ff 100%);
+  border: 1px solid #e7dff6;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+lht-page-hero .lht-page-hero__title-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+lht-page-hero .lht-page-hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(1.12rem, 4.2vw, 1.45rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: #2f1f52;
+  overflow-wrap: anywhere;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 0.85rem;
+  background: rgba(98, 0, 238, 0.14);
+  flex: 0 0 auto;
+}
+
+lht-page-hero .lht-page-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  color: #514a5f;
+  font-size: 0.86rem;
+  line-height: 1.45;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-group {
+  transform: translateY(1px);
+  flex: 0 0 auto;
+  z-index: 41;
+}
+
+lht-page-hero .lht-page-hero__title-main .md-tooltip-content {
+  z-index: 260;
+}
+
+lht-page-hero .lht-page-menu {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-page-hero .md-menu-button {
+  position: static;
+  top: auto;
+  right: auto;
+  margin: 0;
+}
+
+lht-page-hero .md-menu-panel {
+  top: calc(100% + 0.45rem);
+  right: 0;
+  left: auto;
+  z-index: 280;
+}
+
+@media (max-width: 640px) {
+  lht-page-hero {
+    padding: 0.9rem 0.85rem 0.8rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-row {
+    gap: 0.5rem;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  lht-page-hero .lht-page-hero__icon {
+    width: 1.55rem;
+    height: 1.55rem;
+  }
+
+  lht-page-hero .lht-page-hero__subtitle {
+    font-size: 0.82rem;
+  }
+}
+
+lht-command-block {
+  display: block;
+}
+
+lht-text-field-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+lht-select-help .lht-select-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+}
+
+lht-file-select {
+  display: block;
+}
+
+lht-file-select .lht-file-select {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+lht-file-select .lht-file-select__button {
+  --md-filled-button-container-color: var(--md-sys-color-primary, #6200ee);
+  --md-filled-button-label-text-color: #ffffff;
+  --md-filled-button-container-shape: 999px;
+  --md-filled-button-container-height: 54px;
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 24px;
+  --md-filled-button-icon-size: 20px;
+  --md-focus-ring-color: #6c3eea;
+  font-size: 1rem;
+  font-weight: 700;
+  box-shadow: 0 8px 18px rgba(98, 0, 238, 0.24);
+}
+
+lht-file-select .lht-file-select__button--fallback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.55rem;
+  line-height: 1;
+  color: #ffffff;
+  background: var(--md-sys-color-primary, #6200ee);
+  cursor: pointer;
+}
+
+lht-file-select .lht-file-select__button-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+  flex: 0 0 auto;
+}
+
+lht-file-select .lht-file-select__button-text {
+  white-space: nowrap;
+}
+
+lht-file-select .lht-file-select__file-name {
+  font-size: 0.85rem;
+  color: var(--md-sys-color-on-surface-variant, #49454f);
+  word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+md-outlined-text-field.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-text-field-container-shape: 12px;
+  --md-outlined-field-container-shape: 12px;
+  --md-outlined-text-field-top-space: 10px;
+  --md-outlined-text-field-bottom-space: 10px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-text-field-content-space: 12px;
+  --md-outlined-text-field-leading-space: 12px;
+  --md-outlined-text-field-trailing-space: 12px;
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-outline-width: 1.5px;
+  --md-outlined-field-focus-outline-width: 1.5px;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-field-focus-state-layer-opacity: 0;
+  --md-outlined-text-field-error-focus-outline-width: 1px;
+  --md-outlined-field-error-focus-outline-width: 1px;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+  transition: none;
+}
+
+md-outlined-text-field.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  width: 100%;
+  position: relative;
+  color-scheme: light;
+  border-radius: 12px;
+  --md-outlined-select-text-field-container-shape: 12px;
+  --md-outlined-select-text-field-top-space: 10px;
+  --md-outlined-select-text-field-bottom-space: 10px;
+  --md-outlined-select-text-field-content-space: 12px;
+  --md-outlined-select-text-field-leading-space: 12px;
+  --md-outlined-select-text-field-trailing-space: 12px;
+  --md-outlined-field-top-space: 10px;
+  --md-outlined-field-bottom-space: 10px;
+  --md-outlined-field-content-space: 12px;
+  --md-outlined-field-leading-space: 12px;
+  --md-outlined-field-trailing-space: 12px;
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-outline-width: 1.5px;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-opacity: 0;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+  --md-menu-item-one-line-container-height: 44px;
+  --md-menu-item-top-space: 8px;
+  --md-menu-item-bottom-space: 8px;
+  transition: none;
+}
+
+md-outlined-select.md-outlined-field::part(outline) {
+  transition: filter 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field::part(container) {
+  transition: box-shadow 160ms ease;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+lht-switch-help {
+  display: inline-flex;
+  align-items: center;
+}
+
+lht-switch-help .md-switch-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.24rem;
+  font-size: 0.95rem;
+  color: var(--md-sys-color-on-surface);
+}
+
+lht-switch-help .md-switch-label md-switch {
+  --md-switch-track-width: 44px;
+  --md-switch-track-height: 24px;
+  --md-switch-track-outline-width: 1px;
+  --md-switch-handle-width: 20px;
+  --md-switch-handle-height: 20px;
+  --md-switch-selected-handle-width: 20px;
+  --md-switch-selected-handle-height: 20px;
+  --md-switch-with-icon-handle-width: 20px;
+  --md-switch-with-icon-handle-height: 20px;
+  --md-switch-state-layer-size: 24px;
+  --md-focus-ring-color: #6c3eea;
+  flex: 0 0 44px;
+  inline-size: 44px;
+  min-inline-size: 44px;
+  vertical-align: middle;
+}
+
+lht-switch-help .md-switch-label .md-info-chip {
+  margin-left: 0;
+}
+
+/* Switch rows are often near the right edge; anchor tooltip right to avoid clipping. */
+lht-switch-help .md-switch-label .md-tooltip-content {
+  left: auto;
+  right: 0;
+  transform: none;
+  max-width: calc(100vw - 2rem);
+}
+
+.md-help-icon-button {
+  --md-icon-button-icon-size: 18px;
+  --md-icon-button-state-layer-size: 30px;
+  --md-focus-ring-color: #6c3eea;
+  color: #6f6a79;
+}
+
+lht-index-card-link {
+  display: block;
+}
+
+.lht-index-card-link__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.3rem;
+}
+
+.lht-index-card-link__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.45rem;
+  padding: 0.08rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #534a64;
+  background: rgba(108, 62, 234, 0.13);
+}
+
+.lht-index-card-link__desc--clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: var(--lht-desc-lines, 3);
+  overflow: hidden;
+}
+
 :root {
       --md-danger: #b3261e;
       --md-sys-color-background: #f6f4f8;
@@ -212,6 +808,7 @@ limitations under the License.
       background: #fff;
       overflow: auto;
       min-height: 9rem;
+      max-height: min(70vh, 42rem);
     }
 
     .md-preview-stage svg {
@@ -457,16 +1054,16 @@ limitations under the License.
           </span>
         </div>
 
-        <div class="md-radio-group" role="radiogroup" aria-label="入力方式">
-          <label class="md-radio-option">
-            <input id="inputModeFile" type="radio" name="inputMode" value="file" checked />
-            <span>ファイル読込</span>
-          </label>
-          <label class="md-radio-option">
-            <input id="inputModeSource" type="radio" name="inputMode" value="source" />
-            <span>ソースコード入力</span>
-          </label>
-        </div>
+        <lht-input-mode-toggle
+          name="inputMode"
+          group-label="入力方式"
+          file-id="inputModeFile"
+          source-id="inputModeSource"
+          file-label="ファイル読込"
+          source-label="ソースコード入力"
+          source-target-id="sourceInputBlock"
+          file-target-id="fileInputBlock">
+        </lht-input-mode-toggle>
 
         <div id="sourceInputBlock">
           <textarea id="musicxmlInput" class="md-textarea" spellcheck="false"><?xml version="1.0" encoding="UTF-8"?>
@@ -497,18 +1094,15 @@ limitations under the License.
         </div>
 
         <div id="fileInputBlock" class="md-hidden">
-          <div class="md-actions">
-            <button id="fileSelectBtn" class="md-button md-button--primary" type="button">
-              <svg aria-hidden="true" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;margin-right:0.35rem">
-                <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-                <path d="M12 10v6" />
-                <path d="M9.5 13.5 12 16l2.5-2.5" />
-              </svg>
-              <span>ファイルを選択</span>
-            </button>
-            <span id="fileNameText">未選択</span>
-          </div>
-          <input id="fileInput" class="md-file" type="file" accept=".musicxml,.xml,text/xml,application/xml" hidden />
+          <lht-file-select
+            input-id="fileInput"
+            button-id="fileSelectBtn"
+            file-name-id="fileNameText"
+            accept=".musicxml,.xml,text/xml,application/xml"
+            button-label="ファイルを選択"
+            placeholder="未選択"
+            show-file-name>
+          </lht-file-select>
         </div>
       </section>
 
@@ -573,7 +1167,7 @@ limitations under the License.
           </button>
         </div>
         <p class="md-note" id="statusText">Verovio初期化中...</p>
-        <p id="errorText" class="md-error md-hidden" role="alert"></p>
+        <lht-error-alert id="errorText"></lht-error-alert>
       </section>
 
       <section class="md-section">
@@ -626,7 +1220,7 @@ limitations under the License.
     </section>
   </main>
 
-  <div id="toast" class="md-snackbar md-hidden" role="status" aria-live="polite"></div>
+  <lht-toast id="toast"></lht-toast>
 
     
     
@@ -634,6 +1228,1197 @@ limitations under the License.
     
     
     
+    
+  <script>
+/*
+ * lht-cmn components.js
+ * Version: v20260306
+ * Copyright 2026 Toshiki Iga
+ * Licensed under the Apache License, Version 2.0
+ */
+
+class LhtHelpTooltip extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const label = this.getAttribute("label") || "説明";
+    const isWide = this.hasAttribute("wide");
+    const helpContentHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+
+    const group = document.createElement("span");
+    group.className = "md-tooltip-group";
+
+    const button = document.createElement("md-icon-button");
+    button.className = "md-help-icon-button";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
+
+    const tooltip = document.createElement("span");
+    tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
+    tooltip.innerHTML = helpContentHtml;
+
+    group.appendChild(button);
+    group.appendChild(tooltip);
+    this.appendChild(group);
+  }
+}
+
+class LhtTextFieldHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const field = document.createElement("md-outlined-text-field");
+    field.id = fieldId;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) field.setAttribute("label", label);
+
+    const placeholder = this.getAttribute("placeholder");
+    if (placeholder != null) field.setAttribute("placeholder", placeholder);
+
+    const autocomplete = this.getAttribute("autocomplete");
+    if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
+
+    const type = this.getAttribute("type");
+    if (type != null) field.setAttribute("type", type);
+
+    const min = this.getAttribute("min");
+    if (min != null) field.setAttribute("min", min);
+
+    const max = this.getAttribute("max");
+    if (max != null) field.setAttribute("max", max);
+
+    const step = this.getAttribute("step");
+    if (step != null) field.setAttribute("step", step);
+
+    const rows = this.getAttribute("rows");
+    if (rows != null) field.setAttribute("rows", rows);
+
+    const value = this.getAttribute("value");
+    if (value != null) field.setAttribute("value", value);
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    field.classList.add("md-outlined-field");
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      let blurHideTimer = null;
+      field.addEventListener("focus", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+          blurHideTimer = null;
+        }
+        field.supportingText = helpText;
+      });
+      field.addEventListener("blur", () => {
+        if (blurHideTimer) {
+          clearTimeout(blurHideTimer);
+        }
+        blurHideTimer = setTimeout(() => {
+          field.supportingText = "";
+          blurHideTimer = null;
+        }, hideDelayMs);
+      });
+    }
+
+    this.textContent = "";
+    this.appendChild(field);
+  }
+}
+
+class LhtSelectHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const fieldId = (this.getAttribute("field-id") || "").trim();
+    if (!fieldId) return;
+
+    const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
+    const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
+    field.id = fieldId;
+    this._lhtField = field;
+    this._isFallbackSelect = !hasMdOutlinedSelect;
+
+    const label = (this.getAttribute("label") || "").trim();
+    if (label) {
+      if (this._isFallbackSelect) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
+
+    const value = this.getAttribute("value");
+    if (value != null) field.value = value;
+
+    const fieldClass = (this.getAttribute("field-class") || "").trim();
+    if (fieldClass) {
+      fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
+    }
+    if (this._isFallbackSelect) {
+      field.classList.add("lht-select-help__fallback");
+    } else {
+      field.classList.add("md-outlined-field");
+    }
+
+    if (this.hasAttribute("required")) {
+      field.required = true;
+      field.setAttribute("required", "");
+    }
+    if (this.hasAttribute("disabled")) field.disabled = true;
+
+    const helpText = (this.getAttribute("help-text") || "").trim();
+    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    if (helpText) {
+      if (this._isFallbackSelect) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
+    }
+
+    this.appendChild(field);
+    this.hydrateOptions();
+
+    if (!this._hasDeclarativeOptions()) {
+      this._optionsObserver = new MutationObserver(() => {
+        this.hydrateOptions();
+      });
+      this._optionsObserver.observe(this, { childList: true, subtree: true });
+      requestAnimationFrame(() => this.hydrateOptions());
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+
+  _hasDeclarativeOptions() {
+    return this.hasAttribute("options") || !!this.querySelector("script[type='application/json'][slot='options']");
+  }
+
+  _normalizeOptions(rawOptions) {
+    return rawOptions
+      .map((entry) => {
+        const value = String(entry?.value ?? entry?.label ?? "");
+        const label = String(entry?.label ?? entry?.text ?? entry?.value ?? "");
+        return {
+          value,
+          label,
+          selected: !!entry?.selected,
+          disabled: !!entry?.disabled
+        };
+      })
+      .filter((entry) => entry.value || entry.label);
+  }
+
+  _readDeclarativeOptions() {
+    const optionsJson = (this.getAttribute("options") || "").trim();
+    if (optionsJson) {
+      try {
+        const parsed = JSON.parse(optionsJson);
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は次の入力ソースへフォールバック
+      }
+    }
+
+    const script = this.querySelector("script[type='application/json'][slot='options']");
+    if (script) {
+      try {
+        const parsed = JSON.parse(script.textContent || "[]");
+        if (Array.isArray(parsed)) return this._normalizeOptions(parsed);
+      } catch (_) {
+        // JSON 不正時は空扱い
+      }
+      return [];
+    }
+
+    return null;
+  }
+
+  _readChildOptionElements() {
+    const sourceOptions = Array.from(this.querySelectorAll("option"));
+    if (sourceOptions.length === 0) return [];
+    return sourceOptions.map((sourceOption) => ({
+      value: sourceOption.getAttribute("value") ?? sourceOption.textContent ?? "",
+      label: sourceOption.textContent ?? "",
+      selected: sourceOption.hasAttribute("selected"),
+      disabled: sourceOption.hasAttribute("disabled")
+    }));
+  }
+
+  _setFieldOptions(options) {
+    const field = this._lhtField;
+    if (!field) return;
+    field.innerHTML = "";
+
+    for (const entry of options) {
+      if (this._isFallbackSelect) {
+        const option = document.createElement("option");
+        option.value = entry.value;
+        option.textContent = entry.label;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          field.value = entry.value;
+        }
+        field.appendChild(option);
+      } else {
+        const option = document.createElement("md-select-option");
+        option.value = entry.value;
+        if (entry.disabled) option.disabled = true;
+        if (entry.selected) {
+          option.selected = true;
+          option.setAttribute("selected", "");
+          field.value = entry.value;
+        }
+        const headline = document.createElement("div");
+        headline.slot = "headline";
+        headline.textContent = entry.label;
+        option.appendChild(headline);
+        field.appendChild(option);
+      }
+    }
+  }
+
+  hydrateOptions() {
+    const declarativeOptions = this._readDeclarativeOptions();
+    if (Array.isArray(declarativeOptions)) {
+      this._setFieldOptions(declarativeOptions);
+      const jsonScript = this.querySelector("script[type='application/json'][slot='options']");
+      if (jsonScript) jsonScript.remove();
+      if (this._optionsObserver) {
+        this._optionsObserver.disconnect();
+        this._optionsObserver = null;
+      }
+      return;
+    }
+
+    const optionsFromChildren = this._readChildOptionElements();
+    if (optionsFromChildren.length === 0) return;
+    this._setFieldOptions(optionsFromChildren);
+    this.querySelectorAll("option").forEach((option) => option.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
+    }
+  }
+}
+
+class LhtFileSelect extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const inputId = (this.getAttribute("input-id") || "fileInput").trim();
+    const buttonId = (this.getAttribute("button-id") || "fileSelectBtn").trim();
+    const fileNameId = (this.getAttribute("file-name-id") || "fileNameText").trim();
+    const accept = (this.getAttribute("accept") || "").trim();
+    const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
+    const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
+    const showFileName = this.hasAttribute("show-file-name");
+
+    this.textContent = "";
+
+    const root = document.createElement("div");
+    root.className = "lht-file-select";
+
+    const hasMdFilledButton = !!(window.customElements && window.customElements.get("md-filled-button"));
+    const triggerButton = document.createElement(hasMdFilledButton ? "md-filled-button" : "button");
+    if (!hasMdFilledButton) {
+      triggerButton.type = "button";
+    }
+    triggerButton.id = buttonId;
+    triggerButton.className = `lht-file-select__button${hasMdFilledButton ? "" : " lht-file-select__button--fallback"}`;
+
+    const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    icon.setAttribute("slot", "icon");
+    icon.setAttribute("aria-hidden", "true");
+    icon.setAttribute("viewBox", "0 0 24 24");
+    icon.setAttribute("class", "lht-file-select__button-icon");
+    icon.setAttribute("fill", "none");
+    icon.setAttribute("stroke", "currentColor");
+    icon.setAttribute("stroke-width", "1.9");
+    icon.setAttribute("stroke-linecap", "round");
+    icon.setAttribute("stroke-linejoin", "round");
+    icon.innerHTML = '<path d="M4 7h7l2 2h7v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path><path d="M12 10v6"></path><path d="M9 13l3 3 3-3"></path>';
+
+    const labelNode = document.createElement("span");
+    labelNode.className = "lht-file-select__button-text";
+    labelNode.textContent = buttonLabel;
+    triggerButton.appendChild(icon);
+    triggerButton.appendChild(labelNode);
+
+    const input = document.createElement("input");
+    input.id = inputId;
+    input.type = "file";
+    input.className = "md-file";
+    input.hidden = true;
+    if (accept) input.setAttribute("accept", accept);
+    if (this.hasAttribute("multiple")) input.multiple = true;
+
+    const fileName = document.createElement("span");
+    fileName.id = fileNameId;
+    fileName.className = "lht-file-select__file-name";
+    fileName.textContent = placeholder;
+    if (!showFileName) fileName.hidden = true;
+
+    if (this.hasAttribute("disabled")) {
+      input.disabled = true;
+      triggerButton.disabled = true;
+    }
+
+    triggerButton.addEventListener("click", () => input.click());
+    input.addEventListener("change", () => {
+      const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
+      fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+    });
+
+    root.appendChild(triggerButton);
+    root.appendChild(fileName);
+    this.appendChild(root);
+    this.appendChild(input);
+  }
+}
+
+class LhtSwitchHelp extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const switchId = (this.getAttribute("switch-id") || "").trim();
+    if (!switchId) return;
+    const labelText = (this.getAttribute("label") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || `${labelText}の説明`).trim();
+    const helpContentHtml = this.innerHTML.trim();
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    const isChecked = this.hasAttribute("checked");
+    const isHelpWide = this.hasAttribute("help-wide");
+
+    this.textContent = "";
+
+    const label = document.createElement("label");
+    label.className = "md-switch-label";
+
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    if (onChangeFnName) {
+      mdSwitch.addEventListener("change", () => {
+        const fn = window[onChangeFnName];
+        if (typeof fn === "function") {
+          fn();
+        }
+      });
+    }
+    label.appendChild(mdSwitch);
+
+    const labelSpan = document.createElement("span");
+    labelSpan.textContent = labelText;
+    label.appendChild(labelSpan);
+
+    if (helpContentHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (isHelpWide) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpContentHtml;
+      label.appendChild(help);
+    }
+
+    this.appendChild(label);
+  }
+}
+
+class LhtCommandBlock extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const commandId = (this.getAttribute("command-id") || "").trim();
+    if (!commandId) return;
+    const copyButtons = (this.getAttribute("copy-buttons") || "single").trim().toLowerCase();
+    const isDual = copyButtons === "dual";
+
+    this.textContent = "";
+
+    const block = document.createElement("div");
+    block.className = "md-code-block";
+
+    const code = document.createElement("code");
+    code.id = commandId;
+    code.className = `md-code${isDual ? " md-code--dual-copy" : ""}`;
+    block.appendChild(code);
+
+    const topCopyButton = this.createCopyButton("コピー", () => this.copyFromCommand(commandId));
+    block.appendChild(topCopyButton);
+
+    if (isDual) {
+      const bottomCopyButton = this.createCopyButton("コピー（右下）", () => this.copyFromCommand(commandId));
+      bottomCopyButton.classList.add("md-copy-button--bottom-right");
+      block.appendChild(bottomCopyButton);
+    }
+
+    this.appendChild(block);
+  }
+
+  createCopyButton(label, onClick) {
+    const button = document.createElement("md-icon-button");
+    button.className = "md-copy-button md-copy-button--surface";
+    button.setAttribute("aria-label", label);
+    button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  async copyFromCommand(commandId) {
+    const commandElement = document.getElementById(commandId);
+    if (!commandElement) return;
+    const text = (commandElement.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // Clipboard API 利用不可環境では失敗を無視
+    }
+  }
+}
+
+class LhtIndexCardLink extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const href = (this.getAttribute("href") || "").trim();
+    if (!href) return;
+
+    const title = (this.getAttribute("title") || "").trim();
+    const descAttr = (this.getAttribute("desc") || "").trim();
+    const iconAttr = (this.getAttribute("icon") || "").trim();
+    const target = (this.getAttribute("target") || "").trim();
+    const relAttr = (this.getAttribute("rel") || "").trim();
+    const variant = (this.getAttribute("variant") || "default").trim().toLowerCase();
+    const arrowMode = (this.getAttribute("arrow") || "auto").trim().toLowerCase();
+    const badgeText = (this.getAttribute("badge") || "").trim();
+    const descLines = (this.getAttribute("desc-lines") || "").trim();
+
+    if (!title || !descAttr) {
+      const missing = [];
+      if (!title) missing.push("title");
+      if (!descAttr) missing.push("desc");
+      // Fail fast for authoring mistakes in index cards.
+      console.warn(`[lht-index-card-link] Missing required attribute(s): ${missing.join(", ")}`, this);
+      return;
+    }
+
+    this.textContent = "";
+
+    const link = document.createElement("a");
+    link.href = href;
+    link.className = "md-link-card";
+    const isExternalHref = /^(https?:)?\/\//i.test(href);
+    const isExternal = variant === "external" || isExternalHref || target === "_blank";
+    const effectiveTarget = target || (isExternal ? "_blank" : "");
+    if (effectiveTarget) link.target = effectiveTarget;
+    if (effectiveTarget === "_blank") {
+      link.rel = relAttr || "noopener noreferrer";
+    } else if (relAttr) {
+      link.rel = relAttr;
+    }
+    if (variant === "simple") link.classList.add("lht-index-card-link--simple");
+    if (isExternal) link.classList.add("lht-index-card-link--external");
+
+    const head = document.createElement("div");
+    head.className = "md-card-head";
+
+    const h3 = document.createElement("h3");
+    h3.className = "md-card-title";
+    if (iconAttr) {
+      const iconContainer = document.createElement("span");
+      iconContainer.className = "lht-index-card-link__icon";
+      iconContainer.textContent = iconAttr;
+      h3.appendChild(iconContainer);
+    }
+    const titleContainer = document.createElement("span");
+    titleContainer.className = "lht-index-card-link__title";
+    titleContainer.textContent = title;
+    h3.appendChild(titleContainer);
+    if (badgeText) {
+      const badge = document.createElement("span");
+      badge.className = "lht-index-card-link__badge";
+      badge.textContent = badgeText;
+      h3.appendChild(badge);
+    }
+
+    const arrow = document.createElement("span");
+    arrow.className = "md-card-arrow";
+    const showArrow = arrowMode === "auto" ? variant !== "simple" : arrowMode !== "none";
+    arrow.textContent = isExternal ? "↗" : "→";
+    if (!showArrow) arrow.hidden = true;
+
+    const desc = document.createElement("p");
+    desc.className = "md-card-desc";
+    desc.textContent = descAttr;
+    if (descLines && /^\d+$/.test(descLines)) {
+      desc.classList.add("lht-index-card-link__desc--clamp");
+      desc.style.setProperty("--lht-desc-lines", descLines);
+    }
+
+    head.appendChild(h3);
+    head.appendChild(arrow);
+    link.appendChild(head);
+    link.appendChild(desc);
+    this.appendChild(link);
+  }
+}
+
+class LhtPageHero extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const title = (this.getAttribute("title") || "").trim();
+    if (!title) return;
+    const subtitle = (this.getAttribute("subtitle") || "").trim();
+    const icon = (this.getAttribute("icon") || "").trim();
+    const helpLabel = (this.getAttribute("help-label") || "説明").trim();
+    const homeHref = (this.getAttribute("menu-home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("menu-home-label") || "トップへ戻る").trim();
+    const useWideHelp = this.hasAttribute("help-wide");
+    const showMenu = !this.hasAttribute("no-menu");
+    const helpHtml = this.innerHTML.trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-hero");
+
+    const topRow = document.createElement("div");
+    topRow.className = "lht-page-hero__title-row";
+
+    const titleMain = document.createElement("span");
+    titleMain.className = "lht-page-hero__title-main";
+
+    const heading = document.createElement("h1");
+    heading.className = "lht-page-hero__title";
+    if (icon) {
+      const iconNode = document.createElement("span");
+      iconNode.className = "lht-page-hero__icon";
+      iconNode.setAttribute("aria-hidden", "true");
+      iconNode.textContent = icon;
+      heading.appendChild(iconNode);
+    }
+    const titleNode = document.createElement("span");
+    titleNode.textContent = title;
+    heading.appendChild(titleNode);
+    titleMain.appendChild(heading);
+
+    if (helpHtml) {
+      const help = document.createElement("lht-help-tooltip");
+      help.setAttribute("label", helpLabel);
+      if (useWideHelp) {
+        help.setAttribute("wide", "");
+      }
+      help.innerHTML = helpHtml;
+      titleMain.appendChild(help);
+    }
+
+    topRow.appendChild(titleMain);
+
+    if (showMenu) {
+      const actions = document.createElement("span");
+      actions.className = "lht-page-hero__actions";
+      const menu = document.createElement("lht-page-menu");
+      menu.setAttribute("home-href", homeHref);
+      menu.setAttribute("home-label", homeLabel);
+      actions.appendChild(menu);
+      topRow.appendChild(actions);
+    }
+
+    this.appendChild(topRow);
+
+    if (subtitle) {
+      const subtitleNode = document.createElement("div");
+      subtitleNode.className = "lht-page-hero__subtitle";
+      subtitleNode.textContent = subtitle;
+      this.appendChild(subtitleNode);
+    }
+  }
+}
+
+class LhtPageMenu extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const homeHref = (this.getAttribute("home-href") || "../index.html").trim();
+    const homeLabel = (this.getAttribute("home-label") || "トップへ戻る").trim();
+
+    this.textContent = "";
+    this.classList.add("lht-page-menu");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "md-menu-button md-icon-btn";
+    button.setAttribute("aria-label", "メニュー");
+    button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-icon-20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16"></path><path d="M4 12h16"></path><path d="M4 18h16"></path></svg>';
+
+    const panel = document.createElement("div");
+    panel.className = "md-menu-panel md-hidden";
+
+    const link = document.createElement("a");
+    link.className = "md-menu-link";
+    link.href = homeHref;
+    link.textContent = homeLabel;
+    panel.appendChild(link);
+
+    button.addEventListener("click", () => {
+      panel.classList.toggle("md-hidden");
+    });
+
+    document.addEventListener("pointerdown", (event) => {
+      if (!this.contains(event.target)) {
+        panel.classList.add("md-hidden");
+      }
+    });
+
+    this.appendChild(button);
+    this.appendChild(panel);
+  }
+}
+
+if (!customElements.get("lht-help-tooltip")) {
+  customElements.define("lht-help-tooltip", LhtHelpTooltip);
+}
+if (!customElements.get("lht-text-field-help")) {
+  customElements.define("lht-text-field-help", LhtTextFieldHelp);
+}
+if (!customElements.get("lht-select-help")) {
+  customElements.define("lht-select-help", LhtSelectHelp);
+}
+if (!customElements.get("lht-file-select")) {
+  customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
+}
+if (!customElements.get("lht-switch-help")) {
+  customElements.define("lht-switch-help", LhtSwitchHelp);
+}
+if (!customElements.get("lht-command-block")) {
+  customElements.define("lht-command-block", LhtCommandBlock);
+}
+if (!customElements.get("lht-index-card-link")) {
+  customElements.define("lht-index-card-link", LhtIndexCardLink);
+}
+if (!customElements.get("lht-page-hero")) {
+  customElements.define("lht-page-hero", LhtPageHero);
+}
+if (!customElements.get("lht-page-menu")) {
+  customElements.define("lht-page-menu", LhtPageMenu);
+}
+  </script>
+
   <script>
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('node:fs'), require('node:crypto')) :
@@ -1509,7 +3294,9 @@ prevPageBtn.addEventListener("click", showPreviousPage);
 nextPageBtn.addEventListener("click", showNextPage);
 copySvgBtn.addEventListener("click", copySvg);
 fileInput.addEventListener("change", loadMusicXMLFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 document.addEventListener("click", handleDocumentClick);
@@ -1828,25 +3615,31 @@ function copySvg() {
     });
 }
 function setError(message, lineNumber) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
     if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusXmlLine(lineNumber);
     }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/abc-to-musicxml/js/main.js
+++ b/docs/music/src/abc-to-musicxml/js/main.js
@@ -56,7 +56,9 @@ downloadBtn.addEventListener("click", downloadMusicXml);
 playSineBtn.addEventListener("click", playSine);
 copyBtn.addEventListener("click", copyMusicXml);
 fileInput.addEventListener("change", loadAbcFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -215,29 +217,35 @@ function playSine() {
     });
 }
 function setError(message, lineNumber) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
     if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusLine(lineNumber);
     }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/abc-to-musicxml/ts/main.ts
+++ b/docs/music/src/abc-to-musicxml/ts/main.ts
@@ -61,7 +61,9 @@ const abcInput = document.getElementById("abcInput");
     playSineBtn.addEventListener("click", playSine);
     copyBtn.addEventListener("click", copyMusicXml);
     fileInput.addEventListener("change", loadAbcFile);
-    fileSelectBtn.addEventListener("click", () => fileInput.click());
+    if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+      fileSelectBtn.addEventListener("click", () => fileInput.click());
+    }
     inputModeSourceRadio.addEventListener("change", applyInputMode);
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
@@ -241,16 +243,24 @@ const abcInput = document.getElementById("abcInput");
     }
 
     function setError(message, lineNumber) {
-      errorText.textContent = message;
-      errorText.classList.remove("md-hidden");
+      if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+      } else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+      }
       if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusLine(lineNumber);
       }
     }
 
     function clearError() {
-      errorText.textContent = "";
-      errorText.classList.add("md-hidden");
+      if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+      } else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+      }
     }
 
     function clearWarning() {
@@ -259,14 +269,10 @@ const abcInput = document.getElementById("abcInput");
     }
 
     function showToast(message) {
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 1400);
+      if (!toast || typeof toast.show !== "function") {
+        return;
+      }
+      toast.show(message, 1400);
     }
 
     function toggleMenu() {

--- a/docs/music/src/midi-to-musicxml/js/main.js
+++ b/docs/music/src/midi-to-musicxml/js/main.js
@@ -38,7 +38,9 @@ let loadedMidiName = "";
 let lastXmlText = "";
 restoreSettings();
 fileInput.addEventListener("change", onFileChange);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -1077,12 +1079,22 @@ function resetOutput() {
     copyBtn.disabled = true;
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
@@ -1172,18 +1184,11 @@ async function copyMusicXml() {
         showToast("コピーに失敗しました。");
     }
 }
-let toastTimer = 0;
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    if (toastTimer) {
-        clearTimeout(toastTimer);
+    if (!toast || typeof toast.show !== "function") {
+        return;
     }
-    toastTimer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1600);
+    toast.show(message, 1600);
 }
 window["toggleMenu"] = function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/midi-to-musicxml/ts/main.ts
+++ b/docs/music/src/midi-to-musicxml/ts/main.ts
@@ -43,7 +43,9 @@ let lastXmlText = "";
 restoreSettings();
 
 fileInput.addEventListener("change", onFileChange);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+  fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -1222,13 +1224,21 @@ function resetOutput() {
 }
 
 function setError(message) {
-  errorText.textContent = message;
-  errorText.classList.remove("md-hidden");
+  if (errorText && typeof errorText.show === "function") {
+    errorText.show(message);
+  } else if (errorText) {
+    errorText.textContent = message;
+    errorText.classList.remove("md-hidden");
+  }
 }
 
 function clearError() {
-  errorText.textContent = "";
-  errorText.classList.add("md-hidden");
+  if (errorText && typeof errorText.clear === "function") {
+    errorText.clear();
+  } else if (errorText) {
+    errorText.textContent = "";
+    errorText.classList.add("md-hidden");
+  }
 }
 
 function clearWarning() {
@@ -1321,18 +1331,11 @@ async function copyMusicXml() {
   }
 }
 
-let toastTimer = 0;
 function showToast(message) {
-  toast.textContent = message;
-  toast.classList.remove("md-hidden");
-  toast.classList.add("md-visible");
-  if (toastTimer) {
-    clearTimeout(toastTimer);
+  if (!toast || typeof toast.show !== "function") {
+    return;
   }
-  toastTimer = setTimeout(() => {
-    toast.classList.remove("md-visible");
-    toast.classList.add("md-hidden");
-  }, 1600);
+  toast.show(message, 1600);
 }
 
 window["toggleMenu"] = function toggleMenu() {

--- a/docs/music/src/musicxml-to-abc/js/main.js
+++ b/docs/music/src/musicxml-to-abc/js/main.js
@@ -48,7 +48,9 @@ downloadBtn.addEventListener("click", downloadAbc);
 playSineBtn.addEventListener("click", playSine);
 copyBtn.addEventListener("click", copyAbc);
 fileInput.addEventListener("change", loadXmlFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -632,26 +634,32 @@ function playSine() {
     });
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/musicxml-to-abc/ts/main.ts
+++ b/docs/music/src/musicxml-to-abc/ts/main.ts
@@ -52,7 +52,9 @@ const xmlInput = document.getElementById("xmlInput");
     playSineBtn.addEventListener("click", playSine);
     copyBtn.addEventListener("click", copyAbc);
     fileInput.addEventListener("change", loadXmlFile);
-    fileSelectBtn.addEventListener("click", () => fileInput.click());
+    if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+      fileSelectBtn.addEventListener("click", () => fileInput.click());
+    }
     inputModeSourceRadio.addEventListener("change", applyInputMode);
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
@@ -720,13 +722,21 @@ const xmlInput = document.getElementById("xmlInput");
     }
 
     function setError(message) {
-      errorText.textContent = message;
-      errorText.classList.remove("md-hidden");
+      if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+      } else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+      }
     }
 
     function clearError() {
-      errorText.textContent = "";
-      errorText.classList.add("md-hidden");
+      if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+      } else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+      }
     }
 
     function clearWarning() {
@@ -735,14 +745,10 @@ const xmlInput = document.getElementById("xmlInput");
     }
 
     function showToast(message) {
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 1400);
+      if (!toast || typeof toast.show !== "function") {
+        return;
+      }
+      toast.show(message, 1400);
     }
 
     function toggleMenu() {

--- a/docs/music/src/musicxml-to-midi/js/main.js
+++ b/docs/music/src/musicxml-to-midi/js/main.js
@@ -38,7 +38,9 @@ downloadBtn.addEventListener("click", downloadMidi);
 playBtn.addEventListener("click", playMidi);
 stopBtn.addEventListener("click", stopMidi);
 fileInput.addEventListener("change", loadXmlFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 defaultTitleInput.addEventListener("change", persistSettings);
@@ -671,26 +673,32 @@ function stopMidi(showMessage = true) {
     }
 }
 function setError(message) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function clearWarning() {
     warningText.textContent = "";
     warningText.classList.add("md-hidden");
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/musicxml-to-midi/ts/main.ts
+++ b/docs/music/src/musicxml-to-midi/ts/main.ts
@@ -42,7 +42,9 @@ const xmlInput = document.getElementById("xmlInput");
     playBtn.addEventListener("click", playMidi);
     stopBtn.addEventListener("click", stopMidi);
     fileInput.addEventListener("change", loadXmlFile);
-    fileSelectBtn.addEventListener("click", () => fileInput.click());
+    if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+      fileSelectBtn.addEventListener("click", () => fileInput.click());
+    }
     inputModeSourceRadio.addEventListener("change", applyInputMode);
     inputModeFileRadio.addEventListener("change", applyInputMode);
     defaultTitleInput.addEventListener("change", persistSettings);
@@ -757,13 +759,21 @@ const xmlInput = document.getElementById("xmlInput");
     }
 
     function setError(message) {
-      errorText.textContent = message;
-      errorText.classList.remove("md-hidden");
+      if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+      } else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+      }
     }
 
     function clearError() {
-      errorText.textContent = "";
-      errorText.classList.add("md-hidden");
+      if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+      } else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+      }
     }
 
     function clearWarning() {
@@ -772,14 +782,10 @@ const xmlInput = document.getElementById("xmlInput");
     }
 
     function showToast(message) {
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 1400);
+      if (!toast || typeof toast.show !== "function") {
+        return;
+      }
+      toast.show(message, 1400);
     }
 
     function toggleMenu() {

--- a/docs/music/src/musicxml-to-svg/css/app.css
+++ b/docs/music/src/musicxml-to-svg/css/app.css
@@ -189,6 +189,7 @@
       background: #fff;
       overflow: auto;
       min-height: 9rem;
+      max-height: min(70vh, 42rem);
     }
 
     .md-preview-stage svg {

--- a/docs/music/src/musicxml-to-svg/js/main.js
+++ b/docs/music/src/musicxml-to-svg/js/main.js
@@ -60,7 +60,9 @@ prevPageBtn.addEventListener("click", showPreviousPage);
 nextPageBtn.addEventListener("click", showNextPage);
 copySvgBtn.addEventListener("click", copySvg);
 fileInput.addEventListener("change", loadMusicXMLFile);
-fileSelectBtn.addEventListener("click", () => fileInput.click());
+if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+    fileSelectBtn.addEventListener("click", () => fileInput.click());
+}
 inputModeSourceRadio.addEventListener("change", applyInputMode);
 inputModeFileRadio.addEventListener("change", applyInputMode);
 document.addEventListener("click", handleDocumentClick);
@@ -379,25 +381,31 @@ function copySvg() {
     });
 }
 function setError(message, lineNumber) {
-    errorText.textContent = message;
-    errorText.classList.remove("md-hidden");
+    if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+    }
+    else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+    }
     if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusXmlLine(lineNumber);
     }
 }
 function clearError() {
-    errorText.textContent = "";
-    errorText.classList.add("md-hidden");
+    if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+    }
+    else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+    }
 }
 function showToast(message) {
-    toast.textContent = message;
-    toast.classList.remove("md-hidden");
-    toast.classList.add("md-visible");
-    clearTimeout(showToast.timer);
-    showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-    }, 1400);
+    if (!toast || typeof toast.show !== "function") {
+        return;
+    }
+    toast.show(message, 1400);
 }
 function toggleMenu() {
     menuPanel.classList.toggle("md-hidden");

--- a/docs/music/src/musicxml-to-svg/ts/main.ts
+++ b/docs/music/src/musicxml-to-svg/ts/main.ts
@@ -64,7 +64,9 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     nextPageBtn.addEventListener("click", showNextPage);
     copySvgBtn.addEventListener("click", copySvg);
     fileInput.addEventListener("change", loadMusicXMLFile);
-    fileSelectBtn.addEventListener("click", () => fileInput.click());
+    if (!(fileSelectBtn && fileSelectBtn.closest("lht-file-select"))) {
+      fileSelectBtn.addEventListener("click", () => fileInput.click());
+    }
     inputModeSourceRadio.addEventListener("change", applyInputMode);
     inputModeFileRadio.addEventListener("change", applyInputMode);
     document.addEventListener("click", handleDocumentClick);
@@ -413,27 +415,31 @@ const musicxmlInput = document.getElementById("musicxmlInput");
     }
 
     function setError(message, lineNumber) {
-      errorText.textContent = message;
-      errorText.classList.remove("md-hidden");
+      if (errorText && typeof errorText.show === "function") {
+        errorText.show(message);
+      } else if (errorText) {
+        errorText.textContent = message;
+        errorText.classList.remove("md-hidden");
+      }
       if (Number.isInteger(lineNumber) && lineNumber > 0) {
         focusXmlLine(lineNumber);
       }
     }
 
     function clearError() {
-      errorText.textContent = "";
-      errorText.classList.add("md-hidden");
+      if (errorText && typeof errorText.clear === "function") {
+        errorText.clear();
+      } else if (errorText) {
+        errorText.textContent = "";
+        errorText.classList.add("md-hidden");
+      }
     }
 
     function showToast(message) {
-      toast.textContent = message;
-      toast.classList.remove("md-hidden");
-      toast.classList.add("md-visible");
-      clearTimeout(showToast.timer);
-      showToast.timer = setTimeout(() => {
-        toast.classList.remove("md-visible");
-        toast.classList.add("md-hidden");
-      }, 1400);
+      if (!toast || typeof toast.show !== "function") {
+        return;
+      }
+      toast.show(message, 1400);
     }
 
     function toggleMenu() {

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -26,7 +26,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -267,6 +267,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1992,7 +2164,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2301,6 +2473,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2720,6 +3318,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -556,7 +556,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -797,6 +797,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2001,7 +2173,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2310,6 +2482,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2729,6 +3327,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -636,7 +636,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -877,6 +877,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2041,7 +2213,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2350,6 +2522,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2769,6 +3367,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1110,7 +1110,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1351,6 +1351,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2895,7 +3067,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -3204,6 +3376,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -3623,6 +4221,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -998,7 +998,7 @@ limitations under the License.
   <style>
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -1239,6 +1239,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -2067,7 +2239,7 @@ lht-index-card-link {
   <script>
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -2376,6 +2548,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -2795,6 +3393,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -2,7 +2,7 @@
 
 `lht-cmn` は `local-html-tools` 全体で共有する UI コンポーネント基盤です。
 
-- Version: `v20260222`
+- Version: `v20260306`
 - License: Apache License 2.0 (`lht-cmn/LICENSE`)
 - Copyright: Toshiki Iga
 
@@ -64,6 +64,11 @@
 | `lht-page-menu` | 右上メニュー（トップへ戻る等）を共通化できる | 内部でメニューボタン + パネル + リンクを生成。外側クリックで自動クローズ |
 | `lht-index-card-link` | `docs/index` のカードリンクを統一フォーマットで記述できる | 内部でカードDOM（`a` + タイトル + 説明 + 矢印/バッジ）を生成し、`variant`/`target`/外部リンク判定を吸収 |
 | `lht-file-select` | ファイル選択UI（Filledボタン + ファイル名表示）を共通化できる | 内部で hidden `input[type=file]` とトリガUIを生成。`md-filled-button` が使える環境ではそれを利用し、未定義時はフォールバックボタンで動作維持 |
+| `lht-loading-overlay` | 処理中オーバーレイ（スピナー + メッセージ）を共通化できる | `active` で表示制御し、`aria-live`/`aria-hidden` を同期。必要に応じて `aria-busy` 更新と操作無効化も連動 |
+| `lht-toast` | 一時通知トースト（コピー完了など）を共通化できる | `active` と `show()/hide()` で表示制御し、`role="status"` / `aria-live="polite"` を標準化。`window.showToast` が未定義なら自動補完 |
+| `lht-error-alert` | エラー表示（`role="alert"`）を共通化できる | `active` と `show()/hide()` で表示制御し、`aria-live="assertive"` と表示/非表示同期を標準化（`clear()` は補助） |
+| `lht-input-mode-toggle` | 入力モード切替（file/source ラジオ）を共通化できる | 既定ID（`inputModeFile`/`inputModeSource`）を維持しつつ、`source/file` ブロックの `md-hidden` 切替を自動化できる |
+| `lht-preview-output` | プレビュー表示 + コピー導線を共通化できる | `preview` 枠とコピーボタンを1タグで提供し、`copy-target-id` 指定で既存出力要素からのコピーにも対応 |
 
 ## 利用方法
 
@@ -85,6 +90,13 @@ HTML から次を読み込みます。
   - 入力系は `lht-text-field-help` / `lht-select-help` / `lht-switch-help` 側に `label` と `help-text` を集約する
   - 必須指定は可能な限りコンポーネント側（`required`）へ寄せる
 - 例外にする場合は、対象画面側に理由を残す（表示密度・既存互換・重複説明の回避など）
+
+### コンポーネント設計規約（表示制御とAPI）
+
+- 表示/非表示を持つ `lht-*` は、表示状態の正本属性を `active` とする
+- 表示制御メソッドは `show()` / `hide()` を標準とする
+- `clear()` は「内容を消して非表示にする」用途でのみ任意追加する（`show/hide` の代替にはしない）
+- `active` の更新時は `aria-hidden` を同期する
 
 ## ドロップダウン置換手順（`lht-select-help`）
 
@@ -175,6 +187,61 @@ HTML から次を読み込みます。
 
 - 用途: ファイル選択UI（ボタン + hidden file input + ファイル名表示）
 - 主な属性: `input-id`, `button-id`, `file-name-id`, `accept`, `button-label`, `placeholder`, `file-label`, `multiple`, `disabled`, `show-file-name`
+
+### `lht-loading-overlay`
+
+- 用途: ファイル読み込みなどの非同期処理中オーバーレイ（indeterminate loading）
+- 主な属性: `active`, `text`, `busy-target-id`, `disable-target-ids`
+- 補助メソッド: `setActive(boolean)`, `isActive()`, `waitForNextPaint()`
+- ARIAルール:
+  - 常時 `role="status"` と `aria-live="polite"` を持つ
+  - `active` に応じて `aria-hidden` を `false/true` へ同期する
+  - `busy-target-id` 指定時は対象へ `aria-busy` を `true/false` で同期する
+- 推奨フロー:
+  1. `overlay.setActive(true)` で開始
+  2. `await overlay.waitForNextPaint()` で先に描画を確定
+  3. 重い処理を実行
+  4. `finally` で `overlay.setActive(false)` を必ず実行
+
+### `lht-toast`
+
+- 用途: コピー完了などの短時間通知（toast/snackbar）
+- 主な属性: `active`, `text`, `duration-ms`
+- 補助メソッド: `show(message?, durationMs?)`, `hide()`
+- ARIAルール:
+  - 常時 `role="status"` と `aria-live="polite"` を持つ
+  - 常時 `aria-atomic="true"` を持つ
+- 運用メモ:
+  - ページ側に `<lht-toast id="toast"></lht-toast>` を1つ配置して使う
+  - 既存コードが `window.showToast(...)` を呼ぶ場合、未定義時は `lht-toast` 側が自動補完する
+
+### `lht-error-alert`
+
+- 用途: 画面内エラー表示の共通化（`errorText` パターンの置換）
+- 主な属性: `text`, `active`
+- 補助メソッド: `show(message?)`, `hide()`, `clear()`, `isVisible()`
+- ARIAルール:
+  - 常時 `role="alert"` と `aria-live="assertive"` を持つ
+  - 常時 `aria-atomic="true"` を持つ
+  - 表示状態に応じて `aria-hidden` を同期する
+
+### `lht-input-mode-toggle`
+
+- 用途: `file/source` 入力切替ラジオUIの共通化（music系の重複置換）
+- 主な属性: `name`, `group-label`, `file-id`, `source-id`, `file-label`, `source-label`, `default-mode`, `source-target-id`, `file-target-id`, `on-change`, `disabled`
+- 補助メソッド: `getMode()`, `setMode(mode)`, `applyModeUi()`
+- 互換メモ:
+  - 既定の `file-id` / `source-id` は `inputModeFile` / `inputModeSource`
+  - 既存JSが `document.getElementById("inputModeFile")` 等を参照していても置換しやすい
+
+### `lht-preview-output`
+
+- 用途: プレビュー表示とコピー導線の共通化（`preview + copyBtn` パターンの置換）
+- 主な属性: `preview-id`, `copy-button-id`, `copy-target-id`, `placeholder`, `copy-label`, `copy-aria-label`, `preview-tag`, `no-copy`
+- 補助メソッド: `getText()`, `setText(text)`, `copy(targetId?)`, `clear()`
+- 運用メモ:
+  - 既定の `preview-id` / `copy-button-id` は `previewText` / `copyBtn`
+  - `copy-target-id` を指定すると、プレビュー枠とは別要素のテキストをコピーできる
 
 ## Appendix
 

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -1,6 +1,6 @@
 /*
  * lht-cmn components.css
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -241,6 +241,178 @@ lht-file-select .lht-file-select__file-name {
   font-size: 0.85rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   word-break: break-all;
+}
+
+lht-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(17, 13, 27, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+lht-loading-overlay[active] {
+  display: flex;
+}
+
+lht-loading-overlay[aria-hidden="true"] {
+  pointer-events: none;
+}
+
+lht-loading-overlay .lht-loading-overlay__dialog {
+  min-width: 13rem;
+  border-radius: 16px;
+  border: 1px solid #ded4ef;
+  background: #ffffff;
+  box-shadow: 0 18px 36px rgba(24, 18, 36, 0.24);
+  padding: 1rem 1.2rem;
+  display: grid;
+  justify-items: center;
+  gap: 0.65rem;
+}
+
+lht-loading-overlay .lht-loading-overlay__spinner {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  border: 3px solid #d8caee;
+  border-top-color: var(--md-sys-color-primary, #6200ee);
+  animation: lht-loading-spin 0.95s linear infinite;
+}
+
+lht-loading-overlay .lht-loading-overlay__text {
+  margin: 0;
+  color: #383247;
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+lht-toast {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px) + 0.5rem);
+  transform: translate(-50%, 18px);
+  z-index: 340;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+lht-toast[active] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+lht-toast .lht-toast__body {
+  min-width: 8.5rem;
+  max-width: min(30rem, calc(100vw - 2rem));
+  border-radius: 12px;
+  padding: 0.62rem 0.9rem;
+  background: rgba(43, 34, 63, 0.94);
+  color: #ffffff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 10px 24px rgba(18, 14, 28, 0.35);
+}
+
+lht-error-alert {
+  display: none;
+  margin: 0;
+}
+
+lht-error-alert[active] {
+  display: block;
+}
+
+lht-error-alert .lht-error-alert__body {
+  margin: 0;
+  border-radius: 12px;
+  border: 1px solid #f3c7c9;
+  background: #fff3f3;
+  color: #9a1a1f;
+  padding: 0.58rem 0.72rem;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+lht-input-mode-toggle {
+  display: block;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__group {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.36rem;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  font-size: 0.92rem;
+}
+
+lht-input-mode-toggle .lht-input-mode-toggle__option input[type="radio"] {
+  inline-size: 1rem;
+  block-size: 1rem;
+  margin: 0;
+  accent-color: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-preview-output {
+  display: block;
+}
+
+lht-preview-output .lht-preview-output__root {
+  position: relative;
+}
+
+lht-preview-output .lht-preview-output__preview {
+  margin: 0;
+  min-height: 6.4rem;
+  border-radius: 12px;
+  border: 1px solid #d4cede;
+  background: #f8f6fb;
+  color: #231f2b;
+  padding: 0.78rem 0.84rem;
+  line-height: 1.45;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+lht-preview-output .lht-preview-output__copy-button {
+  position: absolute;
+  top: 0.48rem;
+  right: 0.48rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+lht-preview-output .lht-preview-output__copy-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@keyframes lht-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 md-outlined-text-field.md-outlined-field {

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -1,6 +1,6 @@
 /*
  * lht-cmn components.js
- * Version: v20260222
+ * Version: v20260306
  * Copyright 2026 Toshiki Iga
  * Licensed under the Apache License, Version 2.0
  */
@@ -309,6 +309,432 @@ class LhtSelectHelp extends HTMLElement {
     if (this._optionsObserver) {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
+    }
+  }
+}
+
+class LhtLoadingOverlay extends HTMLElement {
+  static get observedAttributes() {
+    return ["active", "text"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+
+    const text = (this.getAttribute("text") || "Loading...").trim();
+
+    this.textContent = "";
+
+    const dialog = document.createElement("div");
+    dialog.className = "lht-loading-overlay__dialog";
+
+    const spinner = document.createElement("div");
+    spinner.className = "lht-loading-overlay__spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    const message = document.createElement("p");
+    message.className = "lht-loading-overlay__text";
+    message.textContent = text;
+
+    dialog.appendChild(spinner);
+    dialog.appendChild(message);
+    this.appendChild(dialog);
+
+    this._messageNode = message;
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text" && this._messageNode) {
+      const text = (newValue || "Loading...").trim();
+      this._messageNode.textContent = text || "Loading...";
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isActive() {
+    return this.hasAttribute("active");
+  }
+
+  setActive(inProgress) {
+    const next = !!inProgress;
+    this.toggleAttribute("active", next);
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+
+    const busyTargetId = (this.getAttribute("busy-target-id") || "").trim();
+    if (busyTargetId) {
+      const target = document.getElementById(busyTargetId);
+      if (target) target.setAttribute("aria-busy", next ? "true" : "false");
+    }
+
+    const disableTargetIds = (this.getAttribute("disable-target-ids") || "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    for (const id of disableTargetIds) {
+      const element = document.getElementById(id);
+      if (!element || !("disabled" in element)) continue;
+      element.disabled = next;
+    }
+  }
+
+  waitForNextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+}
+
+class LhtToast extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "完了").trim();
+    const text = initialText || "完了";
+
+    this.textContent = "";
+
+    const body = document.createElement("div");
+    body.className = "lht-toast__body";
+    body.textContent = text;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+
+    if (typeof window.showToast !== "function") {
+      window.showToast = (message, durationMs) => {
+        this.show(message, durationMs);
+      };
+    }
+  }
+
+  disconnectedCallback() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      if (!this._body) return;
+      const text = (newValue || "").trim();
+      if (text) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  show(message, durationMs) {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+
+    const defaultDurationMs = Number(this.getAttribute("duration-ms"));
+    const fallbackDuration = Number.isFinite(defaultDurationMs) && defaultDurationMs > 0 ? defaultDurationMs : 1600;
+    const nextDuration = Number(durationMs);
+    const hideAfterMs = Number.isFinite(nextDuration) && nextDuration > 0 ? nextDuration : fallbackDuration;
+
+    const text = (message || this.getAttribute("text") || this._body?.textContent || "完了").trim();
+    if (this._body) this._body.textContent = text || "完了";
+
+    this.setActive(true);
+
+    this._hideTimer = setTimeout(() => {
+      this.hide();
+    }, hideAfterMs);
+  }
+
+  hide() {
+    if (this._hideTimer) {
+      clearTimeout(this._hideTimer);
+      this._hideTimer = null;
+    }
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtErrorAlert extends HTMLElement {
+  static get observedAttributes() {
+    return ["text", "active"];
+  }
+
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    this.setAttribute("role", "alert");
+    this.setAttribute("aria-live", "assertive");
+    this.setAttribute("aria-atomic", "true");
+
+    const initialText = (this.getAttribute("text") || this.textContent || "").trim();
+
+    this.textContent = "";
+
+    const body = document.createElement("p");
+    body.className = "lht-error-alert__body";
+    body.textContent = initialText;
+    this.appendChild(body);
+    this._body = body;
+
+    this.setActive(this.hasAttribute("active"));
+  }
+
+  attributeChangedCallback(name, _oldValue, newValue) {
+    if (name === "text") {
+      const text = (newValue || "").trim();
+      if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "active") {
+      this.setActive(newValue !== null);
+    }
+  }
+
+  isVisible() {
+    return this.getAttribute("data-visible") === "true";
+  }
+
+  show(message) {
+    const text = (message || this.getAttribute("text") || "").trim();
+    if (this._body) this._body.textContent = text;
+    this.setActive(text.length > 0);
+  }
+
+  clear() {
+    if (this._body) this._body.textContent = "";
+    this.hide();
+  }
+
+  hide() {
+    this.setActive(false);
+  }
+
+  setActive(active) {
+    const next = !!active;
+    this.toggleAttribute("active", next);
+    this.setAttribute("data-visible", next ? "true" : "false");
+    this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+}
+
+class LhtInputModeToggle extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const groupLabel = (this.getAttribute("group-label") || "入力方式").trim();
+    const groupName = (this.getAttribute("name") || "inputMode").trim();
+    const fileId = (this.getAttribute("file-id") || "inputModeFile").trim();
+    const sourceId = (this.getAttribute("source-id") || "inputModeSource").trim();
+    const fileLabel = (this.getAttribute("file-label") || "ファイル読込").trim();
+    const sourceLabel = (this.getAttribute("source-label") || "ソースコード入力").trim();
+    const defaultMode = (this.getAttribute("default-mode") || "file").trim().toLowerCase();
+    const disabled = this.hasAttribute("disabled");
+
+    this.textContent = "";
+    this.classList.add("lht-input-mode-toggle");
+
+    const group = document.createElement("div");
+    group.className = "lht-input-mode-toggle__group";
+    group.setAttribute("role", "radiogroup");
+    group.setAttribute("aria-label", groupLabel);
+
+    const fileOption = this.createOption({
+      id: fileId,
+      name: groupName,
+      label: fileLabel,
+      value: "file",
+      checked: defaultMode !== "source",
+      disabled
+    });
+
+    const sourceOption = this.createOption({
+      id: sourceId,
+      name: groupName,
+      label: sourceLabel,
+      value: "source",
+      checked: defaultMode === "source",
+      disabled
+    });
+
+    group.appendChild(fileOption.label);
+    group.appendChild(sourceOption.label);
+    this.appendChild(group);
+
+    this._fileRadio = fileOption.input;
+    this._sourceRadio = sourceOption.input;
+
+    const onChange = () => this.applyModeUi();
+    this._fileRadio.addEventListener("change", onChange);
+    this._sourceRadio.addEventListener("change", onChange);
+
+    this.applyModeUi();
+  }
+
+  createOption({ id, name, label, value, checked, disabled }) {
+    const optionLabel = document.createElement("label");
+    optionLabel.className = "lht-input-mode-toggle__option";
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = "radio";
+    input.name = name;
+    input.value = value;
+    input.checked = !!checked;
+    input.disabled = !!disabled;
+
+    const text = document.createElement("span");
+    text.textContent = label;
+
+    optionLabel.appendChild(input);
+    optionLabel.appendChild(text);
+    return { label: optionLabel, input };
+  }
+
+  getMode() {
+    return this._sourceRadio?.checked ? "source" : "file";
+  }
+
+  setMode(mode) {
+    const normalized = (mode || "").trim().toLowerCase();
+    const sourceMode = normalized === "source";
+    if (this._sourceRadio) this._sourceRadio.checked = sourceMode;
+    if (this._fileRadio) this._fileRadio.checked = !sourceMode;
+    this.applyModeUi();
+  }
+
+  applyModeUi() {
+    const sourceMode = this.getMode() === "source";
+    const sourceTargetId = (this.getAttribute("source-target-id") || "").trim();
+    const fileTargetId = (this.getAttribute("file-target-id") || "").trim();
+
+    if (sourceTargetId) {
+      const sourceTarget = document.getElementById(sourceTargetId);
+      if (sourceTarget) sourceTarget.classList.toggle("md-hidden", !sourceMode);
+    }
+    if (fileTargetId) {
+      const fileTarget = document.getElementById(fileTargetId);
+      if (fileTarget) fileTarget.classList.toggle("md-hidden", sourceMode);
+    }
+
+    const onChangeFnName = (this.getAttribute("on-change") || "").trim();
+    if (onChangeFnName) {
+      const fn = window[onChangeFnName];
+      if (typeof fn === "function") fn(this.getMode());
+    }
+
+    this.dispatchEvent(new CustomEvent("input-mode-change", {
+      detail: { mode: this.getMode() },
+      bubbles: true
+    }));
+  }
+}
+
+class LhtPreviewOutput extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === "true") return;
+    this.dataset.initialized = "true";
+
+    const previewId = (this.getAttribute("preview-id") || "previewText").trim();
+    const copyButtonId = (this.getAttribute("copy-button-id") || "copyBtn").trim();
+    const copyTargetId = (this.getAttribute("copy-target-id") || previewId).trim();
+    const placeholder = this.getAttribute("placeholder") || "未変換";
+    const copyLabel = (this.getAttribute("copy-label") || "コピー").trim();
+    const copyAriaLabel = (this.getAttribute("copy-aria-label") || `${copyLabel}をコピー`).trim();
+    const previewTag = (this.getAttribute("preview-tag") || "div").trim().toLowerCase();
+    const showCopyButton = !this.hasAttribute("no-copy");
+
+    this.textContent = "";
+    this.classList.add("lht-preview-output");
+
+    const root = document.createElement("div");
+    root.className = "lht-preview-output__root";
+
+    const preview = document.createElement(previewTag === "pre" ? "pre" : "div");
+    preview.id = previewId;
+    preview.className = "lht-preview-output__preview";
+    preview.textContent = placeholder;
+    root.appendChild(preview);
+    this._previewNode = preview;
+
+    if (showCopyButton) {
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.id = copyButtonId;
+      copyButton.className = "lht-preview-output__copy-button";
+      copyButton.setAttribute("aria-label", copyAriaLabel);
+      copyButton.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="lht-preview-output__copy-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"></rect><rect x="4" y="4" width="11" height="11" rx="2"></rect></svg>';
+      copyButton.addEventListener("click", () => this.copy(copyTargetId));
+      root.appendChild(copyButton);
+      this._copyButton = copyButton;
+    }
+
+    this.appendChild(root);
+  }
+
+  getText() {
+    return (this._previewNode?.textContent || "").trim();
+  }
+
+  setText(text) {
+    if (!this._previewNode) return;
+    this._previewNode.textContent = text == null ? "" : String(text);
+  }
+
+  clear() {
+    if (!this._previewNode) return;
+    const placeholder = this.getAttribute("placeholder") || "";
+    this._previewNode.textContent = placeholder;
+  }
+
+  async copy(targetId) {
+    const target = document.getElementById(targetId);
+    const text = (target?.textContent || "").trim();
+    if (!text) return;
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const temp = document.createElement("textarea");
+        temp.value = text;
+        document.body.appendChild(temp);
+        temp.select();
+        document.execCommand("copy");
+        document.body.removeChild(temp);
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+    } catch (_) {
+      // コピー不可環境では失敗を握りつぶす
     }
   }
 }
@@ -728,6 +1154,21 @@ if (!customElements.get("lht-select-help")) {
 }
 if (!customElements.get("lht-file-select")) {
   customElements.define("lht-file-select", LhtFileSelect);
+}
+if (!customElements.get("lht-loading-overlay")) {
+  customElements.define("lht-loading-overlay", LhtLoadingOverlay);
+}
+if (!customElements.get("lht-toast")) {
+  customElements.define("lht-toast", LhtToast);
+}
+if (!customElements.get("lht-error-alert")) {
+  customElements.define("lht-error-alert", LhtErrorAlert);
+}
+if (!customElements.get("lht-input-mode-toggle")) {
+  customElements.define("lht-input-mode-toggle", LhtInputModeToggle);
+}
+if (!customElements.get("lht-preview-output")) {
+  customElements.define("lht-preview-output", LhtPreviewOutput);
 }
 if (!customElements.get("lht-switch-help")) {
   customElements.define("lht-switch-help", LhtSwitchHelp);

--- a/scripts/build-music.mjs
+++ b/scripts/build-music.mjs
@@ -29,8 +29,12 @@ const TARGETS = [
     id: "midi-to-musicxml",
     srcHtml: "docs/music/midi-to-musicxml-src.html",
     outHtml: "docs/music/midi-to-musicxml.html",
-    cssOrder: ["src/midi-to-musicxml/css/app.css"],
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/midi-to-musicxml/css/app.css"
+    ],
     jsOrder: [
+      "../../lht-cmn/js/components.js",
       "src/common/js/musicxml-writer-common.js",
       "src/midi-to-musicxml/js/main.js"
     ],
@@ -43,8 +47,12 @@ const TARGETS = [
     id: "musicxml-to-abc",
     srcHtml: "docs/music/musicxml-to-abc-src.html",
     outHtml: "docs/music/musicxml-to-abc.html",
-    cssOrder: ["src/musicxml-to-abc/css/app.css"],
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/musicxml-to-abc/css/app.css"
+    ],
     jsOrder: [
+      "../../lht-cmn/js/components.js",
       "src/common/js/musicxml-common.js",
       "src/common/js/musicxml-synth-schedule-common.js",
       "src/common/js/music-synth-common.js",
@@ -63,8 +71,12 @@ const TARGETS = [
     id: "abc-to-musicxml",
     srcHtml: "docs/music/abc-to-musicxml-src.html",
     outHtml: "docs/music/abc-to-musicxml.html",
-    cssOrder: ["src/abc-to-musicxml/css/app.css"],
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/abc-to-musicxml/css/app.css"
+    ],
     jsOrder: [
+      "../../lht-cmn/js/components.js",
       "src/common/js/abc-common.js",
       "src/common/js/musicxml-common.js",
       "src/common/js/musicxml-synth-schedule-common.js",
@@ -87,8 +99,12 @@ const TARGETS = [
     id: "musicxml-to-svg",
     srcHtml: "docs/music/musicxml-to-svg-src.html",
     outHtml: "docs/music/musicxml-to-svg.html",
-    cssOrder: ["src/musicxml-to-svg/css/app.css"],
+    cssOrder: [
+      "../../lht-cmn/css/components.css",
+      "src/musicxml-to-svg/css/app.css"
+    ],
     jsOrder: [
+      "../../lht-cmn/js/components.js",
       "src/musicxml-to-svg/js/verovio.js",
       "src/musicxml-to-svg/js/jszip.js",
       "src/common/js/musicxml-common.js",


### PR DESCRIPTION
…ルール統一

## 概要

`lht-cmn` に UI 共通コンポーネントを追加・拡張し、`music` / `git` 系画面へ適用しました。 あわせて、表示制御属性・API命名のルールを README に明文化し、関連画面を再ビルドしています。

## 変更内容

### 1. `lht-cmn` の機能追加・更新

- `lht-cmn/js/components.js` を `v20260306` に更新
- 追加/拡張コンポーネント:
  - `lht-loading-overlay`
  - `lht-toast`
  - `lht-error-alert`
  - `lht-input-mode-toggle`
  - `lht-preview-output`
- `lht-cmn/css/components.css` に上記コンポーネントの標準スタイルを追加

### 2. ルール整備（README）

- 表示制御属性を `active` に統一する方針を追記
- API命名規約を追記
  - 表示制御: `show/hide`
  - 内容消去系: `show/clear`（補助用途）

### 3. `music` / `git` への適用

- `music` 各ツールに `lht-cmn` 読み込みと新コンポーネント適用を反映
- `git` 各ツールの toast を `lht-toast` ベースへ統一
- `showToast` の旧実装（`md-visible/md-hidden` 直接操作）を削減/整理
- `git-pseudo-squash` の toast レイアウト競合（横余白拡大）を修正
- `lht-file-select` 導入時のファイル選択ダイアログ二重オープン対策を反映

### 4. ビルド構成更新

- `scripts/build-music.mjs` で `lht-cmn` の CSS/JS を対象に含めるよう更新
- 生成HTML（`docs/*`）を再ビルドして反映
- `docs/index.html` の更新日もビルド結果に合わせて更新

### 5. TODO更新

- `toast` だけでなく、他コンポーネント/ルールの横展開方針を追記
- 運用スタイル（新規必須、既存は触るタイミングで順次置換）を明記

## 影響範囲

- `lht-cmn` 共通基盤
- `docs/music/*`（src + 生成HTML）
- `docs/git/*`（src + 生成HTML）
- 各カテゴリの生成HTML（共通基盤更新に伴う再生成差分）

## 確認

- `npm run build:music`
- `npm run build:git`
- `npm run build:docs`

## 補足

このPRは共通基盤更新に伴い、生成HTMLの差分量が大きくなっています（ビルド成果物の更新を含む）。