### PR TITLE
prompt-gen の候補ラベル採番と prompt-gen テスト追加を実施

### DIFF
--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -3261,7 +3261,7 @@ if (!customElements.get("lht-page-menu")) {
 const promptDefinitions = [
     {
         id: "pr-request",
-        label: "GitHub PR 文面作成",
+        label: "501: GitHub PR 文面の作成",
         keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
@@ -3270,7 +3270,7 @@ const promptDefinitions = [
     },
     {
         id: "release-request",
-        label: "GitHub Release 文面作成",
+        label: "502: GitHub Release 文面の作成",
         keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
@@ -3279,14 +3279,14 @@ const promptDefinitions = [
     },
     {
         id: "inline-code-request",
-        label: "Markdown インラインコードとして出力",
+        label: "303: Markdown インラインコードとして出力",
         keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
         buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
     },
     {
         id: "github-no-change-request",
-        label: "GitHub 変更操作の禁止",
+        label: "503: GitHub 変更操作の禁止",
         keywords: ["github", "push", "pr", "comment", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
         requiresCommitId: false,
         buildBody: () => "GitHub 変更操作の禁止。GitHubへの push、GitHub PR の作成や PR へのコメントなど、GitHub への変更をおこなう操作は行わないでください。"
@@ -3300,63 +3300,77 @@ const promptDefinitions = [
     },
     {
         id: "conversation-handover-request",
-        label: "会話の引継テキストの生成",
+        label: "301: 会話の引継テキストの生成",
         keywords: ["handover", "conversation", "引き継ぎ", "会話", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
         requiresCommitId: false,
         buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
     },
     {
         id: "spec-discussion-request",
-        label: "仕様検討モードで進める",
+        label: "703: 仕様検討モードで進める",
         keywords: ["spec", "specification", "仕様", "検討", "todo", "todo.md", "しよう", "けんとう", "とぅーどぅー", "shiyou", "kentou", "すぺっく"],
         requiresCommitId: false,
         buildBody: () => "今からの作業は仕様の検討です。実装を開始しないでください。一方で、まとまった仕様が実施事項に落としこめる場合には、TODO.mdに作業タスクとして分解して記述してください。"
     },
     {
         id: "small-test-request",
-        label: "事象の再発防止テストを追加",
+        label: "702: 事象の再発防止テストを追加",
         keywords: ["test", "testing", "small test", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
         requiresCommitId: false,
         buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
     },
     {
         id: "disagreement-first-request",
-        label: "違和感や誤りを先に指摘",
+        label: "302: 違和感や誤りを先に指摘",
         keywords: ["disagree", "wrong", "違和感", "間違い", "指摘", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
         requiresCommitId: false,
         buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
     },
     {
         id: "todo-cleanup-request",
-        label: "TODO.md の完了項目を整理",
+        label: "704: TODO.md の完了項目を整理",
         keywords: ["todo", "todo.md", "cleanup", "close", "closed", "整理", "完了", "クローズ", "削除", "とぅーどぅー", "せいり", "かんりょう", "s e i r i", "kanryou"],
         requiresCommitId: false,
         buildBody: () => "TODO.mdのなかで、すでに対応済みで実施済みとなっているTODOがあれば、それをクローズしたり、あるいは以前にすでにクローズ済みのTODOがあればこれを削除してください。"
     },
     {
         id: "completion-check-request",
-        label: "依頼内容の実施状況を確認",
+        label: "306: 依頼内容の実施状況を確認",
         keywords: ["done", "completed", "status", "check", "実施済み", "未実施", "確認", "じっしずみ", "みじっし", "かくにん", "jisshizumi", "mijisshi", "kakunin"],
         requiresCommitId: false,
         buildBody: () => "さきほどお願いした一連の依頼内容は、基本的に全て実施済みでしょうか。それともまだ未実施のものはありますでしょうか。"
     },
     {
         id: "critical-review-request",
-        label: "批判的レビューを依頼",
+        label: "304: 批判的レビューの依頼",
         keywords: ["review", "critical review", "typo", "批判的", "レビュー", "誤り", "間違い", "たいぽ", "ひはんてき", "れびゅー", "まちがい", "typo", "hibanteki", "rebyu-"],
         requiresCommitId: false,
         buildBody: () => "これから批判的なレビューを実施して欲しいです。誤り、間違い、TYPO、ささいなものでも批判的に指摘してください。それら批判的な指摘はこのコンテキストでは喜ばれます。"
     },
     {
         id: "markdown-update-check-request",
-        label: "markdown 更新漏れの確認",
+        label: "102: markdown 更新漏れの確認",
         keywords: ["markdown", "md", "update", "doc", "docs", "更新漏れ", "未更新", "追加すべき", "まーくだうん", "みこうしん", "こうしんもれ", "markdown", "mikkoushin", "koushinmore"],
         requiresCommitId: false,
         buildBody: () => "実装の側に変更がおこなわれましたが、これに対応する markdown (.md) で未更新のものはありますか。あるいは新規で markdown (.md) を追加すべき変更はありましたか。"
     },
     {
+        id: "hallucination-check-request",
+        label: "305: 回答のハルシネーション有無を再確認",
+        keywords: ["hallucination", "fact check", "web search", "裏どり", "裏取り", "ハルシネーション", "再確認", "回答確認", "うらどり", "さいかくにん", "かいとうかくにん"],
+        requiresCommitId: false,
+        buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
+    },
+    {
+        id: "directory-summary-markdown-request",
+        label: "101: ディレクトリ内容整理 markdown を作成",
+        keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "整理", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
+        requiresCommitId: false,
+        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+    },
+    {
         id: "single-file-web-app-request",
-        label: "Single-file Web App の維持",
+        label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
         buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -1,7 +1,7 @@
 const promptDefinitions = [
     {
         id: "pr-request",
-        label: "GitHub PR 文面作成",
+        label: "501: GitHub PR 文面の作成",
         keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
@@ -10,7 +10,7 @@ const promptDefinitions = [
     },
     {
         id: "release-request",
-        label: "GitHub Release 文面作成",
+        label: "502: GitHub Release 文面の作成",
         keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
@@ -19,14 +19,14 @@ const promptDefinitions = [
     },
     {
         id: "inline-code-request",
-        label: "Markdown インラインコードとして出力",
+        label: "303: Markdown インラインコードとして出力",
         keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
         buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
     },
     {
         id: "github-no-change-request",
-        label: "GitHub 変更操作の禁止",
+        label: "503: GitHub 変更操作の禁止",
         keywords: ["github", "push", "pr", "comment", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
         requiresCommitId: false,
         buildBody: () => "GitHub 変更操作の禁止。GitHubへの push、GitHub PR の作成や PR へのコメントなど、GitHub への変更をおこなう操作は行わないでください。"
@@ -40,63 +40,77 @@ const promptDefinitions = [
     },
     {
         id: "conversation-handover-request",
-        label: "会話の引継テキストの生成",
+        label: "301: 会話の引継テキストの生成",
         keywords: ["handover", "conversation", "引き継ぎ", "会話", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
         requiresCommitId: false,
         buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
     },
     {
         id: "spec-discussion-request",
-        label: "仕様検討モードで進める",
+        label: "703: 仕様検討モードで進める",
         keywords: ["spec", "specification", "仕様", "検討", "todo", "todo.md", "しよう", "けんとう", "とぅーどぅー", "shiyou", "kentou", "すぺっく"],
         requiresCommitId: false,
         buildBody: () => "今からの作業は仕様の検討です。実装を開始しないでください。一方で、まとまった仕様が実施事項に落としこめる場合には、TODO.mdに作業タスクとして分解して記述してください。"
     },
     {
         id: "small-test-request",
-        label: "事象の再発防止テストを追加",
+        label: "702: 事象の再発防止テストを追加",
         keywords: ["test", "testing", "small test", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
         requiresCommitId: false,
         buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
     },
     {
         id: "disagreement-first-request",
-        label: "違和感や誤りを先に指摘",
+        label: "302: 違和感や誤りを先に指摘",
         keywords: ["disagree", "wrong", "違和感", "間違い", "指摘", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
         requiresCommitId: false,
         buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
     },
     {
         id: "todo-cleanup-request",
-        label: "TODO.md の完了項目を整理",
+        label: "704: TODO.md の完了項目を整理",
         keywords: ["todo", "todo.md", "cleanup", "close", "closed", "整理", "完了", "クローズ", "削除", "とぅーどぅー", "せいり", "かんりょう", "s e i r i", "kanryou"],
         requiresCommitId: false,
         buildBody: () => "TODO.mdのなかで、すでに対応済みで実施済みとなっているTODOがあれば、それをクローズしたり、あるいは以前にすでにクローズ済みのTODOがあればこれを削除してください。"
     },
     {
         id: "completion-check-request",
-        label: "依頼内容の実施状況を確認",
+        label: "306: 依頼内容の実施状況を確認",
         keywords: ["done", "completed", "status", "check", "実施済み", "未実施", "確認", "じっしずみ", "みじっし", "かくにん", "jisshizumi", "mijisshi", "kakunin"],
         requiresCommitId: false,
         buildBody: () => "さきほどお願いした一連の依頼内容は、基本的に全て実施済みでしょうか。それともまだ未実施のものはありますでしょうか。"
     },
     {
         id: "critical-review-request",
-        label: "批判的レビューを依頼",
+        label: "304: 批判的レビューの依頼",
         keywords: ["review", "critical review", "typo", "批判的", "レビュー", "誤り", "間違い", "たいぽ", "ひはんてき", "れびゅー", "まちがい", "typo", "hibanteki", "rebyu-"],
         requiresCommitId: false,
         buildBody: () => "これから批判的なレビューを実施して欲しいです。誤り、間違い、TYPO、ささいなものでも批判的に指摘してください。それら批判的な指摘はこのコンテキストでは喜ばれます。"
     },
     {
         id: "markdown-update-check-request",
-        label: "markdown 更新漏れの確認",
+        label: "102: markdown 更新漏れの確認",
         keywords: ["markdown", "md", "update", "doc", "docs", "更新漏れ", "未更新", "追加すべき", "まーくだうん", "みこうしん", "こうしんもれ", "markdown", "mikkoushin", "koushinmore"],
         requiresCommitId: false,
         buildBody: () => "実装の側に変更がおこなわれましたが、これに対応する markdown (.md) で未更新のものはありますか。あるいは新規で markdown (.md) を追加すべき変更はありましたか。"
     },
     {
+        id: "hallucination-check-request",
+        label: "305: 回答のハルシネーション有無を再確認",
+        keywords: ["hallucination", "fact check", "web search", "裏どり", "裏取り", "ハルシネーション", "再確認", "回答確認", "うらどり", "さいかくにん", "かいとうかくにん"],
+        requiresCommitId: false,
+        buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
+    },
+    {
+        id: "directory-summary-markdown-request",
+        label: "101: ディレクトリ内容整理 markdown を作成",
+        keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "整理", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
+        requiresCommitId: false,
+        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+    },
+    {
         id: "single-file-web-app-request",
-        label: "Single-file Web App の維持",
+        label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
         buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -9,7 +9,7 @@ type PromptDefinition = {
 const promptDefinitions: PromptDefinition[] = [
   {
     id: "pr-request",
-    label: "GitHub PR 文面作成",
+    label: "501: GitHub PR 文面の作成",
     keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
     requiresCommitId: true,
     buildBody: (commitId: string) => commitId
@@ -18,7 +18,7 @@ const promptDefinitions: PromptDefinition[] = [
   },
   {
     id: "release-request",
-    label: "GitHub Release 文面作成",
+    label: "502: GitHub Release 文面の作成",
     keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
     requiresCommitId: true,
     buildBody: (commitId: string) => commitId
@@ -27,14 +27,14 @@ const promptDefinitions: PromptDefinition[] = [
   },
   {
     id: "inline-code-request",
-    label: "Markdown インラインコードとして出力",
+    label: "303: Markdown インラインコードとして出力",
     keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
     requiresCommitId: false,
     buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
   },
   {
     id: "github-no-change-request",
-    label: "GitHub 変更操作の禁止",
+    label: "503: GitHub 変更操作の禁止",
     keywords: ["github", "push", "pr", "comment", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
     requiresCommitId: false,
     buildBody: () => "GitHub 変更操作の禁止。GitHubへの push、GitHub PR の作成や PR へのコメントなど、GitHub への変更をおこなう操作は行わないでください。"
@@ -48,63 +48,77 @@ const promptDefinitions: PromptDefinition[] = [
   },
   {
     id: "conversation-handover-request",
-    label: "会話の引継テキストの生成",
+    label: "301: 会話の引継テキストの生成",
     keywords: ["handover", "conversation", "引き継ぎ", "会話", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
     requiresCommitId: false,
     buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
   },
   {
     id: "spec-discussion-request",
-    label: "仕様検討モードで進める",
+    label: "703: 仕様検討モードで進める",
     keywords: ["spec", "specification", "仕様", "検討", "todo", "todo.md", "しよう", "けんとう", "とぅーどぅー", "shiyou", "kentou", "すぺっく"],
     requiresCommitId: false,
     buildBody: () => "今からの作業は仕様の検討です。実装を開始しないでください。一方で、まとまった仕様が実施事項に落としこめる場合には、TODO.mdに作業タスクとして分解して記述してください。"
   },
   {
     id: "small-test-request",
-    label: "事象の再発防止テストを追加",
+    label: "702: 事象の再発防止テストを追加",
     keywords: ["test", "testing", "small test", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
     requiresCommitId: false,
     buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
   },
   {
     id: "disagreement-first-request",
-    label: "違和感や誤りを先に指摘",
+    label: "302: 違和感や誤りを先に指摘",
     keywords: ["disagree", "wrong", "違和感", "間違い", "指摘", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
     requiresCommitId: false,
     buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
   },
   {
     id: "todo-cleanup-request",
-    label: "TODO.md の完了項目を整理",
+    label: "704: TODO.md の完了項目を整理",
     keywords: ["todo", "todo.md", "cleanup", "close", "closed", "整理", "完了", "クローズ", "削除", "とぅーどぅー", "せいり", "かんりょう", "s e i r i", "kanryou"],
     requiresCommitId: false,
     buildBody: () => "TODO.mdのなかで、すでに対応済みで実施済みとなっているTODOがあれば、それをクローズしたり、あるいは以前にすでにクローズ済みのTODOがあればこれを削除してください。"
   },
   {
     id: "completion-check-request",
-    label: "依頼内容の実施状況を確認",
+    label: "306: 依頼内容の実施状況を確認",
     keywords: ["done", "completed", "status", "check", "実施済み", "未実施", "確認", "じっしずみ", "みじっし", "かくにん", "jisshizumi", "mijisshi", "kakunin"],
     requiresCommitId: false,
     buildBody: () => "さきほどお願いした一連の依頼内容は、基本的に全て実施済みでしょうか。それともまだ未実施のものはありますでしょうか。"
   },
   {
     id: "critical-review-request",
-    label: "批判的レビューを依頼",
+    label: "304: 批判的レビューの依頼",
     keywords: ["review", "critical review", "typo", "批判的", "レビュー", "誤り", "間違い", "たいぽ", "ひはんてき", "れびゅー", "まちがい", "typo", "hibanteki", "rebyu-"],
     requiresCommitId: false,
     buildBody: () => "これから批判的なレビューを実施して欲しいです。誤り、間違い、TYPO、ささいなものでも批判的に指摘してください。それら批判的な指摘はこのコンテキストでは喜ばれます。"
   },
   {
     id: "markdown-update-check-request",
-    label: "markdown 更新漏れの確認",
+    label: "102: markdown 更新漏れの確認",
     keywords: ["markdown", "md", "update", "doc", "docs", "更新漏れ", "未更新", "追加すべき", "まーくだうん", "みこうしん", "こうしんもれ", "markdown", "mikkoushin", "koushinmore"],
     requiresCommitId: false,
     buildBody: () => "実装の側に変更がおこなわれましたが、これに対応する markdown (.md) で未更新のものはありますか。あるいは新規で markdown (.md) を追加すべき変更はありましたか。"
   },
   {
+    id: "hallucination-check-request",
+    label: "305: 回答のハルシネーション有無を再確認",
+    keywords: ["hallucination", "fact check", "web search", "裏どり", "裏取り", "ハルシネーション", "再確認", "回答確認", "うらどり", "さいかくにん", "かいとうかくにん"],
+    requiresCommitId: false,
+    buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
+  },
+  {
+    id: "directory-summary-markdown-request",
+    label: "101: ディレクトリ内容整理 markdown を作成",
+    keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "整理", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
+    requiresCommitId: false,
+    buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+  },
+  {
     id: "single-file-web-app-request",
-    label: "Single-file Web App の維持",
+    label: "701: Single-file Web App の維持",
     keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
     requiresCommitId: false,
     buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const promptDefinitionsCode = readFileSync(
+  path.resolve(__dirname, "../src/prompt-gen/js/prompt-definitions.js"),
+  "utf8"
+);
+const mainCode = readFileSync(
+  path.resolve(__dirname, "../src/prompt-gen/js/main.js"),
+  "utf8"
+);
+
+function defineElementIfNeeded(tagName) {
+  if (!customElements.get(tagName)) {
+    customElements.define(tagName, class extends HTMLElement {});
+  }
+}
+
+function mountPromptDom() {
+  document.body.innerHTML = `
+    <input id="promptSearch" />
+    <div id="promptCandidateArea"></div>
+    <div id="commitInputSection" class="md-hidden"></div>
+    <div id="promptOutputSection" class="md-hidden"></div>
+    <input id="commitId" />
+    <input id="includeLabelPrefix" type="checkbox" />
+    <div id="promptOutput"></div>
+  `;
+}
+
+async function bootPromptPage() {
+  defineElementIfNeeded("lht-text-field-help");
+  mountPromptDom();
+  new Function(`${promptDefinitionsCode}\n${mainCode}`)();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("prompt-gen main", () => {
+  it("generates PR prompt text after unique match and commit id input", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const commitId = document.getElementById("commitId");
+    const commitInputSection = document.getElementById("commitInputSection");
+    const promptOutputSection = document.getElementById("promptOutputSection");
+    const promptOutput = document.getElementById("promptOutput");
+
+    promptSearch.value = "pull request";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    const buttons = [...document.querySelectorAll(".md-chip-button")];
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].textContent).toContain("GitHub PR 文面作成");
+    expect(buttons[0].classList.contains("is-active")).toBe(true);
+    expect(commitInputSection.classList.contains("md-hidden")).toBe(false);
+    expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
+    expect(promptOutput.textContent).toBe("");
+
+    commitId.value = "abc1234";
+    commitId.dispatchEvent(new Event("input"));
+
+    expect(promptOutput.textContent).toContain("対象コミット abc1234 における変更内容について");
+    expect(promptOutput.textContent).toContain("PRタイトルとPR本文");
+  });
+
+  it("adds label prefix for fixed prompt when switch is enabled", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const includeLabelPrefix = document.getElementById("includeLabelPrefix");
+    const commitInputSection = document.getElementById("commitInputSection");
+    const promptOutput = document.getElementById("promptOutput");
+
+    promptSearch.value = "single-file web app";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
+    expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
+    expect(promptOutput.textContent).toBe(
+      "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+    );
+
+    includeLabelPrefix.checked = true;
+    includeLabelPrefix.dispatchEvent(new Event("change"));
+
+    expect(promptOutput.textContent).toBe(
+      "[Single-file Web App の維持] 原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+    );
+  });
+
+  it("clears selected state and generated output when search query changes", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const commitId = document.getElementById("commitId");
+    const promptOutput = document.getElementById("promptOutput");
+    const commitInputSection = document.getElementById("commitInputSection");
+    const promptOutputSection = document.getElementById("promptOutputSection");
+
+    promptSearch.value = "pull request";
+    promptSearch.dispatchEvent(new Event("input"));
+    commitId.value = "abc1234";
+    commitId.dispatchEvent(new Event("input"));
+    expect(promptOutput.textContent).toContain("abc1234");
+
+    promptSearch.value = "spec";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(commitId.value).toBe("");
+    expect(promptOutput.textContent).not.toContain("abc1234");
+    expect(promptOutput.textContent).toContain("今からの作業は仕様の検討です。");
+    expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
+    expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
+    expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` に対して、候補ボタンのラベルに分類ベースの番号付けを進めました。 あわせて `prompt-gen` の最小動作を検証する Vitest テストを追加しています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` を更新し、候補ラベルの整理を実施
- GitHub 系の候補に 500 番台を付与
- `501: GitHub PR 文面の作成`
- `502: GitHub Release 文面の作成`
- `503: GitHub 変更操作の禁止`
- 会話・レビュー・確認系の候補に 300 番台を付与
- `301: 会話の引継テキストの生成`
- `302: 違和感や誤りを先に指摘`
- `303: Markdown インラインコードとして出力`
- `304: 批判的レビューの依頼`
- `305: 回答のハルシネーション有無を再確認`
- `306: 依頼内容の実施状況を確認`
- ディレクトリや markdown 確認系に 100 番台を付与
- `100: ディレクトリ内の内容を確認して把握`
- `101: ディレクトリ内容整理 markdown を作成`
- `102: markdown 更新漏れの確認`
- 実装方針や運用整理系に 700 番台を付与
- `701: Single-file Web App の維持`
- `702: 事象の再発防止テストを追加`
- `703: 仕様検討モードで進める`
- `704: TODO.md の完了項目を整理`
- `docs/prompt/tests/prompt-gen-main.test.js` を追加し、`prompt-gen` の最小 UI 動作テストを追加
- 一意候補絞り込み後の PR 文面生成
- 固定文面でのラベル接頭辞 ON/OFF
- 検索語変更時の commit ID クリアと出力切替
- 生成済みの `docs/prompt/prompt-gen.html` と `docs/prompt/src/prompt-gen/js/prompt-definitions.js` を再生成

## 影響

- `prompt-gen` 上の候補ボタン名と並び順が変わります
- 候補の分類意図が番号から読み取りやすくなります
- `prompt-gen` に対する最小限の回帰テストが追加されます