### PR TITLE
Git系ページ向けの小さな vitest を追加して回帰検知を強化

### DIFF
--- a/docs/git/tests/git-branch-diff-main.test.js
+++ b/docs/git/tests/git-branch-diff-main.test.js
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mainCode = readFileSync(
+  path.resolve(__dirname, "../src/git-branch-diff/js/main.js"),
+  "utf8"
+);
+
+function mountDom() {
+  document.body.innerHTML = `
+    <input id="branchA" value="feature-a" />
+    <input id="branchB" value="feature-b" />
+    <input id="scopeA" type="checkbox" checked />
+    <input id="scopeB" type="checkbox" checked />
+    <input id="lockOrigin" type="checkbox" checked />
+    <div id="remoteNameBlock" class="md-hidden"></div>
+    <input id="remoteName" value="origin" />
+    <select id="diffMode">
+      <option value="" selected>(none)</option>
+      <option value="--stat">--stat</option>
+      <option value="--name-only">--name-only</option>
+    </select>
+    <input id="useStat200" type="checkbox" />
+    <input id="useTripleDot" type="checkbox" />
+    <div id="statWidthBlock" class="md-hidden"></div>
+    <div id="diffCmd"></div>
+    <div id="toast"></div>
+  `;
+
+  const toast = document.getElementById("toast");
+  toast.show = vi.fn();
+}
+
+function bootPage() {
+  mountDom();
+  const instrumentedCode = `${mainCode}
+window.__gitBranchDiffTest = {
+  generateCommands,
+  updateRemoteState,
+  updateStatWidthState
+};`;
+  new Function(instrumentedCode)();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+}
+
+describe("git-branch-diff main", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.__gitBranchDiffTest = undefined;
+    window.alert = vi.fn();
+  });
+
+  it("generates fetch and remote diff commands by default", () => {
+    bootPage();
+
+    window.__gitBranchDiffTest.generateCommands({ silent: true });
+
+    expect(document.getElementById("diffCmd").textContent).toBe(
+      "git fetch origin\ngit diff origin/feature-a..origin/feature-b"
+    );
+  });
+
+  it("uses triple dot and --stat=200 when those options are enabled", () => {
+    bootPage();
+
+    document.getElementById("diffMode").value = "--stat";
+    document.getElementById("useStat200").checked = true;
+    document.getElementById("useTripleDot").checked = true;
+
+    window.__gitBranchDiffTest.generateCommands({ silent: true });
+
+    expect(document.getElementById("diffCmd").textContent).toBe(
+      "git fetch origin\ngit diff --stat=200 origin/feature-a...origin/feature-b"
+    );
+  });
+
+  it("uses a custom remote name when origin lock is disabled", () => {
+    bootPage();
+
+    document.getElementById("lockOrigin").checked = false;
+    document.getElementById("remoteName").value = "upstream";
+    window.__gitBranchDiffTest.updateRemoteState();
+
+    window.__gitBranchDiffTest.generateCommands({ silent: true });
+
+    expect(document.getElementById("remoteName").disabled).toBe(false);
+    expect(document.getElementById("diffCmd").textContent).toBe(
+      "git fetch upstream\ngit diff upstream/feature-a..upstream/feature-b"
+    );
+  });
+});

