### PR TITLE
プロンプト作成支援ページの候補・検索・表示挙動を改善

### DIFF
--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -64,6 +64,13 @@ limitations under the License.
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .md-search-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 16px;
+      align-items: start;
+    }
+
     .md-chip-row {
       display: flex;
       flex-wrap: wrap;
@@ -80,37 +87,49 @@ limitations under the License.
     }
 
     .md-chip-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
       appearance: none;
-      border: none;
+      border: 1px solid #d8d1e3;
       border-radius: 999px;
-      background: var(--md-sys-color-primary, #6200ee);
-      color: var(--md-sys-color-on-primary, #ffffff);
-      padding: 0.6rem 1.2rem;
-      font-size: 0.95rem;
+      background: #f7f2fa;
+      color: #4a4458;
+      padding: 0.32rem 0.9rem;
+      font-size: 0.88rem;
       font-weight: 600;
+      line-height: 1.1;
       cursor: pointer;
-      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
-      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
     }
 
     .md-chip-button:hover {
-      background: #4f00c9;
+      background: #efe7f8;
+      border-color: #cfc3e3;
+      color: #352f41;
       transform: translateY(-1px);
-      box-shadow: 0 6px 14px rgba(98, 0, 238, 0.24);
+      box-shadow: 0 4px 10px rgba(74, 68, 88, 0.10);
     }
 
     .md-chip-button.is-active {
-      background: #4f00c9;
+      border-color: transparent;
+      background: var(--md-sys-color-primary, #6200ee);
       color: var(--md-sys-color-on-primary, #ffffff);
       box-shadow: 0 6px 14px rgba(98, 0, 238, 0.24);
     }
 
-    .md-helper-text {
-      margin: 0;
-      padding: 0 1rem;
-      font-size: 0.75rem;
-      line-height: 1rem;
-      color: var(--md-sys-color-on-surface-variant, #49454f);
+    .md-chip-button .md-chip-label {
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .md-chip-button lht-help-tooltip {
+      flex: 0 0 auto;
+    }
+
+    .md-chip-button lht-help-tooltip .md-tooltip-content {
+      z-index: 400;
     }
 
     .md-output-title {
@@ -204,30 +223,31 @@ limitations under the License.
   <div class="md-surface-card md-card">
     <lht-page-hero
       title="プロンプト作成支援"
-      subtitle="定型よくある生成AIプロンプトを作成支援。"
+      subtitle="定型的な生成AIプロンプトを作成支援します。"
       icon="📝"
       help-label="プロンプト作成支援の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      AI や人に依頼するための文面を、用途別に短く組み立てるためのページです。<br><br>
-      初版では、PR タイトルと PR 本文を作成依頼するための文面を生成します。
+      このツールは、生成AIに引き渡すためのプロンプト作成を支援します。<br><br>
+      初版では、PR 文面、GitHub Release 文面、Markdown 出力指示、GitHub 操作禁止指示、ディレクトリ内容確認指示、会話引き継ぎ指示、仕様検討指示、軽量テスト追加指示、違和感や誤りの指摘優先指示、TODO 整理指示、実施状況確認指示、批判的レビュー指示、markdown 更新漏れ確認指示を作成依頼するための文面を生成します。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
-      <lht-text-field-help
-        field-id="promptSearch"
-        label="やりたいこと"
-        required
-        placeholder="例: pr"
-        help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら PR 作成依頼を表示します。">
-      </lht-text-field-help>
+      <div class="md-search-row">
+        <lht-text-field-help
+          field-id="promptSearch"
+          label="やりたいこと"
+          required
+          placeholder="例: pr / release"
+          help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら各種プロンプト候補を表示します。">
+        </lht-text-field-help>
+      </div>
 
-      <p class="md-helper-text">小窓に `p` `r` `pr` などを入れると、候補キーワードへの部分一致として `PR作成依頼` ボタンを表示します。</p>
       <div id="promptCandidateArea" class="md-chip-row" aria-live="polite"></div>
     </section>
 
-    <section id="prRequestSection" class="md-section md-stack-md md-hidden">
+    <section id="commitInputSection" class="md-section md-stack-md md-hidden">
       <div class="md-form-grid md-form-grid-2">
         <lht-text-field-help
           field-id="commitId"
@@ -237,9 +257,17 @@ limitations under the License.
           help-text="PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。">
         </lht-text-field-help>
       </div>
+    </section>
 
+    <section id="promptOutputSection" class="md-section md-stack-md md-hidden">
       <p class="md-output-title">生成結果</p>
       <lht-command-block command-id="promptOutput"></lht-command-block>
+      <lht-switch-help
+        switch-id="includeLabelPrefix"
+        label="ラベル名を先頭に含める"
+        help-label="ラベル名を先頭に含める説明">
+        ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
+      </lht-switch-help>
     </section>
 
     <lht-toast id="toast"></lht-toast>
@@ -253,47 +281,357 @@ limitations under the License.
 
       const promptSearch = document.getElementById("promptSearch");
       const promptCandidateArea = document.getElementById("promptCandidateArea");
-      const prRequestSection = document.getElementById("prRequestSection");
+      const commitInputSection = document.getElementById("commitInputSection");
+      const promptOutputSection = document.getElementById("promptOutputSection");
       const commitIdInput = document.getElementById("commitId");
+      const includeLabelPrefix = document.getElementById("includeLabelPrefix");
       const promptOutput = document.getElementById("promptOutput");
 
-      if (!promptSearch || !commitIdInput) {
+      if (!promptSearch || !commitIdInput || !includeLabelPrefix) {
         return;
       }
 
       let selectedPrompt = "";
-      const prRequestKeywords = ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文"];
+      let lastSearchQuery = "";
+      const promptDefinitions = [
+        {
+          id: "pr-request",
+          label: "GitHub PR 文面作成",
+          keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"]
+        },
+        {
+          id: "release-request",
+          label: "GitHub Release 文面作成",
+          keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"]
+        },
+        {
+          id: "inline-code-request",
+          label: "Markdown インラインコードとして出力",
+          keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"]
+        },
+        {
+          id: "github-no-change-request",
+          label: "GitHub 変更操作を禁止",
+          keywords: ["github", "push", "pr", "comment", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"]
+        },
+        {
+          id: "directory-markdown-check-request",
+          label: "100: ディレクトリ内の内容を確認して把握",
+          keywords: ["readme", "markdown", "directory", "ディレクトリ", "内容確認", "md確認", "でぃれくとり", "ないようかくにん", "direkutori", "naiyoukakunin", "りーどみー", "まーくだうん", "えむでぃー"]
+        },
+        {
+          id: "conversation-handover-request",
+          label: "会話の引継テキストを生成",
+          keywords: ["handover", "conversation", "引き継ぎ", "会話", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"]
+        },
+        {
+          id: "spec-discussion-request",
+          label: "仕様検討モードで進める",
+          keywords: ["spec", "specification", "仕様", "検討", "todo", "todo.md", "しよう", "けんとう", "とぅーどぅー", "shiyou", "kentou", "すぺっく"]
+        },
+        {
+          id: "small-test-request",
+          label: "事象の再発防止テストを追加",
+          keywords: ["test", "testing", "small test", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"]
+        },
+        {
+          id: "disagreement-first-request",
+          label: "違和感や誤りを先に指摘",
+          keywords: ["disagree", "wrong", "違和感", "間違い", "指摘", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"]
+        },
+        {
+          id: "todo-cleanup-request",
+          label: "TODO.md の完了項目を整理",
+          keywords: ["todo", "todo.md", "cleanup", "close", "closed", "整理", "完了", "クローズ", "削除", "とぅーどぅー", "せいり", "かんりょう", "s e i r i", "kanryou"]
+        },
+        {
+          id: "completion-check-request",
+          label: "依頼内容の実施状況を確認",
+          keywords: ["done", "completed", "status", "check", "実施済み", "未実施", "確認", "じっしずみ", "みじっし", "かくにん", "jisshizumi", "mijisshi", "kakunin"]
+        },
+        {
+          id: "critical-review-request",
+          label: "批判的レビューを依頼",
+          keywords: ["review", "critical review", "typo", "批判的", "レビュー", "誤り", "間違い", "たいぽ", "ひはんてき", "れびゅー", "まちがい", "typo", "hibanteki", "rebyu-"]
+        },
+        {
+          id: "markdown-update-check-request",
+          label: "markdown 更新漏れを確認",
+          keywords: ["markdown", "md", "update", "doc", "docs", "更新漏れ", "未更新", "追加すべき", "まーくだうん", "みこうしん", "こうしんもれ", "markdown", "mikkoushin", "koushinmore"]
+        }
+      ];
 
-      function createCandidateButton(label, id) {
+      const kanaToRomajiMap = new Map([
+        ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
+        ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
+        ["ちゃ", "cha"], ["ちゅ", "chu"], ["ちょ", "cho"],
+        ["にゃ", "nya"], ["にゅ", "nyu"], ["にょ", "nyo"],
+        ["ひゃ", "hya"], ["ひゅ", "hyu"], ["ひょ", "hyo"],
+        ["みゃ", "mya"], ["みゅ", "myu"], ["みょ", "myo"],
+        ["りゃ", "rya"], ["りゅ", "ryu"], ["りょ", "ryo"],
+        ["ぎゃ", "gya"], ["ぎゅ", "gyu"], ["ぎょ", "gyo"],
+        ["じゃ", "ja"], ["じゅ", "ju"], ["じょ", "jo"],
+        ["びゃ", "bya"], ["びゅ", "byu"], ["びょ", "byo"],
+        ["ぴゃ", "pya"], ["ぴゅ", "pyu"], ["ぴょ", "pyo"],
+        ["ゔぁ", "va"], ["ゔぃ", "vi"], ["ゔ", "vu"], ["ゔぇ", "ve"], ["ゔぉ", "vo"],
+        ["あ", "a"], ["い", "i"], ["う", "u"], ["え", "e"], ["お", "o"],
+        ["か", "ka"], ["き", "ki"], ["く", "ku"], ["け", "ke"], ["こ", "ko"],
+        ["さ", "sa"], ["し", "shi"], ["す", "su"], ["せ", "se"], ["そ", "so"],
+        ["た", "ta"], ["ち", "chi"], ["つ", "tsu"], ["て", "te"], ["と", "to"],
+        ["な", "na"], ["に", "ni"], ["ぬ", "nu"], ["ね", "ne"], ["の", "no"],
+        ["は", "ha"], ["ひ", "hi"], ["ふ", "fu"], ["へ", "he"], ["ほ", "ho"],
+        ["ま", "ma"], ["み", "mi"], ["む", "mu"], ["め", "me"], ["も", "mo"],
+        ["や", "ya"], ["ゆ", "yu"], ["よ", "yo"],
+        ["ら", "ra"], ["り", "ri"], ["る", "ru"], ["れ", "re"], ["ろ", "ro"],
+        ["わ", "wa"], ["を", "wo"], ["ん", "n"],
+        ["が", "ga"], ["ぎ", "gi"], ["ぐ", "gu"], ["げ", "ge"], ["ご", "go"],
+        ["ざ", "za"], ["じ", "ji"], ["ず", "zu"], ["ぜ", "ze"], ["ぞ", "zo"],
+        ["だ", "da"], ["ぢ", "ji"], ["づ", "zu"], ["で", "de"], ["ど", "do"],
+        ["ば", "ba"], ["び", "bi"], ["ぶ", "bu"], ["べ", "be"], ["ぼ", "bo"],
+        ["ぱ", "pa"], ["ぴ", "pi"], ["ぷ", "pu"], ["ぺ", "pe"], ["ぽ", "po"]
+      ]);
+
+      function toHiragana(text) {
+        return String(text || "").replace(/[\u30A1-\u30F6]/g, (char) =>
+          String.fromCharCode(char.charCodeAt(0) - 0x60)
+        );
+      }
+
+      function toKatakana(text) {
+        return String(text || "").replace(/[\u3041-\u3096]/g, (char) =>
+          String.fromCharCode(char.charCodeAt(0) + 0x60)
+        );
+      }
+
+      function isKanaText(text) {
+        return /^[\u3041-\u3096ー]+$/.test(text);
+      }
+
+      function kanaToRomaji(text) {
+        const hiragana = toHiragana(text);
+        if (!hiragana || !isKanaText(hiragana)) {
+          return "";
+        }
+
+        let result = "";
+        for (let index = 0; index < hiragana.length; index += 1) {
+          const current = hiragana[index];
+          const next = hiragana[index + 1] || "";
+          const pair = current + next;
+
+          if (current === "っ") {
+            const nextPair = hiragana.slice(index + 1, index + 3);
+            const nextRomaji =
+              kanaToRomajiMap.get(nextPair) ||
+              kanaToRomajiMap.get(next) ||
+              "";
+            if (nextRomaji) {
+              result += nextRomaji[0];
+            }
+            continue;
+          }
+
+          if (current === "ー") {
+            const lastChar = result[result.length - 1] || "";
+            if (/[aeiou]/.test(lastChar)) {
+              result += lastChar;
+            }
+            continue;
+          }
+
+          if (kanaToRomajiMap.has(pair)) {
+            result += kanaToRomajiMap.get(pair);
+            index += 1;
+            continue;
+          }
+
+          if (kanaToRomajiMap.has(current)) {
+            result += kanaToRomajiMap.get(current);
+            continue;
+          }
+
+          return "";
+        }
+
+        return result;
+      }
+
+      function buildSearchTokens(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").toLowerCase();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
+
+        if (label) {
+          tokens.add(label);
+          for (const part of label.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+            const hiraganaPart = toHiragana(part);
+            const katakanaPart = toKatakana(part);
+            if (hiraganaPart !== part) {
+              tokens.add(hiraganaPart);
+            }
+            if (katakanaPart !== part) {
+              tokens.add(katakanaPart);
+            }
+            const romaji = kanaToRomaji(part);
+            if (romaji) {
+              tokens.add(romaji);
+            }
+          }
+        }
+
+        for (const keyword of keywords) {
+          const normalizedKeyword = String(keyword || "").toLowerCase().trim();
+          if (!normalizedKeyword) {
+            continue;
+          }
+          tokens.add(normalizedKeyword);
+          const hiraganaKeyword = toHiragana(normalizedKeyword);
+          const katakanaKeyword = toKatakana(normalizedKeyword);
+          if (hiraganaKeyword !== normalizedKeyword) {
+            tokens.add(hiraganaKeyword);
+          }
+          if (katakanaKeyword !== normalizedKeyword) {
+            tokens.add(katakanaKeyword);
+          }
+          const romajiKeyword = kanaToRomaji(normalizedKeyword);
+          if (romajiKeyword) {
+            tokens.add(romajiKeyword);
+          }
+          for (const part of normalizedKeyword.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+            const hiraganaPart = toHiragana(part);
+            const katakanaPart = toKatakana(part);
+            if (hiraganaPart !== part) {
+              tokens.add(hiraganaPart);
+            }
+            if (katakanaPart !== part) {
+              tokens.add(katakanaPart);
+            }
+            const romaji = kanaToRomaji(part);
+            if (romaji) {
+              tokens.add(romaji);
+            }
+          }
+        }
+
+        return Array.from(tokens);
+      }
+
+      function buildDisplayKeywords(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").trim();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
+
+        if (label) {
+          tokens.add(label);
+        }
+
+        for (const keyword of keywords) {
+          const normalizedKeyword = String(keyword || "").trim();
+          if (!normalizedKeyword) {
+            continue;
+          }
+          tokens.add(normalizedKeyword);
+        }
+
+        return Array.from(tokens);
+      }
+
+      function createCandidateButton(definition) {
         const button = document.createElement("button");
         button.type = "button";
         button.className = "md-chip-button";
-        button.textContent = label;
-        button.dataset.promptId = id;
-        button.addEventListener("click", () => selectPrompt(id, button));
+        button.dataset.promptId = definition.id;
+        button.addEventListener("click", () => selectPrompt(definition.id, button));
+
+        const label = document.createElement("span");
+        label.className = "md-chip-label";
+        label.textContent = definition.label;
+        button.appendChild(label);
+
+        const help = document.createElement("lht-help-tooltip");
+        help.setAttribute("label", "キーワード");
+        help.setAttribute("placement", "bottom");
+        help.innerHTML = buildDisplayKeywords(definition).join(", ");
+        help.addEventListener("click", (event) => {
+          event.stopPropagation();
+        });
+        help.addEventListener("mousedown", (event) => {
+          event.stopPropagation();
+        });
+        button.appendChild(help);
+
         return button;
       }
 
       function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
+        const queryChanged = query !== lastSearchQuery;
+        lastSearchQuery = query;
         promptCandidateArea.innerHTML = "";
 
-        const matched = query && prRequestKeywords.some((keyword) => keyword.includes(query));
+        if (queryChanged) {
+          selectedPrompt = "";
+          commitInputSection.classList.add("md-hidden");
+          promptOutputSection.classList.add("md-hidden");
+          commitIdInput.value = "";
+          promptOutput.textContent = "";
+        }
 
-        if (!matched) {
-          if (selectedPrompt === "pr-request") {
+        const terms = query ? query.split(/\s+/).filter(Boolean) : [];
+        const matchedDefinitions = query
+          ? promptDefinitions.filter((definition) =>
+              terms.every((term) =>
+                buildSearchTokens(definition).some((token) => token.includes(term))
+              )
+            )
+          : promptDefinitions;
+        matchedDefinitions.sort((left, right) => {
+          if (left.label < right.label) return -1;
+          if (left.label > right.label) return 1;
+          return 0;
+        });
+
+        if (matchedDefinitions.length === 0) {
+          if (selectedPrompt) {
             selectedPrompt = "";
-            prRequestSection.classList.add("md-hidden");
+            commitInputSection.classList.add("md-hidden");
+            promptOutputSection.classList.add("md-hidden");
             updateOutput();
           }
           return;
         }
 
-        const button = createCandidateButton("PR作成依頼", "pr-request");
-        if (selectedPrompt === "pr-request") {
-          button.classList.add("is-active");
+        const hasSingleMatch = matchedDefinitions.length === 1;
+
+        if (hasSingleMatch && !selectedPrompt) {
+          selectedPrompt = matchedDefinitions[0].id;
+        } else if (
+          !hasSingleMatch &&
+          selectedPrompt &&
+          !matchedDefinitions.some((definition) => definition.id === selectedPrompt)
+        ) {
+          selectedPrompt = "";
         }
-        promptCandidateArea.appendChild(button);
+
+        for (const definition of matchedDefinitions) {
+          const button = createCandidateButton(definition);
+          if (hasSingleMatch && selectedPrompt === definition.id) {
+            button.classList.add("is-active");
+          }
+          promptCandidateArea.appendChild(button);
+        }
+
+        if (hasSingleMatch && selectedPrompt === matchedDefinitions[0].id) {
+          if (selectedPrompt === "pr-request" || selectedPrompt === "release-request") {
+            commitInputSection.classList.remove("md-hidden");
+          } else {
+            commitInputSection.classList.add("md-hidden");
+          }
+          promptOutputSection.classList.remove("md-hidden");
+          updateOutput();
+        }
       }
 
       function selectPrompt(id, button) {
@@ -303,9 +641,13 @@ limitations under the License.
         }
         button.classList.add("is-active");
 
-        if (id === "pr-request") {
-          prRequestSection.classList.remove("md-hidden");
+        promptOutputSection.classList.remove("md-hidden");
+
+        if (id === "pr-request" || id === "release-request") {
+          commitInputSection.classList.remove("md-hidden");
           commitIdInput.focus();
+        } else {
+          commitInputSection.classList.add("md-hidden");
         }
 
         updateOutput();
@@ -313,10 +655,61 @@ limitations under the License.
 
       function buildPromptText() {
         const commitId = (commitIdInput.value || "").trim();
-        if (selectedPrompt !== "pr-request" || !commitId) {
+        if (!selectedPrompt) {
           return "";
         }
-        return `${commitId} における変更内容についての、PRテキストとPRタイトルを markdown 形式で欲しい。`;
+        const selectedDefinition = promptDefinitions.find((definition) => definition.id === selectedPrompt);
+        const label = selectedDefinition ? selectedDefinition.label : "";
+        let body = "";
+        if (selectedPrompt === "pr-request") {
+          if (!commitId) {
+            return "";
+          }
+          body = `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は \`\`\` で囲まれた一塊として回答してください。`;
+        }
+        if (selectedPrompt === "release-request") {
+          if (!commitId) {
+            return "";
+          }
+          body = `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown 形式で作文してください。`;
+        }
+        if (selectedPrompt === "inline-code-request") {
+          body = "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。";
+        }
+        if (selectedPrompt === "github-no-change-request") {
+          body = "GitHub 変更操作の禁止。GitHubへの push、GitHub PR の作成や PR へのコメントなど、GitHub への変更をおこなう操作は行わないでください。";
+        }
+        if (selectedPrompt === "directory-markdown-check-request") {
+          body = "README.md などこのディレクトリの内容をあらわす markdown の内容を確認してください。";
+        }
+        if (selectedPrompt === "conversation-handover-request") {
+          body = "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。";
+        }
+        if (selectedPrompt === "spec-discussion-request") {
+          body = "今からの作業は仕様の検討です。実装を開始しないでください。一方で、まとまった仕様が実施事項に落としこめる場合には、TODO.mdに作業タスクとして分解して記述してください。";
+        }
+        if (selectedPrompt === "small-test-request") {
+          body = "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。";
+        }
+        if (selectedPrompt === "disagreement-first-request") {
+          body = "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。";
+        }
+        if (selectedPrompt === "todo-cleanup-request") {
+          body = "TODO.mdのなかで、すでに対応済みで実施済みとなっているTODOがあれば、それをクローズしたり、あるいは以前にすでにクローズ済みのTODOがあればこれを削除してください。";
+        }
+        if (selectedPrompt === "completion-check-request") {
+          body = "さきほどお願いした一連の依頼内容は、基本的に全て実施済みでしょうか。それともまだ未実施のものはありますでしょうか。";
+        }
+        if (selectedPrompt === "critical-review-request") {
+          body = "これから批判的なレビューを実施して欲しいです。誤り、間違い、TYPO、ささいなものでも批判的に指摘してください。それら批判的な指摘はこのコンテキストでは喜ばれます。";
+        }
+        if (selectedPrompt === "markdown-update-check-request") {
+          body = "実装の側に変更がおこなわれましたが、これに対応する markdown (.md) で未更新のものはありますか。あるいは新規で markdown (.md) を追加すべき変更はありましたか。";
+        }
+        if (!body || !label) {
+          return "";
+        }
+        return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
       }
 
       function updateOutput() {
@@ -326,6 +719,7 @@ limitations under the License.
 
       promptSearch.addEventListener("input", renderCandidates);
       commitIdInput.addEventListener("input", updateOutput);
+      includeLabelPrefix.addEventListener("change", updateOutput);
 
       renderCandidates();
       updateOutput();

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -64,6 +64,13 @@ limitations under the License.
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .md-search-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 16px;
+      align-items: start;
+    }
+
     .md-chip-row {
       display: flex;
       flex-wrap: wrap;
@@ -80,37 +87,49 @@ limitations under the License.
     }
 
     .md-chip-button {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
       appearance: none;
-      border: none;
+      border: 1px solid #d8d1e3;
       border-radius: 999px;
-      background: var(--md-sys-color-primary, #6200ee);
-      color: var(--md-sys-color-on-primary, #ffffff);
-      padding: 0.6rem 1.2rem;
-      font-size: 0.95rem;
+      background: #f7f2fa;
+      color: #4a4458;
+      padding: 0.32rem 0.9rem;
+      font-size: 0.88rem;
       font-weight: 600;
+      line-height: 1.1;
       cursor: pointer;
-      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
-      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
     }
 
     .md-chip-button:hover {
-      background: #4f00c9;
+      background: #efe7f8;
+      border-color: #cfc3e3;
+      color: #352f41;
       transform: translateY(-1px);
-      box-shadow: 0 6px 14px rgba(98, 0, 238, 0.24);
+      box-shadow: 0 4px 10px rgba(74, 68, 88, 0.10);
     }
 
     .md-chip-button.is-active {
-      background: #4f00c9;
+      border-color: transparent;
+      background: var(--md-sys-color-primary, #6200ee);
       color: var(--md-sys-color-on-primary, #ffffff);
       box-shadow: 0 6px 14px rgba(98, 0, 238, 0.24);
     }
 
-    .md-helper-text {
-      margin: 0;
-      padding: 0 1rem;
-      font-size: 0.75rem;
-      line-height: 1rem;
-      color: var(--md-sys-color-on-surface-variant, #49454f);
+    .md-chip-button .md-chip-label {
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .md-chip-button lht-help-tooltip {
+      flex: 0 0 auto;
+    }
+
+    .md-chip-button lht-help-tooltip .md-tooltip-content {
+      z-index: 400;
     }
 
     .md-output-title {
@@ -1153,30 +1172,31 @@ lht-index-card-link {
   <div class="md-surface-card md-card">
     <lht-page-hero
       title="プロンプト作成支援"
-      subtitle="定型よくある生成AIプロンプトを作成支援。"
+      subtitle="定型的な生成AIプロンプトを作成支援します。"
       icon="📝"
       help-label="プロンプト作成支援の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      AI や人に依頼するための文面を、用途別に短く組み立てるためのページです。<br><br>
-      初版では、PR タイトルと PR 本文を作成依頼するための文面を生成します。
+      このツールは、生成AIに引き渡すためのプロンプト作成を支援します。<br><br>
+      初版では、PR 文面、GitHub Release 文面、Markdown 出力指示、GitHub 操作禁止指示、ディレクトリ内容確認指示、会話引き継ぎ指示、仕様検討指示、軽量テスト追加指示、違和感や誤りの指摘優先指示、TODO 整理指示、実施状況確認指示、批判的レビュー指示、markdown 更新漏れ確認指示を作成依頼するための文面を生成します。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
-      <lht-text-field-help
-        field-id="promptSearch"
-        label="やりたいこと"
-        required
-        placeholder="例: pr"
-        help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら PR 作成依頼を表示します。">
-      </lht-text-field-help>
+      <div class="md-search-row">
+        <lht-text-field-help
+          field-id="promptSearch"
+          label="やりたいこと"
+          required
+          placeholder="例: pr / release"
+          help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら各種プロンプト候補を表示します。">
+        </lht-text-field-help>
+      </div>
 
-      <p class="md-helper-text">小窓に `p` `r` `pr` などを入れると、候補キーワードへの部分一致として `PR作成依頼` ボタンを表示します。</p>
       <div id="promptCandidateArea" class="md-chip-row" aria-live="polite"></div>
     </section>
 
-    <section id="prRequestSection" class="md-section md-stack-md md-hidden">
+    <section id="commitInputSection" class="md-section md-stack-md md-hidden">
       <div class="md-form-grid md-form-grid-2">
         <lht-text-field-help
           field-id="commitId"
@@ -1186,9 +1206,17 @@ lht-index-card-link {
           help-text="PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。">
         </lht-text-field-help>
       </div>
+    </section>
 
+    <section id="promptOutputSection" class="md-section md-stack-md md-hidden">
       <p class="md-output-title">生成結果</p>
       <lht-command-block command-id="promptOutput"></lht-command-block>
+      <lht-switch-help
+        switch-id="includeLabelPrefix"
+        label="ラベル名を先頭に含める"
+        help-label="ラベル名を先頭に含める説明">
+        ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
+      </lht-switch-help>
     </section>
 
     <lht-toast id="toast"></lht-toast>
@@ -1202,47 +1230,357 @@ lht-index-card-link {
 
       const promptSearch = document.getElementById("promptSearch");
       const promptCandidateArea = document.getElementById("promptCandidateArea");
-      const prRequestSection = document.getElementById("prRequestSection");
+      const commitInputSection = document.getElementById("commitInputSection");
+      const promptOutputSection = document.getElementById("promptOutputSection");
       const commitIdInput = document.getElementById("commitId");
+      const includeLabelPrefix = document.getElementById("includeLabelPrefix");
       const promptOutput = document.getElementById("promptOutput");
 
-      if (!promptSearch || !commitIdInput) {
+      if (!promptSearch || !commitIdInput || !includeLabelPrefix) {
         return;
       }
 
       let selectedPrompt = "";
-      const prRequestKeywords = ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文"];
+      let lastSearchQuery = "";
+      const promptDefinitions = [
+        {
+          id: "pr-request",
+          label: "GitHub PR 文面作成",
+          keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"]
+        },
+        {
+          id: "release-request",
+          label: "GitHub Release 文面作成",
+          keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"]
+        },
+        {
+          id: "inline-code-request",
+          label: "Markdown インラインコードとして出力",
+          keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"]
+        },
+        {
+          id: "github-no-change-request",
+          label: "GitHub 変更操作を禁止",
+          keywords: ["github", "push", "pr", "comment", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"]
+        },
+        {
+          id: "directory-markdown-check-request",
+          label: "100: ディレクトリ内の内容を確認して把握",
+          keywords: ["readme", "markdown", "directory", "ディレクトリ", "内容確認", "md確認", "でぃれくとり", "ないようかくにん", "direkutori", "naiyoukakunin", "りーどみー", "まーくだうん", "えむでぃー"]
+        },
+        {
+          id: "conversation-handover-request",
+          label: "会話の引継テキストを生成",
+          keywords: ["handover", "conversation", "引き継ぎ", "会話", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"]
+        },
+        {
+          id: "spec-discussion-request",
+          label: "仕様検討モードで進める",
+          keywords: ["spec", "specification", "仕様", "検討", "todo", "todo.md", "しよう", "けんとう", "とぅーどぅー", "shiyou", "kentou", "すぺっく"]
+        },
+        {
+          id: "small-test-request",
+          label: "事象の再発防止テストを追加",
+          keywords: ["test", "testing", "small test", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"]
+        },
+        {
+          id: "disagreement-first-request",
+          label: "違和感や誤りを先に指摘",
+          keywords: ["disagree", "wrong", "違和感", "間違い", "指摘", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"]
+        },
+        {
+          id: "todo-cleanup-request",
+          label: "TODO.md の完了項目を整理",
+          keywords: ["todo", "todo.md", "cleanup", "close", "closed", "整理", "完了", "クローズ", "削除", "とぅーどぅー", "せいり", "かんりょう", "s e i r i", "kanryou"]
+        },
+        {
+          id: "completion-check-request",
+          label: "依頼内容の実施状況を確認",
+          keywords: ["done", "completed", "status", "check", "実施済み", "未実施", "確認", "じっしずみ", "みじっし", "かくにん", "jisshizumi", "mijisshi", "kakunin"]
+        },
+        {
+          id: "critical-review-request",
+          label: "批判的レビューを依頼",
+          keywords: ["review", "critical review", "typo", "批判的", "レビュー", "誤り", "間違い", "たいぽ", "ひはんてき", "れびゅー", "まちがい", "typo", "hibanteki", "rebyu-"]
+        },
+        {
+          id: "markdown-update-check-request",
+          label: "markdown 更新漏れを確認",
+          keywords: ["markdown", "md", "update", "doc", "docs", "更新漏れ", "未更新", "追加すべき", "まーくだうん", "みこうしん", "こうしんもれ", "markdown", "mikkoushin", "koushinmore"]
+        }
+      ];
 
-      function createCandidateButton(label, id) {
+      const kanaToRomajiMap = new Map([
+        ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
+        ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
+        ["ちゃ", "cha"], ["ちゅ", "chu"], ["ちょ", "cho"],
+        ["にゃ", "nya"], ["にゅ", "nyu"], ["にょ", "nyo"],
+        ["ひゃ", "hya"], ["ひゅ", "hyu"], ["ひょ", "hyo"],
+        ["みゃ", "mya"], ["みゅ", "myu"], ["みょ", "myo"],
+        ["りゃ", "rya"], ["りゅ", "ryu"], ["りょ", "ryo"],
+        ["ぎゃ", "gya"], ["ぎゅ", "gyu"], ["ぎょ", "gyo"],
+        ["じゃ", "ja"], ["じゅ", "ju"], ["じょ", "jo"],
+        ["びゃ", "bya"], ["びゅ", "byu"], ["びょ", "byo"],
+        ["ぴゃ", "pya"], ["ぴゅ", "pyu"], ["ぴょ", "pyo"],
+        ["ゔぁ", "va"], ["ゔぃ", "vi"], ["ゔ", "vu"], ["ゔぇ", "ve"], ["ゔぉ", "vo"],
+        ["あ", "a"], ["い", "i"], ["う", "u"], ["え", "e"], ["お", "o"],
+        ["か", "ka"], ["き", "ki"], ["く", "ku"], ["け", "ke"], ["こ", "ko"],
+        ["さ", "sa"], ["し", "shi"], ["す", "su"], ["せ", "se"], ["そ", "so"],
+        ["た", "ta"], ["ち", "chi"], ["つ", "tsu"], ["て", "te"], ["と", "to"],
+        ["な", "na"], ["に", "ni"], ["ぬ", "nu"], ["ね", "ne"], ["の", "no"],
+        ["は", "ha"], ["ひ", "hi"], ["ふ", "fu"], ["へ", "he"], ["ほ", "ho"],
+        ["ま", "ma"], ["み", "mi"], ["む", "mu"], ["め", "me"], ["も", "mo"],
+        ["や", "ya"], ["ゆ", "yu"], ["よ", "yo"],
+        ["ら", "ra"], ["り", "ri"], ["る", "ru"], ["れ", "re"], ["ろ", "ro"],
+        ["わ", "wa"], ["を", "wo"], ["ん", "n"],
+        ["が", "ga"], ["ぎ", "gi"], ["ぐ", "gu"], ["げ", "ge"], ["ご", "go"],
+        ["ざ", "za"], ["じ", "ji"], ["ず", "zu"], ["ぜ", "ze"], ["ぞ", "zo"],
+        ["だ", "da"], ["ぢ", "ji"], ["づ", "zu"], ["で", "de"], ["ど", "do"],
+        ["ば", "ba"], ["び", "bi"], ["ぶ", "bu"], ["べ", "be"], ["ぼ", "bo"],
+        ["ぱ", "pa"], ["ぴ", "pi"], ["ぷ", "pu"], ["ぺ", "pe"], ["ぽ", "po"]
+      ]);
+
+      function toHiragana(text) {
+        return String(text || "").replace(/[\u30A1-\u30F6]/g, (char) =>
+          String.fromCharCode(char.charCodeAt(0) - 0x60)
+        );
+      }
+
+      function toKatakana(text) {
+        return String(text || "").replace(/[\u3041-\u3096]/g, (char) =>
+          String.fromCharCode(char.charCodeAt(0) + 0x60)
+        );
+      }
+
+      function isKanaText(text) {
+        return /^[\u3041-\u3096ー]+$/.test(text);
+      }
+
+      function kanaToRomaji(text) {
+        const hiragana = toHiragana(text);
+        if (!hiragana || !isKanaText(hiragana)) {
+          return "";
+        }
+
+        let result = "";
+        for (let index = 0; index < hiragana.length; index += 1) {
+          const current = hiragana[index];
+          const next = hiragana[index + 1] || "";
+          const pair = current + next;
+
+          if (current === "っ") {
+            const nextPair = hiragana.slice(index + 1, index + 3);
+            const nextRomaji =
+              kanaToRomajiMap.get(nextPair) ||
+              kanaToRomajiMap.get(next) ||
+              "";
+            if (nextRomaji) {
+              result += nextRomaji[0];
+            }
+            continue;
+          }
+
+          if (current === "ー") {
+            const lastChar = result[result.length - 1] || "";
+            if (/[aeiou]/.test(lastChar)) {
+              result += lastChar;
+            }
+            continue;
+          }
+
+          if (kanaToRomajiMap.has(pair)) {
+            result += kanaToRomajiMap.get(pair);
+            index += 1;
+            continue;
+          }
+
+          if (kanaToRomajiMap.has(current)) {
+            result += kanaToRomajiMap.get(current);
+            continue;
+          }
+
+          return "";
+        }
+
+        return result;
+      }
+
+      function buildSearchTokens(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").toLowerCase();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
+
+        if (label) {
+          tokens.add(label);
+          for (const part of label.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+            const hiraganaPart = toHiragana(part);
+            const katakanaPart = toKatakana(part);
+            if (hiraganaPart !== part) {
+              tokens.add(hiraganaPart);
+            }
+            if (katakanaPart !== part) {
+              tokens.add(katakanaPart);
+            }
+            const romaji = kanaToRomaji(part);
+            if (romaji) {
+              tokens.add(romaji);
+            }
+          }
+        }
+
+        for (const keyword of keywords) {
+          const normalizedKeyword = String(keyword || "").toLowerCase().trim();
+          if (!normalizedKeyword) {
+            continue;
+          }
+          tokens.add(normalizedKeyword);
+          const hiraganaKeyword = toHiragana(normalizedKeyword);
+          const katakanaKeyword = toKatakana(normalizedKeyword);
+          if (hiraganaKeyword !== normalizedKeyword) {
+            tokens.add(hiraganaKeyword);
+          }
+          if (katakanaKeyword !== normalizedKeyword) {
+            tokens.add(katakanaKeyword);
+          }
+          const romajiKeyword = kanaToRomaji(normalizedKeyword);
+          if (romajiKeyword) {
+            tokens.add(romajiKeyword);
+          }
+          for (const part of normalizedKeyword.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+            const hiraganaPart = toHiragana(part);
+            const katakanaPart = toKatakana(part);
+            if (hiraganaPart !== part) {
+              tokens.add(hiraganaPart);
+            }
+            if (katakanaPart !== part) {
+              tokens.add(katakanaPart);
+            }
+            const romaji = kanaToRomaji(part);
+            if (romaji) {
+              tokens.add(romaji);
+            }
+          }
+        }
+
+        return Array.from(tokens);
+      }
+
+      function buildDisplayKeywords(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").trim();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
+
+        if (label) {
+          tokens.add(label);
+        }
+
+        for (const keyword of keywords) {
+          const normalizedKeyword = String(keyword || "").trim();
+          if (!normalizedKeyword) {
+            continue;
+          }
+          tokens.add(normalizedKeyword);
+        }
+
+        return Array.from(tokens);
+      }
+
+      function createCandidateButton(definition) {
         const button = document.createElement("button");
         button.type = "button";
         button.className = "md-chip-button";
-        button.textContent = label;
-        button.dataset.promptId = id;
-        button.addEventListener("click", () => selectPrompt(id, button));
+        button.dataset.promptId = definition.id;
+        button.addEventListener("click", () => selectPrompt(definition.id, button));
+
+        const label = document.createElement("span");
+        label.className = "md-chip-label";
+        label.textContent = definition.label;
+        button.appendChild(label);
+
+        const help = document.createElement("lht-help-tooltip");
+        help.setAttribute("label", "キーワード");
+        help.setAttribute("placement", "bottom");
+        help.innerHTML = buildDisplayKeywords(definition).join(", ");
+        help.addEventListener("click", (event) => {
+          event.stopPropagation();
+        });
+        help.addEventListener("mousedown", (event) => {
+          event.stopPropagation();
+        });
+        button.appendChild(help);
+
         return button;
       }
 
       function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
+        const queryChanged = query !== lastSearchQuery;
+        lastSearchQuery = query;
         promptCandidateArea.innerHTML = "";
 
-        const matched = query && prRequestKeywords.some((keyword) => keyword.includes(query));
+        if (queryChanged) {
+          selectedPrompt = "";
+          commitInputSection.classList.add("md-hidden");
+          promptOutputSection.classList.add("md-hidden");
+          commitIdInput.value = "";
+          promptOutput.textContent = "";
+        }
 
-        if (!matched) {
-          if (selectedPrompt === "pr-request") {
+        const terms = query ? query.split(/\s+/).filter(Boolean) : [];
+        const matchedDefinitions = query
+          ? promptDefinitions.filter((definition) =>
+              terms.every((term) =>
+                buildSearchTokens(definition).some((token) => token.includes(term))
+              )
+            )
+          : promptDefinitions;
+        matchedDefinitions.sort((left, right) => {
+          if (left.label < right.label) return -1;
+          if (left.label > right.label) return 1;
+          return 0;
+        });
+
+        if (matchedDefinitions.length === 0) {
+          if (selectedPrompt) {
             selectedPrompt = "";
-            prRequestSection.classList.add("md-hidden");
+            commitInputSection.classList.add("md-hidden");
+            promptOutputSection.classList.add("md-hidden");
             updateOutput();
           }
           return;
         }
 
-        const button = createCandidateButton("PR作成依頼", "pr-request");
-        if (selectedPrompt === "pr-request") {
-          button.classList.add("is-active");
+        const hasSingleMatch = matchedDefinitions.length === 1;
+
+        if (hasSingleMatch && !selectedPrompt) {
+          selectedPrompt = matchedDefinitions[0].id;
+        } else if (
+          !hasSingleMatch &&
+          selectedPrompt &&
+          !matchedDefinitions.some((definition) => definition.id === selectedPrompt)
+        ) {
+          selectedPrompt = "";
         }
-        promptCandidateArea.appendChild(button);
+
+        for (const definition of matchedDefinitions) {
+          const button = createCandidateButton(definition);
+          if (hasSingleMatch && selectedPrompt === definition.id) {
+            button.classList.add("is-active");
+          }
+          promptCandidateArea.appendChild(button);
+        }
+
+        if (hasSingleMatch && selectedPrompt === matchedDefinitions[0].id) {
+          if (selectedPrompt === "pr-request" || selectedPrompt === "release-request") {
+            commitInputSection.classList.remove("md-hidden");
+          } else {
+            commitInputSection.classList.add("md-hidden");
+          }
+          promptOutputSection.classList.remove("md-hidden");
+          updateOutput();
+        }
       }
 
       function selectPrompt(id, button) {
@@ -1252,9 +1590,13 @@ lht-index-card-link {
         }
         button.classList.add("is-active");
 
-        if (id === "pr-request") {
-          prRequestSection.classList.remove("md-hidden");
+        promptOutputSection.classList.remove("md-hidden");
+
+        if (id === "pr-request" || id === "release-request") {
+          commitInputSection.classList.remove("md-hidden");
           commitIdInput.focus();
+        } else {
+          commitInputSection.classList.add("md-hidden");
         }
 
         updateOutput();
@@ -1262,10 +1604,61 @@ lht-index-card-link {
 
       function buildPromptText() {
         const commitId = (commitIdInput.value || "").trim();
-        if (selectedPrompt !== "pr-request" || !commitId) {
+        if (!selectedPrompt) {
           return "";
         }
-        return `${commitId} における変更内容についての、PRテキストとPRタイトルを markdown 形式で欲しい。`;
+        const selectedDefinition = promptDefinitions.find((definition) => definition.id === selectedPrompt);
+        const label = selectedDefinition ? selectedDefinition.label : "";
+        let body = "";
+        if (selectedPrompt === "pr-request") {
+          if (!commitId) {
+            return "";
+          }
+          body = `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は \`\`\` で囲まれた一塊として回答してください。`;
+        }
+        if (selectedPrompt === "release-request") {
+          if (!commitId) {
+            return "";
+          }
+          body = `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown 形式で作文してください。`;
+        }
+        if (selectedPrompt === "inline-code-request") {
+          body = "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。";
+        }
+        if (selectedPrompt === "github-no-change-request") {
+          body = "GitHub 変更操作の禁止。GitHubへの push、GitHub PR の作成や PR へのコメントなど、GitHub への変更をおこなう操作は行わないでください。";
+        }
+        if (selectedPrompt === "directory-markdown-check-request") {
+          body = "README.md などこのディレクトリの内容をあらわす markdown の内容を確認してください。";
+        }
+        if (selectedPrompt === "conversation-handover-request") {
+          body = "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。";
+        }
+        if (selectedPrompt === "spec-discussion-request") {
+          body = "今からの作業は仕様の検討です。実装を開始しないでください。一方で、まとまった仕様が実施事項に落としこめる場合には、TODO.mdに作業タスクとして分解して記述してください。";
+        }
+        if (selectedPrompt === "small-test-request") {
+          body = "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。";
+        }
+        if (selectedPrompt === "disagreement-first-request") {
+          body = "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。";
+        }
+        if (selectedPrompt === "todo-cleanup-request") {
+          body = "TODO.mdのなかで、すでに対応済みで実施済みとなっているTODOがあれば、それをクローズしたり、あるいは以前にすでにクローズ済みのTODOがあればこれを削除してください。";
+        }
+        if (selectedPrompt === "completion-check-request") {
+          body = "さきほどお願いした一連の依頼内容は、基本的に全て実施済みでしょうか。それともまだ未実施のものはありますでしょうか。";
+        }
+        if (selectedPrompt === "critical-review-request") {
+          body = "これから批判的なレビューを実施して欲しいです。誤り、間違い、TYPO、ささいなものでも批判的に指摘してください。それら批判的な指摘はこのコンテキストでは喜ばれます。";
+        }
+        if (selectedPrompt === "markdown-update-check-request") {
+          body = "実装の側に変更がおこなわれましたが、これに対応する markdown (.md) で未更新のものはありますか。あるいは新規で markdown (.md) を追加すべき変更はありましたか。";
+        }
+        if (!body || !label) {
+          return "";
+        }
+        return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
       }
 
       function updateOutput() {
@@ -1275,6 +1668,7 @@ lht-index-card-link {
 
       promptSearch.addEventListener("input", renderCandidates);
       commitIdInput.addEventListener("input", updateOutput);
+      includeLabelPrefix.addEventListener("change", updateOutput);
 
       renderCandidates();
       updateOutput();

--- a/lht-cmn/FEEDBACK.md
+++ b/lht-cmn/FEEDBACK.md
@@ -19,3 +19,19 @@
 - 補足:
   - 今回 `docs/prompt/prompt-gen-src.html` では、既存画面に合わせるためページ側へ上記スタイルを追加して回避した
   - 根本対応は `lht-cmn` 側で行うべき
+
+## 2026-03-08 `lht-switch-help` material bundle gap
+
+- 症状:
+  - `lht-switch-help` を利用しても、ページ側で `md-switch` が未登録のため fallback 実装に落ちる
+  - `prompt-gen` では text field は Material 表示なのに switch だけ fallback 表示になる
+- 問題:
+  - `lht-*` を使っても、入力部品ごとに Material / fallback が混在しやすい
+  - ページ側から見ると `lht-switch-help` の見た目が他の Material 部品と揃わず、利用側で原因が見えにくい
+- 期待:
+  - `lht-switch-help` も `lht-cmn` 側で Material 実装を self-contained に利用できる形に寄せたい
+  - 少なくとも `md-switch` 用 bundle の vendor / 読み込み導線を `lht-cmn` 側で用意したい
+  - それが難しい場合でも、README に「switch は fallback 前提になりうる」ことを明記したい
+- 補足:
+  - 現状の `lht-switch-help` は `window.customElements.get("md-switch")` が false のとき fallback DOM を生成する実装になっている
+  - `lht-cmn/vendor` には `material-web-outlined-text-field.bundle.js` はあるが、`md-switch` 相当の bundle は見当たらない


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` を中心に、プロンプト作成支援ページの候補ボタン、検索挙動、出力形式、UI配置を見直しました。 あわせて `lht-cmn` の switch 表示に関する課題を `FEEDBACK.md` へ追記しています。

## 変更内容

- `docs/prompt/prompt-gen-src.html` を更新し、固定文面テンプレートの候補を追加
- 候補ボタンの表示順をラベル基準でソートするよう調整
- 候補検索を改善
- 空欄時は全候補表示
- 空白区切りの AND 検索に対応
- ラベル、関連キーワード、ひらがな、カタカナ、ローマ字を検索トークンとして利用
- 候補が1件に絞れた時だけ primary 表示に変更
- 生成結果の書式や固定文面の表現を複数回調整
- `ラベル名を先頭に含める` スイッチの配置を見直し、生成結果エリアの下へ移動
- 候補ボタン内に `(i)` を配置し、キーワード参照を `lht-help-tooltip` で確認できるよう変更
- 重複して見えていた検索用内部トークンは、ホバー表示では出さないよう整理
- `lht-cmn/FEEDBACK.md` に `lht-switch-help` の Material bundle 不足に関する課題を追記

## 影響

- `prompt-gen` ページの操作性と見た目が改善されます
- 候補の探しやすさが向上し、かな・カナ・ローマ字でもヒットしやすくなります
- `lht-cmn` 側に switch 表示まわりの未整備事項がフィードバックとして記録されます