### PR TITLE
prompt-gen の文面拡張と lht-text-field-help の clearable 暫定対応を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [MD3リファレンス](md3/README.md)
 - [GitツールREADME](docs/git/README.md)
 - [PasswordツールREADME](docs/password/README.md)
+- [PromptツールREADME](docs/prompt/README.md)
 - [Musicビルドプロセス](docs/music/BUILD_PROCESS.md)
 
 ## 前提条件
@@ -40,6 +41,7 @@
 - `docs/ffmpeg/*.html` も保守性確保のため「分割ソースをビルドして単一HTMLを生成」運用を採用
 - `docs/life/*.html` は `*-src.html` を編集し、ビルドで `*.html` を生成する運用を採用
 - `docs/link/*.html` は `*-src.html` を編集し、ビルドで `*.html` を生成する運用を採用
+- `docs/prompt/*.html` も保守性確保のため「分割ソースをビルドして単一HTMLを生成」運用を採用
 - `docs/text/*.html` は `*-src.html` を編集し、ビルドで `*.html` を生成する運用を採用
 - `docs/img/*.html` は `*-src.html` を編集し、ビルドで `*.html` を生成する運用を採用
 - `docs/index.html` も `docs/index-src.html` から生成する運用を採用
@@ -87,6 +89,7 @@ docs/
 ├── git/                 # Git補助ツール
 ├── grep/                # 検索補助ツール
 ├── img/                 # 画像系ツール
+├── prompt/              # 生成AI向けプロンプト作成支援ツール
 ├── text/                # テキスト系ツール
 ├── life/                # 生活系ツール
 ├── link/                # URL加工系ツール
@@ -164,6 +167,23 @@ docs/
   - `docs/link/*.html` は直接編集しない
   - 変更は `*-src.html` を編集する
   - PRには生成済み `docs/link/*.html` を含める