--- a/docs/git/tests/git-config-advanced-setup-main.test.js
+++ b/docs/git/tests/git-config-advanced-setup-main.test.js
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mainCode = readFileSync(
+  path.resolve(__dirname, "../src/git-config-advanced-setup/js/main.js"),
+  "utf8"
+);
+
+function mountDom() {
+  document.body.innerHTML = `
+    <input id="enableAutocrlf" type="checkbox" />
+    <div id="autocrlfOptions">
+      <input id="autocrlf-true" type="radio" name="autocrlf" value="true" checked />
+      <input id="autocrlf-input" type="radio" name="autocrlf" value="input" />
+      <input id="autocrlf-false" type="radio" name="autocrlf" value="false" />
+    </div>
+    <input id="enablePushDefault" type="checkbox" />
+    <div id="pushDefaultOptions">
+      <input id="pushdefault-simple" type="radio" name="pushdefault" value="simple" checked />
+      <input id="pushdefault-current" type="radio" name="pushdefault" value="current" />
+      <input id="pushdefault-upstream" type="radio" name="pushdefault" value="upstream" />
+      <input id="pushdefault-matching" type="radio" name="pushdefault" value="matching" />
+    </div>
+    <div id="checkCmd"></div>
+    <div id="configCmd"></div>
+    <div id="toast"></div>
+  `;
+
+  const toast = document.getElementById("toast");
+  toast.show = vi.fn();
+}
+
+function bootPage() {
+  mountDom();
+  const instrumentedCode = `${mainCode}
+window.__gitConfigAdvancedSetupTest = {
+  generateConfigCommand,
+  toggleAutocrlfOptions,
+  togglePushDefaultOptions
+};`;
+  new Function(instrumentedCode)();
+}
+
+describe("git-config-advanced-setup main", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.__gitConfigAdvancedSetupTest = undefined;
+    window.alert = vi.fn();
+  });
+
+  it("leaves config command empty when no setting is selected in silent mode", () => {
+    bootPage();
+
+    window.__gitConfigAdvancedSetupTest.generateConfigCommand({ silent: true });
+
+    expect(document.getElementById("configCmd").textContent).toBe("");
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it("generates core.autocrlf command when autocrlf is enabled", () => {
+    bootPage();
+
+    document.getElementById("enableAutocrlf").checked = true;
+    document.getElementById("autocrlf-input").checked = true;
+
+    window.__gitConfigAdvancedSetupTest.generateConfigCommand({ silent: true });
+
+    expect(document.getElementById("configCmd").textContent).toBe(
+      "git config --global core.autocrlf input"
+    );
+  });
+
+  it("generates both commands when autocrlf and push.default are enabled", () => {
+    bootPage();
+
+    document.getElementById("enableAutocrlf").checked = true;
+    document.getElementById("autocrlf-false").checked = true;
+    document.getElementById("enablePushDefault").checked = true;
+    document.getElementById("pushdefault-current").checked = true;
+
+    window.__gitConfigAdvancedSetupTest.generateConfigCommand({ silent: true });
+
+    expect(document.getElementById("configCmd").textContent).toBe(
+      "git config --global core.autocrlf false\n" +
+      "git config --global push.default current"
+    );
+  });
+});

