### PR TITLE
prompt-gen の GitHub 導線追加と git-pseudo-squash の PR整形を簡素化

### DIFF
--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -3859,6 +3859,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3891,6 +3895,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -5544,6 +5544,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -5576,6 +5580,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -4267,6 +4267,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4299,6 +4303,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -4021,6 +4021,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4053,6 +4057,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -4292,6 +4292,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4324,6 +4328,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -4136,6 +4136,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4168,6 +4172,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -4287,6 +4287,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4319,6 +4323,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -4034,6 +4034,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4066,6 +4070,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -4044,6 +4044,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4076,6 +4080,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -4067,6 +4067,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4099,6 +4103,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -4110,6 +4110,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4142,6 +4146,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -4199,6 +4199,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4231,6 +4235,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -4111,6 +4111,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4143,6 +4147,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -4653,6 +4653,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4685,6 +4689,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);
@@ -5296,15 +5327,15 @@ if (!customElements.get("lht-page-menu")) {
         return false;
       }
       const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text)\s*[:：]?$/.test(headingText);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]?$/.test(headingText);
     }
 
-    function isFenceStartLine(line) {
-      return /^```(?:[a-z0-9_-]+)?\s*$/i.test(String(line || "").trim());
+    function isTildeFenceStartLine(line) {
+      return /^~~~+(?:[a-z0-9_-]+)?\s*$/i.test(String(line || "").trim());
     }
 
-    function isFenceEndLine(line) {
-      return /^```\s*$/.test(String(line || "").trim());
+    function isTildeFenceEndLine(line) {
+      return /^~~~+\s*$/.test(String(line || "").trim());
     }
 
     function normalizeCommitMessageForPr() {
@@ -5314,7 +5345,7 @@ if (!customElements.get("lht-page-menu")) {
       const original = String(commitMessageField.value || "");
       let lines = original.replace(/\r\n?/g, "\n").split("\n");
 
-      // 先頭は「空行 / PRタイトル見出し / 開始フェンス」が
+      // 先頭は「空行 / PRタイトル見出し / チルダフェンス開始」が
       // 混在しやすいため、順不同で連続除去する。
       let changed = true;
       let removedPrTitleHeading = false;
@@ -5333,7 +5364,7 @@ if (!customElements.get("lht-page-menu")) {
           changed = true;
           continue;
         }
-        if (lines.length > 0 && isFenceStartLine(lines[0])) {
+        if (lines.length > 0 && isTildeFenceStartLine(lines[0])) {
           lines.shift();
           changed = true;
         }
@@ -5349,8 +5380,8 @@ if (!customElements.get("lht-page-menu")) {
         }
       }
 
-      // 「## PRテキスト」セクションは、見出し自体を除去する。
-      // 直後が ```markdown で始まる場合はフェンスを外して本文だけ残す。
+      // 「## PRテキスト」「## PR本文」見出しは、見出し行自体を除去する。
+      // 見出し直後の空行もスキップする。
       {
         const rewritten = [];
         let i = 0;
@@ -5366,27 +5397,6 @@ if (!customElements.get("lht-page-menu")) {
           while (i < lines.length && lines[i].trim() === "") {
             i += 1;
           }
-
-          // この条件の ```markdown だけを除去対象にする。
-          if (i < lines.length && /^```markdown\s*$/i.test(lines[i].trim())) {
-            i += 1;
-            const blockLines = [];
-            while (i < lines.length && !isFenceEndLine(lines[i])) {
-              blockLines.push(lines[i]);
-              i += 1;
-            }
-            if (i < lines.length && isFenceEndLine(lines[i])) {
-              i += 1;
-            }
-
-            while (blockLines.length > 0 && blockLines[0].trim() === "") {
-              blockLines.shift();
-            }
-            while (blockLines.length > 0 && blockLines[blockLines.length - 1].trim() === "") {
-              blockLines.pop();
-            }
-            rewritten.push(...blockLines);
-          }
         }
         lines = rewritten;
       }
@@ -5395,7 +5405,7 @@ if (!customElements.get("lht-page-menu")) {
         lines.pop();
       }
 
-      if (lines.length > 0 && isFenceEndLine(lines[lines.length - 1])) {
+      if (lines.length > 0 && isTildeFenceEndLine(lines[lines.length - 1])) {
         lines.pop();
       }
 

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -498,15 +498,15 @@
         return false;
       }
       const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text)\s*[:：]?$/.test(headingText);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]?$/.test(headingText);
     }
 
-    function isFenceStartLine(line) {
-      return /^```(?:[a-z0-9_-]+)?\s*$/i.test(String(line || "").trim());
+    function isTildeFenceStartLine(line) {
+      return /^~~~+(?:[a-z0-9_-]+)?\s*$/i.test(String(line || "").trim());
     }
 
-    function isFenceEndLine(line) {
-      return /^```\s*$/.test(String(line || "").trim());
+    function isTildeFenceEndLine(line) {
+      return /^~~~+\s*$/.test(String(line || "").trim());
     }
 
     function normalizeCommitMessageForPr() {
@@ -516,7 +516,7 @@
       const original = String(commitMessageField.value || "");
       let lines = original.replace(/\r\n?/g, "\n").split("\n");
 
-      // 先頭は「空行 / PRタイトル見出し / 開始フェンス」が
+      // 先頭は「空行 / PRタイトル見出し / チルダフェンス開始」が
       // 混在しやすいため、順不同で連続除去する。
       let changed = true;
       let removedPrTitleHeading = false;
@@ -535,7 +535,7 @@
           changed = true;
           continue;
         }
-        if (lines.length > 0 && isFenceStartLine(lines[0])) {
+        if (lines.length > 0 && isTildeFenceStartLine(lines[0])) {
           lines.shift();
           changed = true;
         }
@@ -551,8 +551,8 @@
         }
       }
 
-      // 「## PRテキスト」セクションは、見出し自体を除去する。
-      // 直後が ```markdown で始まる場合はフェンスを外して本文だけ残す。
+      // 「## PRテキスト」「## PR本文」見出しは、見出し行自体を除去する。
+      // 見出し直後の空行もスキップする。
       {
         const rewritten = [];
         let i = 0;
@@ -568,27 +568,6 @@
           while (i < lines.length && lines[i].trim() === "") {
             i += 1;
           }
-
-          // この条件の ```markdown だけを除去対象にする。
-          if (i < lines.length && /^```markdown\s*$/i.test(lines[i].trim())) {
-            i += 1;
-            const blockLines = [];
-            while (i < lines.length && !isFenceEndLine(lines[i])) {
-              blockLines.push(lines[i]);
-              i += 1;
-            }
-            if (i < lines.length && isFenceEndLine(lines[i])) {
-              i += 1;
-            }
-
-            while (blockLines.length > 0 && blockLines[0].trim() === "") {
-              blockLines.shift();
-            }
-            while (blockLines.length > 0 && blockLines[blockLines.length - 1].trim() === "") {
-              blockLines.pop();
-            }
-            rewritten.push(...blockLines);
-          }
         }
         lines = rewritten;
       }
@@ -597,7 +576,7 @@
         lines.pop();
       }
 
-      if (lines.length > 0 && isFenceEndLine(lines[lines.length - 1])) {
+      if (lines.length > 0 && isTildeFenceEndLine(lines[lines.length - 1])) {
         lines.pop();
       }
 

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -4139,6 +4139,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4171,6 +4175,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -5529,6 +5529,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -5561,6 +5565,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/index.html
+++ b/docs/index.html
@@ -4218,6 +4218,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4250,6 +4254,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -3632,6 +3632,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3664,6 +3668,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -4295,6 +4295,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4327,6 +4331,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -4121,6 +4121,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4153,6 +4157,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -4062,6 +4062,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4094,6 +4098,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -4120,6 +4120,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4152,6 +4156,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -4066,6 +4066,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4098,6 +4102,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -4061,6 +4061,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4093,6 +4097,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -3118,6 +3118,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3150,6 +3154,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -3081,6 +3081,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3113,6 +3117,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -3135,6 +3135,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3167,6 +3171,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -3583,6 +3583,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3615,6 +3619,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -3129,6 +3129,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3161,6 +3165,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -4061,6 +4061,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4093,6 +4097,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -27,6 +27,9 @@ limitations under the License.
 <body class="md-page">
   <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
     <defs>
+      <symbol id="md-icon-github" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M8 0a8 8 0 0 0-2.53 15.6c.4.08.55-.17.55-.38v-1.33c-2.25.49-2.72-1.08-2.72-1.08-.36-.94-.9-1.2-.9-1.2-.74-.5.06-.49.06-.49.81.06 1.25.84 1.25.84.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.8-.21-3.69-.9-3.69-3.98 0-.88.32-1.6.83-2.16-.08-.2-.36-1.02.08-2.12 0 0 .68-.22 2.2.82A7.7 7.7 0 0 1 8 3.9c.68 0 1.37.1 2 .3 1.52-1.03 2.2-.82 2.2-.82.44 1.1.16 1.93.08 2.12.52.56.83 1.28.83 2.16 0 3.1-1.89 3.77-3.7 3.97.29.25.55.74.55 1.49v2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"/>
+      </symbol>
       <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
@@ -44,6 +47,10 @@ limitations under the License.
       subtitle="定型的な生成AIプロンプトの作成を支援します。"
       icon="📝"
       help-label="生成AIプロンプト作成の説明"
+      action-href="https://github.com/igapyon/local-html-tools/tree/devel/docs/prompt"
+      action-label="GitHub"
+      action-aria-label="Open prompt-gen GitHub repository"
+      action-icon-id="md-icon-github"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1064,6 +1064,31 @@ body.md-page {
   margin-top: 28px;
 }
 
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: #4a3d6b;
+  text-decoration: none;
+  transition: color 150ms ease, transform 150ms ease;
+}
+
+.ms-hero-link:hover {
+  color: #2f2347;
+  transform: translateY(-1px);
+}
+
+.ms-hero-link span {
+  display: none;
+}
+
+.ms-btn-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+}
+
 .md-stack-md {
   display: grid;
   gap: 16px;
@@ -1235,6 +1260,9 @@ md-icon-button.md-copy-button--surface {
 <body class="md-page">
   <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
     <defs>
+      <symbol id="md-icon-github" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M8 0a8 8 0 0 0-2.53 15.6c.4.08.55-.17.55-.38v-1.33c-2.25.49-2.72-1.08-2.72-1.08-.36-.94-.9-1.2-.9-1.2-.74-.5.06-.49.06-.49.81.06 1.25.84 1.25.84.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.8-.21-3.69-.9-3.69-3.98 0-.88.32-1.6.83-2.16-.08-.2-.36-1.02.08-2.12 0 0 .68-.22 2.2.82A7.7 7.7 0 0 1 8 3.9c.68 0 1.37.1 2 .3 1.52-1.03 2.2-.82 2.2-.82.44 1.1.16 1.93.08 2.12.52.56.83 1.28.83 2.16 0 3.1-1.89 3.77-3.7 3.97.29.25.55.74.55 1.49v2.2c0 .21.14.46.55.38A8 8 0 0 0 8 0z"/>
+      </symbol>
       <symbol id="md-icon-menu" viewBox="0 0 24 24">
         <path d="M4 6h16"/>
         <path d="M4 12h16"/>
@@ -1252,6 +1280,10 @@ md-icon-button.md-copy-button--surface {
       subtitle="定型的な生成AIプロンプトの作成を支援します。"
       icon="📝"
       help-label="生成AIプロンプト作成の説明"
+      action-href="https://github.com/igapyon/local-html-tools/tree/devel/docs/prompt"
+      action-label="GitHub"
+      action-aria-label="Open prompt-gen GitHub repository"
+      action-icon-id="md-icon-github"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
@@ -3245,6 +3277,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -3277,6 +3313,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);
@@ -3404,7 +3467,7 @@ const promptDefinitions = [
         keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown 形式で作文してください。`
+            ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
             : ""
     },
     {
@@ -3412,14 +3475,14 @@ const promptDefinitions = [
         label: "303: Markdown をチルダフェンスで出力",
         keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
-        buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+        buildBody: () => "markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "extract-to-inline-code-request",
         label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
         keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
         requiresCommitId: false,
-        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "github-no-change-request",

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -25,6 +25,31 @@ body.md-page {
   margin-top: 28px;
 }
 
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: #4a3d6b;
+  text-decoration: none;
+  transition: color 150ms ease, transform 150ms ease;
+}
+
+.ms-hero-link:hover {
+  color: #2f2347;
+  transform: translateY(-1px);
+}
+
+.ms-hero-link span {
+  display: none;
+}
+
+.ms-btn-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  flex: 0 0 auto;
+}
+
 .md-stack-md {
   display: grid;
   gap: 16px;

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -14,7 +14,7 @@ const promptDefinitions = [
         keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown 形式で作文してください。`
+            ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
             : ""
     },
     {
@@ -22,14 +22,14 @@ const promptDefinitions = [
         label: "303: Markdown をチルダフェンスで出力",
         keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
         requiresCommitId: false,
-        buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+        buildBody: () => "markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "extract-to-inline-code-request",
         label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
         keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
         requiresCommitId: false,
-        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+        buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
     },
     {
         id: "github-no-change-request",

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -22,7 +22,7 @@ const promptDefinitions: PromptDefinition[] = [
     keywords: ["release", "github release", "github", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "ぶんめんさくせい", "riri-su", "bunmensakusei", "ぎっとはぶ", "りりーす"],
     requiresCommitId: true,
     buildBody: (commitId: string) => commitId
-      ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown 形式で作文してください。`
+      ? `${commitId} よりも後に行われた変更(${commitId}での変更内容は除外する)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文は ~~~~ で囲まれた一塊として回答してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。`
       : ""
   },
   {
@@ -30,14 +30,14 @@ const promptDefinitions: PromptDefinition[] = [
     label: "303: Markdown をチルダフェンスで出力",
     keywords: ["markdown", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "code", "チルダフェンス", "markdown出力", "コード形式", "出力", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "shutsuryoku", "まーくだうん", "こーど"],
     requiresCommitId: false,
-    buildBody: () => "回答は、そのままコピーしやすいように markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+    buildBody: () => "markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
   },
   {
     id: "extract-to-inline-code-request",
     label: "351: 添付ファイル等の抽出結果をチルダフェンスで出力",
     keywords: ["extract", "attachment", "text", "tilde fence", "tilde fenced", "tilde-fence", "tilde-fenced", "fenced markdown", "code fence", "code block", "markdown", "抽出", "添付ファイル", "テキスト", "チルダフェンス", "出力", "ちゅうしゅつ", "てんぷふぁいる", "てきすと", "ちるだふぇんす", "こーどふぇんす", "こーどぶろっく", "しゅつりょく"],
     requiresCommitId: false,
-    buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキストを ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
+    buildBody: () => "添付ファイルから、あるいは与えるテキストから情報を抽出して、markdown テキスト形式で出力してください。回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。"
   },
   {
     id: "github-no-change-request",

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -4070,6 +4070,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4102,6 +4106,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -4110,6 +4110,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4142,6 +4146,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -4964,6 +4964,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4996,6 +5000,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -4136,6 +4136,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -4168,6 +4172,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);

--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -1479,6 +1479,10 @@ class LhtPageHero extends HTMLElement {
     const useWideHelp = this.hasAttribute("help-wide");
     const showMenu = !this.hasAttribute("no-menu");
     const helpHtml = this.innerHTML.trim();
+    const actionHref = (this.getAttribute("action-href") || "").trim();
+    const actionLabel = (this.getAttribute("action-label") || "").trim();
+    const actionAriaLabel = (this.getAttribute("action-aria-label") || actionLabel).trim();
+    const actionIconId = (this.getAttribute("action-icon-id") || "").trim();
 
     this.textContent = "";
     this.classList.add("lht-page-hero");
@@ -1511,6 +1515,33 @@ class LhtPageHero extends HTMLElement {
       }
       help.innerHTML = helpHtml;
       titleMain.appendChild(help);
+    }
+
+    if (actionHref && actionLabel) {
+      const actionLink = document.createElement("a");
+      actionLink.href = actionHref;
+      actionLink.className = "ms-hero-link";
+      actionLink.target = "_blank";
+      actionLink.rel = "noopener noreferrer";
+      if (actionAriaLabel) {
+        actionLink.setAttribute("aria-label", actionAriaLabel);
+      }
+      if (actionIconId) {
+        const iconSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        iconSvg.setAttribute("aria-hidden", "true");
+        iconSvg.setAttribute("viewBox", "0 0 16 16");
+        iconSvg.setAttribute("class", "ms-btn-icon");
+        iconSvg.setAttribute("fill", "currentColor");
+        const useNode = document.createElementNS("http://www.w3.org/2000/svg", "use");
+        useNode.setAttribute("href", `#${actionIconId}`);
+        useNode.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", `#${actionIconId}`);
+        iconSvg.appendChild(useNode);
+        actionLink.appendChild(iconSvg);
+      }
+      const labelNode = document.createElement("span");
+      labelNode.textContent = actionLabel;
+      actionLink.appendChild(labelNode);
+      titleMain.appendChild(actionLink);
     }
 
     topRow.appendChild(titleMain);


### PR DESCRIPTION
### 概要
`prompt-gen` のヒーローに GitHub への導線を追加し、`git-pseudo-squash` の PR整形ロジックを現在のプロンプト運用に合わせて簡素化しました。あわせて、`prompt-gen` 側の固定文言もチルダフェンス前提で統一しています。

### 変更内容
- `lht-cmn/js/components.js` を拡張
  - `lht-page-hero` に右側アクションリンクを出せる `action-*` 属性を追加
- `docs/prompt/prompt-gen-src.html` を更新
  - ヒーロー右側に GitHub アイコンリンクを追加
  - ページタイトル文言を `生成AIプロンプト作成` に調整
- `docs/prompt/src/prompt-gen/css/app.css` を更新
  - GitHub 導線用の `ms-hero-link` / `ms-btn-icon` スタイルを追加
  - 表示はアイコンのみで、角丸ボタン風の装飾を外すよう調整
- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts` を更新
  - `502: GitHub Release 文面の作成` に `~~~~` で囲んだ一塊出力の指示を追加
  - `303` と `351` の文言を `markdown テキスト形式` + `~~~~` 前提の表現へ統一
- `docs/git/src/git-pseudo-squash/js/main.js` を更新
  - PR整形で `## PR本文` も除去対象に追加
  - 外側のチルダフェンス `~~~~` を対象にするよう変更
  - ` ```markdown ` ブロックを特別扱いして剥がす旧ロジックを削除
  - 現在の `prompt-gen` 出力形式に合わせて、見出し除去 + 外側チルダ除去中心へ簡素化
- 各生成物を再ビルド
  - `docs/prompt/prompt-gen.html`
  - `docs/git/git-pseudo-squash.html`
  - その他 `build:git` に含まれる各ページ

### 背景
`prompt-gen` 側では PR 文面や Markdown 出力系の定型を `~~~~` で囲う運用へ寄ってきていました。一方で `git-pseudo-squash` の PR整形は旧来の fenced markdown 解除ロジックを前提にしており、現在の出力形式と少しずれていました。今回の変更で、生成側と整形側の前提を揃えています。

### 期待される効果
- `prompt-gen` から GitHub ソースへ直接辿りやすくなる
- PR 文面生成、Release 文面生成、Markdown 出力系の文言ルールが揃う
- `git-pseudo-squash` の PR整形が、現在の `~~~~` ベースの出力に対して自然に動作する
- `## PR本文` を含む入力でも不要見出しを除去しやすくなる

### 確認事項
- `npm run build:prompt` 実行済み
- `npm run build:git` 実行済み
- `prompt-gen` の GitHub リンクがヒーロー右側に出ることを確認済み
- `git-pseudo-squash` の PR整形ロジックが `~~~~` 前提に更新されていることを確認済み