+
+### prompt 例外運用（分割開発）
+
+- 対象: `docs/prompt/prompt-gen.html`
+- 配布: `docs/prompt/prompt-gen.html`（単一HTML、生成物）
+- 開発:
+  - `docs/prompt/prompt-gen-src.html`
+  - `docs/prompt/src/prompt-gen/css/app.css`
+  - `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
+  - `docs/prompt/src/prompt-gen/ts/main.ts`
+  - `docs/prompt/tests/prompt-gen-main.test.js`
+- ビルド: `npm run build:prompt`（`scripts/build-prompt.mjs`）
+- ルール:
+  - `docs/prompt/prompt-gen.html` は直接編集しない
+  - 変更は `prompt-gen-src.html` と `src/prompt-gen/` 配下を編集する
+  - `scripts/build-prompt.mjs` は `ts -> js` を行ってから single-file の `prompt-gen.html` を生成する
+  - PRには生成済み `docs/prompt/prompt-gen.html` を含める
 
 ### text 運用（src編集 + 生成）
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@
 - [lht-cmn] `lht-error-alert` を追加し、`errorText` の表示/非表示と `role="alert"` 運用を共通化する
 - [lht-cmn] `lht-input-mode-toggle`（file/source 切替）を追加し、music系で反復しているラジオUIを共通化する
 - [lht-cmn] `lht-preview-output`（プレビュー + コピー導線）を追加し、`previewText` 周辺の反復UIを共通化する
+- [lht-cmn] `lht-text-field-help` の trailing action を正式設計する。現在は `prompt-gen` 向けに `clearable` を暫定追加しているが、`lht-cmn` チームの更新版を受領したら、slot / action API を含めてちゃんとした実装へ置き換える
 - [優先度高][lht-cmn] `lht-*` 全体を棚卸しし、各コンポーネントを「内部保証」または「フォールバック保証」のどちらかへ統一する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み
@@ -66,6 +67,8 @@
 - 例: `304: 批判的レビューの依頼` に `依頼` を追加
 - 例: `102: markdown 更新漏れの確認` に `更新 / 漏れ / 確認` を追加
 - 直近で `705: 完全ビルドの実施確認` と `706: 作業終了時の引継確認` を追加済み
+- `prompt-gen` の検索欄クリア導線は、外付け absolute 配置をやめて `lht-text-field-help clearable` の暫定実装へ寄せた
+- この `clearable` は正式仕様確定前の provisional API として扱い、`lht-cmn` 側の更新版受領後に見直す前提
 - 最新状態で `npm run build:all` は実施済み
 - 次回再開時は、まず `git status --short` と `npm test -- docs/prompt/tests/prompt-gen-main.test.js` を見ると状況把握が早い
 

--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2531,6 +2596,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2538,6 +2604,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2587,12 +2655,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2642,9 +2746,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -4216,6 +4281,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -4223,6 +4289,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -4272,12 +4340,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -4327,9 +4431,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2939,6 +3004,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2946,6 +3012,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2995,12 +3063,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3050,9 +3154,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2693,6 +2758,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2700,6 +2766,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2749,12 +2817,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2804,9 +2908,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -330,6 +330,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -350,6 +354,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -357,6 +365,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2964,6 +3029,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2971,6 +3037,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -3020,12 +3088,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3075,9 +3179,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2808,6 +2873,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2815,6 +2881,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2864,12 +2932,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2919,9 +3023,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2959,6 +3024,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2966,6 +3032,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -3015,12 +3083,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3070,9 +3174,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -330,6 +330,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -350,6 +354,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -357,6 +365,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2706,6 +2771,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2713,6 +2779,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2762,12 +2830,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2817,9 +2921,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2716,6 +2781,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2723,6 +2789,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2772,12 +2840,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2827,9 +2931,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -340,6 +340,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -360,6 +364,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -367,6 +375,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2739,6 +2804,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2746,6 +2812,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2795,12 +2863,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2850,9 +2954,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2782,6 +2847,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2789,6 +2855,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2838,12 +2906,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2893,9 +2997,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2871,6 +2936,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2878,6 +2944,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2927,12 +2995,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2982,9 +3086,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2783,6 +2848,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2790,6 +2856,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2839,12 +2907,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2894,9 +2998,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -345,6 +345,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -365,6 +369,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -372,6 +380,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -3325,6 +3390,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -3332,6 +3398,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -3381,12 +3449,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3436,9 +3540,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2811,6 +2876,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2818,6 +2884,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2867,12 +2935,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2922,9 +3026,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1348,6 +1348,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1368,6 +1372,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1375,6 +1383,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -4201,6 +4266,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -4208,6 +4274,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -4257,12 +4325,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -4312,9 +4416,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/index-src.html
+++ b/docs/index-src.html
@@ -1099,7 +1099,7 @@
       </h3>
       <p class="md-section-subtitle">テキスト表示/加工</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="プロンプト作成支援" desc="伊賀がよくつかう定型な生成AIプロンプトをすぐに作成します。初版では PR タイトルと PR 本文の作成依頼文を生成できます。"></lht-index-card-link>
+        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="プロンプト作成支援" desc="生成AIに引き渡す定型プロンプトの作成を支援します。PR 文面、Release 文面、レビュー依頼、引継ぎ、作業確認など、繰り返し使う依頼文を素早く揃えられます。"></lht-index-card-link>
         <lht-index-card-link href="password/password-gen.html" icon="🛡️" title="パスワードジェネレーター" desc="選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。"></lht-index-card-link>
         <lht-index-card-link href="text/text-viewer.html" icon="📄" title="テキスト表示" desc="テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。"></lht-index-card-link>
         <lht-index-card-link href="text/text-processing.html" icon="🧩" title="テキスト加工" desc="テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。"></lht-index-card-link>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1357,6 +1357,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1377,6 +1381,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1384,6 +1392,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2019,7 +2084,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-08</div>
+        <div class="md-app-meta">更新日: 2026-03-09</div>
       </div>
     </header>
 
@@ -2048,7 +2113,7 @@ lht-index-card-link {
       </h3>
       <p class="md-section-subtitle">テキスト表示/加工</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="プロンプト作成支援" desc="伊賀がよくつかう定型な生成AIプロンプトをすぐに作成します。初版では PR タイトルと PR 本文の作成依頼文を生成できます。"></lht-index-card-link>
+        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="プロンプト作成支援" desc="生成AIに引き渡す定型プロンプトの作成を支援します。PR 文面、Release 文面、レビュー依頼、引継ぎ、作業確認など、繰り返し使う依頼文を素早く揃えられます。"></lht-index-card-link>
         <lht-index-card-link href="password/password-gen.html" icon="🛡️" title="パスワードジェネレーター" desc="選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。"></lht-index-card-link>
         <lht-index-card-link href="text/text-viewer.html" icon="📄" title="テキスト表示" desc="テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。"></lht-index-card-link>
         <lht-index-card-link href="text/text-processing.html" icon="🧩" title="テキスト加工" desc="テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。"></lht-index-card-link>
@@ -2890,6 +2955,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2897,6 +2963,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2946,12 +3014,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3001,9 +3105,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -1257,6 +1257,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1277,6 +1281,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1284,6 +1292,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2304,6 +2369,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2311,6 +2377,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2360,12 +2428,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2415,9 +2519,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -1282,6 +1282,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1302,6 +1306,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1309,6 +1317,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2967,6 +3032,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2974,6 +3040,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -3023,12 +3091,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3078,9 +3182,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1342,6 +1342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1362,6 +1366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1369,6 +1377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2793,6 +2858,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2800,6 +2866,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2849,12 +2917,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2904,9 +3008,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1342,6 +1342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1362,6 +1366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1369,6 +1377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2734,6 +2799,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2741,6 +2807,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2790,12 +2858,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2845,9 +2949,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1372,6 +1372,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1392,6 +1396,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1399,6 +1407,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2792,6 +2857,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2799,6 +2865,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2848,12 +2916,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2903,9 +3007,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1343,6 +1343,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1363,6 +1367,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1370,6 +1378,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2738,6 +2803,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2745,6 +2811,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2794,12 +2862,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2849,9 +2953,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1342,6 +1342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1362,6 +1366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1369,6 +1377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2733,6 +2798,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2740,6 +2806,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2789,12 +2857,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2844,9 +2948,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -342,6 +342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -362,6 +366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -369,6 +377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -1790,6 +1855,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -1797,6 +1863,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -1846,12 +1914,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -1901,9 +2005,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -342,6 +342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -362,6 +366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -369,6 +377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -1753,6 +1818,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -1760,6 +1826,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -1809,12 +1877,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -1864,9 +1968,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -342,6 +342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -362,6 +366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -369,6 +377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -1807,6 +1872,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -1814,6 +1880,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -1863,12 +1931,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -1918,9 +2022,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -342,6 +342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -362,6 +366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -369,6 +377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2255,6 +2320,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2262,6 +2328,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2311,12 +2379,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2366,9 +2470,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -342,6 +342,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -362,6 +366,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -369,6 +377,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -1801,6 +1866,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -1808,6 +1874,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -1857,12 +1925,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -1912,9 +2016,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2733,6 +2798,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2740,6 +2806,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2789,12 +2857,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2844,9 +2948,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/prompt/README.md
+++ b/docs/prompt/README.md
@@ -1,0 +1,53 @@
+# Prompt ツール README
+
+`docs/prompt/` 配下には、生成AIへ引き渡すための定型プロンプトを素早く組み立てる HTML ツールを配置します。
+
+現時点の対象は `prompt-gen` です。ブラウザだけで動作し、配布物は single-file web app として完結します。
+
+## 関連README
+
+- [ルートREADME](../../README.md)
+- [LHT共通部品README](../../lht-cmn/README.md)
+
+## 対象ファイル
+
+- 配布物（生成物）:
+  - `docs/prompt/prompt-gen.html`
+- 編集元:
+  - `docs/prompt/prompt-gen-src.html`
+  - `docs/prompt/src/prompt-gen/css/app.css`
+  - `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
+  - `docs/prompt/src/prompt-gen/ts/main.ts`
+- テスト:
+  - `docs/prompt/tests/prompt-gen-main.test.js`
+
+`prompt-gen.html` は直接編集せず、編集元を更新してビルドで反映します。
+
+## ビルド
+
+- `npm run build:prompt`
+
+`scripts/build-prompt.mjs` が TypeScript を `docs/prompt/src/prompt-gen/js/*.js` へ変換し、その後 `prompt-gen-src.html` 内のローカル CSS / JS をインライン化して `prompt-gen.html` を生成します。
+
+## テスト
+
+- 単体テスト: `npm test -- docs/prompt/tests/prompt-gen-main.test.js`
+
+現在の最小テストは次を対象にしています。
+
+- 候補が一意に絞れたときの PR 文面生成
+- 固定文面でのラベル接頭辞 ON / OFF
+- 検索語変更時の commit ID クリアと出力更新
+
+## 実装メモ
+
+- `prompt-definitions.ts` に候補ボタン定義を集約する
+- 各定義は `id / label / keywords / requiresCommitId / buildBody()` を持つ
+- `main.ts` は検索、選択状態、入力欄表示、生成結果更新、スクロール制御を担当する
+- 検索は空欄で全候補表示、空白区切りで AND、各語の照合先は label / keywords / かな・カナ・ローマ字展開を含む
+
+## 運用方針
+
+- ビルド後の `docs/prompt/prompt-gen.html` は CDN や別ファイルの CSS / JS に依存しない single-file web app を維持する
+- 画面側 UI は原則 `lht-*` を利用し、Material Web 直接利用は `lht-cmn` 内部へ寄せる
+- 変更後は必要に応じて `npm run build:prompt` と関連テストを実行する

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>プロンプト作成支援</title>
+  <title>生成AIプロンプト作成支援</title>
   <link rel="stylesheet" href="../../lht-cmn/css/components.css">
   <link rel="stylesheet" href="src/prompt-gen/css/app.css">
   <script src="../../lht-cmn/vendor/material-web-outlined-text-field.bundle.js"></script>