--- a/docs/git/tests/git-config-setup-main.test.js
+++ b/docs/git/tests/git-config-setup-main.test.js
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mainCode = readFileSync(
+  path.resolve(__dirname, "../src/git-config-setup/js/main.js"),
+  "utf8"
+);
+
+function mountDom() {
+  document.body.innerHTML = `
+    <input id="userName" value="" />
+    <input id="userEmail" value="" />
+    <div id="checkCmd"></div>
+    <div id="setupCmd"></div>
+    <div id="toast"></div>
+  `;
+
+  const toast = document.getElementById("toast");
+  toast.show = vi.fn();
+}
+
+function bootPage() {
+  mountDom();
+  const instrumentedCode = `${mainCode}
+window.__gitConfigSetupTest = {
+  generateCheckCommand,
+  generateSetupCommand
+};`;
+  new Function(instrumentedCode)();
+}
+
+describe("git-config-setup main", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.__gitConfigSetupTest = undefined;
+    window.alert = vi.fn();
+  });
+
+  it("generates the global config check command on bootstrap", () => {
+    bootPage();
+
+    expect(document.getElementById("checkCmd").textContent).toBe(
+      "git config --global user.name\ngit config --global user.email"
+    );
+  });
+
+  it("quotes user.name with spaces when generating setup commands", () => {
+    bootPage();
+
+    document.getElementById("userName").value = "Toshiki Iga";
+    document.getElementById("userEmail").value = "iga@example.com";
+
+    window.__gitConfigSetupTest.generateSetupCommand({ silent: true });
+
+    expect(document.getElementById("setupCmd").textContent).toBe(
+      'git config --global user.name "Toshiki Iga"\n' +
+      "git config --global user.email iga@example.com"
+    );
+  });
+
+  it("clears setup command when required fields are missing in silent mode", () => {
+    bootPage();
+
+    document.getElementById("userName").value = "Toshiki Iga";
+    document.getElementById("userEmail").value = "";
+
+    window.__gitConfigSetupTest.generateSetupCommand({ silent: true });
+
+    expect(document.getElementById("setupCmd").textContent).toBe("");
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+});

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mainCode = readFileSync(
+  path.resolve(__dirname, "../src/git-pseudo-squash/js/main.js"),
+  "utf8"
+);
+
+function mountGitPseudoSquashDom() {
+  document.body.innerHTML = `
+    <input id="squashBaseBranch" value="devel" data-help-text="help" />
+    <div id="baseBranchMenu"></div>
+    <input id="workBranch" value="tiga0309iaq" data-help-text="help" />
+    <input id="shellEnvPowerShell" type="checkbox" />
+    <input id="lockOrigin" type="checkbox" checked />
+    <select id="squashBaseScope">
+      <option value="remote" selected>remote</option>
+      <option value="local">local</option>
+    </select>
+    <div id="baseRemoteRow"></div>
+    <input id="baseRemote" value="origin" data-help-text="help" />
+    <div id="squashRemoteRow"></div>
+    <input id="squashRemote" value="origin" data-help-text="help" />
+    <textarea id="commitMessage" data-help-text="help"></textarea>
+    <input id="useCurrentBranch" type="checkbox" checked />
+    <div id="createBranchCmd"></div>
+    <div id="rebaseCmd"></div>
+    <div id="pushCmd"></div>
+    <div id="plannedDiffCmd"></div>
+    <div id="toast"></div>
+    <dialog id="normalizeDiffDialog"></dialog>
+    <div id="normalizeDiffBefore"></div>
+    <div id="normalizeDiffAfter"></div>
+  `;
+
+  const menu = document.getElementById("baseBranchMenu");
+  menu.show = vi.fn(() => {
+    menu.open = true;
+  });
+  menu.close = vi.fn(() => {
+    menu.open = false;
+  });
+  menu.open = false;
+
+  const toast = document.getElementById("toast");
+  toast.show = vi.fn();
+
+  const dialog = document.getElementById("normalizeDiffDialog");
+  dialog.showModal = vi.fn(() => {
+    dialog.open = true;
+  });
+  dialog.close = vi.fn(() => {
+    dialog.open = false;
+  });
+}
+
+function installLocalStorageMock() {
+  const store = new Map();
+  const localStorageMock = {
+    getItem: vi.fn((key) => (store.has(key) ? store.get(key) : null)),
+    setItem: vi.fn((key, value) => {
+      store.set(String(key), String(value));
+    }),
+    removeItem: vi.fn((key) => {
+      store.delete(String(key));
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    })
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock,
+    configurable: true
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageMock,
+    configurable: true
+  });
+}
+
+function bootGitPseudoSquashPage() {
+  mountGitPseudoSquashDom();
+  const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences
+};`;
+  new Function(instrumentedCode)();
+}
+
+describe("git-pseudo-squash main", () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    localStorage.clear();
+    document.body.innerHTML = "";
+    window.__gitPseudoSquashTest = undefined;
+    window.confirm = vi.fn(() => true);
+  });
+
+  it("does not include git switch in rebase command when current branch mode is enabled", () => {
+    bootGitPseudoSquashPage();
+
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+    commitMessage.value = "prompt-gen の GitHub 導線追加と git-pseudo-squash の PR整形を簡素化";
+    commitMessage.dispatchEvent(new Event("input"));
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
+    expect(rebaseCmd.textContent).toContain("git fetch origin");
+    expect(rebaseCmd.textContent).toContain("git reset --soft origin/devel");
+    expect(rebaseCmd.textContent).not.toContain("git switch tiga0309iaq");
+  });
+
+  it("includes git switch in rebase command when current branch mode is disabled", () => {
+    bootGitPseudoSquashPage();
+
+    const useCurrentBranch = document.getElementById("useCurrentBranch");
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+
+    useCurrentBranch.checked = false;
+    useCurrentBranch.dispatchEvent(new Event("change"));
+    commitMessage.value = "コミットメッセージ";
+    commitMessage.dispatchEvent(new Event("input"));
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
+    expect(rebaseCmd.textContent).toContain("git switch tiga0309iaq");
+  });
+
+  it("forces both remotes to origin and hides remote rows when lockOrigin is enabled", () => {
+    bootGitPseudoSquashPage();
+
+    const lockOrigin = document.getElementById("lockOrigin");
+    const baseRemote = document.getElementById("baseRemote");
+    const squashRemote = document.getElementById("squashRemote");
+    const baseRemoteRow = document.getElementById("baseRemoteRow");
+    const squashRemoteRow = document.getElementById("squashRemoteRow");
+
+    localStorage.setItem("gitPseudoSquash.ui.baseRemote", "upstream");
+    localStorage.setItem("gitPseudoSquash.ui.squashRemote", "backup");
+
+    lockOrigin.checked = false;
+    window.__gitPseudoSquashTest.toggleOriginLock();
+    expect(baseRemote.disabled).toBe(false);
+    expect(squashRemote.disabled).toBe(false);
+
+    lockOrigin.checked = true;
+    window.__gitPseudoSquashTest.toggleOriginLock();
+
+    expect(baseRemote.value).toBe("origin");
+    expect(squashRemote.value).toBe("origin");
+    expect(baseRemote.disabled).toBe(true);
+    expect(squashRemote.disabled).toBe(true);
+    expect(baseRemoteRow.classList.contains("md-hidden")).toBe(true);
+    expect(squashRemoteRow.classList.contains("md-hidden")).toBe(true);
+  });
+
+  it("normalizes prompt-gen style PR text by removing headings and outer tilde fences", () => {
+    bootGitPseudoSquashPage();
+
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+    commitMessage.value = `~~~~
+## PRタイトル
+
+prompt-gen の GitHub 導線追加と git-pseudo-squash の PR整形を簡素化
+
+## PR本文
+
+### 概要
+変更内容です。
+~~~~`;
+
+    window.__gitPseudoSquashTest.normalizeCommitMessageForPr();
+
+    expect(commitMessage.value).toBe(`prompt-gen の GitHub 導線追加と git-pseudo-squash の PR整形を簡素化
+
+### 概要
+変更内容です。`);
+    expect(rebaseCmd.textContent).toContain("prompt-gen の GitHub 導線追加と git-pseudo-squash の PR整形を簡素化");
+    expect(rebaseCmd.textContent).not.toContain("## PR本文");
+    expect(rebaseCmd.textContent).not.toContain("~~~~");
+    expect(rebaseCmd.textContent).not.toContain("git switch tiga0309iaq");
+  });
+
+  it("generates PowerShell rebase command with here-string and no git switch in current branch mode", () => {
+    bootGitPseudoSquashPage();
+
+    const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+
+    shellEnvPowerShell.checked = true;
+    shellEnvPowerShell.dispatchEvent(new Event("change"));
+    commitMessage.value = "PowerShell 用コミットメッセージ";
+    commitMessage.dispatchEvent(new Event("input"));
+
+    expect(rebaseCmd.textContent).toContain("$CommitMsgFile = New-TemporaryFile");
+    expect(rebaseCmd.textContent).toContain("'@ | Set-Content -Path $CommitMsgFile -Encoding UTF8");
+    expect(rebaseCmd.textContent).toContain("git commit -F $CommitMsgFile");
+    expect(rebaseCmd.textContent).not.toContain('COMMIT_MSG_FILE=$(mktemp)');
+    expect(rebaseCmd.textContent).not.toContain("git switch tiga0309iaq");
+  });
+
+  it("generates PowerShell rebase command with git switch when current branch mode is disabled", () => {
+    bootGitPseudoSquashPage();
+
+    const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
+    const useCurrentBranch = document.getElementById("useCurrentBranch");
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+
+    shellEnvPowerShell.checked = true;
+    shellEnvPowerShell.dispatchEvent(new Event("change"));
+    useCurrentBranch.checked = false;
+    useCurrentBranch.dispatchEvent(new Event("change"));
+    commitMessage.value = "PowerShell で別ブランチ利用";
+    commitMessage.dispatchEvent(new Event("input"));
+
+    expect(rebaseCmd.textContent).toContain("git switch tiga0309iaq");
+    expect(rebaseCmd.textContent).toContain("$CommitMsgFile = New-TemporaryFile");
+  });
+
+  it("updates push and planned diff commands when current branch mode is toggled", () => {
+    bootGitPseudoSquashPage();
+
+    const useCurrentBranch = document.getElementById("useCurrentBranch");
+    const commitMessage = document.getElementById("commitMessage");
+    const pushCmd = document.getElementById("pushCmd");
+    const plannedDiffCmd = document.getElementById("plannedDiffCmd");
+
+    commitMessage.value = "コミットメッセージ";
+    commitMessage.dispatchEvent(new Event("input"));
+
+    expect(pushCmd.textContent).toContain("git push --force-with-lease origin HEAD");
+    expect(plannedDiffCmd.textContent).toContain("git diff origin/devel..HEAD");
+
+    useCurrentBranch.checked = false;
+    useCurrentBranch.dispatchEvent(new Event("change"));
+
+    expect(pushCmd.textContent).toContain("git push --force-with-lease origin tiga0309iaq");
+    expect(plannedDiffCmd.textContent).toContain("git diff origin/devel..tiga0309iaq");
+  });
+
+  it("clears persisted settings and restores default UI values", () => {
+    bootGitPseudoSquashPage();
+
+    localStorage.setItem("gitPseudoSquash.ui.shellEnvPowerShell", "true");
+    localStorage.setItem("gitPseudoSquash.ui.lockOrigin", "false");
+    localStorage.setItem("gitPseudoSquash.ui.squashBaseScope", "local");
+    localStorage.setItem("gitPseudoSquash.ui.baseRemote", "upstream");
+    localStorage.setItem("gitPseudoSquash.ui.squashRemote", "backup");
+    localStorage.setItem("gitPseudoSquash.ui.useCurrentBranch", "false");
+    localStorage.setItem("gitPseudoSquash.squashBaseBranchHistory", '["main","devel"]');
+
+    document.getElementById("shellEnvPowerShell").checked = true;
+    document.getElementById("lockOrigin").checked = false;
+    document.getElementById("squashBaseScope").value = "local";
+    document.getElementById("baseRemote").value = "upstream";
+    document.getElementById("squashRemote").value = "backup";
+    document.getElementById("useCurrentBranch").checked = false;
+    document.getElementById("squashBaseBranch").value = "release";
+    document.getElementById("workBranch").value = "topic-branch";
+    document.getElementById("commitMessage").value = "残ってはいけない";
+
+    window.__gitPseudoSquashTest.clearUiPreferences();
+
+    expect(document.getElementById("shellEnvPowerShell").checked).toBe(false);
+    expect(document.getElementById("lockOrigin").checked).toBe(true);
+    expect(document.getElementById("squashBaseScope").value).toBe("remote");
+    expect(document.getElementById("baseRemote").value).toBe("origin");
+    expect(document.getElementById("squashRemote").value).toBe("origin");
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
+    expect(document.getElementById("squashBaseBranch").value).toBe("devel");
+    expect(document.getElementById("commitMessage").value).toBe("");
+    expect(document.getElementById("workBranch").value).toMatch(/^tiga\d{4}[a-z]{3}$/);
+    expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.baseRemote");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.squashRemote");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.useCurrentBranch");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.squashBaseBranchHistory");
+    expect(localStorage.setItem).toHaveBeenCalledWith("gitPseudoSquash.squashBaseBranch", "devel");
+  });
+});


### PR DESCRIPTION
### 概要
`docs/git` 配下の主要ページについて、小さな `vitest` を追加し、コマンド生成ロジックや UI 状態に依存する重要な分岐を回帰検知できるようにしました。

### 変更内容
- `git-pseudo-squash` の既存テストを拡充
  - `リモート + origin` の固定挙動
  - `作業` スイッチによる `push` / `planned diff` の切替
  - `設定をクリア` による localStorage 初期化と UI リセット
- 新規テストを追加
  - `docs/git/tests/git-config-setup-main.test.js`
  - `docs/git/tests/git-config-advanced-setup-main.test.js`
  - `docs/git/tests/git-branch-diff-main.test.js`

### 各テストで確認していること
- `git-config-setup`
  - `git config --global user.name` / `user.email` の確認コマンド生成
  - `user.name` に空白がある場合のクォート
  - 必須入力不足時の空出力
- `git-config-advanced-setup`
  - 未選択時にコマンドが空になること
  - `core.autocrlf` の生成
  - `push.default` を含む複数設定の生成
- `git-branch-diff`
  - `origin` 前提の `git fetch` + `git diff`
  - `...` と `--stat=200` の反映
  - `origin` ロック解除時のカスタム remote 利用
- `git-pseudo-squash`
  - `git switch` の有無
  - PowerShell 用コマンド生成
  - `PR整形`
  - `lockOrigin`
  - `useCurrentBranch`
  - `clearUiPreferences`

### 期待される効果
- Git系ページの重要な生成コマンドを、小さいテストで継続的に守れる
- UI スイッチや保存済み設定に起因する挙動差分を早めに検知できる
- 特に PowerShell 側や `git-pseudo-squash` のような重要ページの破壊を見つけやすくなる

### 確認事項
- `npm test -- docs/git/tests/git-config-setup-main.test.js docs/git/tests/git-config-advanced-setup-main.test.js docs/git/tests/git-branch-diff-main.test.js docs/git/tests/git-pseudo-squash-main.test.js` 実行済み
- `14 tests` すべて成功