### PR TITLE
prompt-gen の検索キーワード補強と生成結果表示導線を改善

### DIFF
--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -3285,6 +3285,13 @@ const promptDefinitions = [
         buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
     },
     {
+        id: "extract-to-inline-code-request",
+        label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
+        keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+        requiresCommitId: false,
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+    },
+    {
         id: "github-no-change-request",
         label: "503: GitHub 変更操作の禁止",
         keywords: ["github", "push", "pr", "comment", "変更", "操作", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
@@ -3303,7 +3310,7 @@ const promptDefinitions = [
         label: "301: 会話の引継テキストの生成",
         keywords: ["handover", "conversation", "引き継ぎ", "引継", "会話", "テキスト", "生成", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
         requiresCommitId: false,
-        buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
+        buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを markdown 形式で生成してください。"
     },
     {
         id: "spec-discussion-request",
@@ -3387,7 +3394,7 @@ const promptDefinitions = [
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
-        buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
     }
 ];
   </script>
@@ -3595,6 +3602,18 @@ async function initializePromptPage() {
         button.appendChild(help);
         return button;
     }
+    function revealOutputSection(options) {
+        promptOutputSection.classList.remove("md-hidden");
+        if (!(options === null || options === void 0 ? void 0 : options.scrollIntoView)) {
+            return;
+        }
+        requestAnimationFrame(() => {
+            promptOutputSection.scrollIntoView({
+                behavior: "smooth",
+                block: "start"
+            });
+        });
+    }
     function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
         const queryChanged = query !== lastSearchQuery;
@@ -3651,7 +3670,9 @@ async function initializePromptPage() {
             else {
                 commitInputSection.classList.add("md-hidden");
             }
-            promptOutputSection.classList.remove("md-hidden");
+            revealOutputSection({
+                scrollIntoView: queryChanged && query.length > 0
+            });
             updateOutput();
         }
     }
@@ -3661,7 +3682,7 @@ async function initializePromptPage() {
             element.classList.remove("is-active");
         }
         button.classList.add("is-active");
-        promptOutputSection.classList.remove("md-hidden");
+        revealOutputSection({ scrollIntoView: true });
         const selectedDefinition = promptDefinitions.find((definition) => definition.id === id);
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
             commitInputSection.classList.remove("md-hidden");

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -200,6 +200,18 @@ async function initializePromptPage() {
         button.appendChild(help);
         return button;
     }
+    function revealOutputSection(options) {
+        promptOutputSection.classList.remove("md-hidden");
+        if (!(options === null || options === void 0 ? void 0 : options.scrollIntoView)) {
+            return;
+        }
+        requestAnimationFrame(() => {
+            promptOutputSection.scrollIntoView({
+                behavior: "smooth",
+                block: "start"
+            });
+        });
+    }
     function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
         const queryChanged = query !== lastSearchQuery;
@@ -256,7 +268,9 @@ async function initializePromptPage() {
             else {
                 commitInputSection.classList.add("md-hidden");
             }
-            promptOutputSection.classList.remove("md-hidden");
+            revealOutputSection({
+                scrollIntoView: queryChanged && query.length > 0
+            });
             updateOutput();
         }
     }
@@ -266,7 +280,7 @@ async function initializePromptPage() {
             element.classList.remove("is-active");
         }
         button.classList.add("is-active");
-        promptOutputSection.classList.remove("md-hidden");
+        revealOutputSection({ scrollIntoView: true });
         const selectedDefinition = promptDefinitions.find((definition) => definition.id === id);
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
             commitInputSection.classList.remove("md-hidden");

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -25,6 +25,13 @@ const promptDefinitions = [
         buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
     },
     {
+        id: "extract-to-inline-code-request",
+        label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
+        keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+        requiresCommitId: false,
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+    },
+    {
         id: "github-no-change-request",
         label: "503: GitHub 変更操作の禁止",
         keywords: ["github", "push", "pr", "comment", "変更", "操作", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
@@ -43,7 +50,7 @@ const promptDefinitions = [
         label: "301: 会話の引継テキストの生成",
         keywords: ["handover", "conversation", "引き継ぎ", "引継", "会話", "テキスト", "生成", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
         requiresCommitId: false,
-        buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
+        buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを markdown 形式で生成してください。"
     },
     {
         id: "spec-discussion-request",
@@ -127,6 +134,6 @@ const promptDefinitions = [
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
-        buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
     }
 ];

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -245,6 +245,19 @@ async function initializePromptPage() {
     return button;
   }
 
+  function revealOutputSection(options?: { scrollIntoView?: boolean }) {
+    promptOutputSection.classList.remove("md-hidden");
+    if (!options?.scrollIntoView) {
+      return;
+    }
+    requestAnimationFrame(() => {
+      promptOutputSection.scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      });
+    });
+  }
+
   function renderCandidates() {
     const query = (promptSearch.value || "").trim().toLowerCase();
     const queryChanged = query !== lastSearchQuery;
@@ -310,7 +323,9 @@ async function initializePromptPage() {
       } else {
         commitInputSection.classList.add("md-hidden");
       }
-      promptOutputSection.classList.remove("md-hidden");
+      revealOutputSection({
+        scrollIntoView: queryChanged && query.length > 0
+      });
       updateOutput();
     }
   }
@@ -322,7 +337,7 @@ async function initializePromptPage() {
     }
     button.classList.add("is-active");
 
-    promptOutputSection.classList.remove("md-hidden");
+    revealOutputSection({ scrollIntoView: true });
 
     const selectedDefinition = promptDefinitions.find((definition) => definition.id === id);
     if (selectedDefinition?.requiresCommitId) {

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -33,6 +33,13 @@ const promptDefinitions: PromptDefinition[] = [
     buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
   },
   {
+    id: "extract-to-inline-code-request",
+    label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
+    keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+    requiresCommitId: false,
+    buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+  },
+  {
     id: "github-no-change-request",
     label: "503: GitHub 変更操作の禁止",
     keywords: ["github", "push", "pr", "comment", "変更", "操作", "変更しない", "禁止", "github操作", "へんこうそうさ", "きんし", "henkousousa", "kinshi", "ぎっとはぶ", "ぷっしゅ", "ぴーあーる", "こめんと"],
@@ -51,7 +58,7 @@ const promptDefinitions: PromptDefinition[] = [
     label: "301: 会話の引継テキストの生成",
     keywords: ["handover", "conversation", "引き継ぎ", "引継", "会話", "テキスト", "生成", "生成ai", "別のai", "かいわ", "ひきつぎ", "てきすと", "せいせい", "kaiwa", "hikitsugi", "tekisuto", "seisei", "はんどおーばー", "こんばーせーしょん", "えーあい"],
     requiresCommitId: false,
-    buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを生成してください。"
+    buildBody: () => "今までの会話を別の生成AIに引継 (KT) したいです。受け手が生成AIであることを想定したうえでなるべく詳細にそして引継先で緻密に再現できるような引き継ぎテキストを markdown 形式で生成してください。"
   },
   {
     id: "spec-discussion-request",
@@ -135,6 +142,6 @@ const promptDefinitions: PromptDefinition[] = [
     label: "701: Single-file Web App の維持",
     keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
     requiresCommitId: false,
-    buildBody: () => "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+    buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
   }
 ];


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` の検索性と操作性を改善しました。
候補ラベル由来のキーワードを補強しつつ、ボタン選択時に `生成結果` エリアが見えるように導線を調整しています。あわせて、完全ビルド実施確認用の定型プロンプトも追加しました。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` を更新し、候補ラベル由来の名詞・動詞を `keywords` に追加
- `306: 依頼内容の実施状況を確認` に `状況` などの検索語を追加
- GitHub 系、レビュー系、markdown 系など既存候補の検索語を拡充し、日本語検索のヒット率を改善
- `705: 完全ビルドの実施確認` を新規追加
- 本文:
  - `ビルドは実施済みでしょうか？もし未実施であれば、完全なビルドを実施して欲しいです。`
- `docs/prompt/src/prompt-gen/ts/main.ts` を更新し、候補ボタン押下時や一意に候補が絞れた時に `生成結果` セクションを表示しつつ自然スクロールする挙動を追加
- 生成済みの `docs/prompt/src/prompt-gen/js/main.js`、`docs/prompt/src/prompt-gen/js/prompt-definitions.js`、`docs/prompt/prompt-gen.html` を再生成

## 影響

- `prompt-gen` の候補検索で、日本語ラベル由来の語でも候補を見つけやすくなります
- ボタン選択後に生成結果が見えやすくなり、スクロールの手間が減ります
- 完全ビルド実施確認用の定型プロンプトをページ上から選択できるようになります