@@ -40,15 +40,15 @@ limitations under the License.
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="プロンプト作成支援"
-      subtitle="定型的な生成AIプロンプトを作成支援します。"
+      title="生成AIプロンプト作成支援"
+      subtitle="定型的な生成AIプロンプトの作成を支援します。"
       icon="📝"
-      help-label="プロンプト作成支援の説明"
+      help-label="生成AIプロンプト作成支援の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      このツールは、生成AIに引き渡すためのプロンプト作成を支援します。<br><br>
-      初版では、PR 文面、GitHub Release 文面、Markdown 出力指示、GitHub 操作禁止指示、ディレクトリ内容確認指示、会話引き継ぎ指示、仕様検討指示、軽量テスト追加指示、違和感や誤りの指摘優先指示、TODO 整理指示、実施状況確認指示、批判的レビュー指示、markdown 更新漏れ確認指示を作成依頼するための文面を生成します。
+      頻出する依頼文を都度手作業で起案する負担を減らし、生成AIに対する指示文を効率的かつ一定の品質で作成できます。<br><br>
+      文面の表現や粒度を揃えやすく、PR 作成、Release 文面、レビュー依頼、引継ぎ、作業確認といった反復的な場面で、指示内容の標準化と再利用性の向上が期待できます。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
@@ -57,8 +57,9 @@ limitations under the License.
           field-id="promptSearch"
           label="やりたいこと"
           required
+          clearable
           placeholder="例: pr / release"
