### PR TITLE
固定文面ボタンの直接クリック時に自動コピーする挙動を追加

### DIFF
--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -374,7 +374,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -374,7 +374,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -384,7 +384,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -389,7 +389,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1392,7 +1392,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1401,7 +1401,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -1301,7 +1301,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -1326,7 +1326,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1386,7 +1386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1386,7 +1386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1416,7 +1416,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1387,7 +1387,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1386,7 +1386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -386,7 +386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -386,7 +386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -386,7 +386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -386,7 +386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -386,7 +386,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -388,7 +388,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;
@@ -3756,7 +3756,9 @@ async function initializePromptPage() {
         button.type = "button";
         button.className = "md-chip-button";
         button.dataset.promptId = definition.id;
-        button.addEventListener("click", () => selectPrompt(definition.id, button));
+        button.addEventListener("click", () => {
+            void selectPrompt(definition.id, button, { autoCopy: true });
+        });
         const label = document.createElement("span");
         label.className = "md-chip-label";
         label.textContent = definition.label;
@@ -3785,6 +3787,37 @@ async function initializePromptPage() {
                 block: "start"
             });
         });
+    }
+    async function copyText(text) {
+        if (!text) {
+            return false;
+        }
+        try {
+            if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+                await navigator.clipboard.writeText(text);
+            }
+            else {
+                const helper = document.createElement("textarea");
+                helper.value = text;
+                helper.setAttribute("readonly", "");
+                helper.style.position = "fixed";
+                helper.style.opacity = "0";
+                document.body.appendChild(helper);
+                helper.select();
+                document.execCommand("copy");
+                helper.remove();
+            }
+            if (typeof window.showToast === "function") {
+                window.showToast("コピーしました");
+            }
+            return true;
+        }
+        catch (_error) {
+            if (typeof window.showToast === "function") {
+                window.showToast("コピーに失敗しました");
+            }
+            return false;
+        }
     }
     function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
@@ -3848,7 +3881,7 @@ async function initializePromptPage() {
             updateOutput();
         }
     }
-    function selectPrompt(id, button) {
+    async function selectPrompt(id, button, options) {
         selectedPrompt = id;
         for (const element of promptCandidateArea.querySelectorAll(".md-chip-button")) {
             element.classList.remove("is-active");
@@ -3864,6 +3897,9 @@ async function initializePromptPage() {
             commitInputSection.classList.add("md-hidden");
         }
         updateOutput();
+        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && !selectedDefinition.requiresCommitId) {
+            await copyText(promptOutput.textContent || "");
+        }
     }
     function buildPromptText() {
         if (!selectedPrompt) {

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -182,7 +182,9 @@ async function initializePromptPage() {
         button.type = "button";
         button.className = "md-chip-button";
         button.dataset.promptId = definition.id;
-        button.addEventListener("click", () => selectPrompt(definition.id, button));
+        button.addEventListener("click", () => {
+            void selectPrompt(definition.id, button, { autoCopy: true });
+        });
         const label = document.createElement("span");
         label.className = "md-chip-label";
         label.textContent = definition.label;
@@ -211,6 +213,37 @@ async function initializePromptPage() {
                 block: "start"
             });
         });
+    }
+    async function copyText(text) {
+        if (!text) {
+            return false;
+        }
+        try {
+            if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+                await navigator.clipboard.writeText(text);
+            }
+            else {
+                const helper = document.createElement("textarea");
+                helper.value = text;
+                helper.setAttribute("readonly", "");
+                helper.style.position = "fixed";
+                helper.style.opacity = "0";
+                document.body.appendChild(helper);
+                helper.select();
+                document.execCommand("copy");
+                helper.remove();
+            }
+            if (typeof window.showToast === "function") {
+                window.showToast("コピーしました");
+            }
+            return true;
+        }
+        catch (_error) {
+            if (typeof window.showToast === "function") {
+                window.showToast("コピーに失敗しました");
+            }
+            return false;
+        }
     }
     function renderCandidates() {
         const query = (promptSearch.value || "").trim().toLowerCase();
@@ -274,7 +307,7 @@ async function initializePromptPage() {
             updateOutput();
         }
     }
