### PR TITLE
prompt-gen の固定文言をチルダフェンス前提に統一し TYPO を修正

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,16 @@
 - [lht-cmn] `lht-input-mode-toggle`（file/source 切替）を追加し、music系で反復しているラジオUIを共通化する
 - [lht-cmn] `lht-preview-output`（プレビュー + コピー導線）を追加し、`previewText` 周辺の反復UIを共通化する
 - [lht-cmn] `lht-text-field-help` の trailing action を正式設計する。現在は `prompt-gen` 向けに `clearable` を暫定追加しているが、`lht-cmn` チームの更新版を受領したら、slot / action API を含めてちゃんとした実装へ置き換える
+- [prompt-gen][仕様検討] JSON から追加ボタン定義を投入し、`localStorage` に保存して再表示できる仕組みを初版スコープで整理する
+- [prompt-gen][仕様検討] 初版は「固定文面ボタンのみ追加可能」とし、`commitId` 差し込みや任意ロジックは対象外と明記する
+- [prompt-gen][仕様検討] 追加ボタン定義の JSON schema を固定する（初版: `id` / `label` / `keywords` / `body`。`requiresCommitId` は常に `false` 扱い）
+- [prompt-gen][仕様検討] JSON schema の妥当性チェック方針を決める（必須項目欠落・重複 `id`・不正 JSON の扱い）
+- [prompt-gen][仕様検討] 組み込み定義とユーザー追加定義のマージ方針を決める（組み込み優先。衝突時は追加定義を拒否する想定）
+- [prompt-gen][仕様検討] `localStorage` 保存キーを 1 つに固定し、保存データに `version` を持たせるか決める
+- [prompt-gen][仕様検討] `localStorage` 破損時の復旧方針を決める（読み飛ばし・初期化・エラーメッセージ表示）
+- [prompt-gen][仕様検討] 追加定義の削除 UI は初版で「追加ボタン全削除」のみとし、個別削除は次段階に回す
+- [prompt-gen][仕様検討] 追加ボタンの投入 UI を決める（JSON 入力欄、取り込みボタン、エラー表示、保存完了通知）
+- [prompt-gen][仕様検討] Single-file Web App 方針のまま成立することを確認し、README / prompt README への反映要否を整理する
 - [優先度高][lht-cmn] `lht-*` 全体を棚卸しし、各コンポーネントを「内部保証」または「フォールバック保証」のどちらかへ統一する
 - [music] `docs/music/musicxml-to-midi.html` に、ダウンロードせずその場でMIDI再生できる機能を追加する
   - 現状: Web Audio による簡易シンセ再生は実装済み

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -3395,7 +3395,7 @@ const promptDefinitions = [
         keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "文面", "作成", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は \`\`\` で囲まれた一塊として回答してください。`
+            ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
             : ""
     },
     {
@@ -3409,17 +3409,17 @@ const promptDefinitions = [
     },
     {
         id: "inline-code-request",
-        label: "303: Markdown インラインコードとして出力",
-        keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "出力", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
+        label: "303: Markdown をチルダフェンスで出力",
+        keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
-        buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
+        buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "extract-to-inline-code-request",
-        label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
-        keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+        label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
+        keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
         requiresCommitId: false,
-        buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "github-no-change-request",
@@ -3454,14 +3454,14 @@ const promptDefinitions = [
         label: "702: 事象の再発防止テストを追加",
         keywords: ["test", "testing", "small test", "再発", "防止", "テスト", "追加", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
         requiresCommitId: false,
-        buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
+        buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、容易に実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
     },
     {
         id: "disagreement-first-request",
         label: "302: 違和感や誤りを先に指摘",
         keywords: ["disagree", "wrong", "違和感", "誤り", "間違い", "指摘", "先", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
         requiresCommitId: false,
-        buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
+        buildBody: () => "私の指示や指摘について、あなたが強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
     },
     {
         id: "todo-cleanup-request",
@@ -3510,7 +3510,7 @@ const promptDefinitions = [
         label: "300: 確認範囲は概ね良好で LGTM",
         keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
         requiresCommitId: false,
-        buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+        buildBody: () => "いいね！いい感じです。確認した範囲はおおよそ良さそうです。LGTMです。"
     },
     {
         id: "peer-feedback-analysis-request",
@@ -3541,11 +3541,18 @@ const promptDefinitions = [
         buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
     },
     {
+        id: "reconsider-answer-request",
+        label: "313: 回答を改めて再考して確認",
+        keywords: ["reconsider", "rethink", "fresh look", "answer review", "再考", "再確認", "改めて", "新鮮な気持ち", "もう一度", "回答", "見直し", "さいこう", "さいかくにん", "あらためて", "みなおし"],
+        requiresCommitId: false,
+        buildBody: () => "その回答について、いったん先入観を外して、改めて新鮮な気持ちでよく考え直したうえでもう一度回答してください。見落としや早とちり、先入観による偏った考え方、さらに別の解釈の余地がないかも含めて再確認して欲しいです。"
+    },
+    {
         id: "directory-summary-markdown-request",
         label: "101: ディレクトリ内容整理 markdown を作成",
         keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "内容", "整理", "markdown作成", "作成", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
         requiresCommitId: false,
-        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切なファイル名の markdown ファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
     },
     {
         id: "build-check-request",
@@ -3559,14 +3566,14 @@ const promptDefinitions = [
         label: "706: 作業終了時の引継確認",
         keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
         requiresCommitId: false,
-        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに必要な情報を記入してもらえませんか。そして必要があれば、直近の作業で何を実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
     },
     {
         id: "single-file-web-app-request",
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
-        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
+        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDN や別ファイルの CSS / JS ファイルを利用していないことを確認してください。"
     }
 ];
   </script>

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -5,7 +5,7 @@ const promptDefinitions = [
         keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "文面", "作成", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は \`\`\` で囲まれた一塊として回答してください。`
+            ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
             : ""
     },
     {
@@ -19,17 +19,17 @@ const promptDefinitions = [
     },
     {
         id: "inline-code-request",
-        label: "303: Markdown インラインコードとして出力",
-        keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "出力", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
+        label: "303: Markdown をチルダフェンスで出力",
+        keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
-        buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
+        buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "extract-to-inline-code-request",
-        label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
-        keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+        label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
+        keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
         requiresCommitId: false,
-        buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "github-no-change-request",
@@ -64,14 +64,14 @@ const promptDefinitions = [
         label: "702: 事象の再発防止テストを追加",
         keywords: ["test", "testing", "small test", "再発", "防止", "テスト", "追加", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
         requiresCommitId: false,
-        buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
+        buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、容易に実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
     },
     {
         id: "disagreement-first-request",
         label: "302: 違和感や誤りを先に指摘",
         keywords: ["disagree", "wrong", "違和感", "誤り", "間違い", "指摘", "先", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
         requiresCommitId: false,
-        buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
+        buildBody: () => "私の指示や指摘について、あなたが強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
     },
     {
         id: "todo-cleanup-request",
@@ -120,7 +120,7 @@ const promptDefinitions = [
         label: "300: 確認範囲は概ね良好で LGTM",
         keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
         requiresCommitId: false,
-        buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+        buildBody: () => "いいね！いい感じです。確認した範囲はおおよそ良さそうです。LGTMです。"
     },
     {
         id: "peer-feedback-analysis-request",
@@ -151,11 +151,18 @@ const promptDefinitions = [
         buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
     },
     {
+        id: "reconsider-answer-request",
+        label: "313: 回答を改めて再考して確認",
+        keywords: ["reconsider", "rethink", "fresh look", "answer review", "再考", "再確認", "改めて", "新鮮な気持ち", "もう一度", "回答", "見直し", "さいこう", "さいかくにん", "あらためて", "みなおし"],
+        requiresCommitId: false,
+        buildBody: () => "その回答について、いったん先入観を外して、改めて新鮮な気持ちでよく考え直したうえでもう一度回答してください。見落としや早とちり、先入観による偏った考え方、さらに別の解釈の余地がないかも含めて再確認して欲しいです。"
+    },
+    {
         id: "directory-summary-markdown-request",
         label: "101: ディレクトリ内容整理 markdown を作成",
         keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "内容", "整理", "markdown作成", "作成", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
         requiresCommitId: false,
-        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+        buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切なファイル名の markdown ファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
     },
     {
         id: "build-check-request",
@@ -169,13 +176,13 @@ const promptDefinitions = [
         label: "706: 作業終了時の引継確認",
         keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
         requiresCommitId: false,
-        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+        buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに必要な情報を記入してもらえませんか。そして必要があれば、直近の作業で何を実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
     },
     {
         id: "single-file-web-app-request",
         label: "701: Single-file Web App の維持",
         keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
         requiresCommitId: false,
-        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
+        buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDN や別ファイルの CSS / JS ファイルを利用していないことを確認してください。"
     }
 ];

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -13,7 +13,7 @@ const promptDefinitions: PromptDefinition[] = [
     keywords: ["pr", "pull request", "pr作成依頼", "prタイトル", "pr本文", "文面", "作成", "ぶんめんさくせい", "bunmensakusei", "ぴーあーる", "ぷるりくえすと", "ぎっとはぶ"],
     requiresCommitId: true,
     buildBody: (commitId: string) => commitId
-      ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は \`\`\` で囲まれた一塊として回答してください。`
+      ? `対象コミット ${commitId} における変更内容について、PRタイトルとPR本文を markdown テキスト形式で作文してください。PRタイトルとPR本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
       : ""
   },
   {
@@ -27,17 +27,17 @@ const promptDefinitions: PromptDefinition[] = [
   },
   {
     id: "inline-code-request",
-    label: "303: Markdown インラインコードとして出力",
-    keywords: ["markdown", "inline code", "code", "インラインコード", "markdown出力", "コード形式", "出力", "いんらいんこーど", "しゅつりょく", "inrainko-do", "shutsuryoku", "まーくだうん", "こーど"],
+    label: "303: Markdown をチルダフェンスで出力",
+    keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
     requiresCommitId: false,
-    buildBody: () => "出力はインラインコード形式で markdown テキストで出力してください。回答が ``` と ``` とで囲まれるイメージです。"
+    buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
   },
   {
     id: "extract-to-inline-code-request",
-    label: "351: 添付ファイル等の抽出結果をインラインコードで出力",
-    keywords: ["extract", "attachment", "text", "inline code", "markdown", "抽出", "添付ファイル", "テキスト", "インラインコード", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "しゅつりょく"],
+    label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
+    keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
     requiresCommitId: false,
-    buildBody: () => "添付ファイルから、あるいは与えるテキストから 情報を抽出して、インラインコードの markdown テキストに出力してください。"
+    buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
   },
   {
     id: "github-no-change-request",
@@ -72,14 +72,14 @@ const promptDefinitions: PromptDefinition[] = [
     label: "702: 事象の再発防止テストを追加",
     keywords: ["test", "testing", "small test", "再発", "防止", "テスト", "追加", "再現テスト", "小さなテスト", "軽量テスト", "てすと", "さいげんてすと", "しょうさなてすと", "tesuto", "saigentesuto"],
     requiresCommitId: false,
-    buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、よういに実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
+    buildBody: () => "今回の事象が再現したときにすぐに気づくように、とても小さなシンプルなテストについて、容易に実現可能であればこれを追加して欲しいです。困難な場合は作業せずにその旨指摘してください。"
   },
   {
     id: "disagreement-first-request",
     label: "302: 違和感や誤りを先に指摘",
     keywords: ["disagree", "wrong", "違和感", "誤り", "間違い", "指摘", "先", "先に指摘", "いわかん", "まちがい", "してき", "iwakan", "machigai", "shiteki"],
     requiresCommitId: false,
-    buildBody: () => "私の指示や指摘について、あなたか強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
+    buildBody: () => "私の指示や指摘について、あなたが強い違和感を感じたり、あるいはあなたが間違っていると感じている場合には、指示を続行せずに、その違和感や間違いを回答して欲しい。"
   },
   {
     id: "todo-cleanup-request",
@@ -128,7 +128,7 @@ const promptDefinitions: PromptDefinition[] = [
     label: "300: 確認範囲は概ね良好で LGTM",
     keywords: ["lgtm", "looks good to me", "確認", "範囲", "良さそう", "良好", "概ね", "おおよそ", "レビュー", "かくにん", "はんい", "りょうこう", "れびゅー"],
     requiresCommitId: false,
-    buildBody: () => "いいえ。いい感じ。確認した範囲はおおよそ良さそうだ。LGTMです。"
+    buildBody: () => "いいね！いい感じです。確認した範囲はおおよそ良さそうです。LGTMです。"
   },
   {
     id: "peer-feedback-analysis-request",
@@ -159,11 +159,18 @@ const promptDefinitions: PromptDefinition[] = [
     buildBody: () => "開発中の試行錯誤や調査の過程で入れた暫定変更、デバッグ用コード、確認用の一時対応が、解決後も残ったままになっていないか確認してください。もし不要な暫定変更が残っていれば、どこにあり、なぜ不要と判断できるのかを指摘してください。"
   },
   {
+    id: "reconsider-answer-request",
+    label: "313: 回答を改めて再考して確認",
+    keywords: ["reconsider", "rethink", "fresh look", "answer review", "再考", "再確認", "改めて", "新鮮な気持ち", "もう一度", "回答", "見直し", "さいこう", "さいかくにん", "あらためて", "みなおし"],
+    requiresCommitId: false,
+    buildBody: () => "その回答について、いったん先入観を外して、改めて新鮮な気持ちでよく考え直したうえでもう一度回答してください。見落としや早とちり、先入観による偏った考え方、さらに別の解釈の余地がないかも含めて再確認して欲しいです。"
+  },
+  {
     id: "directory-summary-markdown-request",
     label: "101: ディレクトリ内容整理 markdown を作成",
     keywords: ["directory", "markdown", "summary", "index", "scan cost", "ディレクトリ", "内容", "整理", "markdown作成", "作成", "md作成", "概要整理", "走査コスト削減", "でぃれくとり", "せいり", "がいよう", "そうさこすと"],
     requiresCommitId: false,
-    buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切ないファイル名のmarkdownファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
+    buildBody: () => "いま作業しているディレクトリに含まれるファイルについて、無理のない範囲で、内容を調べて、それを整理した markdown (.md)ファイルを作成してほしい。既存の該当する対象ファイルがあればそれを更新あるいは加筆し、もし妥当な該当する対象ファイルがない場合は適切なファイル名の markdown ファイルを新規作成してそこに記述して欲しい。これは次回に生成AIがこのディレクトリを開いた時の走査のコストを削減することについても期待される効果となっています。"
   },
   {
     id: "build-check-request",
@@ -177,13 +184,13 @@ const promptDefinitions: PromptDefinition[] = [
     label: "706: 作業終了時の引継確認",
     keywords: ["session close", "wrap up", "handover", "todo", "todo.md", "作業終了", "終了", "引継", "伝達事項", "再開", "復帰", "さぎょうしゅうりょう", "しゅうりょう", "ひきつぎ", "でんたつじこう", "さいかい", "ふっき"],
     requiresCommitId: false,
-    buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに 必要な情報を記入してもらえませんか。そして必要があれば、直近の作業出ないを実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
+    buildBody: () => "今回の作業はここまで。終わりにします。なお、次回に再開する時にスムーズに復帰できるように何か伝達事項はあるだろうか。もしそのようなものがあるのであれば、TODO.mdに必要な情報を記入してもらえませんか。そして必要があれば、直近の作業で何を実施したのかを実施済み引き継ぎ事項として TODO.md に記載して欲しいです。"
   },
   {
     id: "single-file-web-app-request",
     label: "701: Single-file Web App の維持",
     keywords: ["single-file", "single file", "web app", "html", "css", "js", "cdn", "維持", "依存なし", "単一html", "single-file web app", "しんぐるふぁいる", "しんぐるふぁいるうぇぶあぷり", "たんいつhtml", "いぞんなし"],
     requiresCommitId: false,
-    buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDNや 別ファイルのcss/jsファイルを利用していないことを確認してください。"
+    buildBody: () => "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDN や別ファイルの CSS / JS ファイルを利用していないことを確認してください。"
   }
 ];


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` の固定文面を見直し、TYPO や表記ゆれを修正しました。 あわせて、Markdown 本文内に backtick の code fence が含まれても壊れにくいよう、PR 文面作成や Markdown 出力系の定型を `~~~~` によるチルダフェンス前提へ統一しています。

## 変更内容

- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` の固定文面を修正
- `よういに実現可能であれば` を `容易に実現可能であれば` に修正
- `あなたか強い違和感` を `あなたが強い違和感` に修正
- `適切ないファイル名` を `適切なファイル名` に修正
- `直近の作業出ないを実施したのか` を `直近の作業で何を実施したのか` に修正
- `テキストから 情報` の不要な空白を削除
- `CDNや 別ファイルのcss/jsファイル` を `CDN や別ファイルの CSS / JS ファイル` に修正
- `303` のラベルを `303: Markdown をチルダフェンスで出力` に変更
- `351` のラベルを `351: 添付ファイル等の抽出結果をチルダフェンスで出力` に変更
- `501` の本文を、PRタイトルとPR本文を `~~~~` で囲まれた一塊として回答させる指示に変更
- `303` の本文を、Markdown テキストを `~~~~` で囲まれた一塊として出力させる指示に変更
- `351` の本文を、抽出結果を `~~~~` で囲まれた一塊の Markdown として出力させる指示に変更
- `303` と `351` の検索キーワードを更新
- 英語キーワードとして `tilde fence`, `tilde-fenced`, `fenced markdown`, `code fence`, `code block` などを追加
- 日本語キーワードとして `チルダフェンス`, `こーどふぇんす`, `こーどぶろっく` などを追加
- `tilda` の綴りを `tilde` に修正
- 生成済みの `docs/prompt/prompt-gen.html` を再生成

## 影響

- `prompt-gen` の固定文面に含まれる明らかな TYPO や表記ゆれが解消されます
- PR 文面作成と Markdown 出力系の定型が、実際の出力形式に沿った説明へ揃います
- Markdown 本文内に backtick の code fence が含まれるケースでも、外側を `~~~~` で囲む前提で扱いやすくなります
- `tilde fence` などの英語キーワードでも対象ボタンを検索しやすくなります