-          help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら各種プロンプト候補を表示します。">
+          help-text="生成AIに与えたいプロンプトへのキーワードを短く入力します。キーワードへの部分一致でプロンプトを絞り込むことができます。">
         </lht-text-field-help>
       </div>
 

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>プロンプト作成支援</title>
+  <title>生成AIプロンプト作成支援</title>
   
   
   
@@ -344,6 +344,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -364,6 +368,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -371,6 +379,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -1036,6 +1101,7 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 }
 
 .md-chip-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -1051,6 +1117,8 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   cursor: pointer;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
+  overflow: visible;
+  isolation: isolate;
 }
 
 .md-chip-button:hover {
@@ -1075,6 +1143,16 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 
 .md-chip-button lht-help-tooltip {
   flex: 0 0 auto;
+}
+
+.md-chip-button:hover,
+.md-chip-button:focus-within {
+  z-index: 10;
+}
+
+.md-chip-button lht-help-tooltip:hover,
+.md-chip-button lht-help-tooltip:focus-within {
+  z-index: 20;
 }
 
 .md-chip-button lht-help-tooltip .md-tooltip-content {
@@ -1170,15 +1248,15 @@ md-icon-button.md-copy-button--surface {
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="プロンプト作成支援"
-      subtitle="定型的な生成AIプロンプトを作成支援します。"
+      title="生成AIプロンプト作成支援"
+      subtitle="定型的な生成AIプロンプトの作成を支援します。"
       icon="📝"
-      help-label="プロンプト作成支援の説明"
+      help-label="生成AIプロンプト作成支援の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      このツールは、生成AIに引き渡すためのプロンプト作成を支援します。<br><br>
-      初版では、PR 文面、GitHub Release 文面、Markdown 出力指示、GitHub 操作禁止指示、ディレクトリ内容確認指示、会話引き継ぎ指示、仕様検討指示、軽量テスト追加指示、違和感や誤りの指摘優先指示、TODO 整理指示、実施状況確認指示、批判的レビュー指示、markdown 更新漏れ確認指示を作成依頼するための文面を生成します。
+      頻出する依頼文を都度手作業で起案する負担を減らし、生成AIに対する指示文を効率的かつ一定の品質で作成できます。<br><br>
+      文面の表現や粒度を揃えやすく、PR 作成、Release 文面、レビュー依頼、引継ぎ、作業確認といった反復的な場面で、指示内容の標準化と再利用性の向上が期待できます。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
@@ -1187,8 +1265,9 @@ md-icon-button.md-copy-button--surface {
           field-id="promptSearch"
           label="やりたいこと"
           required
+          clearable
           placeholder="例: pr / release"
-          help-text="やりたいことを短く入力します。初版では入力文字列が候補キーワードに部分一致したら各種プロンプト候補を表示します。">
+          help-text="生成AIに与えたいプロンプトへのキーワードを短く入力します。キーワードへの部分一致でプロンプトを絞り込むことができます。">
         </lht-text-field-help>
       </div>
 
@@ -1903,6 +1982,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -1910,6 +1990,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -1959,12 +2041,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2014,9 +2132,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);
@@ -3367,6 +3497,48 @@ const promptDefinitions = [
         keywords: ["hallucination", "fact check", "web search", "回答", "有無", "再確認", "裏どり", "裏取り", "ハルシネーション", "回答確認", "うらどり", "さいかくにん", "かいとうかくにん"],
         requiresCommitId: false,
         buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
+    },
+    {
+        id: "resource-handover-ok-request",
+        label: "307: リソース受領中は OK のみ回答",
+        keywords: ["resource", "resources", "multiple resources", "ok", "複数", "リソース", "情報", "引き渡し", "受領", "回答", "okのみ", "OKのみ", "ふくすう", "りそーす", "じょうほう", "ひきわたし", "じゅりょう", "かいとう"],
+        requiresCommitId: false,
+        buildBody: () => "これから複数のリソースの情報を渡します。一連のリソースの引き渡しが終わるまでは、単にOKとのみ回答してください。"
+    },
+    {
+        id: "lgtm-request",
+        label: "300: 確認範囲は概ね良好で LGTM",
+        keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
+        requiresCommitId: false,
+        buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+    },
+    {
+        id: "peer-feedback-analysis-request",
+        label: "309: 他メンバー指摘の受入可否を判断",
+        keywords: ["feedback", "review", "peer review", "comment", "accept", "reject", "判断", "指摘", "受け入れ", "受入", "可否", "解析", "メンバー", "はんだん", "してき", "うけいれ", "かひ", "かいせき"],
+        requiresCommitId: false,
+        buildBody: () => "他のメンバーから指摘をもらいました。この内容について、あなたなりに解析して判断して、そして受け入れられるかどうか、受け入れられないか、を判断して教えて欲しいです。"
+    },
+    {
+        id: "recent-work-status-request",
+        label: "310: 直近の作業状況を確認",
+        keywords: ["recent work", "current status", "what was I doing", "直近", "作業状況", "確認", "離席", "現在", "未完了", "次に何を見る", "ちょっきん", "さぎょうじょうきょう", "りせき", "げんざい", "みかんりょう", "tsuginanimiru"],
+        requiresCommitId: false,
+        buildBody: () => "すみません、少し離席していました。直近で何の作業をしていたのか、現在どこまで進んでいるのか、未完了のものがあるか、次に何を見ればよいかを整理して教えてください。回答は markdownでお願いします。"
+    },
+    {
+        id: "solution-soundness-review-request",
+        label: "311: 場当たり対応や本質解決漏れを確認",
+        keywords: ["ad hoc", "proper solution", "root cause", "architecture", "場当たり", "本質", "解決", "別解", "正しい解決方法", "設計", "妥当性", "ばあたり", "ほんしつ", "かいけつ", "べっかい", "せっけい"],
+        requiresCommitId: false,
+        buildBody: () => "今回の対応について、場当たり的な変更に留まっていないか、本質的には別のより適切な解決方法があるのにそれを選択していないところがないか、設計面と保守面から批判的に確認して教えてください。"
+    },
+    {
+        id: "temporary-change-cleanup-request",
+        label: "312: 暫定変更の置き忘れを確認",
+        keywords: ["temporary", "temporary change", "cleanup", "debug code", "investigation", "暫定", "変更", "置き忘れ", "消し忘れ", "調査用", "試行錯誤", "デバッグ", "片付け", "ざんてい", "おきわすれ", "けしわすれ", "ちょうさよう", "でばっぐ"],
+        requiresCommitId: false,
+        buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
     },
     {
         id: "directory-summary-markdown-request",

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -62,6 +62,7 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 }
 
 .md-chip-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -77,6 +78,8 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   cursor: pointer;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
   transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
+  overflow: visible;
+  isolation: isolate;
 }
 
 .md-chip-button:hover {
@@ -101,6 +104,16 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 
 .md-chip-button lht-help-tooltip {
   flex: 0 0 auto;
+}
+
+.md-chip-button:hover,
+.md-chip-button:focus-within {
+  z-index: 10;
+}
+
+.md-chip-button lht-help-tooltip:hover,
+.md-chip-button lht-help-tooltip:focus-within {
+  z-index: 20;
 }
 
 .md-chip-button lht-help-tooltip .md-tooltip-content {

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -109,6 +109,48 @@ const promptDefinitions = [
         buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
     },
     {
+        id: "resource-handover-ok-request",
+        label: "307: リソース受領中は OK のみ回答",
+        keywords: ["resource", "resources", "multiple resources", "ok", "複数", "リソース", "情報", "引き渡し", "受領", "回答", "okのみ", "OKのみ", "ふくすう", "りそーす", "じょうほう", "ひきわたし", "じゅりょう", "かいとう"],
+        requiresCommitId: false,
+        buildBody: () => "これから複数のリソースの情報を渡します。一連のリソースの引き渡しが終わるまでは、単にOKとのみ回答してください。"
+    },
+    {
+        id: "lgtm-request",
+        label: "300: 確認範囲は概ね良好で LGTM",
+        keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
+        requiresCommitId: false,
+        buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+    },
+    {
+        id: "peer-feedback-analysis-request",
+        label: "309: 他メンバー指摘の受入可否を判断",
+        keywords: ["feedback", "review", "peer review", "comment", "accept", "reject", "判断", "指摘", "受け入れ", "受入", "可否", "解析", "メンバー", "はんだん", "してき", "うけいれ", "かひ", "かいせき"],
+        requiresCommitId: false,
+        buildBody: () => "他のメンバーから指摘をもらいました。この内容について、あなたなりに解析して判断して、そして受け入れられるかどうか、受け入れられないか、を判断して教えて欲しいです。"
+    },
+    {
+        id: "recent-work-status-request",
+        label: "310: 直近の作業状況を確認",
+        keywords: ["recent work", "current status", "what was I doing", "直近", "作業状況", "確認", "離席", "現在", "未完了", "次に何を見る", "ちょっきん", "さぎょうじょうきょう", "りせき", "げんざい", "みかんりょう", "tsuginanimiru"],
+        requiresCommitId: false,
+        buildBody: () => "すみません、少し離席していました。直近で何の作業をしていたのか、現在どこまで進んでいるのか、未完了のものがあるか、次に何を見ればよいかを整理して教えてください。回答は markdownでお願いします。"
+    },
+    {
+        id: "solution-soundness-review-request",
+        label: "311: 場当たり対応や本質解決漏れを確認",
+        keywords: ["ad hoc", "proper solution", "root cause", "architecture", "場当たり", "本質", "解決", "別解", "正しい解決方法", "設計", "妥当性", "ばあたり", "ほんしつ", "かいけつ", "べっかい", "せっけい"],
+        requiresCommitId: false,
+        buildBody: () => "今回の対応について、場当たり的な変更に留まっていないか、本質的には別のより適切な解決方法があるのにそれを選択していないところがないか、設計面と保守面から批判的に確認して教えてください。"
+    },
+    {
+        id: "temporary-change-cleanup-request",
+        label: "312: 暫定変更の置き忘れを確認",
+        keywords: ["temporary", "temporary change", "cleanup", "debug code", "investigation", "暫定", "変更", "置き忘れ", "消し忘れ", "調査用", "試行錯誤", "デバッグ", "片付け", "ざんてい", "おきわすれ", "けしわすれ", "ちょうさよう", "でばっぐ"],
+        requiresCommitId: false,
+        buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
+    },
+    {
         id: "directory-summary-markdown-request",
         label: "101: ディレクトリ内容整理 markdown を作成",
         keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "内容", "整理", "markdown作成", "作成", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -117,6 +117,48 @@ const promptDefinitions: PromptDefinition[] = [
     buildBody: () => "先程の回答にハルシネーションが含まれていないか、いまいちど新しい気持ちで考えてみて欲しいです。適宜必要に応じてWebを検索して裏どりを実施してください。"
   },
   {
+    id: "resource-handover-ok-request",
+    label: "307: リソース受領中は OK のみ回答",
+    keywords: ["resource", "resources", "multiple resources", "ok", "複数", "リソース", "情報", "引き渡し", "受領", "回答", "okのみ", "OKのみ", "ふくすう", "りそーす", "じょうほう", "ひきわたし", "じゅりょう", "かいとう"],
+    requiresCommitId: false,
+    buildBody: () => "これから複数のリソースの情報を渡します。一連のリソースの引き渡しが終わるまでは、単にOKとのみ回答してください。"
+  },
+  {
+    id: "lgtm-request",
+    label: "300: 確認範囲は概ね良好で LGTM",
+    keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
+    requiresCommitId: false,
+    buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+  },
+  {
+    id: "peer-feedback-analysis-request",
+    label: "309: 他メンバー指摘の受入可否を判断",
+    keywords: ["feedback", "review", "peer review", "comment", "accept", "reject", "判断", "指摘", "受け入れ", "受入", "可否", "解析", "メンバー", "はんだん", "してき", "うけいれ", "かひ", "かいせき"],
+    requiresCommitId: false,
+    buildBody: () => "他のメンバーから指摘をもらいました。この内容について、あなたなりに解析して判断して、そして受け入れられるかどうか、受け入れられないか、を判断して教えて欲しいです。"
+  },
+  {
+    id: "recent-work-status-request",
+    label: "310: 直近の作業状況を確認",
+    keywords: ["recent work", "current status", "what was I doing", "直近", "作業状況", "確認", "離席", "現在", "未完了", "次に何を見る", "ちょっきん", "さぎょうじょうきょう", "りせき", "げんざい", "みかんりょう", "tsuginanimiru"],
+    requiresCommitId: false,
+    buildBody: () => "すみません、少し離席していました。直近で何の作業をしていたのか、現在どこまで進んでいるのか、未完了のものがあるか、次に何を見ればよいかを整理して教えてください。回答は markdownでお願いします。"
+  },
+  {
+    id: "solution-soundness-review-request",
+    label: "311: 場当たり対応や本質解決漏れを確認",
+    keywords: ["ad hoc", "proper solution", "root cause", "architecture", "場当たり", "本質", "解決", "別解", "正しい解決方法", "設計", "妥当性", "ばあたり", "ほんしつ", "かいけつ", "べっかい", "せっけい"],
+    requiresCommitId: false,
+    buildBody: () => "今回の対応について、場当たり的な変更に留まっていないか、本質的には別のより適切な解決方法があるのにそれを選択していないところがないか、設計面と保守面から批判的に確認して教えてください。"
+  },
+  {
+    id: "temporary-change-cleanup-request",
+    label: "312: 暫定変更の置き忘れを確認",
+    keywords: ["temporary", "temporary change", "cleanup", "debug code", "investigation", "暫定", "変更", "置き忘れ", "消し忘れ", "調査用", "試行錯誤", "デバッグ", "片付け", "ざんてい", "おきわすれ", "けしわすれ", "ちょうさよう", "でばっぐ"],
+    requiresCommitId: false,
+    buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
+  },
+  {
     id: "directory-summary-markdown-request",
     label: "101: ディレクトリ内容整理 markdown を作成",
     keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "内容", "整理", "markdown作成", "作成", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -874,6 +874,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -894,6 +898,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -901,6 +909,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2742,6 +2807,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2749,6 +2815,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2798,12 +2866,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2853,9 +2957,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -954,6 +954,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -974,6 +978,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -981,6 +989,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2782,6 +2847,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2789,6 +2855,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2838,12 +2906,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2893,9 +2997,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1428,6 +1428,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1448,6 +1452,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1455,6 +1463,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -3636,6 +3701,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -3643,6 +3709,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -3692,12 +3760,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -3747,9 +3851,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -1316,6 +1316,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -1336,6 +1340,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -1343,6 +1351,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {
@@ -2808,6 +2873,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -2815,6 +2881,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -2864,12 +2932,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -2919,9 +3023,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);

--- a/lht-cmn/FEEDBACK.md
+++ b/lht-cmn/FEEDBACK.md
@@ -35,3 +35,20 @@
 - 補足:
   - 現状の `lht-switch-help` は `window.customElements.get("md-switch")` が false のとき fallback DOM を生成する実装になっている
   - `lht-cmn/vendor` には `material-web-outlined-text-field.bundle.js` はあるが、`md-switch` 相当の bundle は見当たらない
+
+## 2026-03-09 `lht-text-field-help` trailing action gap
+
+- 症状:
+  - `prompt-gen` で「やりたいこと」入力欄に `×` クリアボタンを付けたかったが、`lht-text-field-help` 自体には trailing action / trailing icon を安全に差し込む契約がない
+  - 外付け absolute 配置では、Material 側の見た目中心と合いにくく、位置合わせが不安定だった
+- 問題:
+  - 画面ごとに似た「入力クリア」「末尾アイコン」「補助アクション」実装が再発しやすい
+  - `lht-text-field-help` を使っていても、入力欄内アクションはページ側の局所 CSS に依存しやすい
+  - fallback 実装と Material 実装で、末尾アクションの見た目や余白が揃いにくい
+- 期待:
+  - `lht-text-field-help` に trailing action slot、または `clearable` のような共通機能を検討したい
+  - もし汎用化しない場合でも、「入力欄右端に後付けアクションを重ねる時の推奨パターン」を README に明記したい
+- 補足:
+  - 今回は暫定対応として `lht-text-field-help` に `clearable` 属性をローカル追加し、`prompt-gen` ではそれを利用する形へ寄せた
+  - ただしこれは prompt-gen 都合で先に入れた provisional API なので、`lht-cmn` チーム側では trailing action 全般を扱える正式な契約として見直したい
+  - 正式方針が固まったら、今回の `clearable` 実装や CSS 調整はレビューのうえ置き換えたい

--- a/lht-cmn/components.test.js
+++ b/lht-cmn/components.test.js
@@ -415,6 +415,37 @@ describe("lht-text-field-help fallback", () => {
     expect(supportingText.hidden).toBe(true);
     vi.useRealTimers();
   });
+
+  it("supports clearable fallback text fields and dispatches input/change when cleared", async () => {
+    document.body.innerHTML = `
+      <lht-text-field-help
+        field-id="nameField"
+        label="Name"
+        value="Alice"
+        clearable
+      ></lht-text-field-help>
+    `;
+
+    const field = document.querySelector("lht-text-field-help input");
+    const clearButton = document.querySelector("lht-text-field-help .lht-text-field-help__clear-button");
+    const inputListener = vi.fn();
+    const changeListener = vi.fn();
+
+    field.addEventListener("input", inputListener);
+    field.addEventListener("change", changeListener);
+
+    await waitForMicrotask();
+
+    expect(clearButton).not.toBeNull();
+    expect(clearButton.hidden).toBe(false);
+
+    clearButton.click();
+
+    expect(field.value).toBe("");
+    expect(clearButton.hidden).toBe(true);
+    expect(inputListener).toHaveBeenCalledTimes(1);
+    expect(changeListener).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("lht-file-select events", () => {

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -318,6 +318,10 @@ lht-text-field-help {
   min-width: 0;
 }
 
+lht-text-field-help .lht-text-field-help__control-wrap {
+  position: relative;
+}
+
 lht-text-field-help .lht-text-field-help__fallback-wrap {
   display: flex;
   flex-direction: column;
@@ -338,6 +342,10 @@ lht-text-field-help .lht-text-field-help__fallback {
   resize: vertical;
 }
 
+lht-text-field-help .lht-text-field-help__fallback.lht-text-field-help__field--clearable {
+  padding-right: 2.8rem;
+}
+
 lht-text-field-help .lht-text-field-help__supporting-text {
   min-height: 1rem;
   padding: 0 1rem;
@@ -345,6 +353,63 @@ lht-text-field-help .lht-text-field-help__supporting-text {
   line-height: 1rem;
   color: var(--md-sys-color-on-surface-variant, #49454f);
   box-sizing: border-box;
+}
+
+lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
+  --md-outlined-text-field-trailing-space: 40px;
+  --md-outlined-field-trailing-space: 40px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button {
+  position: absolute;
+  top: 28px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(103, 80, 164, 0.10);
+  color: #625b71;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transform: translateY(-50%);
+  transition: background 150ms ease, color 150ms ease, transform 150ms ease;
+  z-index: 2;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:hover {
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:active {
+  transform: translateY(-50%) scale(0.96);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button:focus-visible {
+  outline: 2px solid #6750a4;
+  outline-offset: 2px;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before,
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::before {
+  transform: rotate(45deg);
+}
+
+lht-text-field-help .lht-text-field-help__clear-button::after {
+  transform: rotate(-45deg);
 }
 
 lht-select-help {

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -216,6 +216,7 @@ class LhtTextFieldHelp extends HTMLElement {
 
     const hasMdOutlinedTextField = !!(window.customElements && window.customElements.get("md-outlined-text-field"));
     const isTextarea = (this.getAttribute("type") || "").trim().toLowerCase() === "textarea" || this.hasAttribute("rows");
+    const isClearable = this.hasAttribute("clearable") && !isTextarea;
     const field = hasMdOutlinedTextField
       ? document.createElement("md-outlined-text-field")
       : document.createElement(isTextarea ? "textarea" : "input");
@@ -223,6 +224,8 @@ class LhtTextFieldHelp extends HTMLElement {
     this._isFallbackTextField = !hasMdOutlinedTextField;
     let fallbackWrapper = null;
     let fallbackSupportingText = null;
+    let controlWrap = null;
+    let clearButton = null;
 
     const label = (this.getAttribute("label") || "").trim();
     if (label) {
@@ -272,12 +275,48 @@ class LhtTextFieldHelp extends HTMLElement {
       fieldClass.split(/\s+/).filter(Boolean).forEach((name) => field.classList.add(name));
     }
     field.classList.add(this._isFallbackTextField ? "lht-text-field-help__fallback" : "md-outlined-field");
+    if (isClearable) {
+      field.classList.add("lht-text-field-help__field--clearable");
+    }
 
     if (this.hasAttribute("required")) {
       field.required = true;
       field.setAttribute("required", "");
     }
     if (this.hasAttribute("disabled")) field.disabled = true;
+
+    if (isClearable) {
+      controlWrap = document.createElement("div");
+      controlWrap.className = "lht-text-field-help__control-wrap";
+
+      clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "lht-text-field-help__clear-button";
+      clearButton.hidden = true;
+      clearButton.setAttribute("aria-label", `${label || fieldId}をクリア`);
+
+      const syncClearButtonVisibility = () => {
+        const currentValue = String(field.value || "");
+        clearButton.hidden = currentValue.length === 0 || !!field.disabled;
+      };
+
+      clearButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        field.value = "";
+        if (!this._isFallbackTextField) {
+          field.setAttribute("value", "");
+        }
+        syncClearButtonVisibility();
+        field.focus();
+        field.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+      });
+
+      field.addEventListener("input", syncClearButtonVisibility);
+      field.addEventListener("change", syncClearButtonVisibility);
+      queueMicrotask(syncClearButtonVisibility);
+    }
 
     const helpText = (this.getAttribute("help-text") || "").trim();
     const hideDelayMsAttr = this.getAttribute("hide-delay-ms");
@@ -327,9 +366,21 @@ class LhtTextFieldHelp extends HTMLElement {
 
     this.textContent = "";
     if (fallbackWrapper) {
-      fallbackWrapper.appendChild(field);
+      if (controlWrap) {
+        controlWrap.appendChild(field);
+        controlWrap.appendChild(clearButton);
+        fallbackWrapper.appendChild(controlWrap);
+      } else {
+        fallbackWrapper.appendChild(field);
+      }
       fallbackWrapper.appendChild(fallbackSupportingText);
       this.appendChild(fallbackWrapper);
+      return;
+    }
+    if (controlWrap) {
+      controlWrap.appendChild(field);
+      controlWrap.appendChild(clearButton);
+      this.appendChild(controlWrap);
       return;
     }
     this.appendChild(field);


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` を中心に、生成AI向け定型プロンプトの候補追加、文言調整、README/TODO/FEEDBACK の整備を進めました。 あわせて、検索欄のクリア導線を改善するため `lht-text-field-help` に暫定 `clearable` を追加し、`lht-cmn` 側のフィードバックと今後の正式化 TODO も記録しています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` を更新し、固定文面候補を追加
- `307: リソース受領中は OK のみ回答`
- `300: 確認範囲は概ね良好で LGTM`
- `309: 他メンバー指摘の受入可否を判断`
- `310: 直近の作業状況を確認`
- `311: 場当たり対応や本質解決漏れを確認`
- `312: 暫定変更の置き忘れを確認`
- 既存候補の文言を複数回調整
- `301` の引継ぎ文面を markdown 出力前提に更新
- `309` の指摘受領文面を丁寧な表現へ更新
- `310` の離席復帰文面に markdown 指示を追加
- `docs/prompt/prompt-gen-src.html` を更新
- ページタイトルを `生成AIプロンプト作成支援` に変更
- subtitle / help 文面 / 入力欄の supporting text / index 連携文言を調整
- `やりたいこと` 入力欄のクリア導線を改善
- 当初は `prompt-gen` 側の外付け `×` を試したが、位置ずれのため撤回
- 最終的に `lht-text-field-help clearable` を使う構成へ変更
- `lht-cmn/js/components.js` と `lht-cmn/css/components.css` に `lht-text-field-help` の暫定 `clearable` 対応を追加
- fallback / Material 両方でクリアボタンを出せるよう調整
- `lht-cmn/components.test.js` に clearable fallback の回帰テストを追加
- `README.md` に `docs/prompt/` の運用を追記し、`docs/prompt/README.md` を新規追加
- `lht-cmn/FEEDBACK.md` に `lht-text-field-help` trailing action gap を追記
- `TODO.md` に `clearable` は provisional API であり、`lht-cmn` 側の正式 trailing action 設計に置き換える前提を追記
- `docs/index-src.html` / `docs/index.html` の `prompt-gen` カード説明を現状機能に合わせて更新
- 生成済みの `docs/prompt/prompt-gen.html`、`docs/index.html`、各 `js` 生成物を再生成

## 影響

- `prompt-gen` で選べる定型プロンプトの種類が増えます
- ページタイトルや説明文が現状の用途に合う内容へ更新されます
- `やりたいこと` 欄のクリア導線は改善されますが、`clearable` はまだ `lht-cmn` の暫定 API です
- `lht-cmn` 側には trailing action 正式化に向けたフィードバックと TODO が残ります
- README / prompt README / TODO / FEEDBACK まで含めて、現在の実装状況を追いやすくなります