-    function selectPrompt(id, button) {
+    async function selectPrompt(id, button, options) {
         selectedPrompt = id;
         for (const element of promptCandidateArea.querySelectorAll(".md-chip-button")) {
             element.classList.remove("is-active");
@@ -290,6 +323,9 @@ async function initializePromptPage() {
             commitInputSection.classList.add("md-hidden");
         }
         updateOutput();
+        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && !selectedDefinition.requiresCommitId) {
+            await copyText(promptOutput.textContent || "");
+        }
     }
     function buildPromptText() {
         if (!selectedPrompt) {

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -223,7 +223,9 @@ async function initializePromptPage() {
     button.type = "button";
     button.className = "md-chip-button";
     button.dataset.promptId = definition.id;
-    button.addEventListener("click", () => selectPrompt(definition.id, button));
+    button.addEventListener("click", () => {
+      void selectPrompt(definition.id, button, { autoCopy: true });
+    });
 
     const label = document.createElement("span");
     label.className = "md-chip-label";
@@ -256,6 +258,37 @@ async function initializePromptPage() {
         block: "start"
       });
     });
+  }
+
+  async function copyText(text: string) {
+    if (!text) {
+      return false;
+    }
+
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const helper = document.createElement("textarea");
+        helper.value = text;
+        helper.setAttribute("readonly", "");
+        helper.style.position = "fixed";
+        helper.style.opacity = "0";
+        document.body.appendChild(helper);
+        helper.select();
+        document.execCommand("copy");
+        helper.remove();
+      }
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーしました");
+      }
+      return true;
+    } catch (_error) {
+      if (typeof window.showToast === "function") {
+        window.showToast("コピーに失敗しました");
+      }
+      return false;
+    }
   }
 
   function renderCandidates() {
@@ -330,7 +363,7 @@ async function initializePromptPage() {
     }
   }
 
-  function selectPrompt(id: string, button: HTMLButtonElement) {
+  async function selectPrompt(id: string, button: HTMLButtonElement, options?: { autoCopy?: boolean }) {
     selectedPrompt = id;
     for (const element of promptCandidateArea.querySelectorAll(".md-chip-button")) {
       element.classList.remove("is-active");
@@ -348,6 +381,10 @@ async function initializePromptPage() {
     }
 
     updateOutput();
+
+    if (options?.autoCopy && selectedDefinition && !selectedDefinition.requiresCommitId) {
+      await copyText(promptOutput.textContent || "");
+    }
   }
 
   function buildPromptText() {

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -918,7 +918,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -998,7 +998,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1472,7 +1472,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -1360,7 +1360,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -362,7 +362,7 @@ lht-text-field-help .md-outlined-field.lht-text-field-help__field--clearable {
 
 lht-text-field-help .lht-text-field-help__clear-button {
   position: absolute;
-  top: 28px;
+  top: 26px;
   right: 14px;
   width: 28px;
   height: 28px;


### PR DESCRIPTION
## 概要

`prompt-gen` において、commit ID などの追加入力を必要としない固定文面ボタンを直接クリックした際、その場で生成結果をクリップボードへ自動コピーするようにしました。 一方で、検索結果が 1 件に絞れただけの自動選択時にはコピーしないままとし、意図しない clipboard 上書きを避けています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/main.ts` を更新
- 固定文面ボタンのクリック時に `selectPrompt(..., { autoCopy: true })` を呼ぶよう変更
- `copyText()` を追加し、Clipboard API または `textarea` fallback でコピーできるよう対応
- コピー成功時は `コピーしました`、失敗時は `コピーに失敗しました` をトースト表示
- 自動コピーは `requiresCommitId: false` の候補に限定
- `PR` / `Release` のように commit ID 入力が必要な候補では従来どおり自動コピーしない
- 検索で 1 件に絞れた際の自動選択・primary 表示は維持しつつ、その経路では自動コピーしない挙動を維持
- `docs/prompt/src/prompt-gen/js/main.js` と `docs/prompt/prompt-gen.html` を再生成
- `lht-cmn/css/components.css` の `lht-text-field-help__clear-button` の縦位置を微調整
- この変更に伴い、各生成済み single-file HTML へ共通 CSS 差分を反映

## 影響

- 固定文面ボタンは、クリックした時点で即コピーできるため操作が 1 手減ります
- 検索で候補が 1 件に絞れただけでは clipboard は変更されません
- commit ID を必要とする文面では、従来どおり入力後に内容を確認してコピーする流れです
- 共通 CSS の微調整により、`lht-text-field-help` の clear ボタン位置が各生成済み HTML にも反映されます