### PR TITLE
lht-cmn を self-contained 化し、主要画面の raw md-* 依存を lht-* へ置換

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@
 - [lht-cmn] `lht-error-alert` を追加し、`errorText` の表示/非表示と `role="alert"` 運用を共通化する
 - [lht-cmn] `lht-input-mode-toggle`（file/source 切替）を追加し、music系で反復しているラジオUIを共通化する
 - [lht-cmn] `lht-preview-output`（プレビュー + コピー導線）を追加し、`previewText` 周辺の反復UIを共通化する
+- [優先度高][lht-cmn] `lht-*` 全体を棚卸しし、各コンポーネントを「内部保証」または「フォールバック保証」のどちらかへ統一する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み
   - 未実装: 生成したMIDI実データ（SMF）のその場再生（MIDIパーサ/プレイヤー経由）
@@ -78,7 +79,20 @@
 - [対応] `lht-cmn/css/components.css` に横スクロール抑止の共通ルールを追加（`.md-page { overflow-x: clip; }`）
 - [対応] `lht-help-tooltip` の表示制御と幅制限を `lht` 側へ共通化（非表示時 `display:none`、表示時のみ表示、モバイルで右寄せ + `calc(100vw - 2rem)` 制限）
 - [反映] Music 以外の各アプリを再ビルドし、共通ルールを生成HTMLへ反映（`git/grep/password/diagram/ffmpeg/life/link/text/img/docs-index`）
-- [注意] `npm run build:all` は既存の Music 側 TypeScript エラー（`src/common/ts/musicxml-writer-common.ts`）で停止するため、Music 系への同反映は別途対応が必要
+- [対応] `lht-select-help` で declarative-options 判定を script 消費前に確定し、不要な再 hydration を防止
+- [対応] `lht-switch-help` を self-contained 化し、`md-switch` 未読込時 fallback を正式サポート
+- [対応] `lht-help-tooltip` を self-contained 化し、`md-icon-button` 未読込時 fallback と `placement="auto|left|right|top|bottom"` を追加
+- [対応] pre-upgrade content flash を防ぐ初期化ガードを `lht-cmn/css/components.css` に追加し、`data-initialized="true"` 契約を明文化
+- [対応] `lht-file-select` に `lht-file-select:before-open` / `lht-file-select:change` と `auto-open="false"` を追加し、event ownership を明文化
+- [対応] `lht-select-help` に `setOptions([...])` / `getValue()` / `setValue()` を追加し、selected-value retention を定義
+- [対応] `lht-cmn/README.md` に integration contract / fallback parity 表 / `lht-select-help` lifecycle を追加
+- [反映] `npm run build:all` が最後まで通る状態を確認
+- [対応] `lht-error-alert` に `variant="error|warning|info"` を追加し、variant ごとに `role` / `aria-live` を整理
+- [対応] `lht-cmn/components.test.js` に Material 読込あり / なし の両モード回帰テストを追加
+- [対応] `lht-text-field-help` を self-contained 化し、`md-outlined-text-field` 未読込時 fallback を追加
+- [対応] `lht-command-block` を self-contained 化し、`md-icon-button` 未読込時 fallback を追加
+- [対応] `docs/git/git-branch-diff-src.html` と `docs/git/git-pseudo-squash-src.html` に残っていた raw `md-*` field/switch/select を `lht-*` へ置換
+- [対応] `docs/grep/find-gen-src.html` に残っていた raw `md-outlined-select` を `lht-select-help` へ置換
 - 対象: docs/grep/find-gen.html
 - 対象: docs/img/img2svg.html
 - 対象: docs/password/password-gen.html

--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1975,24 +2101,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2004,11 +2302,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2017,7 +2326,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2032,13 +2341,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2050,23 +2365,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2081,6 +2400,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2146,7 +2466,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2220,6 +2540,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2249,6 +2570,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2272,6 +2597,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2445,15 +2807,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2466,6 +2826,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2473,6 +2834,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2504,6 +2869,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2713,6 +3101,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2764,10 +3154,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2796,29 +3211,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2835,6 +3241,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2871,8 +3318,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -3660,24 +3786,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -3689,11 +3987,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -3702,7 +4011,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -3717,13 +4026,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -3735,23 +4050,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -3766,6 +4085,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -3831,7 +4151,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -3905,6 +4225,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -3934,6 +4255,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -3957,6 +4282,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -4130,15 +4492,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -4151,6 +4511,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -4158,6 +4519,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -4189,6 +4554,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -4398,6 +4786,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -4449,10 +4839,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -4481,29 +4896,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -4520,6 +4926,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -4556,8 +5003,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2383,24 +2509,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2412,11 +2710,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2425,7 +2734,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2440,13 +2749,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2458,23 +2773,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2489,6 +2808,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2554,7 +2874,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2628,6 +2948,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2657,6 +2978,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2680,6 +3005,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2853,15 +3215,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2874,6 +3234,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2881,6 +3242,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2912,6 +3277,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3121,6 +3509,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3172,10 +3562,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3204,29 +3619,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3243,6 +3649,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3279,8 +3726,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2137,24 +2263,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2166,11 +2464,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2179,7 +2488,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2194,13 +2503,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2212,23 +2527,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2243,6 +2562,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2308,7 +2628,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2382,6 +2702,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2411,6 +2732,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2434,6 +2759,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2607,15 +2969,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2628,6 +2988,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2635,6 +2996,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2666,6 +3031,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2875,6 +3263,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2926,10 +3316,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2958,29 +3373,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2997,6 +3403,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3033,8 +3480,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -22,6 +22,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -36,6 +58,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -178,10 +204,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -350,6 +409,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -556,6 +627,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -573,6 +681,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2408,24 +2534,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2437,11 +2735,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2450,7 +2759,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2465,13 +2774,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2483,23 +2798,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2514,6 +2833,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2579,7 +2899,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2653,6 +2973,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2682,6 +3003,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2705,6 +3030,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2878,15 +3240,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2899,6 +3259,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2906,6 +3267,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2937,6 +3302,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3146,6 +3534,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3197,10 +3587,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3229,29 +3644,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3268,6 +3674,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3304,8 +3751,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2252,24 +2378,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2281,11 +2579,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2294,7 +2603,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2309,13 +2618,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2327,23 +2642,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2358,6 +2677,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2423,7 +2743,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2497,6 +2817,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2526,6 +2847,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2549,6 +2874,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2722,15 +3084,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2743,6 +3103,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2750,6 +3111,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2781,6 +3146,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2990,6 +3378,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3041,10 +3431,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3073,29 +3488,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3112,6 +3518,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3148,8 +3595,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2403,24 +2529,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2432,11 +2730,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2445,7 +2754,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2460,13 +2769,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2478,23 +2793,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2509,6 +2828,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2574,7 +2894,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2648,6 +2968,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2677,6 +2998,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2700,6 +3025,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2873,15 +3235,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2894,6 +3254,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2901,6 +3262,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2932,6 +3297,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3141,6 +3529,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3192,10 +3582,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3224,29 +3639,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3263,6 +3669,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3299,8 +3746,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -22,6 +22,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -36,6 +58,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -178,10 +204,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -350,6 +409,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -556,6 +627,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -573,6 +681,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2150,24 +2276,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2179,11 +2477,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2192,7 +2501,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2207,13 +2516,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2225,23 +2540,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2256,6 +2575,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2321,7 +2641,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2395,6 +2715,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2424,6 +2745,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2447,6 +2772,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2620,15 +2982,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2641,6 +3001,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2648,6 +3009,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2679,6 +3044,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2888,6 +3276,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2939,10 +3329,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2971,29 +3386,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3010,6 +3416,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3046,8 +3493,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2160,24 +2286,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2189,11 +2487,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2202,7 +2511,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2217,13 +2526,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2235,23 +2550,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2266,6 +2585,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2331,7 +2651,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2405,6 +2725,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2434,6 +2755,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2457,6 +2782,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2630,15 +2992,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2651,6 +3011,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2658,6 +3019,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2689,6 +3054,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2898,6 +3286,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2949,10 +3339,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2981,29 +3396,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3020,6 +3426,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3056,8 +3503,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -32,6 +32,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -46,6 +68,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -188,10 +214,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -360,6 +419,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -566,6 +637,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -583,6 +691,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2143,24 +2269,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2172,11 +2470,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2185,7 +2494,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2200,13 +2509,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2218,23 +2533,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2249,6 +2568,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2314,7 +2634,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2388,6 +2708,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2417,6 +2738,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2440,6 +2765,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2613,15 +2975,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2634,6 +2994,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2641,6 +3002,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2672,6 +3037,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2881,6 +3269,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2932,10 +3322,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2964,29 +3379,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3003,6 +3409,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3039,8 +3486,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -57,20 +57,12 @@ limitations under the License.
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
         <lht-text-field-help field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
-        <label class="md-switch-label">
-          <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
-          <span class="md-switch" aria-hidden="true"></span>
-          リモートとして扱う
-        </label>
+        <lht-switch-help switch-id="scopeA" label="リモートとして扱う" on-change="updateRemoteState"></lht-switch-help>
       </div>
 
       <div class="md-form-row md-form-row--nowrap">
         <lht-text-field-help field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
-        <label class="md-switch-label">
-          <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
-          <span class="md-switch" aria-hidden="true"></span>
-          リモートとして扱う
-        </label>
+        <lht-switch-help switch-id="scopeB" label="リモートとして扱う" on-change="updateRemoteState"></lht-switch-help>
       </div>
     </div>
 
@@ -91,17 +83,13 @@ limitations under the License.
     </div>
 
     <div class="md-section md-form-row md-form-row--nowrap">
