### PR TITLE
prompt-gen の検索キーワード補強と作業引継メモ整備を追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,6 +44,31 @@
 
 # DONE
 
+- [引継] `docs/prompt/prompt-gen` を段階的に整理済み
+- `docs/prompt/prompt-gen-src.html` の巨大 inline CSS / JS は外出し済み
+- 開発時ソースは `docs/prompt/src/prompt-gen/css/app.css` と `docs/prompt/src/prompt-gen/ts/*.ts`
+- `scripts/build-prompt.mjs` で `ts -> js` を行ってから single-file の `docs/prompt/prompt-gen.html` を生成する構成に変更済み
+- `promptDefinitions` は `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` へ切り出し済み
+- 各定義は `id / label / keywords / requiresCommitId / buildBody()` を持つ形に整理済み
+- `main.ts` は検索・選択・表示制御側へ寄せ、本文生成ロジックは定義側へ集約済み
+- `docs/prompt/tests/prompt-gen-main.test.js` を追加済み
+- 現在の最小テスト対象:
+- 一意候補絞り込み後の PR 文面生成
+- 固定文面でのラベル接頭辞 ON/OFF
+- 検索語変更時の commit ID クリアと出力切替
+- `prompt-gen` の候補ボタンには分類用の番号帯を付与済み
+- `100` 台: ディレクトリ/markdown 確認系
+- `300` 台: 会話/レビュー/確認系
+- `500` 台: GitHub 文面系
+- `700` 台: 実装方針/運用/ビルド系
+- 直近では `keywords` に、日本語ラベル由来の名詞・動詞を明示追加する改善を実施済み
+- 例: `306: 依頼内容の実施状況を確認` に `依頼 / 内容 / 実施 / 状況 / じょうきょう / joukyou` を追加
+- 例: `304: 批判的レビューの依頼` に `依頼` を追加
+- 例: `102: markdown 更新漏れの確認` に `更新 / 漏れ / 確認` を追加
+- 直近で `705: 完全ビルドの実施確認` と `706: 作業終了時の引継確認` を追加済み
+- 最新状態で `npm run build:all` は実施済み
+- 次回再開時は、まず `git status --short` と `npm test -- docs/prompt/tests/prompt-gen-main.test.js` を見ると状況把握が早い
+
 - `scripts/lib/single-html.mjs` を導入し、`text/link/life/img/docs-index` の `*-src.html` から配布用 `*.html` 生成時にローカル `link/script src` をインライン化（単一HTML化）する運用へ統一
 - 各HTMLのタイトル右に「?」説明を置く方針に統一し、その文言を docs/index.html のホバー説明へ転記する対応を実施
 - [優先度高] タイトルに「?」が未設置のHTML一覧（対応済み分）

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -3376,6 +3376,13 @@ const promptDefinitions = [
         buildBody: () => "ビルドは実施済みでしょうか？もし未実施であれば、完全なビルドを実施して欲しいです。"
     },
     {
+        id: "session-close-request",
+        label: "706: 作業終了時の引継確認",
+        keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
+        requiresCommitId: false,
+        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+    },
+    {
         id: "single-file-web-app-request",
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -116,6 +116,13 @@ const promptDefinitions = [
         buildBody: () => "ビルドは実施済みでしょうか？もし未実施であれば、完全なビルドを実施して欲しいです。"
     },
     {
+        id: "session-close-request",
+        label: "706: 作業終了時の引継確認",
+        keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
+        requiresCommitId: false,
+        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+    },
+    {
         id: "single-file-web-app-request",
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -124,6 +124,13 @@ const promptDefinitions: PromptDefinition[] = [
     buildBody: () => "ビルドは実施済みでしょうか？もし未実施であれば、完全なビルドを実施して欲しいです。"
   },
   {
+    id: "session-close-request",
+    label: "706: 作業終了時の引継確認",
+    keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
+    requiresCommitId: false,
+    buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+  },
+  {
     id: "single-file-web-app-request",
     label: "701: Single-file Web App の維持",
     keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` の検索精度を高めるため、候補ラベル由来の日本語名詞・動詞を `keywords` に補強しました。 あわせて、作業終了時の引継確認用ボタンを追加し、`TODO.md` に次回再開向けの引継メモを記録しています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` を更新し、複数候補の `keywords` を拡充
- ラベル由来の名詞・動詞を明示追加
- 例:
  - `501: GitHub PR 文面の作成` に `文面`, `作成`
  - `503: GitHub 変更操作の禁止` に `変更`, `操作`
  - `306: 依頼内容の実施状況を確認` に `依頼`, `内容`, `実施`, `状況`, `じょうきょう`, `joukyou`
  - `304: 批判的レビューの依頼` に `依頼`
  - `102: markdown 更新漏れの確認` に `更新`, `漏れ`, `確認`
  - `101: ディレクトリ内容整理 markdown を作成` に `内容`, `作成`
- `706: 作業終了時の引継確認` を候補として追加
- 出力文:
  - `今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。`
- `TODO.md` に `prompt-gen` の現状整理、番号帯方針、直近対応内容、次回再開時の見どころを追記
- 生成済みの `docs/prompt/src/prompt-gen/js/prompt-definitions.js` と `docs/prompt/prompt-gen.html` を再生成

## 影響

- `prompt-gen` で日本語ラベル語彙による候補検索がしやすくなります
- 作業終了時に `TODO.md` へ引継ぎ事項を残すための定型文が利用可能になります
- 次回再開時に `TODO.md` を見れば、`prompt-gen` 周辺の直近整理内容を把握しやすくなります