### PR TITLE
prompt-gen の検索優先順位と一致率ベースの並び順を改善

### DIFF
--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -3677,63 +3677,141 @@ async function initializePromptPage() {
         }
         return result;
     }
-    function buildSearchTokens(definition) {
+    function buildExpandedForms(token) {
         const tokens = new Set();
-        const label = (definition.label || "").toLowerCase();
-        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
-        if (label) {
-            tokens.add(label);
-            for (const part of label.split(/\s+/).filter(Boolean)) {
-                tokens.add(part);
-                const hiraganaPart = toHiragana(part);
-                const katakanaPart = toKatakana(part);
-                if (hiraganaPart !== part) {
-                    tokens.add(hiraganaPart);
-                }
-                if (katakanaPart !== part) {
-                    tokens.add(katakanaPart);
-                }
-                const romaji = kanaToRomaji(part);
-                if (romaji) {
-                    tokens.add(romaji);
-                }
+        const normalizedToken = String(token || "").toLowerCase().trim();
+        if (!normalizedToken) {
+            return [];
+        }
+        tokens.add(normalizedToken);
+        for (const part of normalizedToken.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+        }
+        for (const current of Array.from(tokens)) {
+            const hiragana = toHiragana(current);
+            const katakana = toKatakana(current);
+            const romaji = kanaToRomaji(current);
+            if (hiragana !== current) {
+                tokens.add(hiragana);
+            }
+            if (katakana !== current) {
+                tokens.add(katakana);
+            }
+            if (romaji) {
+                tokens.add(romaji);
             }
         }
+        return Array.from(tokens);
+    }
+    function buildLabelTokens(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").toLowerCase().trim();
+        if (!label) {
+            return [];
+        }
+        tokens.add(label);
+        for (const part of label.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+        }
+        return Array.from(tokens);
+    }
+    function buildKeywordTokens(definition) {
+        const tokens = new Set();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
         for (const keyword of keywords) {
             const normalizedKeyword = String(keyword || "").toLowerCase().trim();
             if (!normalizedKeyword) {
                 continue;
             }
             tokens.add(normalizedKeyword);
-            const hiraganaKeyword = toHiragana(normalizedKeyword);
-            const katakanaKeyword = toKatakana(normalizedKeyword);
-            if (hiraganaKeyword !== normalizedKeyword) {
-                tokens.add(hiraganaKeyword);
-            }
-            if (katakanaKeyword !== normalizedKeyword) {
-                tokens.add(katakanaKeyword);
-            }
-            const romajiKeyword = kanaToRomaji(normalizedKeyword);
-            if (romajiKeyword) {
-                tokens.add(romajiKeyword);
-            }
             for (const part of normalizedKeyword.split(/\s+/).filter(Boolean)) {
                 tokens.add(part);
-                const hiraganaPart = toHiragana(part);
-                const katakanaPart = toKatakana(part);
-                if (hiraganaPart !== part) {
-                    tokens.add(hiraganaPart);
-                }
-                if (katakanaPart !== part) {
-                    tokens.add(katakanaPart);
-                }
-                const romaji = kanaToRomaji(part);
-                if (romaji) {
-                    tokens.add(romaji);
-                }
             }
         }
         return Array.from(tokens);
+    }
+    function buildExpandedTokens(definition) {
+        const tokens = new Set();
+        for (const token of buildLabelTokens(definition)) {
+            for (const expanded of buildExpandedForms(token)) {
+                tokens.add(expanded);
+            }
+        }
+        for (const token of buildKeywordTokens(definition)) {
+            for (const expanded of buildExpandedForms(token)) {
+                tokens.add(expanded);
+            }
+        }
+        for (const token of buildLabelTokens(definition)) {
+            tokens.delete(token);
+        }
+        for (const token of buildKeywordTokens(definition)) {
+            tokens.delete(token);
+        }
+        return Array.from(tokens);
+    }
+    function matchesAllTerms(tokens, terms) {
+        if (terms.length === 0) {
+            return true;
+        }
+        return terms.every((term) => tokens.some((token) => token.includes(term)));
+    }
+    function calculateMatchScore(tokens, terms) {
+        if (terms.length === 0) {
+            return 0;
+        }
+        let score = 0;
+        for (const term of terms) {
+            let bestScoreForTerm = 0;
+            for (const token of tokens) {
+                if (!token.includes(term) || token.length === 0) {
+                    continue;
+                }
+                const currentScore = term.length / token.length;
+                if (currentScore > bestScoreForTerm) {
+                    bestScoreForTerm = currentScore;
+                }
+            }
+            score += bestScoreForTerm;
+        }
+        return score;
+    }
+    function sortDefinitions(definitions) {
+        return [...definitions].sort((left, right) => {
+            if (left.label < right.label)
+                return -1;
+            if (left.label > right.label)
+                return 1;
+            return 0;
+        });
+    }
+    function sortDefinitionsByScore(definitions, terms, tokenBuilder) {
+        return [...definitions].sort((left, right) => {
+            const rightScore = calculateMatchScore(tokenBuilder(right), terms);
+            const leftScore = calculateMatchScore(tokenBuilder(left), terms);
+            if (rightScore !== leftScore) {
+                return rightScore - leftScore;
+            }
+            if (left.label < right.label)
+                return -1;
+            if (left.label > right.label)
+                return 1;
+            return 0;
+        });
+    }
+    function mergeDefinitionGroups(groups) {
+        const merged = [];
+        const seenIds = new Set();
+        for (const group of groups) {
+            for (const definition of group) {
+                if (seenIds.has(definition.id)) {
+                    continue;
+                }
+                seenIds.add(definition.id);
+                merged.push(definition);
+            }
+        }
+        return merged;
     }
     function buildDisplayKeywords(definition) {
         const tokens = new Set();
@@ -3832,16 +3910,18 @@ async function initializePromptPage() {
             promptOutput.textContent = "";
         }
         const terms = query ? query.split(/\s+/).filter(Boolean) : [];
+        const labelMatches = query
+            ? sortDefinitions(promptDefinitions.filter((definition) => matchesAllTerms(buildLabelTokens(definition), terms)))
+            : sortDefinitions(promptDefinitions);
+        const keywordMatches = query
+            ? sortDefinitionsByScore(promptDefinitions.filter((definition) => matchesAllTerms(buildKeywordTokens(definition), terms)), terms, buildKeywordTokens)
+            : [];
+        const expandedMatches = query
+            ? sortDefinitionsByScore(promptDefinitions.filter((definition) => matchesAllTerms(buildExpandedTokens(definition), terms)), terms, buildExpandedTokens)
+            : [];
         const matchedDefinitions = query
-            ? promptDefinitions.filter((definition) => terms.every((term) => buildSearchTokens(definition).some((token) => token.includes(term))))
-            : promptDefinitions;
-        matchedDefinitions.sort((left, right) => {
-            if (left.label < right.label)
-                return -1;
-            if (left.label > right.label)
-                return 1;
-            return 0;
-        });
+            ? mergeDefinitionGroups([labelMatches, keywordMatches, expandedMatches])
+            : labelMatches;
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
@@ -3851,24 +3931,29 @@ async function initializePromptPage() {
             }
             return;
         }
-        const hasSingleMatch = matchedDefinitions.length === 1;
-        if (hasSingleMatch && !selectedPrompt) {
-            selectedPrompt = matchedDefinitions[0].id;
+        const prioritizedSingleDefinition = labelMatches.length === 1
+            ? labelMatches[0]
+            : labelMatches.length === 0 && keywordMatches.length === 1
+                ? keywordMatches[0]
+                : labelMatches.length === 0 && keywordMatches.length === 0 && expandedMatches.length === 1
+                    ? expandedMatches[0]
+                    : null;
+        if (prioritizedSingleDefinition) {
+            selectedPrompt = prioritizedSingleDefinition.id;
         }
-        else if (!hasSingleMatch &&
-            selectedPrompt &&
+        else if (selectedPrompt &&
             !matchedDefinitions.some((definition) => definition.id === selectedPrompt)) {
             selectedPrompt = "";
         }
         for (const definition of matchedDefinitions) {
             const button = createCandidateButton(definition);
-            if (hasSingleMatch && selectedPrompt === definition.id) {
+            if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
                 button.classList.add("is-active");
             }
             promptCandidateArea.appendChild(button);
         }
-        if (hasSingleMatch && selectedPrompt === matchedDefinitions[0].id) {
-            const selectedDefinition = matchedDefinitions[0];
+        if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
+            const selectedDefinition = prioritizedSingleDefinition;
             if (selectedDefinition.requiresCommitId) {
                 commitInputSection.classList.remove("md-hidden");
             }

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -103,63 +103,141 @@ async function initializePromptPage() {
         }
         return result;
     }
-    function buildSearchTokens(definition) {
+    function buildExpandedForms(token) {
         const tokens = new Set();
-        const label = (definition.label || "").toLowerCase();
-        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
-        if (label) {
-            tokens.add(label);
-            for (const part of label.split(/\s+/).filter(Boolean)) {
-                tokens.add(part);
-                const hiraganaPart = toHiragana(part);
-                const katakanaPart = toKatakana(part);
-                if (hiraganaPart !== part) {
-                    tokens.add(hiraganaPart);
-                }
-                if (katakanaPart !== part) {
-                    tokens.add(katakanaPart);
-                }
-                const romaji = kanaToRomaji(part);
-                if (romaji) {
-                    tokens.add(romaji);
-                }
+        const normalizedToken = String(token || "").toLowerCase().trim();
+        if (!normalizedToken) {
+            return [];
+        }
+        tokens.add(normalizedToken);
+        for (const part of normalizedToken.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+        }
+        for (const current of Array.from(tokens)) {
+            const hiragana = toHiragana(current);
+            const katakana = toKatakana(current);
+            const romaji = kanaToRomaji(current);
+            if (hiragana !== current) {
+                tokens.add(hiragana);
+            }
+            if (katakana !== current) {
+                tokens.add(katakana);
+            }
+            if (romaji) {
+                tokens.add(romaji);
             }
         }
+        return Array.from(tokens);
+    }
+    function buildLabelTokens(definition) {
+        const tokens = new Set();
+        const label = (definition.label || "").toLowerCase().trim();
+        if (!label) {
+            return [];
+        }
+        tokens.add(label);
+        for (const part of label.split(/\s+/).filter(Boolean)) {
+            tokens.add(part);
+        }
+        return Array.from(tokens);
+    }
+    function buildKeywordTokens(definition) {
+        const tokens = new Set();
+        const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
         for (const keyword of keywords) {
             const normalizedKeyword = String(keyword || "").toLowerCase().trim();
             if (!normalizedKeyword) {
                 continue;
             }
             tokens.add(normalizedKeyword);
-            const hiraganaKeyword = toHiragana(normalizedKeyword);
-            const katakanaKeyword = toKatakana(normalizedKeyword);
-            if (hiraganaKeyword !== normalizedKeyword) {
-                tokens.add(hiraganaKeyword);
-            }
-            if (katakanaKeyword !== normalizedKeyword) {
-                tokens.add(katakanaKeyword);
-            }
-            const romajiKeyword = kanaToRomaji(normalizedKeyword);
-            if (romajiKeyword) {
-                tokens.add(romajiKeyword);
-            }
             for (const part of normalizedKeyword.split(/\s+/).filter(Boolean)) {
                 tokens.add(part);
-                const hiraganaPart = toHiragana(part);
-                const katakanaPart = toKatakana(part);
-                if (hiraganaPart !== part) {
-                    tokens.add(hiraganaPart);
-                }
-                if (katakanaPart !== part) {
-                    tokens.add(katakanaPart);
-                }
-                const romaji = kanaToRomaji(part);
-                if (romaji) {
-                    tokens.add(romaji);
-                }
             }
         }
         return Array.from(tokens);
+    }
+    function buildExpandedTokens(definition) {
+        const tokens = new Set();
+        for (const token of buildLabelTokens(definition)) {
+            for (const expanded of buildExpandedForms(token)) {
+                tokens.add(expanded);
+            }
+        }
+        for (const token of buildKeywordTokens(definition)) {
+            for (const expanded of buildExpandedForms(token)) {
+                tokens.add(expanded);
+            }
+        }
+        for (const token of buildLabelTokens(definition)) {
+            tokens.delete(token);
+        }
+        for (const token of buildKeywordTokens(definition)) {
+            tokens.delete(token);
+        }
+        return Array.from(tokens);
+    }
+    function matchesAllTerms(tokens, terms) {
+        if (terms.length === 0) {
+            return true;
+        }
+        return terms.every((term) => tokens.some((token) => token.includes(term)));
+    }
+    function calculateMatchScore(tokens, terms) {
+        if (terms.length === 0) {
+            return 0;
+        }
+        let score = 0;
+        for (const term of terms) {
+            let bestScoreForTerm = 0;
+            for (const token of tokens) {
+                if (!token.includes(term) || token.length === 0) {
+                    continue;
+                }
+                const currentScore = term.length / token.length;
+                if (currentScore > bestScoreForTerm) {
+                    bestScoreForTerm = currentScore;
+                }
+            }
+            score += bestScoreForTerm;
+        }
+        return score;
+    }
+    function sortDefinitions(definitions) {
+        return [...definitions].sort((left, right) => {
+            if (left.label < right.label)
+                return -1;
+            if (left.label > right.label)
+                return 1;
+            return 0;
+        });
+    }
+    function sortDefinitionsByScore(definitions, terms, tokenBuilder) {
+        return [...definitions].sort((left, right) => {
+            const rightScore = calculateMatchScore(tokenBuilder(right), terms);
+            const leftScore = calculateMatchScore(tokenBuilder(left), terms);
+            if (rightScore !== leftScore) {
+                return rightScore - leftScore;
+            }
+            if (left.label < right.label)
+                return -1;
+            if (left.label > right.label)
+                return 1;
+            return 0;
+        });
+    }
+    function mergeDefinitionGroups(groups) {
+        const merged = [];
+        const seenIds = new Set();
+        for (const group of groups) {
+            for (const definition of group) {
+                if (seenIds.has(definition.id)) {
+                    continue;
+                }
+                seenIds.add(definition.id);
+                merged.push(definition);
+            }
+        }
+        return merged;
     }
     function buildDisplayKeywords(definition) {
         const tokens = new Set();
@@ -258,16 +336,18 @@ async function initializePromptPage() {
             promptOutput.textContent = "";
         }
         const terms = query ? query.split(/\s+/).filter(Boolean) : [];
+        const labelMatches = query
+            ? sortDefinitions(promptDefinitions.filter((definition) => matchesAllTerms(buildLabelTokens(definition), terms)))
+            : sortDefinitions(promptDefinitions);
+        const keywordMatches = query
+            ? sortDefinitionsByScore(promptDefinitions.filter((definition) => matchesAllTerms(buildKeywordTokens(definition), terms)), terms, buildKeywordTokens)
+            : [];
+        const expandedMatches = query
+            ? sortDefinitionsByScore(promptDefinitions.filter((definition) => matchesAllTerms(buildExpandedTokens(definition), terms)), terms, buildExpandedTokens)
+            : [];
         const matchedDefinitions = query
-            ? promptDefinitions.filter((definition) => terms.every((term) => buildSearchTokens(definition).some((token) => token.includes(term))))
-            : promptDefinitions;
-        matchedDefinitions.sort((left, right) => {
-            if (left.label < right.label)
-                return -1;
-            if (left.label > right.label)
-                return 1;
-            return 0;
-        });
+            ? mergeDefinitionGroups([labelMatches, keywordMatches, expandedMatches])
+            : labelMatches;
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
@@ -277,24 +357,29 @@ async function initializePromptPage() {
             }
             return;
         }
-        const hasSingleMatch = matchedDefinitions.length === 1;
-        if (hasSingleMatch && !selectedPrompt) {
-            selectedPrompt = matchedDefinitions[0].id;
+        const prioritizedSingleDefinition = labelMatches.length === 1
+            ? labelMatches[0]
+            : labelMatches.length === 0 && keywordMatches.length === 1
+                ? keywordMatches[0]
+                : labelMatches.length === 0 && keywordMatches.length === 0 && expandedMatches.length === 1
+                    ? expandedMatches[0]
+                    : null;
+        if (prioritizedSingleDefinition) {
+            selectedPrompt = prioritizedSingleDefinition.id;
         }
-        else if (!hasSingleMatch &&
-            selectedPrompt &&
+        else if (selectedPrompt &&
             !matchedDefinitions.some((definition) => definition.id === selectedPrompt)) {
             selectedPrompt = "";
         }
         for (const definition of matchedDefinitions) {
             const button = createCandidateButton(definition);
-            if (hasSingleMatch && selectedPrompt === definition.id) {
+            if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
                 button.classList.add("is-active");
             }
             promptCandidateArea.appendChild(button);
         }
-        if (hasSingleMatch && selectedPrompt === matchedDefinitions[0].id) {
-            const selectedDefinition = matchedDefinitions[0];
+        if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
+            const selectedDefinition = prioritizedSingleDefinition;
             if (selectedDefinition.requiresCommitId) {
                 commitInputSection.classList.remove("md-hidden");
             }

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -136,29 +136,54 @@ async function initializePromptPage() {
     return result;
   }
 
-  function buildSearchTokens(definition: PromptDefinition) {
+  function buildExpandedForms(token: string) {
     const tokens = new Set<string>();
-    const label = (definition.label || "").toLowerCase();
-    const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
+    const normalizedToken = String(token || "").toLowerCase().trim();
+    if (!normalizedToken) {
+      return [];
+    }
 
-    if (label) {
-      tokens.add(label);
-      for (const part of label.split(/\s+/).filter(Boolean)) {
-        tokens.add(part);
-        const hiraganaPart = toHiragana(part);
-        const katakanaPart = toKatakana(part);
-        if (hiraganaPart !== part) {
-          tokens.add(hiraganaPart);
-        }
-        if (katakanaPart !== part) {
-          tokens.add(katakanaPart);
-        }
-        const romaji = kanaToRomaji(part);
-        if (romaji) {
-          tokens.add(romaji);
-        }
+    tokens.add(normalizedToken);
+    for (const part of normalizedToken.split(/\s+/).filter(Boolean)) {
+      tokens.add(part);
+    }
+
+    for (const current of Array.from(tokens)) {
+      const hiragana = toHiragana(current);
+      const katakana = toKatakana(current);
+      const romaji = kanaToRomaji(current);
+      if (hiragana !== current) {
+        tokens.add(hiragana);
+      }
+      if (katakana !== current) {
+        tokens.add(katakana);
+      }
+      if (romaji) {
+        tokens.add(romaji);
       }
     }
+
+    return Array.from(tokens);
+  }
+
+  function buildLabelTokens(definition: PromptDefinition) {
+    const tokens = new Set<string>();
+    const label = (definition.label || "").toLowerCase().trim();
+    if (!label) {
+      return [];
+    }
+
+    tokens.add(label);
+    for (const part of label.split(/\s+/).filter(Boolean)) {
+      tokens.add(part);
+    }
+
+    return Array.from(tokens);
+  }
+
+  function buildKeywordTokens(definition: PromptDefinition) {
+    const tokens = new Set<string>();
+    const keywords = Array.isArray(definition.keywords) ? definition.keywords : [];
 
     for (const keyword of keywords) {
       const normalizedKeyword = String(keyword || "").toLowerCase().trim();
@@ -166,36 +191,104 @@ async function initializePromptPage() {
         continue;
       }
       tokens.add(normalizedKeyword);
-      const hiraganaKeyword = toHiragana(normalizedKeyword);
-      const katakanaKeyword = toKatakana(normalizedKeyword);
-      if (hiraganaKeyword !== normalizedKeyword) {
-        tokens.add(hiraganaKeyword);
-      }
-      if (katakanaKeyword !== normalizedKeyword) {
-        tokens.add(katakanaKeyword);
-      }
-      const romajiKeyword = kanaToRomaji(normalizedKeyword);
-      if (romajiKeyword) {
-        tokens.add(romajiKeyword);
-      }
       for (const part of normalizedKeyword.split(/\s+/).filter(Boolean)) {
         tokens.add(part);
-        const hiraganaPart = toHiragana(part);
-        const katakanaPart = toKatakana(part);
-        if (hiraganaPart !== part) {
-          tokens.add(hiraganaPart);
-        }
-        if (katakanaPart !== part) {
-          tokens.add(katakanaPart);
-        }
-        const romaji = kanaToRomaji(part);
-        if (romaji) {
-          tokens.add(romaji);
-        }
       }
     }
 
     return Array.from(tokens);
+  }
+
+  function buildExpandedTokens(definition: PromptDefinition) {
+    const tokens = new Set<string>();
+
+    for (const token of buildLabelTokens(definition)) {
+      for (const expanded of buildExpandedForms(token)) {
+        tokens.add(expanded);
+      }
+    }
+    for (const token of buildKeywordTokens(definition)) {
+      for (const expanded of buildExpandedForms(token)) {
+        tokens.add(expanded);
+      }
+    }
+
+    for (const token of buildLabelTokens(definition)) {
+      tokens.delete(token);
+    }
+    for (const token of buildKeywordTokens(definition)) {
+      tokens.delete(token);
+    }
+
+    return Array.from(tokens);
+  }
+
+  function matchesAllTerms(tokens: string[], terms: string[]) {
+    if (terms.length === 0) {
+      return true;
+    }
+    return terms.every((term) => tokens.some((token) => token.includes(term)));
+  }
+
+  function calculateMatchScore(tokens: string[], terms: string[]) {
+    if (terms.length === 0) {
+      return 0;
+    }
+
+    let score = 0;
+    for (const term of terms) {
+      let bestScoreForTerm = 0;
+      for (const token of tokens) {
+        if (!token.includes(term) || token.length === 0) {
+          continue;
+        }
+        const currentScore = term.length / token.length;
+        if (currentScore > bestScoreForTerm) {
+          bestScoreForTerm = currentScore;
+        }
+      }
+      score += bestScoreForTerm;
+    }
+
+    return score;
+  }
+
+  function sortDefinitions(definitions: PromptDefinition[]) {
+    return [...definitions].sort((left, right) => {
+      if (left.label < right.label) return -1;
+      if (left.label > right.label) return 1;
+      return 0;
+    });
+  }
+
+  function sortDefinitionsByScore(definitions: PromptDefinition[], terms: string[], tokenBuilder: (definition: PromptDefinition) => string[]) {
+    return [...definitions].sort((left, right) => {
+      const rightScore = calculateMatchScore(tokenBuilder(right), terms);
+      const leftScore = calculateMatchScore(tokenBuilder(left), terms);
+      if (rightScore !== leftScore) {
+        return rightScore - leftScore;
+      }
+      if (left.label < right.label) return -1;
+      if (left.label > right.label) return 1;
+      return 0;
+    });
+  }
+
+  function mergeDefinitionGroups(groups: PromptDefinition[][]) {
+    const merged: PromptDefinition[] = [];
+    const seenIds = new Set<string>();
+
+    for (const group of groups) {
+      for (const definition of group) {
+        if (seenIds.has(definition.id)) {
+          continue;
+        }
+        seenIds.add(definition.id);
+        merged.push(definition);
+      }
+    }
+
+    return merged;
   }
 
   function buildDisplayKeywords(definition: PromptDefinition) {
@@ -306,18 +399,26 @@ async function initializePromptPage() {
     }
 
     const terms = query ? query.split(/\s+/).filter(Boolean) : [];
-    const matchedDefinitions = query
-      ? promptDefinitions.filter((definition) =>
-          terms.every((term) =>
-            buildSearchTokens(definition).some((token) => token.includes(term))
-          )
+    const labelMatches = query
+      ? sortDefinitions(promptDefinitions.filter((definition) => matchesAllTerms(buildLabelTokens(definition), terms)))
+      : sortDefinitions(promptDefinitions);
+    const keywordMatches = query
+      ? sortDefinitionsByScore(
+          promptDefinitions.filter((definition) => matchesAllTerms(buildKeywordTokens(definition), terms)),
+          terms,
+          buildKeywordTokens
         )
-      : promptDefinitions;
-    matchedDefinitions.sort((left, right) => {
-      if (left.label < right.label) return -1;
-      if (left.label > right.label) return 1;
-      return 0;
-    });
+      : [];
+    const expandedMatches = query
+      ? sortDefinitionsByScore(
+          promptDefinitions.filter((definition) => matchesAllTerms(buildExpandedTokens(definition), terms)),
+          terms,
+          buildExpandedTokens
+        )
+      : [];
+    const matchedDefinitions = query
+      ? mergeDefinitionGroups([labelMatches, keywordMatches, expandedMatches])
+      : labelMatches;
 
     if (matchedDefinitions.length === 0) {
       if (selectedPrompt) {
@@ -329,12 +430,18 @@ async function initializePromptPage() {
       return;
     }
 
-    const hasSingleMatch = matchedDefinitions.length === 1;
+    const prioritizedSingleDefinition =
+      labelMatches.length === 1
+        ? labelMatches[0]
+        : labelMatches.length === 0 && keywordMatches.length === 1
+          ? keywordMatches[0]
+          : labelMatches.length === 0 && keywordMatches.length === 0 && expandedMatches.length === 1
+            ? expandedMatches[0]
+            : null;
 
-    if (hasSingleMatch && !selectedPrompt) {
-      selectedPrompt = matchedDefinitions[0].id;
+    if (prioritizedSingleDefinition) {
+      selectedPrompt = prioritizedSingleDefinition.id;
     } else if (
-      !hasSingleMatch &&
       selectedPrompt &&
       !matchedDefinitions.some((definition) => definition.id === selectedPrompt)
     ) {
@@ -343,14 +450,14 @@ async function initializePromptPage() {
 
     for (const definition of matchedDefinitions) {
       const button = createCandidateButton(definition);
-      if (hasSingleMatch && selectedPrompt === definition.id) {
+      if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
         button.classList.add("is-active");
       }
       promptCandidateArea.appendChild(button);
     }
 
-    if (hasSingleMatch && selectedPrompt === matchedDefinitions[0].id) {
-      const selectedDefinition = matchedDefinitions[0];
+    if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
+      const selectedDefinition = prioritizedSingleDefinition;
       if (selectedDefinition.requiresCommitId) {
         commitInputSection.classList.remove("md-hidden");
       } else {

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -39,6 +39,8 @@ function mountPromptDom() {
 async function bootPromptPage() {
   defineElementIfNeeded("lht-text-field-help");
   mountPromptDom();
+  const promptOutputSection = document.getElementById("promptOutputSection");
+  promptOutputSection.scrollIntoView = () => {};
   new Function(`${promptDefinitionsCode}\n${mainCode}`)();
   document.dispatchEvent(new Event("DOMContentLoaded"));
   await Promise.resolve();
@@ -60,7 +62,7 @@ describe("prompt-gen main", () => {
 
     const buttons = [...document.querySelectorAll(".md-chip-button")];
     expect(buttons).toHaveLength(1);
-    expect(buttons[0].textContent).toContain("GitHub PR 文面作成");
+    expect(buttons[0].querySelector(".md-chip-label").textContent).toContain("GitHub PR 文面の作成");
     expect(buttons[0].classList.contains("is-active")).toBe(true);
     expect(commitInputSection.classList.contains("md-hidden")).toBe(false);
     expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
@@ -87,14 +89,14 @@ describe("prompt-gen main", () => {
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
     expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
     expect(promptOutput.textContent).toBe(
-      "原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+      "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
     );
 
     includeLabelPrefix.checked = true;
     includeLabelPrefix.dispatchEvent(new Event("change"));
 
     expect(promptOutput.textContent).toBe(
-      "[Single-file Web App の維持] 原則として Single-file Web App であるようにしてください。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを常に意識してください。"
+      "[701: Single-file Web App の維持] このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
     );
   });
 
@@ -122,5 +124,20 @@ describe("prompt-gen main", () => {
     expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
     expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
+  });
+
+  it("uses a label-derived unique match as the primary selection", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    promptSearch.value = "離席";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    const buttons = [...document.querySelectorAll(".md-chip-button")];
+    expect(buttons).toHaveLength(1);
+
+    const activeButtons = buttons.filter((button) => button.classList.contains("is-active"));
+    expect(activeButtons).toHaveLength(1);
+    expect(activeButtons[0].querySelector(".md-chip-label").textContent).toContain("310: 直近の作業状況を確認");
   });
 });


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` の検索ロジックを見直し、候補表示を「ボタン名一致 → キーワード一致 → 展開語一致」の優先順位で扱うようにしました。 あわせて、キーワード一致および展開語一致のグループ内では、一致率が高い候補を上位に表示するよう改善しています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/main.ts` を更新
- 検索トークン生成を役割別に分離
  - `buildLabelTokens`
  - `buildKeywordTokens`
  - `buildExpandedTokens`
  - `buildExpandedForms`
- 検索結果を優先順位付きで構成
  - 1. ボタン名一致
  - 2. キーワード一致
  - 3. ひらがな / カタカナ / ローマ字などの展開語一致
- グループごとのマージ処理を追加し、重複候補を除外しつつ優先順位順に一覧表示
- primary 判定ルールを優先順位ベースに整理
  - ボタン名一致が 1 件ならそれを primary
  - ボタン名一致が 0 件で、キーワード一致が 1 件ならそれを primary
  - 上記が 0 件で、展開語一致が 1 件ならそれを primary
- `calculateMatchScore` と `sortDefinitionsByScore` を追加し、キーワード一致と展開語一致のグループ内では `検索語長 / マッチしたトークン長` の合計スコアが高い候補を上位表示
- `docs/prompt/tests/prompt-gen-main.test.js` を更新
  - 現行ラベル文言と `Single-file Web App` 文面の期待値を調整
  - `scrollIntoView` の stub を追加
  - ラベル由来の一意マッチが primary になる回帰テストを追加
- 生成済みの `docs/prompt/src/prompt-gen/js/main.js` と `docs/prompt/prompt-gen.html` を再生成

## 影響

- `prompt-gen` の候補表示が、ユーザーの入力意図に近い順で出るようになります
- ボタン名に直接近い語は優先的に候補上位へ出ます
- キーワード一致や展開語一致が複数ある場合も、より直接的に一致した候補が上に来ます
- `prompt-gen` の最小テストは新しい検索仕様に合わせて更新され、回帰確認できる状態です