-      <md-outlined-select id="diffMode" label="出力形式" class="md-outlined-field" value="">
-        <md-select-option value="" selected>
-          <div slot="headline">内容差分 (git diff)</div>
-        </md-select-option>
-        <md-select-option value="--stat">
-          <div slot="headline">差分統計 (git diff --stat)</div>
-        </md-select-option>
-        <md-select-option value="--name-only">
-          <div slot="headline">変更ファイル一覧 (git diff --name-only)</div>
-        </md-select-option>
-      </md-outlined-select>
+      <lht-select-help field-id="diffMode" label="出力形式">
+        <script type="application/json" slot="options">[
+          { "value": "", "label": "内容差分 (git diff)", "selected": true },
+          { "value": "--stat", "label": "差分統計 (git diff --stat)" },
+          { "value": "--name-only", "label": "変更ファイル一覧 (git diff --name-only)" }
+        ]</script>
+      </lht-select-help>
     </div>
 
     <div id="statWidthBlock" class="md-section md-form-row md-form-row--nowrap md-hidden">

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -36,6 +36,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -50,6 +72,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -192,10 +218,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -364,6 +423,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -570,6 +641,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -587,6 +695,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1697,20 +1823,12 @@ lht-index-card-link {
     <div class="md-section md-stack-md">
       <div class="md-form-row md-form-row--nowrap">
         <lht-text-field-help field-id="branchA" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。差分の片側として使われます。例: main / devel。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
-        <label class="md-switch-label">
-          <input type="checkbox" id="scopeA" class="md-switch-input" onchange="updateRemoteState()">
-          <span class="md-switch" aria-hidden="true"></span>
-          リモートとして扱う
-        </label>
+        <lht-switch-help switch-id="scopeA" label="リモートとして扱う" on-change="updateRemoteState"></lht-switch-help>
       </div>
 
       <div class="md-form-row md-form-row--nowrap">
         <lht-text-field-help field-id="branchB" label="比較ブランチ" required placeholder="例: devel" help-text="比較対象のブランチです。2つのブランチ差分を表示します。例: devel / feature123。ローカルとして扱う場合は、ブランチ名に加えてコミットID（SHA）も指定できます。"></lht-text-field-help>
-        <label class="md-switch-label">
-          <input type="checkbox" id="scopeB" class="md-switch-input" onchange="updateRemoteState()">
-          <span class="md-switch" aria-hidden="true"></span>
-          リモートとして扱う
-        </label>
+        <lht-switch-help switch-id="scopeB" label="リモートとして扱う" on-change="updateRemoteState"></lht-switch-help>
       </div>
     </div>
 
@@ -1731,17 +1849,13 @@ lht-index-card-link {
     </div>
 
     <div class="md-section md-form-row md-form-row--nowrap">
-      <md-outlined-select id="diffMode" label="出力形式" class="md-outlined-field" value="">
-        <md-select-option value="" selected>
-          <div slot="headline">内容差分 (git diff)</div>
-        </md-select-option>
-        <md-select-option value="--stat">
-          <div slot="headline">差分統計 (git diff --stat)</div>
-        </md-select-option>
-        <md-select-option value="--name-only">
-          <div slot="headline">変更ファイル一覧 (git diff --name-only)</div>
-        </md-select-option>
-      </md-outlined-select>
+      <lht-select-help field-id="diffMode" label="出力形式">
+        <script type="application/json" slot="options">[
+          { "value": "", "label": "内容差分 (git diff)", "selected": true },
+          { "value": "--stat", "label": "差分統計 (git diff --stat)" },
+          { "value": "--name-only", "label": "変更ファイル一覧 (git diff --name-only)" }
+        ]</script>
+      </lht-select-help>
     </div>
 
     <div id="statWidthBlock" class="md-section md-form-row md-form-row--nowrap md-hidden">
@@ -2238,24 +2352,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2267,11 +2553,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2280,7 +2577,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2295,13 +2596,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2310,26 +2617,31 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2344,6 +2656,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2380,8 +2693,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;
@@ -2409,7 +2723,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2483,6 +2797,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2512,6 +2827,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2535,6 +2854,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2708,15 +3064,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2729,6 +3083,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2736,6 +3091,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2767,6 +3126,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2976,6 +3358,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3027,10 +3411,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3059,29 +3468,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3098,6 +3498,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3134,8 +3575,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -36,6 +36,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -50,6 +72,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -192,10 +218,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -364,6 +423,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -570,6 +641,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -587,6 +695,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2315,24 +2441,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2344,11 +2642,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2357,7 +2666,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2372,13 +2685,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2387,26 +2706,31 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2421,6 +2745,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2457,8 +2782,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;
@@ -2486,7 +2812,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2560,6 +2886,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2589,6 +2916,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2612,6 +2943,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2785,15 +3153,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2806,6 +3172,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2813,6 +3180,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2844,6 +3215,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3053,6 +3447,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3104,10 +3500,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3136,29 +3557,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3175,6 +3587,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3211,8 +3664,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -36,6 +36,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -50,6 +72,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -192,10 +218,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -364,6 +423,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -570,6 +641,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -587,6 +695,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2227,24 +2353,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2256,11 +2554,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2269,7 +2578,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2284,13 +2597,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2299,26 +2618,31 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2333,6 +2657,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2369,8 +2694,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;
@@ -2398,7 +2724,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2472,6 +2798,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2501,6 +2828,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2524,6 +2855,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2697,15 +3065,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2718,6 +3084,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2725,6 +3092,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2756,6 +3127,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2965,6 +3359,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3016,10 +3412,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3048,29 +3469,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3087,6 +3499,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3123,8 +3576,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -66,7 +66,7 @@ limitations under the License.
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">
         <div class="md-form-row md-form-row--nowrap">
-          <md-outlined-text-field id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" class="md-outlined-field" value="devel" data-help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></md-outlined-text-field>
+          <lht-text-field-help field-id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" value="devel" help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></lht-text-field-help>
           <md-menu id="baseBranchMenu" anchor="squashBaseBranch" positioning="popover" quick no-navigation-wrap></md-menu>
           <button type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="clearBaseBranchHistory()" title="基点ブランチ履歴をクリア" aria-label="基点ブランチ履歴をクリア">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
@@ -108,23 +108,21 @@ limitations under the License.
       </div>
       <div id="baseRemoteRow" class="md-form-grid md-form-grid-2">
         <div class="md-form-row">
-          <md-outlined-select id="squashBaseScope" label="基点の参照先" class="md-outlined-field" value="remote" data-help-text="基点ブランチをリモートから参照するか、ローカルで参照するかを指定します。ふだんは最新のリモート状態で切りたいので、リモート基点を選ぶケースが多いです。" onchange="updateBaseScope()">
-            <md-select-option value="remote" selected>
-              <div slot="headline">リモート</div>
-            </md-select-option>
-            <md-select-option value="local">
-              <div slot="headline">ローカル</div>
-            </md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="squashBaseScope" label="基点の参照先" value="remote" help-text="基点ブランチをリモートから参照するか、ローカルで参照するかを指定します。ふだんは最新のリモート状態で切りたいので、リモート基点を選ぶケースが多いです。">
+            <script type="application/json" slot="options">[
+              { "value": "remote", "label": "リモート", "selected": true },
+              { "value": "local", "label": "ローカル" }
+            ]</script>
+          </lht-select-help>
         </div>
         <div class="md-form-row">
-          <md-outlined-text-field id="baseRemote" label="基点リモート" placeholder="例: origin" class="md-outlined-field" value="origin" data-help-text="基点ブランチを参照するリモート名です（例: origin）。「作業開始」と「まとめる予定の作業 (diff)」の基準になります。リモート基点を選ぶ場合は、最新の origin/devel などを参照する想定です。"></md-outlined-text-field>
+          <lht-text-field-help field-id="baseRemote" label="基点リモート" placeholder="例: origin" value="origin" help-text="基点ブランチを参照するリモート名です（例: origin）。「作業開始」と「まとめる予定の作業 (diff)」の基準になります。リモート基点を選ぶ場合は、最新の origin/devel などを参照する想定です。"></lht-text-field-help>
         </div>
       </div>
     </section>
     <div id="extraOptions" class="md-section md-stack-md">
       <div id="squashRemoteRow">
-        <md-outlined-text-field id="squashRemote" label="squashリモート" placeholder="例: origin" class="md-outlined-field" value="origin" data-help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></md-outlined-text-field>
+        <lht-text-field-help field-id="squashRemote" label="squashリモート" placeholder="例: origin" value="origin" help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></lht-text-field-help>
       </div>
     </div>
 
@@ -191,7 +189,7 @@ limitations under the License.
         </span>
       </div>
       <div class="md-form-row">
-        <md-outlined-text-field id="commitMessage" label="コミットメッセージ" type="textarea" rows="12" required class="md-outlined-field" placeholder="コミットの内容を表す一文&#10;&#10;コミットの内容の説明" data-help-text="まとめ後の1コミットの説明文です。複数行入力が可能で、内容は一時ファイルに書き込んで git commit -F で渡されます。macOS / Linux は mktemp + ヒアドキュメント、Windows は PowerShell の New-TemporaryFile で対応します。ヒアドキュメント経由で渡すため、シェルのクォート解析の影響を受けにくくしています。あとで読んで何をおこなったのかわかる内容にしましょう。"></md-outlined-text-field>
+        <lht-text-field-help field-id="commitMessage" label="コミットメッセージ" type="textarea" rows="12" required placeholder="コミットの内容を表す一文&#10;&#10;コミットの内容の説明" help-text="まとめ後の1コミットの説明文です。複数行入力が可能で、内容は一時ファイルに書き込んで git commit -F で渡されます。macOS / Linux は mktemp + ヒアドキュメント、Windows は PowerShell の New-TemporaryFile で対応します。ヒアドキュメント経由で渡すため、シェルのクォート解析の影響を受けにくくしています。あとで読んで何をおこなったのかわかる内容にしましょう。"></lht-text-field-help>
       </div>
     </section>
 

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -37,6 +37,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -51,6 +73,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -193,10 +219,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -365,6 +424,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -571,6 +642,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -588,6 +696,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2059,7 +2185,7 @@ lht-index-card-link {
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">
         <div class="md-form-row md-form-row--nowrap">
-          <md-outlined-text-field id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" class="md-outlined-field" value="devel" data-help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></md-outlined-text-field>
+          <lht-text-field-help field-id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" value="devel" help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></lht-text-field-help>
           <md-menu id="baseBranchMenu" anchor="squashBaseBranch" positioning="popover" quick no-navigation-wrap></md-menu>
           <button type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" onclick="clearBaseBranchHistory()" title="基点ブランチ履歴をクリア" aria-label="基点ブランチ履歴をクリア">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
@@ -2101,23 +2227,21 @@ lht-index-card-link {
       </div>
       <div id="baseRemoteRow" class="md-form-grid md-form-grid-2">
         <div class="md-form-row">
-          <md-outlined-select id="squashBaseScope" label="基点の参照先" class="md-outlined-field" value="remote" data-help-text="基点ブランチをリモートから参照するか、ローカルで参照するかを指定します。ふだんは最新のリモート状態で切りたいので、リモート基点を選ぶケースが多いです。" onchange="updateBaseScope()">
-            <md-select-option value="remote" selected>
-              <div slot="headline">リモート</div>
-            </md-select-option>
-            <md-select-option value="local">
-              <div slot="headline">ローカル</div>
-            </md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="squashBaseScope" label="基点の参照先" value="remote" help-text="基点ブランチをリモートから参照するか、ローカルで参照するかを指定します。ふだんは最新のリモート状態で切りたいので、リモート基点を選ぶケースが多いです。">
+            <script type="application/json" slot="options">[
+              { "value": "remote", "label": "リモート", "selected": true },
+              { "value": "local", "label": "ローカル" }
+            ]</script>
+          </lht-select-help>
         </div>
         <div class="md-form-row">
-          <md-outlined-text-field id="baseRemote" label="基点リモート" placeholder="例: origin" class="md-outlined-field" value="origin" data-help-text="基点ブランチを参照するリモート名です（例: origin）。「作業開始」と「まとめる予定の作業 (diff)」の基準になります。リモート基点を選ぶ場合は、最新の origin/devel などを参照する想定です。"></md-outlined-text-field>
+          <lht-text-field-help field-id="baseRemote" label="基点リモート" placeholder="例: origin" value="origin" help-text="基点ブランチを参照するリモート名です（例: origin）。「作業開始」と「まとめる予定の作業 (diff)」の基準になります。リモート基点を選ぶ場合は、最新の origin/devel などを参照する想定です。"></lht-text-field-help>
         </div>
       </div>
     </section>
     <div id="extraOptions" class="md-section md-stack-md">
       <div id="squashRemoteRow">
-        <md-outlined-text-field id="squashRemote" label="squashリモート" placeholder="例: origin" class="md-outlined-field" value="origin" data-help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></md-outlined-text-field>
+        <lht-text-field-help field-id="squashRemote" label="squashリモート" placeholder="例: origin" value="origin" help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></lht-text-field-help>
       </div>
     </div>
 
@@ -2184,7 +2308,7 @@ lht-index-card-link {
         </span>
       </div>
       <div class="md-form-row">
-        <md-outlined-text-field id="commitMessage" label="コミットメッセージ" type="textarea" rows="12" required class="md-outlined-field" placeholder="コミットの内容を表す一文&#10;&#10;コミットの内容の説明" data-help-text="まとめ後の1コミットの説明文です。複数行入力が可能で、内容は一時ファイルに書き込んで git commit -F で渡されます。macOS / Linux は mktemp + ヒアドキュメント、Windows は PowerShell の New-TemporaryFile で対応します。ヒアドキュメント経由で渡すため、シェルのクォート解析の影響を受けにくくしています。あとで読んで何をおこなったのかわかる内容にしましょう。"></md-outlined-text-field>
+        <lht-text-field-help field-id="commitMessage" label="コミットメッセージ" type="textarea" rows="12" required placeholder="コミットの内容を表す一文&#10;&#10;コミットの内容の説明" help-text="まとめ後の1コミットの説明文です。複数行入力が可能で、内容は一時ファイルに書き込んで git commit -F で渡されます。macOS / Linux は mktemp + ヒアドキュメント、Windows は PowerShell の New-TemporaryFile で対応します。ヒアドキュメント経由で渡すため、シェルのクォート解析の影響を受けにくくしています。あとで読んで何をおこなったのかわかる内容にしましょう。"></lht-text-field-help>
       </div>
     </section>
 
@@ -2771,24 +2895,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2800,11 +3096,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2813,7 +3120,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2828,13 +3139,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2843,26 +3160,31 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2877,6 +3199,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2913,8 +3236,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;
@@ -2942,7 +3266,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -3016,6 +3340,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -3045,6 +3370,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -3068,6 +3397,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -3241,15 +3607,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -3262,6 +3626,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -3269,6 +3634,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -3300,6 +3669,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3509,6 +3901,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3560,10 +3954,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3592,29 +4011,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3631,6 +4041,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3667,8 +4118,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);
@@ -4280,6 +4735,10 @@ if (!customElements.get("lht-page-menu")) {
         element.addEventListener("input", handler);
         element.addEventListener("change", handler);
       });
+      const squashBaseScope = document.getElementById("squashBaseScope");
+      if (squashBaseScope) {
+        squashBaseScope.addEventListener("change", updateBaseScope);
+      }
     }
 
     function setupRebaseAutoUpdate() {

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -332,6 +332,10 @@
         element.addEventListener("input", handler);
         element.addEventListener("change", handler);
       });
+      const squashBaseScope = document.getElementById("squashBaseScope");
+      if (squashBaseScope) {
+        squashBaseScope.addEventListener("change", updateBaseScope);
+      }
     }
 
     function setupRebaseAutoUpdate() {

--- a/docs/grep/find-gen-src.html
+++ b/docs/grep/find-gen-src.html
@@ -59,11 +59,13 @@ limitations under the License.
         <lht-text-field-help field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-text-field-help>
       </div>
       <div class="md-form-row md-form-row--nowrap">
-        <md-outlined-select id="targetType" label="対象の種類" class="md-outlined-field" value="file">
-          <md-select-option value="any"><div slot="headline">指定なし（ファイル/ディレクトリ）</div></md-select-option>
-          <md-select-option value="file" selected><div slot="headline">ファイルのみ (-type f)</div></md-select-option>
-          <md-select-option value="dir"><div slot="headline">ディレクトリのみ (-type d)</div></md-select-option>
-        </md-outlined-select>
+        <lht-select-help field-id="targetType" label="対象の種類" value="file">
+          <script type="application/json" slot="options">[
+            { "value": "any", "label": "指定なし（ファイル/ディレクトリ）" },
+            { "value": "file", "label": "ファイルのみ (-type f)", "selected": true },
+            { "value": "dir", "label": "ディレクトリのみ (-type d)" }
+          ]</script>
+        </lht-select-help>
       </div>
     </div>
 
@@ -84,24 +86,30 @@ limitations under the License.
       <div class="md-details-body md-stack-md">
         <label class="md-label">サイズ条件:</label>
         <div class="md-grid md-grid-3">
-          <md-outlined-select id="sizeComparator" label="比較" class="md-outlined-field" value="min">
-            <md-select-option value="min" selected><div slot="headline">以上 (&gt;=)</div></md-select-option>
-            <md-select-option value="max"><div slot="headline">以下 (&lt;=)</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="sizeComparator" label="比較" value="min">
+            <script type="application/json" slot="options">[
+              { "value": "min", "label": "以上 (>=)", "selected": true },
+              { "value": "max", "label": "以下 (<=)" }
+            ]</script>
+          </lht-select-help>
           <lht-text-field-help field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-text-field-help>
-          <md-outlined-select id="sizeUnit" label="単位" class="md-outlined-field" value="M">
-            <md-select-option value="K"><div slot="headline">KB</div></md-select-option>
-            <md-select-option value="M" selected><div slot="headline">MB</div></md-select-option>
-            <md-select-option value="G"><div slot="headline">GB</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="sizeUnit" label="単位" value="M">
+            <script type="application/json" slot="options">[
+              { "value": "K", "label": "KB" },
+              { "value": "M", "label": "MB", "selected": true },
+              { "value": "G", "label": "GB" }
+            ]</script>
+          </lht-select-help>
         </div>
 
         <label class="md-label">更新日時条件:</label>
         <div class="md-grid md-grid-3">
-          <md-outlined-select id="mtimeComparator" label="期間" class="md-outlined-field" value="within">
-            <md-select-option value="within" selected><div slot="headline">直近N日以内</div></md-select-option>
-            <md-select-option value="older"><div slot="headline">N日より前</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="mtimeComparator" label="期間" value="within">
+            <script type="application/json" slot="options">[
+              { "value": "within", "label": "直近N日以内", "selected": true },
+              { "value": "older", "label": "N日より前" }
+            ]</script>
+          </lht-select-help>
           <lht-text-field-help field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-text-field-help>
           <div class="md-label md-label--muted">日</div>
         </div>

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -36,6 +36,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -50,6 +72,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -192,10 +218,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -364,6 +423,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -570,6 +641,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -587,6 +695,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1700,11 +1826,13 @@ lht-index-card-link {
         <lht-text-field-help field-id="basePath" label="検索開始パス" required placeholder="例: . / ~/projects" value="."></lht-text-field-help>
       </div>
       <div class="md-form-row md-form-row--nowrap">
-        <md-outlined-select id="targetType" label="対象の種類" class="md-outlined-field" value="file">
-          <md-select-option value="any"><div slot="headline">指定なし（ファイル/ディレクトリ）</div></md-select-option>
-          <md-select-option value="file" selected><div slot="headline">ファイルのみ (-type f)</div></md-select-option>
-          <md-select-option value="dir"><div slot="headline">ディレクトリのみ (-type d)</div></md-select-option>
-        </md-outlined-select>
+        <lht-select-help field-id="targetType" label="対象の種類" value="file">
+          <script type="application/json" slot="options">[
+            { "value": "any", "label": "指定なし（ファイル/ディレクトリ）" },
+            { "value": "file", "label": "ファイルのみ (-type f)", "selected": true },
+            { "value": "dir", "label": "ディレクトリのみ (-type d)" }
+          ]</script>
+        </lht-select-help>
       </div>
     </div>
 
@@ -1725,24 +1853,30 @@ lht-index-card-link {
       <div class="md-details-body md-stack-md">
         <label class="md-label">サイズ条件:</label>
         <div class="md-grid md-grid-3">
-          <md-outlined-select id="sizeComparator" label="比較" class="md-outlined-field" value="min">
-            <md-select-option value="min" selected><div slot="headline">以上 (&gt;=)</div></md-select-option>
-            <md-select-option value="max"><div slot="headline">以下 (&lt;=)</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="sizeComparator" label="比較" value="min">
+            <script type="application/json" slot="options">[
+              { "value": "min", "label": "以上 (>=)", "selected": true },
+              { "value": "max", "label": "以下 (<=)" }
+            ]</script>
+          </lht-select-help>
           <lht-text-field-help field-id="sizeValue" type="number" label="サイズ" placeholder="例: 10"></lht-text-field-help>
-          <md-outlined-select id="sizeUnit" label="単位" class="md-outlined-field" value="M">
-            <md-select-option value="K"><div slot="headline">KB</div></md-select-option>
-            <md-select-option value="M" selected><div slot="headline">MB</div></md-select-option>
-            <md-select-option value="G"><div slot="headline">GB</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="sizeUnit" label="単位" value="M">
+            <script type="application/json" slot="options">[
+              { "value": "K", "label": "KB" },
+              { "value": "M", "label": "MB", "selected": true },
+              { "value": "G", "label": "GB" }
+            ]</script>
+          </lht-select-help>
         </div>
 
         <label class="md-label">更新日時条件:</label>
         <div class="md-grid md-grid-3">
-          <md-outlined-select id="mtimeComparator" label="期間" class="md-outlined-field" value="within">
-            <md-select-option value="within" selected><div slot="headline">直近N日以内</div></md-select-option>
-            <md-select-option value="older"><div slot="headline">N日より前</div></md-select-option>
-          </md-outlined-select>
+          <lht-select-help field-id="mtimeComparator" label="期間" value="within">
+            <script type="application/json" slot="options">[
+              { "value": "within", "label": "直近N日以内", "selected": true },
+              { "value": "older", "label": "N日より前" }
+            ]</script>
+          </lht-select-help>
           <lht-text-field-help field-id="mtimeValue" type="number" label="日数" placeholder="例: 7"></lht-text-field-help>
           <div class="md-label md-label--muted">日</div>
         </div>
@@ -2247,24 +2381,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2276,11 +2582,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2289,7 +2606,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2304,13 +2621,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2322,23 +2645,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2353,6 +2680,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2418,7 +2746,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2492,6 +2820,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2521,6 +2850,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2544,6 +2877,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2717,15 +3087,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2738,6 +3106,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2745,6 +3114,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2776,6 +3149,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2985,6 +3381,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3036,10 +3434,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3068,29 +3491,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3107,6 +3521,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3143,8 +3598,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1040,6 +1040,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1054,6 +1076,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1196,10 +1222,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1368,6 +1427,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1574,6 +1645,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1591,6 +1699,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -3645,24 +3771,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -3674,11 +3972,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -3687,7 +3996,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -3702,13 +4011,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -3720,23 +4035,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -3751,6 +4070,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -3816,7 +4136,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -3890,6 +4210,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -3919,6 +4240,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -3942,6 +4267,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -4115,15 +4477,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -4136,6 +4496,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -4143,6 +4504,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -4174,6 +4539,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -4383,6 +4771,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -4434,10 +4824,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -4466,29 +4881,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -4505,6 +4911,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -4541,8 +4988,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1049,6 +1049,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1063,6 +1085,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1205,10 +1231,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1377,6 +1436,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1583,6 +1654,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1600,6 +1708,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2359,24 +2485,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2388,11 +2686,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2401,7 +2710,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2416,13 +2725,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2434,23 +2749,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2465,6 +2784,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2530,7 +2850,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2604,6 +2924,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2633,6 +2954,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2656,6 +2981,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2829,15 +3191,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2850,6 +3210,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2857,6 +3218,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2888,6 +3253,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3097,6 +3485,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3148,10 +3538,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3180,29 +3595,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3219,6 +3625,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3255,8 +3702,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -949,6 +949,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -963,6 +985,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1105,10 +1131,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1277,6 +1336,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1483,6 +1554,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1500,6 +1608,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1748,24 +1874,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1777,11 +2075,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1790,7 +2099,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1805,13 +2114,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1823,23 +2138,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1854,6 +2173,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1919,7 +2239,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1993,6 +2313,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2022,6 +2343,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2045,6 +2370,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2218,15 +2580,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2239,6 +2599,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2246,6 +2607,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2277,6 +2642,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2486,6 +2874,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2537,10 +2927,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2569,29 +2984,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2608,6 +3014,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2644,8 +3091,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -974,6 +974,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -988,6 +1010,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1130,10 +1156,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1302,6 +1361,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1508,6 +1579,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1525,6 +1633,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2411,24 +2537,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2440,11 +2738,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2453,7 +2762,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2468,13 +2777,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2486,23 +2801,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2517,6 +2836,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2582,7 +2902,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2656,6 +2976,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2685,6 +3006,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2708,6 +3033,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2881,15 +3243,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2902,6 +3262,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2909,6 +3270,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2940,6 +3305,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3149,6 +3537,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3200,10 +3590,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3232,29 +3647,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3271,6 +3677,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3307,8 +3754,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1034,6 +1034,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1048,6 +1070,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1190,10 +1216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1362,6 +1421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1568,6 +1639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1585,6 +1693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2237,24 +2363,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2266,11 +2564,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2279,7 +2588,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2294,13 +2603,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2312,23 +2627,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2343,6 +2662,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2408,7 +2728,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2482,6 +2802,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2511,6 +2832,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2534,6 +2859,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2707,15 +3069,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2728,6 +3088,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2735,6 +3096,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2766,6 +3131,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2975,6 +3363,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3026,10 +3416,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3058,29 +3473,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3097,6 +3503,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3133,8 +3580,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1034,6 +1034,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1048,6 +1070,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1190,10 +1216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1362,6 +1421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1568,6 +1639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1585,6 +1693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2178,24 +2304,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2207,11 +2505,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2220,7 +2529,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2235,13 +2544,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2253,23 +2568,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2284,6 +2603,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2349,7 +2669,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2423,6 +2743,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2452,6 +2773,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2475,6 +2800,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2648,15 +3010,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2669,6 +3029,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2676,6 +3037,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2707,6 +3072,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2916,6 +3304,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2967,10 +3357,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2999,29 +3414,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3038,6 +3444,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3074,8 +3521,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1064,6 +1064,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1078,6 +1100,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1220,10 +1246,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1392,6 +1451,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1598,6 +1669,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1615,6 +1723,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2236,24 +2362,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2265,11 +2563,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2278,7 +2587,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2293,13 +2602,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2311,23 +2626,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2342,6 +2661,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2407,7 +2727,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2481,6 +2801,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2510,6 +2831,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2533,6 +2858,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2706,15 +3068,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2727,6 +3087,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2734,6 +3095,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2765,6 +3130,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2974,6 +3362,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3025,10 +3415,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3057,29 +3472,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3096,6 +3502,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3132,8 +3579,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1035,6 +1035,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1049,6 +1071,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1191,10 +1217,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1363,6 +1422,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1569,6 +1640,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1586,6 +1694,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2182,24 +2308,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2211,11 +2509,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2224,7 +2533,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2239,13 +2548,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2257,23 +2572,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2288,6 +2607,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2353,7 +2673,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2427,6 +2747,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2456,6 +2777,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2479,6 +2804,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2652,15 +3014,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2673,6 +3033,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2680,6 +3041,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2711,6 +3076,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2920,6 +3308,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2971,10 +3361,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3003,29 +3418,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3042,6 +3448,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3078,8 +3525,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1034,6 +1034,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1048,6 +1070,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1190,10 +1216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1362,6 +1421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1568,6 +1639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1585,6 +1693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2177,24 +2303,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2206,11 +2504,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2219,7 +2528,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2234,13 +2543,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2252,23 +2567,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2283,6 +2602,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2348,7 +2668,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2422,6 +2742,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2451,6 +2772,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2474,6 +2799,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2647,15 +3009,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2668,6 +3028,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2675,6 +3036,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2706,6 +3071,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2915,6 +3303,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2966,10 +3356,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2998,29 +3413,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3037,6 +3443,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3073,8 +3520,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -34,6 +34,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -48,6 +70,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -190,10 +216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -362,6 +421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -568,6 +639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -585,6 +693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1234,24 +1360,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1263,11 +1561,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1276,7 +1585,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1291,13 +1600,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1309,23 +1624,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1340,6 +1659,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1405,7 +1725,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1479,6 +1799,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -1508,6 +1829,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -1531,6 +1856,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -1704,15 +2066,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -1725,6 +2085,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -1732,6 +2093,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -1763,6 +2128,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -1972,6 +2360,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2023,10 +2413,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2055,29 +2470,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2094,6 +2500,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2130,8 +2577,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -34,6 +34,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -48,6 +70,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -190,10 +216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -362,6 +421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -568,6 +639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -585,6 +693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1197,24 +1323,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1226,11 +1524,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1239,7 +1548,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1254,13 +1563,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1272,23 +1587,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1303,6 +1622,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1368,7 +1688,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1442,6 +1762,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -1471,6 +1792,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -1494,6 +1819,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -1667,15 +2029,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -1688,6 +2048,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -1695,6 +2056,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -1726,6 +2091,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -1935,6 +2323,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -1986,10 +2376,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2018,29 +2433,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2057,6 +2463,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2093,8 +2540,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -34,6 +34,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -48,6 +70,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -190,10 +216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -362,6 +421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -568,6 +639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -585,6 +693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1251,24 +1377,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1280,11 +1578,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1293,7 +1602,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1308,13 +1617,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1326,23 +1641,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1357,6 +1676,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1422,7 +1742,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1496,6 +1816,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -1525,6 +1846,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -1548,6 +1873,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -1721,15 +2083,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -1742,6 +2102,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -1749,6 +2110,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -1780,6 +2145,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -1989,6 +2377,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2040,10 +2430,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2072,29 +2487,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2111,6 +2517,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2147,8 +2594,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -34,6 +34,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -48,6 +70,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -190,10 +216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -362,6 +421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -568,6 +639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -585,6 +693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1699,24 +1825,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1728,11 +2026,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1741,7 +2050,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1756,13 +2065,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1774,23 +2089,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1805,6 +2124,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1870,7 +2190,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1944,6 +2264,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -1973,6 +2294,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -1996,6 +2321,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2169,15 +2531,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2190,6 +2550,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2197,6 +2558,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2228,6 +2593,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2437,6 +2825,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2488,10 +2878,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2520,29 +2935,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2559,6 +2965,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2595,8 +3042,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -34,6 +34,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -48,6 +70,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -190,10 +216,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -362,6 +421,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -568,6 +639,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -585,6 +693,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -1245,24 +1371,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -1274,11 +1572,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -1287,7 +1596,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1302,13 +1611,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -1320,23 +1635,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -1351,6 +1670,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -1416,7 +1736,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -1490,6 +1810,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -1519,6 +1840,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -1542,6 +1867,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -1715,15 +2077,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -1736,6 +2096,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -1743,6 +2104,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -1774,6 +2139,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -1983,6 +2371,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2034,10 +2424,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2066,29 +2481,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -2105,6 +2511,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -2141,8 +2588,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -36,6 +36,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -50,6 +72,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -192,10 +218,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -364,6 +423,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -570,6 +641,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -587,6 +695,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2177,24 +2303,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2206,11 +2504,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2219,7 +2528,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2234,13 +2543,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2252,23 +2567,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2283,6 +2602,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2348,7 +2668,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2422,6 +2742,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2451,6 +2772,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2474,6 +2799,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2647,15 +3009,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2668,6 +3028,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2675,6 +3036,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2706,6 +3071,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2915,6 +3303,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2966,10 +3356,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -2998,29 +3413,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3037,6 +3443,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3073,8 +3520,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -566,6 +566,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -580,6 +602,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -722,10 +748,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -894,6 +953,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1100,6 +1171,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1117,6 +1225,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2186,24 +2312,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2215,11 +2513,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2228,7 +2537,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2243,13 +2552,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2261,23 +2576,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2292,6 +2611,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2357,7 +2677,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2431,6 +2751,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2460,6 +2781,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2483,6 +2808,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2656,15 +3018,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2677,6 +3037,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2684,6 +3045,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2715,6 +3080,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2924,6 +3312,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -2975,10 +3365,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3007,29 +3422,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3046,6 +3452,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3082,8 +3529,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -646,6 +646,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -660,6 +682,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -802,10 +828,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -974,6 +1033,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1180,6 +1251,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1197,6 +1305,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2226,24 +2352,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2255,11 +2553,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2268,7 +2577,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2283,13 +2592,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2301,23 +2616,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2332,6 +2651,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2397,7 +2717,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2471,6 +2791,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2500,6 +2821,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2523,6 +2848,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2696,15 +3058,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2717,6 +3077,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2724,6 +3085,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2755,6 +3120,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2964,6 +3352,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3015,10 +3405,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3047,29 +3462,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3086,6 +3492,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3122,8 +3569,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1120,6 +1120,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1134,6 +1156,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1276,10 +1302,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1448,6 +1507,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1654,6 +1725,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1671,6 +1779,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -3080,24 +3206,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -3109,11 +3407,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -3122,7 +3431,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -3137,13 +3446,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -3155,23 +3470,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -3186,6 +3505,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -3251,7 +3571,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -3325,6 +3645,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -3354,6 +3675,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -3377,6 +3702,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -3550,15 +3912,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -3571,6 +3931,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -3578,6 +3939,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -3609,6 +3974,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -3818,6 +4206,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3869,10 +4259,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3901,29 +4316,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3940,6 +4346,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3976,8 +4423,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -1008,6 +1008,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -1022,6 +1044,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -1164,10 +1190,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -1336,6 +1395,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -1542,6 +1613,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -1559,6 +1667,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {
@@ -2252,24 +2378,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -2281,11 +2579,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -2294,7 +2603,7 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (type != null && !isTextarea) field.setAttribute("type", type);
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2309,13 +2618,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -2327,23 +2642,27 @@ class LhtTextFieldHelp extends HTMLElement {
     const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
     const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -2358,6 +2677,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -2423,7 +2743,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -2497,6 +2817,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -2526,6 +2847,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -2549,6 +2874,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -2722,15 +3084,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -2743,6 +3103,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -2750,6 +3111,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -2781,6 +3146,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -2990,6 +3378,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -3041,10 +3431,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -3073,29 +3488,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -3112,6 +3518,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -3148,8 +3595,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -22,10 +22,15 @@
 ## 基本方針
 
 - デザイン基準は Material Design 3
-- 実現手段として Material Web を優先利用する
-- Material Web に妥当な選択肢がない場合は、`lht-cmn` 側に自前実装（必要に応じて新規 Web Component）を追加し、`lht-*` として提供する
-- Material Web で直接実現できる要素も、画面側では一旦 `lht-*` でラップして利用する
-- 画面側で利用するのは原則 `lht-*` とし、`md-*` 直接利用は `lht-cmn` 内部実装に限定する
+- 画面側の公開 UI レイヤーは常に `lht-*` とし、`md-*` を直接使わせない
+- `lht-*` は self-contained を原則とし、アプリ側へ `md-*` の登録責務を漏らさない
+- 実現手段として Material Web を優先利用してよい
+- ただし Material 利用の有無に関わらず、`lht-*` は最低保証で壊れないことを優先する
+- 内部実装として許可する型は次の 2 つに限定する:
+  - `md-*` 優先 + fallback
+  - 完全自前実装
+- 「Material 依存で fallback なし」は原則避け、採る場合は README に明示する
+- fallback は Material の完全再現ではなく、公開 API の最低保証に留める
 
 ## メリット
 
@@ -56,17 +61,17 @@
 
 | コンポーネント | できること | 内部構造（概要） |
 |---|---|---|
-| `lht-help-tooltip` | `(i)` ヘルプアイコンとツールチップを1タグで配置できる | 内部で `md-icon-button` + `md-tooltip-content` を生成し、タグ内HTMLをツールチップ本文へ差し込む |
-| `lht-text-field-help` | ラベル付き入力（単一行/複数行）とフォーカス時ヘルプ表示を共通化できる | 内部で `md-outlined-text-field` を生成し、属性（`field-id`/`label`/`type`/`rows` など）を透過。`focus/blur` で `supportingText` を制御 |
+| `lht-help-tooltip` | `(i)` ヘルプアイコンとツールチップを1タグで配置できる | `md-icon-button` が使える環境ではそれを利用し、未定義時はネイティブ `button` fallback を生成。タグ内HTMLをツールチップ本文へ差し込む |
+| `lht-text-field-help` | ラベル付き入力（単一行/複数行）とフォーカス時ヘルプ表示を共通化できる | `md-outlined-text-field` が使える環境ではそれを利用し、未定義時はネイティブ `input` / `textarea` fallback を生成。属性（`field-id`/`label`/`type`/`rows` など）を透過する |
 | `lht-select-help` | ラベル付きドロップダウンとヘルプ表示を共通化できる | 内部で `md-outlined-select` を生成し、`<script type="application/json" slot="options">` から `md-select-option` を構築 |
-| `lht-switch-help` | スイッチ + ラベル + ヘルプを1セットで配置できる | 内部で `md-switch` と `lht-help-tooltip` を組み合わせ、`on-change` 指定時はグローバル関数を呼び出す |
-| `lht-command-block` | コマンド表示枠とコピー操作（単一/二重ボタン）を共通化できる | 内部で `code` と `md-icon-button` を生成。クリック時に Clipboard API（不可時は `textarea` フォールバック）でコピー |
+| `lht-switch-help` | スイッチ + ラベル + ヘルプを1セットで配置できる | `md-switch` が使える環境ではそれを利用し、未定義時は `input.md-switch-input + span.md-switch` fallback を生成。`on-change` 指定時はグローバル関数を呼び出す |
+| `lht-command-block` | コマンド表示枠とコピー操作（単一/二重ボタン）を共通化できる | `md-icon-button` が使える環境ではそれを利用し、未定義時はネイティブ `button` fallback を生成。クリック時に Clipboard API（不可時は `textarea` フォールバック）でコピー |
 | `lht-page-menu` | 右上メニュー（トップへ戻る等）を共通化できる | 内部でメニューボタン + パネル + リンクを生成。外側クリックで自動クローズ |
 | `lht-index-card-link` | `docs/index` のカードリンクを統一フォーマットで記述できる | 内部でカードDOM（`a` + タイトル + 説明 + 矢印/バッジ）を生成し、`variant`/`target`/外部リンク判定を吸収 |
-| `lht-file-select` | ファイル選択UI（Filledボタン + ファイル名表示）を共通化できる | 内部で hidden `input[type=file]` とトリガUIを生成。`md-filled-button` が使える環境ではそれを利用し、未定義時はフォールバックボタンで動作維持 |
+| `lht-file-select` | ファイル選択UI（Filledボタン + ファイル名表示）を共通化できる | 内部で hidden `input[type=file]` とトリガUIを生成。`md-filled-button` が使える環境ではそれを利用し、未定義時はフォールバックボタンで動作維持。公開イベントで open ownership を制御できる |
 | `lht-loading-overlay` | 処理中オーバーレイ（スピナー + メッセージ）を共通化できる | `active` で表示制御し、`aria-live`/`aria-hidden` を同期。必要に応じて `aria-busy` 更新と操作無効化も連動 |
 | `lht-toast` | 一時通知トースト（コピー完了など）を共通化できる | `active` と `show()/hide()` で表示制御し、`role="status"` / `aria-live="polite"` を標準化。`window.showToast` が未定義なら自動補完 |
-| `lht-error-alert` | エラー表示（`role="alert"`）を共通化できる | `active` と `show()/hide()` で表示制御し、`aria-live="assertive"` と表示/非表示同期を標準化（`clear()` は補助） |
+| `lht-error-alert` | エラー/警告/情報表示を共通化できる | `variant="error|warning|info"` と `active` / `show()/hide()` で表示制御し、variant ごとに `role` / `aria-live` を標準化（`clear()` は補助） |
 | `lht-input-mode-toggle` | 入力モード切替（file/source ラジオ）を共通化できる | 既定ID（`inputModeFile`/`inputModeSource`）を維持しつつ、`source/file` ブロックの `md-hidden` 切替を自動化できる |
 | `lht-preview-output` | プレビュー表示 + コピー導線を共通化できる | `preview` 枠とコピーボタンを1タグで提供し、`copy-target-id` 指定で既存出力要素からのコピーにも対応 |
 
@@ -80,6 +85,28 @@ HTML から次を読み込みます。
 開発時は上記ファイルを参照し、最終的な配布物はビルド時に単一HTMLへインライン化します。
 
 ページ固有の見た目調整は各画面側の CSS で実施し、共通的な DOM 生成と振る舞いは `lht-cmn` 側で管理します。
+
+## Integration Contract
+
+- アプリ側の公開 UI レイヤーは `lht-*` とし、`md-*` の登録有無を前提に分岐しない
+- `lht-*` が内部で `md-*` を使う場合も、その依存解決責務は `lht-cmn` 側に置く
+- 各コンポーネントは次のどちらかで実装する:
+  - `md-*` 優先 + fallback
+  - 完全自前実装
+- 例外的に Material 依存を残す場合は、その事実と理由を README に明示する
+- fallback の責務は「公開 API の最低保証」であり、Material の完全再現ではない
+- ID の責務:
+  - `field-id` / `switch-id` / `input-id` / `button-id` / `file-name-id` などの公開 ID はアプリ側が指定する
+  - `lht-cmn` はその ID を、公開 API の対象となる内部要素へ引き継ぐ
+- 初期化ライフサイクル:
+  - 各 `lht-*` は `connectedCallback()` 完了時に `data-initialized="true"` を付与する
+  - それまでは `lht-cmn/css/components.css` が pre-upgrade flash を抑止する
+- 公開 API:
+  - 属性、公開イベント、公開メソッドとして README に書いたものだけを契約対象とする
+  - 内部 DOM の細部は fallback 契約で明記したものを除き非公開とみなす
+- CSS 拡張点:
+  - アプリ側 CSS は `lht-*` タグ自身、README に明記した公開 class、テーマ変数の上書きに寄せる
+  - 内部生成 DOM のタグ構造に直接依存する拡張は、fallback 契約で明記された箇所に限定する
 
 ## 適用ルール
 
@@ -97,6 +124,18 @@ HTML から次を読み込みます。
 - 表示制御メソッドは `show()` / `hide()` を標準とする
 - `clear()` は「内容を消して非表示にする」用途でのみ任意追加する（`show/hide` の代替にはしない）
 - `active` の更新時は `aria-hidden` を同期する
+- 初期化完了後は `data-initialized="true"` を付与する
+- `lht-cmn/css/components.css` は `data-initialized="true"` が付くまで未初期化コンテンツを `visibility:hidden` で隠し、pre-upgrade flash を防ぐ
+
+### Fallback / Parity Table
+
+| コンポーネント | Material 未読込時 | fallback | 現在の最小保証 |
+|---|---|---|---|
+| `lht-select-help` | 動作する | ネイティブ `select` | `value` / `required` / `disabled` / `change` / `setOptions()` / `getValue()` / `setValue()` |
+| `lht-text-field-help` | 動作する | ネイティブ `input` / `textarea` | `value` / `required` / `disabled` / `placeholder` / `min` / `max` / `step` / `rows` |
+| `lht-switch-help` | 動作する | `input.md-switch-input + span.md-switch` | `checked` / `change` / `switch-id` / ラベル表示 |
+| `lht-file-select` | 動作する | ネイティブ `button` + hidden `input[type=file]` | `input-id` / `button-id` / `file-name-id` / `before-open` / `change` / `multiple` / `disabled` |
+| `lht-command-block` | 動作する | ネイティブ `button` | `command-id` / 単一・二重 copy button / click-to-copy |
 
 ## ドロップダウン置換手順（`lht-select-help`）
 
@@ -144,28 +183,59 @@ HTML から次を読み込みます。
 ### `lht-help-tooltip`
 
 - 用途: `(i)` ヘルプ表示
-- 主な属性: `label`, `wide`
+- 主な属性: `label`, `wide`, `placement`
+- fallback:
+  - `md-icon-button` 未読込時はネイティブ `button.md-help-icon-button--fallback` を内部生成する
+  - hover / focus-within による tooltip 表示契約は Material / fallback の両方で共通
+- placement:
+  - `placement="auto|left|right|top|bottom"` を指定できる
+  - 既定値は `auto`
+  - `auto` は active 時に viewport overflow が最小になる向きを選び、必要に応じて位置を clamp する
 
 ### `lht-text-field-help`
 
 - 用途: テキスト/数値/複数行入力 + フォーカス時ヘルプ
 - 主な属性: `field-id`, `label`, `help-text`, `hide-delay-ms`, `type`, `placeholder`, `value`, `rows`, `min`, `max`, `step`, `required`, `disabled`, `field-class`
+- fallback:
+  - `md-outlined-text-field` 未読込時はネイティブ `input` / `textarea` を内部生成する
+  - `rows` 指定時は `textarea` fallback を優先する
+  - fallback 時の `help-text` は `title` 属性として提供する
 
 ### `lht-select-help`
 
 - 用途: セレクト入力 + フォーカス時ヘルプ
 - 主な属性: `field-id`, `label`, `help-text`, `hide-delay-ms`, `value`, `required`, `disabled`, `field-class`
 - 選択肢定義: `<script type="application/json" slot="options">[...]</script>`
+- 補助メソッド:
+  - `setOptions([{ value, label, selected?, disabled? }], { preserveValue? })`
+  - `getValue()`
+  - `setValue(value)`
+- lifecycle メモ:
+  - declarative options の有無は初期化開始時点で判定する
+  - `script[slot="options"]` を利用した場合、初期化時に JSON を読んで内部 option へ反映したあと script ノードは消費される
+  - declarative options 利用時は child `option` 監視による再 hydration を行わない
+- dynamic options:
+  - 動的更新は `setOptions([...])` を正規ルートとする
+  - 既定では `preserveValue: true` と同等に動作し、同じ `value` が次の options に残っていれば選択を維持する
+  - 既存選択値が次の options に存在しない場合は空に戻す
+  - 動的更新と declarative JSON / 手動 child mutation の混在は避ける
 
 ### `lht-switch-help`
 
 - 用途: スイッチ + ラベル + ヘルプ
 - 主な属性: `switch-id`, `label`, `help-label`, `help-wide`, `checked`, `on-change`
+- fallback:
+  - `md-switch` 未読込時は `input.md-switch-input + span.md-switch` を内部生成する
+  - `switch-id` は fallback 時も checkbox input に付与される
+  - `checked` 状態と `change` イベントは Material / fallback の両方で利用できる
 
 ### `lht-command-block`
 
 - 用途: コマンド表示 + コピーUI
 - 主な属性: `command-id`, `copy-buttons`（`single` / `dual`）
+- fallback:
+  - `md-icon-button` 未読込時はネイティブ `button.md-copy-button--fallback` を内部生成する
+  - コピー動作は Material / fallback の両方で共通
 
 ### `lht-page-menu`
 
@@ -186,7 +256,15 @@ HTML から次を読み込みます。
 ### `lht-file-select`
 
 - 用途: ファイル選択UI（ボタン + hidden file input + ファイル名表示）
-- 主な属性: `input-id`, `button-id`, `file-name-id`, `accept`, `button-label`, `placeholder`, `file-label`, `multiple`, `disabled`, `show-file-name`
+- 主な属性: `input-id`, `button-id`, `file-name-id`, `accept`, `button-label`, `placeholder`, `file-label`, `multiple`, `disabled`, `show-file-name`, `auto-open`
+- 公開イベント:
+  - `lht-file-select:before-open`
+    - button click 時に発火する cancellable event
+    - `auto-open="false"` のときは発火のみ行い、内部 `input.click()` は実行しない
+    - `auto-open` が既定 `true` の場合でも `preventDefault()` で内部 open を抑止できる
+  - `lht-file-select:change`
+    - hidden file input の `change` 後に発火する
+    - `detail.names` と `detail.files` で選択結果を参照できる
 
 ### `lht-loading-overlay`
 
@@ -217,11 +295,12 @@ HTML から次を読み込みます。
 
 ### `lht-error-alert`
 
-- 用途: 画面内エラー表示の共通化（`errorText` パターンの置換）
-- 主な属性: `text`, `active`
+- 用途: 画面内エラー/警告/情報表示の共通化（`errorText` パターンの置換）
+- 主な属性: `text`, `active`, `variant`
 - 補助メソッド: `show(message?)`, `hide()`, `clear()`, `isVisible()`
 - ARIAルール:
-  - 常時 `role="alert"` と `aria-live="assertive"` を持つ
+  - `variant="error"` は `role="alert"` と `aria-live="assertive"`
+  - `variant="warning|info"` は `role="status"` と `aria-live="polite"`
   - 常時 `aria-atomic="true"` を持つ
   - 表示状態に応じて `aria-hidden` を同期する
 

--- a/lht-cmn/components.test.js
+++ b/lht-cmn/components.test.js
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import "./js/components.js";
+
+function waitForMicrotask() {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+function defineMaterialTestDoubles() {
+  const definitions = {
+    "md-icon-button": class extends HTMLElement {},
+    "md-filled-button": class extends HTMLElement {},
+    "md-switch": class extends HTMLElement {},
+    "md-outlined-text-field": class extends HTMLElement {},
+    "md-outlined-select": class extends HTMLElement {},
+    "md-select-option": class extends HTMLElement {}
+  };
+
+  for (const [tagName, ctor] of Object.entries(definitions)) {
+    if (!customElements.get(tagName)) {
+      customElements.define(tagName, ctor);
+    }
+  }
+}
+
+describe("lht-select-help declarative options", () => {
+  it("does not enable child observer after consuming declarative JSON script", async () => {
+    document.body.innerHTML = `
+      <lht-select-help field-id="test-select">
+        <script type="application/json" slot="options">[
+          {"value":"a","label":"Alpha","selected":true}
+        ]</script>
+      </lht-select-help>
+    `;
+
+    const element = document.querySelector("lht-select-help");
+    const field = element.querySelector("select");
+
+    expect(field).not.toBeNull();
+    expect(field.options).toHaveLength(1);
+    expect(field.options[0].value).toBe("a");
+    expect(field.options[0].textContent).toBe("Alpha");
+    expect(element.querySelector("script[slot='options']")).toBeNull();
+    expect(element._optionsObserver ?? null).toBeNull();
+
+    const lateOption = document.createElement("option");
+    lateOption.value = "b";
+    lateOption.textContent = "Beta";
+    element.appendChild(lateOption);
+    await waitForMicrotask();
+
+    expect(field.options).toHaveLength(1);
+    expect(field.options[0].value).toBe("a");
+  });
+
+  it("supports setOptions and preserves selected value by default", () => {
+    document.body.innerHTML = `
+      <lht-select-help field-id="dynamic-select"></lht-select-help>
+    `;
+
+    const element = document.querySelector("lht-select-help");
+    const field = element.querySelector("select");
+
+    element.setOptions([
+      { value: "a", label: "Alpha" },
+      { value: "b", label: "Beta", selected: true }
+    ]);
+    expect(field.value).toBe("b");
+
+    element.setOptions([
+      { value: "b", label: "Beta 2" },
+      { value: "c", label: "Gamma" }
+    ]);
+
+    expect(field.value).toBe("b");
+    expect(field.options).toHaveLength(2);
+    expect(field.options[0].textContent).toBe("Beta 2");
+  });
+
+  it("clears selected value when preserveValue is disabled or missing from next options", () => {
+    document.body.innerHTML = `
+      <lht-select-help field-id="dynamic-select-2"></lht-select-help>
+    `;
+
+    const element = document.querySelector("lht-select-help");
+    const field = element.querySelector("select");
+
+    element.setOptions([
+      { value: "a", label: "Alpha", selected: true },
+      { value: "b", label: "Beta" }
+    ]);
+    expect(field.value).toBe("a");
+
+    element.setOptions([
+      { value: "c", label: "Gamma" }
+    ], { preserveValue: false });
+    expect(field.value).toBe("c");
+
+    element.setValue("c");
+    expect(element.getValue()).toBe("c");
+
+    element.setOptions([
+      { value: "x", label: "Ex" }
+    ]);
+    expect(field.value).toBe("");
+  });
+});
+
+describe("lht-help-tooltip fallback", () => {
+  it("renders a native button when md-icon-button is unavailable", () => {
+    document.body.innerHTML = `
+      <lht-help-tooltip label="説明ラベル">
+        <strong>help</strong>
+      </lht-help-tooltip>
+    `;
+
+    const button = document.querySelector("lht-help-tooltip .md-help-icon-button--fallback");
+    const tooltip = document.querySelector("lht-help-tooltip .md-tooltip-content");
+
+    expect(button).not.toBeNull();
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.getAttribute("aria-label")).toBe("説明ラベル");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.innerHTML).toContain("<strong>help</strong>");
+  });
+
+  it("supports placement auto and clamps to the lower-overflow side", () => {
+    document.body.innerHTML = `
+      <lht-help-tooltip label="説明ラベル" placement="auto">
+        help
+      </lht-help-tooltip>
+    `;
+
+    const element = document.querySelector("lht-help-tooltip");
+    const group = element.querySelector(".md-tooltip-group");
+    const tooltip = element.querySelector(".md-tooltip-content");
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 320 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 640 });
+    group.getBoundingClientRect = () => ({
+      left: 260,
+      right: 290,
+      top: 100,
+      bottom: 130,
+      width: 30,
+      height: 30
+    });
+    tooltip.getBoundingClientRect = () => ({
+      width: 120,
+      height: 60
+    });
+
+    element._applyTooltipPlacement();
+
+    expect(tooltip.dataset.placement).toBe("right");
+    expect(tooltip.style.left).toBe("-76px");
+    expect(tooltip.style.top).toBe("-15px");
+  });
+
+  it("supports Escape to force-hide the active tooltip", () => {
+    document.body.innerHTML = `
+      <lht-help-tooltip label="説明ラベル">
+        help
+      </lht-help-tooltip>
+    `;
+
+    const element = document.querySelector("lht-help-tooltip");
+    const group = element.querySelector(".md-tooltip-group");
+    const button = group.querySelector(".md-help-icon-button");
+
+    element._handleTooltipEnter();
+    button.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    expect(group.getAttribute("data-force-hidden")).toBe("true");
+    expect(element._activeTooltip).toBe(false);
+
+    element._handleTooltipEnter();
+    expect(group.hasAttribute("data-force-hidden")).toBe(false);
+  });
+});
+
+describe("lht-text-field-help fallback", () => {
+  it("renders native input fallback when md-outlined-text-field is unavailable", () => {
+    document.body.innerHTML = `
+      <lht-text-field-help
+        field-id="nameField"
+        label="Name"
+        placeholder="Your name"
+        value="Alice"
+        help-text="Enter your name"
+      ></lht-text-field-help>
+    `;
+
+    const field = document.querySelector("lht-text-field-help input");
+
+    expect(field).not.toBeNull();
+    expect(field.id).toBe("nameField");
+    expect(field.value).toBe("Alice");
+    expect(field.getAttribute("aria-label")).toBe("Name");
+    expect(field.title).toBe("Enter your name");
+  });
+
+  it("renders native textarea fallback when rows is specified", () => {
+    document.body.innerHTML = `
+      <lht-text-field-help
+        field-id="memoField"
+        label="Memo"
+        rows="4"
+        value="hello"
+      ></lht-text-field-help>
+    `;
+
+    const field = document.querySelector("lht-text-field-help textarea");
+
+    expect(field).not.toBeNull();
+    expect(field.id).toBe("memoField");
+    expect(field.getAttribute("rows")).toBe("4");
+    expect(field.value).toBe("hello");
+  });
+});
+
+describe("lht-file-select events", () => {
+  it("dispatches before-open and auto-clicks input by default", () => {
+    document.body.innerHTML = `
+      <lht-file-select input-id="fileInput" button-id="fileSelectBtn"></lht-file-select>
+    `;
+
+    const element = document.querySelector("lht-file-select");
+    const button = document.getElementById("fileSelectBtn");
+    const input = document.getElementById("fileInput");
+    const beforeOpen = vi.fn();
+    const clickSpy = vi.fn();
+
+    element.addEventListener("lht-file-select:before-open", beforeOpen);
+    input.click = clickSpy;
+
+    button.click();
+
+    expect(beforeOpen).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(beforeOpen.mock.calls[0][0].detail.autoOpen).toBe(true);
+  });
+
+  it("supports host-owned open flow via auto-open=false and emits change event", () => {
+    document.body.innerHTML = `
+      <lht-file-select
+        input-id="fileInput"
+        button-id="fileSelectBtn"
+        file-name-id="fileNameText"
+        show-file-name
+        auto-open="false"
+      ></lht-file-select>
+    `;
+
+    const element = document.querySelector("lht-file-select");
+    const button = document.getElementById("fileSelectBtn");
+    const input = document.getElementById("fileInput");
+    const fileName = document.getElementById("fileNameText");
+    const beforeOpen = vi.fn((event) => {
+      expect(event.detail.autoOpen).toBe(false);
+    });
+    const changeListener = vi.fn();
+    const clickSpy = vi.fn();
+
+    element.addEventListener("lht-file-select:before-open", beforeOpen);
+    element.addEventListener("lht-file-select:change", changeListener);
+    input.click = clickSpy;
+
+    button.click();
+
+    expect(beforeOpen).toHaveBeenCalledTimes(1);
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: [{ name: "score.musicxml" }]
+    });
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(fileName.textContent).toBe("score.musicxml");
+    expect(changeListener).toHaveBeenCalledTimes(1);
+    expect(changeListener.mock.calls[0][0].detail.names).toEqual(["score.musicxml"]);
+  });
+});
+
+describe("lht-error-alert variants", () => {
+  it("uses alert/assertive for error variant by default", () => {
+    document.body.innerHTML = `<lht-error-alert text="boom"></lht-error-alert>`;
+
+    const element = document.querySelector("lht-error-alert");
+
+    expect(element.getAttribute("variant")).toBe("error");
+    expect(element.getAttribute("role")).toBe("alert");
+    expect(element.getAttribute("aria-live")).toBe("assertive");
+  });
+
+  it("uses status/polite for warning and info variants", () => {
+    document.body.innerHTML = `
+      <lht-error-alert variant="warning" text="warn"></lht-error-alert>
+      <lht-error-alert variant="info" text="info"></lht-error-alert>
+    `;
+
+    const warning = document.querySelector('lht-error-alert[variant="warning"]');
+    const info = document.querySelector('lht-error-alert[variant="info"]');
+
+    expect(warning.getAttribute("role")).toBe("status");
+    expect(warning.getAttribute("aria-live")).toBe("polite");
+    expect(info.getAttribute("role")).toBe("status");
+    expect(info.getAttribute("aria-live")).toBe("polite");
+  });
+});
+
+describe("lht-command-block fallback", () => {
+  it("renders native copy buttons when md-icon-button is unavailable", () => {
+    document.body.innerHTML = `
+      <lht-command-block command-id="cmd" copy-buttons="dual"></lht-command-block>
+    `;
+
+    const buttons = document.querySelectorAll("lht-command-block button.md-copy-button--fallback");
+    const code = document.querySelector("lht-command-block code#cmd");
+
+    expect(code).not.toBeNull();
+    expect(buttons).toHaveLength(2);
+  });
+});
+
+describe("lht-switch-help fallback", () => {
+  it("renders supported fallback DOM when md-switch is unavailable", () => {
+    const onChange = vi.fn();
+    window.testSwitchChange = onChange;
+
+    document.body.innerHTML = `
+      <lht-switch-help switch-id="demo-switch" label="Demo" on-change="testSwitchChange" checked>
+        help
+      </lht-switch-help>
+    `;
+
+    const input = document.getElementById("demo-switch");
+    const visual = document.querySelector("lht-switch-help .md-switch-input + .md-switch");
+
+    expect(input).not.toBeNull();
+    expect(input.tagName).toBe("INPUT");
+    expect(input.checked).toBe(true);
+    expect(visual).not.toBeNull();
+
+    input.checked = false;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(input.getAttribute("aria-checked")).toBe("false");
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    delete window.testSwitchChange;
+  });
+});
+
+describe("lht components in material-loaded mode", () => {
+  it("uses md-* elements when the corresponding custom elements are registered", () => {
+    defineMaterialTestDoubles();
+
+    document.body.innerHTML = `
+      <lht-help-tooltip label="help">body</lht-help-tooltip>
+      <lht-text-field-help field-id="textField" label="Text"></lht-text-field-help>
+      <lht-select-help field-id="selectField"></lht-select-help>
+      <lht-file-select input-id="fileInputLoaded" button-id="fileButtonLoaded"></lht-file-select>
+      <lht-switch-help switch-id="switchLoaded" label="Switch"></lht-switch-help>
+      <lht-command-block command-id="cmdLoaded"></lht-command-block>
+    `;
+
+    expect(document.querySelector("lht-help-tooltip md-icon-button")).not.toBeNull();
+    expect(document.querySelector("lht-text-field-help md-outlined-text-field")).not.toBeNull();
+    expect(document.querySelector("lht-select-help md-outlined-select")).not.toBeNull();
+    expect(document.querySelector("lht-file-select md-filled-button")).not.toBeNull();
+    expect(document.querySelector("lht-switch-help md-switch")).not.toBeNull();
+    expect(document.querySelector("lht-command-block md-icon-button")).not.toBeNull();
+  });
+});

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -10,6 +10,28 @@ lht-help-tooltip {
   align-items: center;
 }
 
