### PR TITLE
Add an `lht-cmn` component catalog and move shared MD-style base CSS …

### DIFF
--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -2326,7 +2326,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2362,8 +2366,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2437,8 +2442,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -4011,7 +4011,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -4047,8 +4051,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -4122,8 +4127,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -2734,7 +2734,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2770,8 +2774,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2845,8 +2850,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -2488,7 +2488,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2524,8 +2528,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2599,8 +2604,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -2759,7 +2759,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2795,8 +2799,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2870,8 +2875,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -2603,7 +2603,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2639,8 +2643,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2714,8 +2719,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -2754,7 +2754,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2790,8 +2794,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2865,8 +2870,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -2501,7 +2501,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2537,8 +2541,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2612,8 +2617,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -2511,7 +2511,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2547,8 +2551,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2622,8 +2627,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -2494,7 +2494,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2530,8 +2534,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2605,8 +2610,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -2606,7 +2606,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2642,8 +2646,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2717,8 +2722,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -3996,7 +3996,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -4032,8 +4036,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -4107,8 +4112,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/index.html
+++ b/docs/index.html
@@ -2710,7 +2710,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2746,8 +2750,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2821,8 +2826,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -2099,7 +2099,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2135,8 +2139,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2210,8 +2215,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -2762,7 +2762,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2798,8 +2802,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2873,8 +2878,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -2588,7 +2588,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2624,8 +2628,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2699,8 +2704,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -2529,7 +2529,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2565,8 +2569,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2640,8 +2645,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -2587,7 +2587,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2623,8 +2627,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2698,8 +2703,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -2533,7 +2533,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2569,8 +2573,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2644,8 +2649,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -2528,7 +2528,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2564,8 +2568,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2639,8 +2644,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -1585,7 +1585,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1621,8 +1625,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -1696,8 +1701,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -1548,7 +1548,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1584,8 +1588,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -1659,8 +1664,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -1602,7 +1602,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1638,8 +1642,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -1713,8 +1718,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -2050,7 +2050,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2086,8 +2090,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2161,8 +2166,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -1596,7 +1596,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -1632,8 +1636,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -1707,8 +1712,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -2528,7 +2528,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2564,8 +2568,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2639,8 +2644,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -2537,7 +2537,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2573,8 +2577,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2648,8 +2653,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -2577,7 +2577,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2613,8 +2617,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2688,8 +2693,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -3431,7 +3431,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -3467,8 +3471,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -3542,8 +3547,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -2603,7 +2603,11 @@ class LhtTextFieldHelp extends HTMLElement {
     if (autocomplete != null) field.setAttribute("autocomplete", autocomplete);
 
     const type = this.getAttribute("type");
-    if (type != null && !isTextarea) field.setAttribute("type", type);
+    if (isTextarea && !this._isFallbackTextField) {
+      field.setAttribute("type", "textarea");
+    } else if (type != null && !isTextarea) {
+      field.setAttribute("type", type);
+    }
 
     const min = this.getAttribute("min");
     if (min != null) field.setAttribute("min", min);
@@ -2639,8 +2643,9 @@ class LhtTextFieldHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackTextField) {
         field.title = helpText;
@@ -2714,8 +2719,9 @@ class LhtSelectHelp extends HTMLElement {
     if (this.hasAttribute("disabled")) field.disabled = true;
 
     const helpText = (this.getAttribute("help-text") || "").trim();
-    const hideDelayMsRaw = Number(this.getAttribute("hide-delay-ms"));
-    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 120;
+    const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
+    const hideDelayMsRaw = hideDelayMsAttr == null ? Number.NaN : Number(hideDelayMsAttr);
+    const hideDelayMs = Number.isFinite(hideDelayMsRaw) && hideDelayMsRaw >= 0 ? hideDelayMsRaw : 160;
     if (helpText) {
       if (this._isFallbackSelect) {
         field.title = helpText;

--- a/lht-cmn/README.md
+++ b/lht-cmn/README.md
@@ -56,6 +56,8 @@
   - 共通 Web Components 定義
 - `lht-cmn/css/components.css`
   - 上記コンポーネントの共通スタイル
+- `lht-cmn/catalog/index.html`
+  - 実表示と HTML 利用例を並べて確認するコンポーネントカタログ
 
 ### コンポーネント一覧
 

--- a/lht-cmn/catalog/README.md
+++ b/lht-cmn/catalog/README.md
@@ -1,0 +1,16 @@
+# lht-cmn catalog
+
+`index.html` is a catalog for checking `lht-cmn` Web Components with live previews and HTML code examples side by side.
+
+- `index.html`
+  - Main catalog page
+- `catalog.css`
+  - Catalog-specific layout and presentation
+- `catalog.js`
+  - Demo initialization and code-display helpers
+
+Assets loaded by the catalog:
+
+- `../css/components.css`
+- `../js/components.js`
+- `../../docs/git/src/vendor/material-web-outlined-text-field.bundle.js`

--- a/lht-cmn/catalog/catalog.css
+++ b/lht-cmn/catalog/catalog.css
@@ -1,0 +1,346 @@
+:root {
+  color-scheme: light;
+  --catalog-bg: #f5f1e8;
+  --catalog-surface: rgba(255, 255, 255, 0.84);
+  --catalog-surface-strong: rgba(255, 255, 255, 0.94);
+  --catalog-line: rgba(73, 58, 42, 0.14);
+  --catalog-ink: #2a231d;
+  --catalog-muted: #66584b;
+  --catalog-accent: #0f766e;
+  --catalog-accent-soft: rgba(15, 118, 110, 0.12);
+  --catalog-shadow: 0 24px 70px rgba(65, 49, 35, 0.12);
+  --md-sys-color-primary: #0f766e;
+  --md-sys-color-secondary: #7c5c2f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--catalog-ink);
+  background:
+    radial-gradient(circle at top left, rgba(234, 179, 8, 0.18), transparent 34%),
+    radial-gradient(circle at top right, rgba(15, 118, 110, 0.16), transparent 30%),
+    linear-gradient(180deg, #efe8da 0%, var(--catalog-bg) 55%, #ece5d6 100%);
+  font-family: "Avenir Next", "Hiragino Sans", "Yu Gothic", sans-serif;
+}
+
+code,
+pre {
+  font-family: "SFMono-Regular", "Cascadia Code", "Source Code Pro", monospace;
+}
+
+.catalog-icons {
+  position: absolute;
+}
+
+.catalog-shell {
+  display: grid;
+  grid-template-columns: 288px minmax(0, 1fr);
+  gap: 32px;
+  width: min(1480px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 24px 0 64px;
+}
+
+.catalog-sidebar {
+  position: relative;
+}
+
+.catalog-sidebar__inner {
+  position: sticky;
+  top: 24px;
+  padding: 26px 22px;
+  border: 1px solid var(--catalog-line);
+  border-radius: 28px;
+  background: var(--catalog-surface);
+  backdrop-filter: blur(14px);
+  box-shadow: var(--catalog-shadow);
+}
+
+.catalog-sidebar__eyebrow,
+.catalog-kicker,
+.catalog-section__tag {
+  margin: 0 0 8px;
+  color: var(--catalog-accent);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.catalog-sidebar__title {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.05;
+}
+
+.catalog-sidebar__lead {
+  margin: 16px 0 22px;
+  color: var(--catalog-muted);
+  line-height: 1.7;
+}
+
+.catalog-nav {
+  display: grid;
+  gap: 8px;
+}
+
+.catalog-nav a {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 14px;
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 160ms ease, transform 160ms ease;
+}
+
+.catalog-nav a:hover,
+.catalog-nav a:focus-visible {
+  background: var(--catalog-accent-soft);
+  outline: none;
+  transform: translateX(4px);
+}
+
+.catalog-main {
+  display: grid;
+  gap: 28px;
+}
+
+.catalog-intro,
+.catalog-section {
+  padding: 28px;
+  border: 1px solid var(--catalog-line);
+  border-radius: 30px;
+  background: var(--catalog-surface);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--catalog-shadow);
+}
+
+.catalog-intro h2,
+.catalog-section h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 2.2rem);
+}
+
+.catalog-intro p,
+.catalog-section__header p {
+  color: var(--catalog-muted);
+  line-height: 1.75;
+}
+
+.catalog-section__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: end;
+  margin-bottom: 20px;
+}
+
+.catalog-section__header > * {
+  margin: 0;
+  max-width: 760px;
+}
+
+.catalog-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.catalog-meta > div {
+  padding: 16px 18px;
+  border: 1px solid var(--catalog-line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.catalog-meta strong,
+.catalog-meta span {
+  display: block;
+}
+
+.catalog-meta strong {
+  margin-bottom: 6px;
+}
+
+.catalog-card {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: start;
+}
+
+.catalog-preview,
+.catalog-code,
+.catalog-eventlog {
+  min-width: 0;
+  margin: 0;
+  border: 1px solid var(--catalog-line);
+  border-radius: 22px;
+  background: var(--catalog-surface-strong);
+}
+
+.catalog-preview {
+  position: relative;
+  padding: 22px;
+  overflow: visible;
+}
+
+.catalog-code,
+.catalog-eventlog {
+  padding: 18px 20px;
+  overflow: auto;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.catalog-code code {
+  display: block;
+  font-size: 0.9rem;
+}
+
+.catalog-eventlog {
+  margin-top: 16px;
+  color: var(--catalog-muted);
+}
+
+.catalog-note {
+  margin: 14px 0 0;
+  color: var(--catalog-muted);
+  font-size: 0.95rem;
+}
+
+.catalog-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.catalog-inline-row,
+.catalog-action-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.catalog-inline-label {
+  font-weight: 700;
+}
+
+.catalog-button {
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: var(--catalog-accent);
+  color: #fff;
+  padding: 11px 16px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.catalog-button--ghost {
+  background: rgba(42, 35, 29, 0.08);
+  color: var(--catalog-ink);
+}
+
+.catalog-button:hover,
+.catalog-button:focus-visible {
+  filter: brightness(1.04);
+  outline: none;
+}
+
+.catalog-hero-surface,
+.catalog-menu-surface,
+.catalog-busy-surface,
+.catalog-panel {
+  position: relative;
+  border: 1px solid var(--catalog-line);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.7));
+}
+
+.catalog-hero-surface,
+.catalog-busy-surface,
+.catalog-panel {
+  padding: 18px;
+}
+
+.catalog-menu-surface {
+  min-height: 120px;
+  padding: 18px;
+}
+
+.catalog-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.catalog-busy-surface > p {
+  margin: 12px 0 0;
+  color: var(--catalog-muted);
+}
+
+#catalogLoadingOverlay {
+  border-radius: 22px;
+}
+
+#catalogToast {
+  justify-self: start;
+}
+
+#catalogPreviewText {
+  min-height: 6.4em;
+}
+
+#catalogCommand {
+  display: block;
+  padding-right: 46px;
+  white-space: pre-wrap;
+}
+
+.catalog-section :where(lht-page-menu) {
+  margin-left: auto;
+}
+
+@media (max-width: 1100px) {
+  .catalog-shell {
+    grid-template-columns: 1fr;
+    width: min(1120px, calc(100% - 28px));
+  }
+
+  .catalog-sidebar__inner {
+    position: static;
+  }
+
+  .catalog-nav {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 860px) {
+  .catalog-section__header {
+    display: grid;
+    gap: 10px;
+  }
+
+  .catalog-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-intro,
+  .catalog-section {
+    padding: 22px;
+    border-radius: 24px;
+  }
+}

--- a/lht-cmn/catalog/catalog.js
+++ b/lht-cmn/catalog/catalog.js
@@ -1,0 +1,150 @@
+const demoTemplates = {
+  "hero-basic": {
+    afterRender(preview) {
+      const menu = preview.querySelector("lht-page-menu");
+      if (menu) {
+        const menuPanel = menu.querySelector(".md-menu-panel");
+        if (menuPanel) menuPanel.classList.add("md-hidden");
+      }
+    }
+  },
+  "switch-basic": {
+    afterRender() {
+      window.catalogHandleSwitchChange = () => {
+        const input = document.getElementById("catalogDemoSwitch");
+        const status = document.getElementById("switch-status");
+        if (!input || !status) return;
+        status.textContent = `Switch status: ${input.checked ? "on" : "off"}`;
+      };
+      window.catalogHandleSwitchChange();
+    }
+  },
+  "command-basic": {
+    afterRender(preview) {
+      const command = preview.querySelector("#catalogCommand");
+      if (command) {
+        command.textContent = "git diff --stat origin/main...feature/catalog-page";
+      }
+    }
+  },
+  "file-select-basic": {
+    afterRender(preview) {
+      const element = preview.querySelector("lht-file-select");
+      const log = document.getElementById("file-select-log");
+      if (!element || !log) return;
+
+      element.addEventListener("lht-file-select:before-open", (event) => {
+        log.textContent = `before-open: autoOpen=${String(event.detail.autoOpen)}`;
+      });
+      element.addEventListener("lht-file-select:change", (event) => {
+        const names = Array.isArray(event.detail.names) ? event.detail.names.join(", ") : "";
+        log.textContent = names ? `change: ${names}` : "change: no file names";
+      });
+    }
+  },
+  "preview-basic": {
+    afterRender(preview) {
+      const output = preview.querySelector("#catalogPreviewOutput");
+      if (!output) return;
+
+      preview.querySelector('[data-action="preview-fill"]')?.addEventListener("click", () => {
+        output.setText("<lht-preview-output> can update text via setText().");
+      });
+      preview.querySelector('[data-action="preview-clear"]')?.addEventListener("click", () => {
+        output.clear();
+      });
+    }
+  },
+  "input-mode-basic": {
+    afterRender() {
+      window.catalogHandleModeChange = (mode) => {
+        const status = document.getElementById("input-mode-status");
+        if (!status) return;
+        status.textContent = `Current mode: ${mode}`;
+      };
+      window.catalogHandleModeChange("file");
+    }
+  },
+  "loading-basic": {
+    afterRender(preview) {
+      const overlay = preview.querySelector("#catalogLoadingOverlay");
+      const trigger = preview.querySelector('[data-action="loading-run"]');
+      if (!overlay || !trigger) return;
+
+      trigger.addEventListener("click", async () => {
+        overlay.setActive(true);
+        await overlay.waitForNextPaint();
+        await new Promise((resolve) => window.setTimeout(resolve, 900));
+        overlay.setActive(false);
+      });
+    }
+  },
+  "toast-basic": {
+    afterRender(preview) {
+      const toast = preview.querySelector("#catalogToast");
+      const trigger = preview.querySelector('[data-action="toast-show"]');
+      if (!toast || !trigger) return;
+      trigger.addEventListener("click", () => {
+        toast.show("Catalog toast fired.", 1600);
+      });
+    }
+  },
+  "alert-basic": {
+    afterRender(preview) {
+      const alert = preview.querySelector("#catalogAlert");
+      if (!alert) return;
+
+      preview.querySelector('[data-action="alert-error"]')?.addEventListener("click", () => {
+        alert.setAttribute("variant", "error");
+        alert.show("Error: invalid input.");
+      });
+      preview.querySelector('[data-action="alert-warning"]')?.addEventListener("click", () => {
+        alert.setAttribute("variant", "warning");
+        alert.show("Warning: review your options.");
+      });
+      preview.querySelector('[data-action="alert-info"]')?.addEventListener("click", () => {
+        alert.setAttribute("variant", "info");
+        alert.show("Info: generation completed.");
+      });
+      preview.querySelector('[data-action="alert-clear"]')?.addEventListener("click", () => {
+        alert.clear();
+      });
+    }
+  }
+};
+
+function normalizeIndent(text) {
+  const lines = text.replace(/^\n+|\n+$/g, "").split("\n");
+  const indents = lines
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(/^\s*/)?.[0].length ?? 0);
+  const minIndent = indents.length ? Math.min(...indents) : 0;
+  return lines.map((line) => line.slice(minIndent)).join("\n");
+}
+
+function renderCatalogCard(card) {
+  const key = card.dataset.demo;
+  const template = document.querySelector(`[data-demo-template="${key}"]`);
+  const preview = card.querySelector(".catalog-preview");
+  const code = card.querySelector(".catalog-code code");
+  if (!template || !preview || !code) return;
+
+  const fragment = template.content.cloneNode(true);
+  const source = normalizeIndent(template.innerHTML);
+
+  preview.appendChild(fragment);
+  code.textContent = source;
+
+  const controller = demoTemplates[key];
+  if (controller?.afterRender) {
+    controller.afterRender(preview);
+  }
+}
+
+function bootstrapCatalog() {
+  document.querySelectorAll(".catalog-card").forEach((card) => {
+    renderCatalogCard(card);
+  });
+}
+
+window.addEventListener("DOMContentLoaded", bootstrapCatalog);

--- a/lht-cmn/catalog/index.html
+++ b/lht-cmn/catalog/index.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>lht-cmn Component Catalog</title>
+  <link rel="stylesheet" href="../css/components.css">
+  <link rel="stylesheet" href="./catalog.css">
+  <script src="../../docs/git/src/vendor/material-web-outlined-text-field.bundle.js"></script>
+  <script src="../js/components.js" defer></script>
+  <script src="./catalog.js" defer></script>
+</head>
+<body>
+  <svg width="0" height="0" aria-hidden="true" focusable="false" class="catalog-icons">
+    <symbol id="md-icon-copy" viewBox="0 0 24 24">
+      <rect x="9" y="9" width="11" height="11" rx="2"></rect>
+      <rect x="4" y="4" width="11" height="11" rx="2"></rect>
+    </symbol>
+  </svg>
+
+  <div class="catalog-shell">
+    <aside class="catalog-sidebar">
+      <div class="catalog-sidebar__inner">
+        <p class="catalog-sidebar__eyebrow">lht-cmn</p>
+        <h1 class="catalog-sidebar__title">Component Catalog</h1>
+        <p class="catalog-sidebar__lead">
+          A catalog for checking shared Web Components with live previews and copyable HTML examples.
+        </p>
+        <nav class="catalog-nav" aria-label="Component list">
+          <a href="#overview">Overview</a>
+          <a href="#lht-page-hero">lht-page-hero</a>
+          <a href="#lht-help-tooltip">lht-help-tooltip</a>
+          <a href="#lht-text-field-help">lht-text-field-help</a>
+          <a href="#lht-select-help">lht-select-help</a>
+          <a href="#lht-switch-help">lht-switch-help</a>
+          <a href="#lht-command-block">lht-command-block</a>
+          <a href="#lht-file-select">lht-file-select</a>
+          <a href="#lht-preview-output">lht-preview-output</a>
+          <a href="#lht-input-mode-toggle">lht-input-mode-toggle</a>
+          <a href="#lht-loading-overlay">lht-loading-overlay</a>
+          <a href="#lht-toast">lht-toast</a>
+          <a href="#lht-error-alert">lht-error-alert</a>
+          <a href="#lht-index-card-link">lht-index-card-link</a>
+          <a href="#lht-page-menu">lht-page-menu</a>
+        </nav>
+      </div>
+    </aside>
+
+    <main class="catalog-main">
+      <section id="overview" class="catalog-intro">
+        <p class="catalog-kicker">Reference Page</p>
+        <h2>Live previews and copy-ready examples in one place</h2>
+        <p>
+          This page is not a build artifact. It loads `lht-cmn` as regular multi-file assets so you can inspect each component directly.
+          Every section pairs a live preview with the corresponding code.
+        </p>
+        <div class="catalog-meta">
+          <div>
+            <strong>Components</strong>
+            <span>14</span>
+          </div>
+          <div>
+            <strong>CSS</strong>
+            <span>`../css/components.css`</span>
+          </div>
+          <div>
+            <strong>JS</strong>
+            <span>`../js/components.js`</span>
+          </div>
+        </div>
+      </section>
+
+      <section id="lht-page-hero" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">page head</p>
+            <h2>lht-page-hero</h2>
+          </div>
+          <p>A component for grouping a page title, subtitle, help tooltip, and menu at the top of the page.</p>
+        </header>
+        <div class="catalog-card" data-demo="hero-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-help-tooltip" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">inline help</p>
+            <h2>lht-help-tooltip</h2>
+          </div>
+          <p>A basic example using `placement` and `wide`. The help content appears on hover or focus.</p>
+        </header>
+        <div class="catalog-card" data-demo="tooltip-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-text-field-help" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">form input</p>
+            <h2>lht-text-field-help</h2>
+          </div>
+          <p>Examples for single-line and multi-line input. `help-text` also works as a `title` in fallback mode.</p>
+        </header>
+        <div class="catalog-card" data-demo="text-field-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-select-help" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">select input</p>
+            <h2>lht-select-help</h2>
+          </div>
+          <p>The standard declarative pattern using `script[slot="options"]`.</p>
+        </header>
+        <div class="catalog-card" data-demo="select-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-switch-help" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">toggle</p>
+            <h2>lht-switch-help</h2>
+          </div>
+          <p>A minimal setup using `checked` and `on-change`.</p>
+        </header>
+        <div class="catalog-card" data-demo="switch-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+        <p class="catalog-note" id="switch-status">Switch status: on</p>
+      </section>
+
+      <section id="lht-command-block" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">copy ui</p>
+            <h2>lht-command-block</h2>
+          </div>
+          <p>A block that combines command display and copy actions. The example below uses dual copy buttons.</p>
+        </header>
+        <div class="catalog-card" data-demo="command-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-file-select" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">file input</p>
+            <h2>lht-file-select</h2>
+          </div>
+          <p>A file picker button with selected file feedback. Event output is shown below.</p>
+        </header>
+        <div class="catalog-card" data-demo="file-select-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+        <pre class="catalog-eventlog" id="file-select-log">No file selected.</pre>
+      </section>
+
+      <section id="lht-preview-output" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">preview + copy</p>
+            <h2>lht-preview-output</h2>
+          </div>
+          <p>An example that bundles preview and copy UI into a single tag. Use the buttons to replace the content.</p>
+        </header>
+        <div class="catalog-card" data-demo="preview-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-input-mode-toggle" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">mode switch</p>
+            <h2>lht-input-mode-toggle</h2>
+          </div>
+          <p>A representative example with UI switching between `file` and `source` modes.</p>
+        </header>
+        <div class="catalog-card" data-demo="input-mode-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-loading-overlay" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">busy state</p>
+            <h2>lht-loading-overlay</h2>
+          </div>
+          <p>Shows the overlay temporarily when the button is pressed. It also demonstrates `busy-target-id` and `disable-target-ids`.</p>
+        </header>
+        <div class="catalog-card" data-demo="loading-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-toast" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">toast</p>
+            <h2>lht-toast</h2>
+          </div>
+          <p>Lets you check the behavior of `show(message, durationMs)` in place.</p>
+        </header>
+        <div class="catalog-card" data-demo="toast-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-error-alert" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">alert</p>
+            <h2>lht-error-alert</h2>
+          </div>
+          <p>An example that switches among the `error`, `warning`, and `info` variants.</p>
+        </header>
+        <div class="catalog-card" data-demo="alert-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-index-card-link" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">index card</p>
+            <h2>lht-index-card-link</h2>
+          </div>
+          <p>A link card for top-level index pages. It generates the internal card DOM for you.</p>
+        </header>
+        <div class="catalog-card" data-demo="index-card-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+
+      <section id="lht-page-menu" class="catalog-section">
+        <header class="catalog-section__header">
+          <div>
+            <p class="catalog-section__tag">page menu</p>
+            <h2>lht-page-menu</h2>
+          </div>
+          <p>A standalone example of the top-right page menu. Press the menu button to open the panel.</p>
+        </header>
+        <div class="catalog-card" data-demo="page-menu-basic">
+          <div class="catalog-preview"></div>
+          <pre class="catalog-code"><code></code></pre>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <template data-demo-template="hero-basic">
+        <div class="catalog-hero-surface">
+      <lht-page-hero
+        title="Git Branch Diff"
+        subtitle="A page concept for building branch diff commands"
+        icon="🧰"
+        help-label="Page help"
+        help-wide
+        menu-home-href="../../docs/index.html"
+        menu-home-label="Back to docs index">
+        <p>This hero bundles a title, supporting text, a help tooltip, and the top-right menu.</p>
+      </lht-page-hero>
+    </div>
+  </template>
+
+  <template data-demo-template="tooltip-basic">
+    <div class="catalog-inline-row">
+      <span class="catalog-inline-label">Label with help</span>
+      <lht-help-tooltip label="Additional details" placement="right" wide>
+        <p>This tooltip uses <code>placement="right"</code> together with <code>wide</code>.</p>
+      </lht-help-tooltip>
+    </div>
+  </template>
+
+  <template data-demo-template="text-field-basic">
+    <div class="catalog-stack">
+      <lht-text-field-help
+        field-id="catalogNameField"
+        label="Name"
+        placeholder="Your tool name"
+        help-text="Enter the display name shown to the user."
+        value="local-html-tools">
+      </lht-text-field-help>
+      <lht-text-field-help
+        field-id="catalogMemoField"
+        label="Memo"
+        rows="4"
+        help-text="The same component can also handle multi-line notes."
+        placeholder="Notes">
+      </lht-text-field-help>
+    </div>
+  </template>
+
+  <template data-demo-template="select-basic">
+    <lht-select-help
+      field-id="catalogSelectField"
+      label="Output format"
+      help-text="Choose the format you want to generate.">
+      <script type="application/json" slot="options">[
+        {"value":"html","label":"HTML","selected":true},
+        {"value":"svg","label":"SVG"},
+        {"value":"pdf","label":"PDF","disabled":true}
+      ]</script>
+    </lht-select-help>
+  </template>
+
+  <template data-demo-template="switch-basic">
+    <lht-switch-help
+      switch-id="catalogDemoSwitch"
+      label="Advanced mode"
+      help-label="Advanced mode help"
+      on-change="catalogHandleSwitchChange"
+      checked>
+      Use this toggle when you want to reveal additional inputs or advanced options.
+    </lht-switch-help>
+  </template>
+
+  <template data-demo-template="command-basic">
+    <lht-command-block command-id="catalogCommand" copy-buttons="dual"></lht-command-block>
+  </template>
+
+  <template data-demo-template="file-select-basic">
+    <lht-file-select
+      input-id="catalogFileInput"
+      button-id="catalogFileButton"
+      file-name-id="catalogFileName"
+      button-label="Choose MusicXML"
+      file-label="Selected file"
+      placeholder="No file selected yet"
+      accept=".xml,.musicxml"
+      show-file-name>
+    </lht-file-select>
+  </template>
+
+  <template data-demo-template="preview-basic">
+    <div class="catalog-stack">
+      <div class="catalog-action-row">
+        <button type="button" class="catalog-button" data-action="preview-fill">Set text</button>
+        <button type="button" class="catalog-button catalog-button--ghost" data-action="preview-clear">Clear</button>
+      </div>
+      <lht-preview-output
+        id="catalogPreviewOutput"
+        preview-id="catalogPreviewText"
+        copy-button-id="catalogPreviewCopy"
+        placeholder="Preview result will appear here."
+        preview-tag="pre">
+      </lht-preview-output>
+    </div>
+  </template>
+
+  <template data-demo-template="input-mode-basic">
+    <div class="catalog-stack">
+      <lht-input-mode-toggle
+        name="catalogInputMode"
+        group-label="Input mode"
+        file-id="catalogModeFile"
+        source-id="catalogModeSource"
+        file-label="File upload"
+        source-label="Paste source"
+        source-target-id="catalogSourcePanel"
+        file-target-id="catalogFilePanel"
+        on-change="catalogHandleModeChange">
+      </lht-input-mode-toggle>
+      <div id="catalogFilePanel" class="catalog-panel">
+        <strong>File panel</strong>
+        <p>Place your file selection UI here.</p>
+      </div>
+      <div id="catalogSourcePanel" class="catalog-panel md-hidden">
+        <strong>Source panel</strong>
+        <p>Place your source input area here.</p>
+      </div>
+      <p class="catalog-note" id="input-mode-status">Current mode: file</p>
+    </div>
+  </template>
+
+  <template data-demo-template="loading-basic">
+    <div id="catalogBusySurface" class="catalog-busy-surface">
+      <div class="catalog-action-row">
+        <button type="button" id="catalogRunLoadingDemo" class="catalog-button" data-action="loading-run">Run async demo</button>
+        <button type="button" id="catalogSecondaryAction" class="catalog-button catalog-button--ghost">Secondary action</button>
+      </div>
+      <p>Show the overlay before starting heavy work, then close it after the operation completes.</p>
+      <lht-loading-overlay
+        id="catalogLoadingOverlay"
+        text="Generating preview..."
+        busy-target-id="catalogBusySurface"
+        disable-target-ids="catalogRunLoadingDemo,catalogSecondaryAction">
+      </lht-loading-overlay>
+    </div>
+  </template>
+
+  <template data-demo-template="toast-basic">
+    <div class="catalog-stack">
+      <div class="catalog-action-row">
+        <button type="button" class="catalog-button" data-action="toast-show">Show toast</button>
+      </div>
+      <lht-toast id="catalogToast" text="Saved." duration-ms="1800"></lht-toast>
+    </div>
+  </template>
+
+  <template data-demo-template="alert-basic">
+    <div class="catalog-stack">
+      <div class="catalog-action-row">
+        <button type="button" class="catalog-button" data-action="alert-error">Error</button>
+        <button type="button" class="catalog-button catalog-button--ghost" data-action="alert-warning">Warning</button>
+        <button type="button" class="catalog-button catalog-button--ghost" data-action="alert-info">Info</button>
+        <button type="button" class="catalog-button catalog-button--ghost" data-action="alert-clear">Clear</button>
+      </div>
+      <lht-error-alert id="catalogAlert" text="Initial error message" active></lht-error-alert>
+    </div>
+  </template>
+
+  <template data-demo-template="index-card-basic">
+    <div class="catalog-card-grid">
+      <lht-index-card-link
+        href="../../docs/git/git-branch-diff-src.html"
+        icon="🧰"
+        title="Git Branch Diff"
+        desc="An example link card for a page that generates commands to compare two branches."
+        badge="git"
+        desc-lines="3">
+      </lht-index-card-link>
+      <lht-index-card-link
+        href="https://github.com/"
+        title="External Link"
+        desc="Adding the external variant shifts the presentation toward an external link style."
+        variant="external"
+        badge="ext">
+      </lht-index-card-link>
+    </div>
+  </template>
+
+  <template data-demo-template="page-menu-basic">
+    <div class="catalog-menu-surface">
+      <p class="catalog-note">Press the menu button in the top-right corner.</p>
+      <lht-page-menu home-href="../../docs/index.html" home-label="Back to docs index"></lht-page-menu>
+    </div>
+  </template>
+</body>
+</html>

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -10,6 +10,102 @@ lht-help-tooltip {
   align-items: center;
 }
 
+.md-tooltip-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.md-tooltip-content {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 0.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease;
+  z-index: 50;
+  width: min(20rem, 90vw);
+  max-width: 90vw;
+}
+
+.md-tooltip-group:hover .md-tooltip-content,
+.md-tooltip-group:focus-within .md-tooltip-content {
+  opacity: 1;
+}
+
+.md-tooltip {
+  background: #2b2831;
+  color: #f7f4fb;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.5;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+}
+
+.md-tooltip--wide {
+  width: min(32rem, 90vw);
+}
+
+.md-tooltip--rich {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.md-icon-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0edf5;
+  color: #3f3b46;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+.md-icon-btn:hover {
+  background: #ebe6f3;
+}
+
+.md-menu-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}
+
+.md-menu-panel {
+  position: absolute;
+  top: 56px;
+  right: 16px;
+  background: var(--md-sys-color-surface, #fffbfe);
+  border: 1px solid #e6e1ee;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 4px 0;
+  min-width: 160px;
+  z-index: 20;
+}
+
+.md-menu-link {
+  display: block;
+  padding: 8px 16px;
+  color: var(--md-sys-color-on-surface, #1d1b20);
+  text-decoration: none;
+}
+
+.md-menu-link:hover {
+  background: #f2edf8;
+}
+
+.md-hidden {
+  display: none !important;
+}
+
 /*
  * Hide raw pre-upgrade content until each component finishes connectedCallback()
  * and marks itself initialized. This prevents tooltip/help text from flashing
@@ -691,6 +787,102 @@ lht-switch-help .md-switch-label .md-tooltip-content {
 
 lht-index-card-link {
   display: block;
+}
+
+.md-link-card {
+  position: relative;
+  display: block;
+  padding: 1rem;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface, #fffbfe);
+  border: 1px solid #ece7f3;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
+  overflow: hidden;
+  outline: none;
+  color: inherit;
+  text-decoration: none;
+}
+
+.md-link-card:hover {
+  box-shadow: 0 6px 16px rgba(35, 29, 49, 0.12);
+  border-color: #d7cfee;
+}
+
+.md-link-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--md-sys-color-state-layer, rgba(103, 80, 164, 0.08));
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.md-link-card:hover::after {
+  opacity: 1;
+}
+
+.md-link-card:focus-visible {
+  border-color: rgba(98, 0, 238, 0.55);
+  box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring, rgba(98, 0, 238, 0.22)), 0 6px 16px rgba(35, 29, 49, 0.12);
+}
+
+.md-link-card:focus-visible::after {
+  opacity: 1;
+}
+
+.md-link-card:active::after {
+  opacity: 0.18;
+}
+
+.md-link-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.md-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.md-card-title {
+  font-size: var(--md-typography-title-small, 1.1rem);
+  font-weight: 600;
+  color: #2f2a35;
+}
+
+.md-card-arrow {
+  color: #8f8a98;
+  font-size: 1.2rem;
+}
+
+.md-link-card:hover .md-card-arrow {
+  color: #6d6483;
+}
+
+.md-card-desc {
+  margin-top: 0.5rem;
+  font-size: var(--md-typography-body-small, 0.95rem);
+  color: #5f5a6b;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .md-link-card:hover,
+  .md-link-card:focus-visible {
+    overflow: visible;
+    z-index: 2;
+  }
+
+  .md-link-card:hover .md-card-desc,
+  .md-link-card:focus-visible .md-card-desc {
+    display: block;
+  }
 }
 
 .lht-index-card-link__icon {


### PR DESCRIPTION
…into `lht-cmn`

### Summary

This PR adds a standalone component catalog for `lht-cmn` and consolidates several shared MD-style base CSS rules into `lht-cmn/css/components.css` so catalog previews match production component rendering more closely.

### Changes

- Added a new catalog entry point at `lht-cmn/catalog/index.html`
- Added catalog-specific assets:
  - `lht-cmn/catalog/catalog.css`
  - `lht-cmn/catalog/catalog.js`
  - `lht-cmn/catalog/README.md`
- Updated `lht-cmn/README.md` to include the catalog
- Added shared base styles to `lht-cmn/css/components.css` for:
  - tooltip primitives
  - icon/menu button primitives
  - menu panel/link primitives
  - hidden-state utility
  - index card primitives
- Regenerated built `docs/*.html` files so they reflect the updated `lht-cmn` CSS

### Why

Before this change, `lht-cmn` had API-oriented documentation and tests, but no visual catalog showing:
- live component rendering
- minimal usage examples
- copyable HTML snippets

Also, some visual primitives used by `lht-*` components were still effectively dependent on page-level CSS in built pages, which caused standalone catalog previews to diverge from production appearance.

### Result

- `lht-cmn` now has a browsable catalog for shared Web Components
- Example code and rendered output can be reviewed side by side
- Standalone previews for components such as tooltips, page menus, and index cards render closer to their real usage
- Shared visual primitives are more self-contained within `lht-cmn`

### Notes

- The catalog is a normal multi-file HTML page, not a build artifact
- The catalog presents `lht-*` components as the public layer, while Material/MD-style primitives remain internal implementation details
- Built docs were updated as part of propagating the `lht-cmn` CSS changes