+/*
+ * Hide raw pre-upgrade content until each component finishes connectedCallback()
+ * and marks itself initialized. This prevents tooltip/help text from flashing
+ * into the normal layout before the component rewrites its internal DOM.
+ */
+lht-help-tooltip:not([data-initialized="true"]),
+lht-text-field-help:not([data-initialized="true"]),
+lht-select-help:not([data-initialized="true"]),
+lht-file-select:not([data-initialized="true"]),
+lht-switch-help:not([data-initialized="true"]),
+lht-command-block:not([data-initialized="true"]),
+lht-page-menu:not([data-initialized="true"]),
+lht-page-hero:not([data-initialized="true"]),
+lht-index-card-link:not([data-initialized="true"]),
+lht-loading-overlay:not([data-initialized="true"]),
+lht-toast:not([data-initialized="true"]),
+lht-error-alert:not([data-initialized="true"]),
+lht-input-mode-toggle:not([data-initialized="true"]),
+lht-preview-output:not([data-initialized="true"]) {
+  visibility: hidden;
+}
+
 /* Keep accidental horizontal overflow from creating blank right-space on narrow screens. */
 .md-page {
   overflow-x: clip;
@@ -24,6 +46,10 @@ lht-help-tooltip .md-tooltip-content {
 lht-help-tooltip .md-tooltip-group:hover .md-tooltip-content,
 lht-help-tooltip .md-tooltip-group:focus-within .md-tooltip-content {
   display: block;
+}
+
+lht-help-tooltip .md-tooltip-group[data-force-hidden="true"] .md-tooltip-content {
+  display: none !important;
 }
 
 @media (max-width: 640px) {
@@ -166,10 +192,43 @@ lht-command-block {
   display: block;
 }
 
+lht-command-block .md-copy-button--fallback {
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: #efe9fa;
+  color: #3f3564;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+lht-command-block .md-copy-button--fallback .md-icon-small {
+  width: 16px;
+  height: 16px;
+}
+
 lht-text-field-help {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
+}
+
+lht-text-field-help .lht-text-field-help__fallback {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--md-sys-color-outline, #79747e);
+  background: var(--md-sys-color-surface, #fffbfe);
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  box-sizing: border-box;
+  font: inherit;
+  resize: vertical;
 }
 
 lht-select-help {
@@ -338,6 +397,18 @@ lht-error-alert .lht-error-alert__body {
   padding: 0.58rem 0.72rem;
   font-size: 0.88rem;
   line-height: 1.45;
+}
+
+lht-error-alert[variant="warning"] .lht-error-alert__body {
+  border-color: #f0d59b;
+  background: #fff8e6;
+  color: #8a5a00;
+}
+
+lht-error-alert[variant="info"] .lht-error-alert__body {
+  border-color: #bdd7f5;
+  background: #eef6ff;
+  color: #175ea8;
 }
 
 lht-input-mode-toggle {
@@ -544,6 +615,43 @@ lht-switch-help .md-switch-label md-switch {
   vertical-align: middle;
 }
 
+lht-switch-help .md-switch-label .md-switch-input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+lht-switch-help .md-switch-label .md-switch {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: #d7d2de;
+  position: relative;
+  transition: background 150ms ease;
+  flex: 0 0 44px;
+}
+
+lht-switch-help .md-switch-label .md-switch::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 150ms ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch {
+  background: var(--md-sys-color-primary, #6200ee);
+}
+
+lht-switch-help .md-switch-label .md-switch-input:checked + .md-switch::after {
+  transform: translateX(20px);
+}
+
 lht-switch-help .md-switch-label .md-info-chip {
   margin-left: 0;
 }
@@ -561,6 +669,24 @@ lht-switch-help .md-switch-label .md-tooltip-content {
   --md-icon-button-state-layer-size: 30px;
   --md-focus-ring-color: #6c3eea;
   color: #6f6a79;
+}
+
+.md-help-icon-button--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  cursor: help;
+}
+
+.md-help-icon-button--fallback .md-info-icon {
+  width: 18px;
+  height: 18px;
 }
 
 lht-index-card-link {

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -13,24 +13,196 @@ class LhtHelpTooltip extends HTMLElement {
     const label = this.getAttribute("label") || "説明";
     const isWide = this.hasAttribute("wide");
     const helpContentHtml = this.innerHTML.trim();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
 
     this.textContent = "";
 
     const group = document.createElement("span");
     group.className = "md-tooltip-group";
 
-    const button = document.createElement("md-icon-button");
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
     button.className = "md-help-icon-button";
+    if (!hasMdIconButton) {
+      button.type = "button";
+      button.classList.add("md-help-icon-button--fallback");
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-info-icon" fill="none"><circle cx="12" cy="12" r="9" fill="#cbbcf0"/><rect x="11" y="10" width="2" height="7" rx="1" fill="#ffffff"/><circle cx="12" cy="7.5" r="1" fill="#ffffff"/></svg>';
 
     const tooltip = document.createElement("span");
     tooltip.className = `md-tooltip-content md-tooltip md-tooltip--rich${isWide ? " md-tooltip--wide" : ""}`;
     tooltip.innerHTML = helpContentHtml;
+    tooltip.dataset.placement = placement;
 
     group.appendChild(button);
     group.appendChild(tooltip);
     this.appendChild(group);
+
+    this._group = group;
+    this._tooltip = tooltip;
+    this._activeTooltip = false;
+    this._handleTooltipEnter = () => {
+      this._activeTooltip = true;
+      group.removeAttribute("data-force-hidden");
+      this._applyTooltipPlacement();
+    };
+    this._handleTooltipLeave = () => {
+      this._activeTooltip = false;
+      group.removeAttribute("data-force-hidden");
+      this._resetTooltipPlacement();
+    };
+    this._handleTooltipKeydown = (event) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      this._activeTooltip = false;
+      group.setAttribute("data-force-hidden", "true");
+      this._resetTooltipPlacement();
+      if (document.activeElement && group.contains(document.activeElement)) {
+        document.activeElement.blur();
+      }
+    };
+    this._handleTooltipResize = () => {
+      if (!this._activeTooltip) return;
+      this._applyTooltipPlacement();
+    };
+
+    group.addEventListener("mouseenter", this._handleTooltipEnter);
+    group.addEventListener("focusin", this._handleTooltipEnter);
+    group.addEventListener("mouseleave", this._handleTooltipLeave);
+    group.addEventListener("keydown", this._handleTooltipKeydown);
+    group.addEventListener("focusout", () => {
+      requestAnimationFrame(() => {
+        if (!group.matches(":focus-within")) {
+          this._handleTooltipLeave();
+        }
+      });
+    });
+    window.addEventListener("resize", this._handleTooltipResize);
+  }
+
+  disconnectedCallback() {
+    if (this._group && this._handleTooltipEnter) {
+      this._group.removeEventListener("mouseenter", this._handleTooltipEnter);
+      this._group.removeEventListener("focusin", this._handleTooltipEnter);
+      this._group.removeEventListener("mouseleave", this._handleTooltipLeave);
+      this._group.removeEventListener("keydown", this._handleTooltipKeydown);
+    }
+    if (this._handleTooltipResize) {
+      window.removeEventListener("resize", this._handleTooltipResize);
+    }
+  }
+
+  _normalizePlacement(rawPlacement) {
+    const normalized = (rawPlacement || "auto").trim().toLowerCase();
+    return ["auto", "left", "right", "top", "bottom"].includes(normalized) ? normalized : "auto";
+  }
+
+  _applyTooltipPlacement() {
+    const tooltip = this._tooltip;
+    const group = this._group;
+    if (!tooltip || !group) return;
+
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+    const safeWidth = Math.max(120, viewportWidth - 32);
+    tooltip.style.maxWidth = `${safeWidth}px`;
+    tooltip.style.visibility = "hidden";
+    tooltip.style.display = "block";
+
+    const anchorRect = group.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const placement = this._normalizePlacement(this.getAttribute("placement"));
+    const appliedPlacement = placement === "auto"
+      ? this._pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight)
+      : placement;
+    const position = this._computeTooltipPosition(appliedPlacement, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+    const relativeLeft = position.left - anchorRect.left;
+    const relativeTop = position.top - anchorRect.top;
+
+    tooltip.dataset.placement = appliedPlacement;
+    tooltip.style.left = `${relativeLeft}px`;
+    tooltip.style.top = `${relativeTop}px`;
+    tooltip.style.right = "auto";
+    tooltip.style.bottom = "auto";
+    tooltip.style.transform = "none";
+    tooltip.style.marginTop = "0";
+    tooltip.style.visibility = "";
+  }
+
+  _resetTooltipPlacement() {
+    const tooltip = this._tooltip;
+    if (!tooltip) return;
+    tooltip.dataset.placement = this._normalizePlacement(this.getAttribute("placement"));
+    tooltip.style.left = "";
+    tooltip.style.top = "";
+    tooltip.style.right = "";
+    tooltip.style.bottom = "";
+    tooltip.style.transform = "";
+    tooltip.style.marginTop = "";
+    tooltip.style.maxWidth = "";
+    tooltip.style.visibility = "";
+    tooltip.style.display = "";
+  }
+
+  _pickAutoPlacement(anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const candidates = ["right", "left", "bottom", "top"];
+    let bestPlacement = "right";
+    let bestScore = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+      const position = this._computeTooltipPosition(candidate, anchorRect, tooltipRect, viewportWidth, viewportHeight);
+      const score = this._computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPlacement = candidate;
+      }
+    }
+
+    return bestPlacement;
+  }
+
+  _computeTooltipPosition(placement, anchorRect, tooltipRect, viewportWidth, viewportHeight) {
+    const gap = 8;
+    const minInset = 16;
+    const maxLeft = Math.max(minInset, viewportWidth - tooltipRect.width - minInset);
+    const maxTop = Math.max(minInset, viewportHeight - tooltipRect.height - minInset);
+
+    if (placement === "left") {
+      return {
+        left: Math.max(minInset, anchorRect.left - tooltipRect.width - gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "right") {
+      return {
+        left: Math.min(maxLeft, anchorRect.right + gap),
+        top: this._clamp(anchorRect.top + (anchorRect.height - tooltipRect.height) / 2, minInset, maxTop)
+      };
+    }
+    if (placement === "top") {
+      return {
+        left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+        top: Math.max(minInset, anchorRect.top - tooltipRect.height - gap)
+      };
+    }
+    return {
+      left: this._clamp(anchorRect.left + (anchorRect.width - tooltipRect.width) / 2, minInset, maxLeft),
+      top: Math.min(maxTop, anchorRect.bottom + gap)
+    };
+  }
+
+  _computeOverflowScore(position, tooltipRect, viewportWidth, viewportHeight) {
+    const overflowLeft = Math.max(0, 16 - position.left);
+    const overflowRight = Math.max(0, position.left + tooltipRect.width + 16 - viewportWidth);
+    const overflowTop = Math.max(0, 16 - position.top);
+    const overflowBottom = Math.max(0, position.top + tooltipRect.height + 16 - viewportHeight);
+    return overflowLeft + overflowRight + overflowTop + overflowBottom;
+  }
+
+  _clamp(value, min, max) {
+    return Math.min(max, Math.max(min, value));
   }
 }
 
@@ -42,11 +214,22 @@ class LhtTextFieldHelp extends HTMLElement {
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
 
-    const field = document.createElement("md-outlined-text-field");
+    const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
+    const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const field = hasMdOutlinedTextField
+      ? document.createElement("md-outlined-text-field")
+      : document.createElement(isTextarea ? "textarea" : "input");
     field.id = fieldId;
+    this._isFallbackTextField = !hasMdOutlinedTextField;
 
     const label = (this.getAttribute("label") || "").trim();
-    if (label) field.setAttribute("label", label);
+    if (label) {
+      if (this._isFallbackTextField) {
+        field.setAttribute("aria-label", label);
+      } else {
+        field.setAttribute("label", label);
+      }
+    }
 
     const placeholder = this.getAttribute("placeholder");
     if (placeholder != null) field.setAttribute("placeholder", placeholder);
@@ -55,7 +238,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -70,13 +257,19 @@ class LhtTextFieldHelp extends HTMLElement {
     if (rows != null) field.setAttribute("rows", rows);
 
     const value = this.getAttribute("value");
-    if (value != null) field.setAttribute("value", value);
+    if (value != null) {
+      if (this._isFallbackTextField) {
+        field.value = value;
+      } else {
+        field.setAttribute("value", value);
+      }
+    }
 
     const fieldClass = (this.getAttribute("field-class") || "").trim();
     if (fieldClass) {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
-    field.classList.add("md-outlined-field");
+    field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
 
     if (this.hasAttribute("required")) {
       field.required = true;
@@ -85,26 +278,31 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
-      let blurHideTimer = null;
-      field.addEventListener("focus", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-          blurHideTimer = null;
-        }
-        field.supportingText = helpText;
-      });
-      field.addEventListener("blur", () => {
-        if (blurHideTimer) {
-          clearTimeout(blurHideTimer);
-        }
-        blurHideTimer = setTimeout(() => {
-          field.supportingText = "";
-          blurHideTimer = null;
-        }, hideDelayMs);
-      });
+      if (this._isFallbackTextField) {
+        field.title = helpText;
+      } else {
+        let blurHideTimer = null;
+        field.addEventListener("focus", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+            blurHideTimer = null;
+          }
+          field.supportingText = helpText;
+        });
+        field.addEventListener("blur", () => {
+          if (blurHideTimer) {
+            clearTimeout(blurHideTimer);
+          }
+          blurHideTimer = setTimeout(() => {
+            field.supportingText = "";
+            blurHideTimer = null;
+          }, hideDelayMs);
+        });
+      }
     }
 
     this.textContent = "";
@@ -119,6 +317,7 @@ class LhtSelectHelp extends HTMLElement {
 
     const fieldId = (this.getAttribute("field-id") || "").trim();
     if (!fieldId) return;
+    const hasDeclarativeOptions = this._hasDeclarativeOptions();
 
     const hasMdOutlinedSelect = !!(window.customElements && window.customElements.get("md-outlined-select"));
     const field = document.createElement(hasMdOutlinedSelect ? "md-outlined-select" : "select");
@@ -155,8 +354,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;
@@ -184,7 +384,7 @@ class LhtSelectHelp extends HTMLElement {
     this.appendChild(field);
     this.hydrateOptions();
 
-    if (!this._hasDeclarativeOptions()) {
+    if (!hasDeclarativeOptions) {
       this._optionsObserver = new MutationObserver(() => {
         this.hydrateOptions();
       });
@@ -258,6 +458,7 @@ class LhtSelectHelp extends HTMLElement {
   _setFieldOptions(options) {
     const field = this._lhtField;
     if (!field) return;
+    const previousValue = field.value;
     field.innerHTML = "";
 
     for (const entry of options) {
@@ -287,6 +488,10 @@ class LhtSelectHelp extends HTMLElement {
         field.appendChild(option);
       }
     }
+
+    if (!field.value && previousValue) {
+      field.value = previousValue;
+    }
   }
 
   hydrateOptions() {
@@ -310,6 +515,43 @@ class LhtSelectHelp extends HTMLElement {
       this._optionsObserver.disconnect();
       this._optionsObserver = null;
     }
+  }
+
+  setOptions(rawOptions, config = {}) {
+    const options = this._normalizeOptions(Array.isArray(rawOptions) ? rawOptions : []);
+    const preserveValue = config?.preserveValue !== false;
+    const field = this._lhtField;
+    const previousValue = preserveValue ? (field?.value || "") : "";
+
+    if (field) {
+      field.innerHTML = "";
+    }
+    this.querySelectorAll("option, script[type='application/json'][slot='options']").forEach((node) => node.remove());
+    if (this._optionsObserver) {
+      this._optionsObserver.disconnect();
+      this._optionsObserver = null;
+    }
+
+    const nextOptions = preserveValue && previousValue
+      ? options.map((entry) => ({
+          ...entry,
+          selected: entry.value === previousValue || entry.selected
+        }))
+      : options;
+
+    this._setFieldOptions(nextOptions);
+    if (field && previousValue && !nextOptions.some((entry) => entry.value === previousValue)) {
+      field.value = "";
+    }
+  }
+
+  getValue() {
+    return this._lhtField?.value ?? "";
+  }
+
+  setValue(value) {
+    if (!this._lhtField) return;
+    this._lhtField.value = value == null ? "" : String(value);
   }
 }
 
@@ -483,15 +725,13 @@ class LhtToast extends HTMLElement {
 
 class LhtErrorAlert extends HTMLElement {
   static get observedAttributes() {
-    return ["text", "active"];
+    return ["text", "active", "variant"];
   }
 
   connectedCallback() {
     if (this.dataset.initialized === "true") return;
     this.dataset.initialized = "true";
 
-    this.setAttribute("role", "alert");
-    this.setAttribute("aria-live", "assertive");
     this.setAttribute("aria-atomic", "true");
 
     const initialText = (this.getAttribute("text") || this.textContent || "").trim();
@@ -504,6 +744,7 @@ class LhtErrorAlert extends HTMLElement {
     this.appendChild(body);
     this._body = body;
 
+    this._syncVariant();
     this.setActive(this.hasAttribute("active"));
   }
 
@@ -511,6 +752,10 @@ class LhtErrorAlert extends HTMLElement {
     if (name === "text") {
       const text = (newValue || "").trim();
       if (this._body) this._body.textContent = text;
+      return;
+    }
+    if (name === "variant") {
+      this._syncVariant();
       return;
     }
     if (name === "active") {
@@ -542,6 +787,29 @@ class LhtErrorAlert extends HTMLElement {
     this.toggleAttribute("active", next);
     this.setAttribute("data-visible", next ? "true" : "false");
     this.setAttribute("aria-hidden", next ? "false" : "true");
+  }
+
+  _normalizeVariant(value) {
+    const normalized = (value || "error").trim().toLowerCase();
+    return ["error", "warning", "info"].includes(normalized) ? normalized : "error";
+  }
+
+  _syncVariant() {
+    const variant = this._normalizeVariant(this.getAttribute("variant"));
+    if (this.getAttribute("variant") !== variant) {
+      this.setAttribute("variant", variant);
+      return;
+    }
+    this.setAttribute("data-variant", variant);
+
+    if (variant === "error") {
+      this.setAttribute("role", "alert");
+      this.setAttribute("aria-live", "assertive");
+      return;
+    }
+
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
   }
 }
 
@@ -751,6 +1019,8 @@ class LhtFileSelect extends HTMLElement {
     const buttonLabel = (this.getAttribute("button-label") || "ファイルを選択").trim();
     const placeholder = (this.getAttribute("placeholder") || "未選択").trim();
     const showFileName = this.hasAttribute("show-file-name");
+    const autoOpenValue = (this.getAttribute("auto-open") || "").trim().toLowerCase();
+    const autoOpen = autoOpenValue !== "false";
 
     this.textContent = "";
 
@@ -802,10 +1072,35 @@ class LhtFileSelect extends HTMLElement {
       triggerButton.disabled = true;
     }
 
-    triggerButton.addEventListener("click", () => input.click());
+    triggerButton.addEventListener("click", () => {
+      const beforeOpenEvent = new CustomEvent("lht-file-select:before-open", {
+        detail: {
+          inputId,
+          buttonId,
+          input,
+          triggerButton,
+          autoOpen
+        },
+        bubbles: true,
+        cancelable: true
+      });
+      const canAutoOpen = this.dispatchEvent(beforeOpenEvent);
+      if (autoOpen && canAutoOpen) {
+        input.click();
+      }
+    });
     input.addEventListener("change", () => {
       const names = Array.from(input.files || []).map((file) => file.name).filter(Boolean);
       fileName.textContent = names.length > 0 ? names.join(", ") : placeholder;
+      this.dispatchEvent(new CustomEvent("lht-file-select:change", {
+        detail: {
+          files: Array.from(input.files || []),
+          names,
+          input,
+          fileName
+        },
+        bubbles: true
+      }));
     });
 
     root.appendChild(triggerButton);
@@ -834,29 +1129,20 @@ class LhtSwitchHelp extends HTMLElement {
     const label = document.createElement("label");
     label.className = "md-switch-label";
 
-    const mdSwitch = document.createElement("md-switch");
-    mdSwitch.id = switchId;
-    Object.defineProperty(mdSwitch, "checked", {
-      get() {
-        return !!mdSwitch.selected;
-      },
-      set(value) {
-        mdSwitch.selected = !!value;
-      }
-    });
-    if (isChecked) {
-      mdSwitch.selected = true;
-      mdSwitch.setAttribute("selected", "");
-    }
+    const hasMdSwitch = !!(window.customElements && window.customElements.get("md-switch"));
+    const switchControl = hasMdSwitch
+      ? this._createMaterialSwitch(switchId, isChecked)
+      : this._createFallbackSwitch(switchId, isChecked);
+
     if (onChangeFnName) {
-      mdSwitch.addEventListener("change", () => {
+      switchControl.control.addEventListener("change", () => {
         const fn = window[onChangeFnName];
         if (typeof fn === "function") {
           fn();
         }
       });
     }
-    label.appendChild(mdSwitch);
+    label.appendChild(switchControl.node);
 
     const labelSpan = document.createElement("span");
     labelSpan.textContent = labelText;
@@ -873,6 +1159,47 @@ class LhtSwitchHelp extends HTMLElement {
     }
 
     this.appendChild(label);
+  }
+
+  _createMaterialSwitch(switchId, isChecked) {
+    const mdSwitch = document.createElement("md-switch");
+    mdSwitch.id = switchId;
+    Object.defineProperty(mdSwitch, "checked", {
+      get() {
+        return !!mdSwitch.selected;
+      },
+      set(value) {
+        mdSwitch.selected = !!value;
+      }
+    });
+    if (isChecked) {
+      mdSwitch.selected = true;
+      mdSwitch.setAttribute("selected", "");
+    }
+    return { node: mdSwitch, control: mdSwitch };
+  }
+
+  _createFallbackSwitch(switchId, isChecked) {
+    const input = document.createElement("input");
+    input.id = switchId;
+    input.type = "checkbox";
+    input.className = "md-switch-input";
+    input.checked = isChecked;
+    input.setAttribute("role", "switch");
+    input.setAttribute("aria-checked", isChecked ? "true" : "false");
+
+    input.addEventListener("change", () => {
+      input.setAttribute("aria-checked", input.checked ? "true" : "false");
+    });
+
+    const visual = document.createElement("span");
+    visual.className = "md-switch";
+    visual.setAttribute("aria-hidden", "true");
+
+    const fragment = document.createDocumentFragment();
+    fragment.appendChild(input);
+    fragment.appendChild(visual);
+    return { node: fragment, control: input };
   }
 }
 
@@ -909,8 +1236,12 @@ class LhtCommandBlock extends HTMLElement {
   }
 
   createCopyButton(label, onClick) {
-    const button = document.createElement("md-icon-button");
-    button.className = "md-copy-button md-copy-button--surface";
+    const hasMdIconButton = !!(window.customElements && window.customElements.get("md-icon-button"));
+    const button = document.createElement(hasMdIconButton ? "md-icon-button" : "button");
+    button.className = `md-copy-button md-copy-button--surface${hasMdIconButton ? "" : " md-copy-button--fallback"}`;
+    if (!hasMdIconButton) {
+      button.type = "button";
+    }
     button.setAttribute("aria-label", label);
     button.innerHTML = '<svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-copy" xlink:href="#md-icon-copy"></use></svg>';
     button.addEventListener("click", onClick);


### PR DESCRIPTION
## 概要

`lht-cmn` の設計契約を整理し、Material Web の有無に依存せず `lht-*` を公開 UI として使えるように更新しました。 あわせて Git / Grep の source HTML に残っていた raw `md-*` 利用を `lht-*` へ置換し、生成 HTML を再ビルドしています。

## 主な変更

### lht-cmn 本体
- `lht-help-tooltip` を self-contained 化
  - `md-icon-button` 未読込時は fallback button を利用
  - `placement="auto|left|right|top|bottom"` を追加
  - viewport 衝突回避と clamp を実装
  - Escape での強制非表示に対応
- `lht-text-field-help` を self-contained 化
  - `md-outlined-text-field` 未読込時は native `input` / `textarea` fallback を利用
  - `rows` 指定時の textarea fallback をサポート
- `lht-switch-help` を self-contained 化
  - `md-switch` 未読込時は `input.md-switch-input + span.md-switch` fallback を利用
- `lht-command-block` を self-contained 化
  - `md-icon-button` 未読込時は fallback copy button を利用
- `lht-file-select` に公開イベントを追加
  - `lht-file-select:before-open`
  - `lht-file-select:change`
  - `auto-open="false"` に対応
- `lht-select-help` を改善
  - declarative JSON options の判定順を修正
  - `setOptions()`, `getValue()`, `setValue()` を追加
  - selected-value retention を定義
- `lht-error-alert` に `variant="error|warning|info"` を追加
- pre-upgrade flash を防ぐ `data-initialized="true"` 契約と CSS guard を追加

### ドキュメント・テスト
- `lht-cmn/README.md` に以下を追加
  - self-contained 方針
  - integration contract
  - fallback / parity table
  - `lht-select-help` lifecycle / dynamic options contract
  - `lht-file-select` / `lht-error-alert` の公開 API
- `lht-cmn/components.test.js` を追加
  - Material 読込あり / なし の両モード回帰テストを追加

### 画面側の横展開
- `docs/git/git-branch-diff-src.html`
  - raw switch / select を `lht-switch-help` / `lht-select-help` へ置換
- `docs/git/git-pseudo-squash-src.html`
  - raw text field / select を `lht-text-field-help` / `lht-select-help` へ置換
  - `squashBaseScope` の change を JS 側 listener に移行
- `docs/grep/find-gen-src.html`
  - raw `md-outlined-select` を `lht-select-help` へ置換
- 各生成 HTML を再ビルド

## 期待する効果

- アプリ側が `md-*` の登録有無を気にせず `lht-*` を使える
- Material 未読込時も minimum behavior を維持できる
- tooltip / switch / field / file-select の契約が README とテストで明確になる
- source HTML 側の raw `md-*` 依存を段階的に削減できる

## 確認
- `npm run build:all`
- `lht-cmn/components.test.js`