### PR TITLE
prompt-gen に共有リンクコピー機能と URL 初期値反映を追加

### DIFF
--- a/docs/prompt/TODO.md
+++ b/docs/prompt/TODO.md
@@ -24,6 +24,7 @@
 - [ ] S603-001 は A603 との対応が弱いため、別の枝番へ移設する
 - [ ] prompt-gen の可変入力で、`commitId` は SHA らしい文字だけを許可するか検討する
 - [ ] prompt-gen の可変入力で、`subject` は命令ではなく文字列値として扱う文言を本文へ追加するか検討する
+- [ ] prompt-gen の「共有リンクをコピー」ボタンの SVG アイコンを、より一般的で視認性の高い link / chain 表現へ改善する
 - [x] S603-501: Mermaid timeline で図解化(AI提案)
 - [x] S603-502: Mermaid flowchart で図解化(AI提案)
 - [x] S603-503: Mermaid mindmap で図解化(AI提案)

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -39,6 +39,10 @@ limitations under the License.
         <rect x="9" y="9" width="11" height="11" rx="2"/>
         <rect x="4" y="4" width="11" height="11" rx="2"/>
       </symbol>
+      <symbol id="md-icon-link" viewBox="0 0 24 24">
+        <path d="M9.88 14.12a3 3 0 0 1 0-4.24l2-2a3 3 0 1 1 4.24 4.24l-.71.71"/>
+        <path d="M14.12 9.88a3 3 0 0 1 0 4.24l-2 2a3 3 0 1 1-4.24-4.24l.71-.71"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -109,12 +113,20 @@ limitations under the License.
         <div id="promptOutputHelp" class="md-output-help"></div>
       </div>
       <lht-command-block command-id="promptOutput"></lht-command-block>
-      <lht-switch-help
-        switch-id="includeLabelPrefix"
-        label="ラベル名を先頭に含める"
-        help-label="ラベル名を先頭に含める説明">
-        ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
-      </lht-switch-help>
+      <div class="md-output-options">
+        <lht-switch-help
+          switch-id="includeLabelPrefix"
+          label="ラベル名を先頭に含める"
+          help-label="ラベル名を先頭に含める説明">
+          ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
+        </lht-switch-help>
+        <button id="copyShareLinkButton" type="button" class="md-secondary-button">
+          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
+          </svg>
+          <span>共有リンクをコピー</span>
+        </button>
+      </div>
     </section>
 
     <lht-toast id="toast"></lht-toast>

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1193,6 +1193,43 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   flex: 0 0 auto;
 }
 
+.md-output-options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.md-secondary-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  appearance: none;
+  border: 1px solid #d0d7e5;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #28405f;
+  padding: 0.42rem 0.72rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.1;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+}
+
+.md-secondary-button:hover {
+  background: #eef6ff;
+  border-color: #b7c9df;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(40, 64, 95, 0.10);
+}
+
+.md-secondary-button__icon {
+  width: 1.08rem;
+  height: 1.08rem;
+  flex: 0 0 auto;
+}
+
 .md-code-block {
   position: relative;
   margin-top: 0.5rem;
@@ -1331,6 +1368,10 @@ md-icon-button.md-copy-button--surface {
         <rect x="9" y="9" width="11" height="11" rx="2"/>
         <rect x="4" y="4" width="11" height="11" rx="2"/>
       </symbol>
+      <symbol id="md-icon-link" viewBox="0 0 24 24">
+        <path d="M9.88 14.12a3 3 0 0 1 0-4.24l2-2a3 3 0 1 1 4.24 4.24l-.71.71"/>
+        <path d="M14.12 9.88a3 3 0 0 1 0 4.24l-2 2a3 3 0 1 1-4.24-4.24l.71-.71"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -1401,12 +1442,20 @@ md-icon-button.md-copy-button--surface {
         <div id="promptOutputHelp" class="md-output-help"></div>
       </div>
       <lht-command-block command-id="promptOutput"></lht-command-block>
-      <lht-switch-help
-        switch-id="includeLabelPrefix"
-        label="ラベル名を先頭に含める"
-        help-label="ラベル名を先頭に含める説明">
-        ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
-      </lht-switch-help>
+      <div class="md-output-options">
+        <lht-switch-help
+          switch-id="includeLabelPrefix"
+          label="ラベル名を先頭に含める"
+          help-label="ラベル名を先頭に含める説明">
+          ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
+        </lht-switch-help>
+        <button id="copyShareLinkButton" type="button" class="md-secondary-button">
+          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
+          </svg>
+          <span>共有リンクをコピー</span>
+        </button>
+      </div>
     </section>
 
     <lht-toast id="toast"></lht-toast>
@@ -6703,8 +6752,9 @@ async function initializePromptPage() {
     const commitIdInput = document.getElementById("commitId");
     const subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
+    const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -7249,6 +7299,23 @@ async function initializePromptPage() {
         }
         return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
     }
+    function buildShareLink() {
+        const url = new URL(window.location.href);
+        url.search = "";
+        const query = (promptSearch.value || "").trim();
+        const subject = subjectInput.value || "";
+        const commitId = commitIdInput.value || "";
+        if (query) {
+            url.searchParams.set("q", query);
+        }
+        if (subject) {
+            url.searchParams.set("subject", subject);
+        }
+        if (commitId) {
+            url.searchParams.set("commit", commitId);
+        }
+        return url.toString();
+    }
     function updateOutput() {
         renderSelectedPromptHelp();
         const text = buildPromptText();
@@ -7323,8 +7390,32 @@ async function initializePromptPage() {
     commitIdInput.addEventListener("input", updateOutput);
     subjectInput.addEventListener("input", updateOutput);
     includeLabelPrefix.addEventListener("change", updateOutput);
+    copyShareLinkButton.addEventListener("click", () => {
+        void copyText(buildShareLink());
+    });
+    let initialQuery = "";
+    let initialSubject = "";
+    let initialCommitId = "";
+    try {
+        const url = new URL(window.location.href);
+        initialQuery = (url.searchParams.get("q") || "").trim();
+        initialSubject = url.searchParams.get("subject") || "";
+        initialCommitId = url.searchParams.get("commit") || "";
+        if (initialQuery) {
+            promptSearch.value = initialQuery;
+        }
+    }
+    catch (_error) {
+        // Ignore invalid or unavailable location values.
+    }
     createSeriesVisibilityMenu();
     renderCandidates();
+    if (initialSubject) {
+        subjectInput.value = initialSubject;
+    }
+    if (initialCommitId) {
+        commitIdInput.value = initialCommitId;
+    }
     updateOutput();
     requestAnimationFrame(() => {
         promptSearch.focus();

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -154,6 +154,43 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   flex: 0 0 auto;
 }
 
+.md-output-options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.md-secondary-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  appearance: none;
+  border: 1px solid #d0d7e5;
+  border-radius: 999px;
+  background: #f8fbff;
+  color: #28405f;
+  padding: 0.42rem 0.72rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.1;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+}
+
+.md-secondary-button:hover {
+  background: #eef6ff;
+  border-color: #b7c9df;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(40, 64, 95, 0.10);
+}
+
+.md-secondary-button__icon {
+  width: 1.08rem;
+  height: 1.08rem;
+  flex: 0 0 auto;
+}
+
 .md-code-block {
   position: relative;
   margin-top: 0.5rem;

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -44,8 +44,9 @@ async function initializePromptPage() {
     const commitIdInput = document.getElementById("commitId");
     const subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
+    const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -590,6 +591,23 @@ async function initializePromptPage() {
         }
         return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
     }
+    function buildShareLink() {
+        const url = new URL(window.location.href);
+        url.search = "";
+        const query = (promptSearch.value || "").trim();
+        const subject = subjectInput.value || "";
+        const commitId = commitIdInput.value || "";
+        if (query) {
+            url.searchParams.set("q", query);
+        }
+        if (subject) {
+            url.searchParams.set("subject", subject);
+        }
+        if (commitId) {
+            url.searchParams.set("commit", commitId);
+        }
+        return url.toString();
+    }
     function updateOutput() {
         renderSelectedPromptHelp();
         const text = buildPromptText();
@@ -664,8 +682,32 @@ async function initializePromptPage() {
     commitIdInput.addEventListener("input", updateOutput);
     subjectInput.addEventListener("input", updateOutput);
     includeLabelPrefix.addEventListener("change", updateOutput);
+    copyShareLinkButton.addEventListener("click", () => {
+        void copyText(buildShareLink());
+    });
+    let initialQuery = "";
+    let initialSubject = "";
+    let initialCommitId = "";
+    try {
+        const url = new URL(window.location.href);
+        initialQuery = (url.searchParams.get("q") || "").trim();
+        initialSubject = url.searchParams.get("subject") || "";
+        initialCommitId = url.searchParams.get("commit") || "";
+        if (initialQuery) {
+            promptSearch.value = initialQuery;
+        }
+    }
+    catch (_error) {
+        // Ignore invalid or unavailable location values.
+    }
     createSeriesVisibilityMenu();
     renderCandidates();
+    if (initialSubject) {
+        subjectInput.value = initialSubject;
+    }
+    if (initialCommitId) {
+        commitIdInput.value = initialCommitId;
+    }
     updateOutput();
     requestAnimationFrame(() => {
         promptSearch.focus();

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -79,9 +79,10 @@ async function initializePromptPage() {
   const commitIdInput = document.getElementById("commitId") as HTMLInputElement | null;
   const subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
   const includeLabelPrefix = document.getElementById("includeLabelPrefix") as HTMLInputElement | null;
+  const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
 
-  if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+  if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
     return;
   }
 
@@ -727,6 +728,27 @@ async function initializePromptPage() {
     return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
   }
 
+  function buildShareLink() {
+    const url = new URL(window.location.href);
+    url.search = "";
+
+    const query = (promptSearch.value || "").trim();
+    const subject = subjectInput.value || "";
+    const commitId = commitIdInput.value || "";
+
+    if (query) {
+      url.searchParams.set("q", query);
+    }
+    if (subject) {
+      url.searchParams.set("subject", subject);
+    }
+    if (commitId) {
+      url.searchParams.set("commit", commitId);
+    }
+
+    return url.toString();
+  }
+
   function updateOutput() {
     renderSelectedPromptHelp();
     const text = buildPromptText();
@@ -812,9 +834,33 @@ async function initializePromptPage() {
   commitIdInput.addEventListener("input", updateOutput);
   subjectInput.addEventListener("input", updateOutput);
   includeLabelPrefix.addEventListener("change", updateOutput);
+  copyShareLinkButton.addEventListener("click", () => {
+    void copyText(buildShareLink());
+  });
+
+  let initialQuery = "";
+  let initialSubject = "";
+  let initialCommitId = "";
+  try {
+    const url = new URL(window.location.href);
+    initialQuery = (url.searchParams.get("q") || "").trim();
+    initialSubject = url.searchParams.get("subject") || "";
+    initialCommitId = url.searchParams.get("commit") || "";
+    if (initialQuery) {
+      promptSearch.value = initialQuery;
+    }
+  } catch (_error) {
+    // Ignore invalid or unavailable location values.
+  }
 
   createSeriesVisibilityMenu();
   renderCandidates();
+  if (initialSubject) {
+    subjectInput.value = initialSubject;
+  }
+  if (initialCommitId) {
+    commitIdInput.value = initialCommitId;
+  }
   updateOutput();
 
   requestAnimationFrame(() => {

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -73,6 +73,7 @@ function mountPromptDom() {
     <input id="commitId" />
     <input id="subjectInput" />
     <input id="includeLabelPrefix" type="checkbox" />
+    <button id="copyShareLinkButton" type="button"></button>
     <div id="promptOutput"></div>
   `;
 }
@@ -108,12 +109,13 @@ function setRawInputValue(element, value) {
   });
 }
 
-async function bootPromptPage() {
+async function bootPromptPage(urlSearch = "") {
   defineElementIfNeeded("lht-text-field-help");
   defineElementIfNeeded("lht-switch-help");
   defineElementIfNeeded("lht-help-tooltip");
   ensureLocalStorageMock();
   window.localStorage.clear();
+  window.history.replaceState({}, "", urlSearch ? `/${urlSearch.startsWith("?") ? urlSearch : `?${urlSearch}`}` : "/");
   mountPromptDom();
   const promptOutputSection = document.getElementById("promptOutputSection");
   promptOutputSection.scrollIntoView = () => {};
@@ -123,7 +125,71 @@ async function bootPromptPage() {
   await Promise.resolve();
 }
 
+function ensureClipboardMock() {
+  let copiedText = "";
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      async writeText(text) {
+        copiedText = String(text);
+      }
+    }
+  });
+  return () => copiedText;
+}
+
 describe("prompt-gen main", () => {
+  it("copies a share link with q and subject parameters", async () => {
+    const getCopiedText = ensureClipboardMock();
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const subjectInput = document.getElementById("subjectInput");
+    const copyShareLinkButton = document.getElementById("copyShareLinkButton");
+
+    promptSearch.value = "A852";
+    promptSearch.dispatchEvent(new Event("input"));
+    subjectInput.value = "a small fox";
+    subjectInput.dispatchEvent(new Event("input"));
+    copyShareLinkButton.click();
+    await Promise.resolve();
+
+    expect(getCopiedText()).toBe("http://localhost:3000/?q=A852&subject=a+small+fox");
+  });
+
+  it("applies q query parameter to the search field on load", async () => {
+    await bootPromptPage("?q=A852");
+
+    const promptSearch = document.getElementById("promptSearch");
+    const subjectInputSection = document.getElementById("subjectInputSection");
+    const buttons = [...document.querySelectorAll(".md-chip-button")];
+
+    expect(promptSearch.value).toBe("A852");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].querySelector(".md-chip-label").textContent).toContain("和紙切絵作品");
+    expect(subjectInputSection.classList.contains("md-hidden")).toBe(false);
+  });
+
+  it("applies subject query parameter and generates output on load", async () => {
+    await bootPromptPage("?q=A852&subject=a%20small%20fox");
+
+    const subjectInput = document.getElementById("subjectInput");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(subjectInput.value).toBe("a small fox");
+    expect(promptOutput.textContent).toContain("A simplified cute illustration of `a small fox`");
+  });
+
+  it("applies commit query parameter and generates output on load", async () => {
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    const commitId = document.getElementById("commitId");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(commitId.value).toBe("abc1234");
+    expect(promptOutput.textContent).toContain("対象コミット `abc1234` における変更内容について");
+  });
+
   it("generates PR prompt text after unique match and commit id input", async () => {
     await bootPromptPage();
 


### PR DESCRIPTION
### 概要
`docs/prompt/prompt-gen` に、現在の入力状態を URL として共有できる `共有リンクをコピー` ボタンを追加しました。あわせて、`q` / `subject` / `commit` クエリパラメータから初期状態を復元できるようにし、関連テストと TODO を更新しています。

### 主な変更点
- 出力オプション行に `共有リンクをコピー` ボタンを追加
  - `ラベル名を先頭に含める` の右側に配置
  - 小さめのセカンダリーボタンとしてスタイルを追加
  - link / chain 系の SVG アイコンを同梱
- `main.ts` に共有リンク生成処理を追加
  - 現在の `promptSearch` を `q`
  - `subjectInput` を `subject`
  - `commitId` を `commit` として URL に反映し、クリップボードへコピー
- 初期表示時の URL パラメータ読み込みを追加
  - `q` があれば検索欄へ反映
  - `subject` / `commit` があれば対応入力欄へ反映
  - 候補選択後に入力値を流し込み、そのまま出力まで更新する流れに調整
- `TODO.md` に、共有リンクボタンの SVG アイコン改善タスクを追記
- `prompt-gen.html` と生成済み JS を再ビルド

### テスト
- `docs/prompt/tests/prompt-gen-main.test.js` を拡張
  - 共有リンクコピー時に `q` / `subject` を含む URL が生成されること
  - `q` パラメータで候補選択されること
  - `subject` / `commit` パラメータで入力欄と生成結果が初期反映されること
  - 既存の `commitId` / `subject` サニタイズと検索・出力挙動の回帰がないこと
- 実行コマンド
  - `npm run build:prompt`
  - `npm test -- docs/prompt/tests/prompt-gen-main.test.js`

### 注意点
- 共有リンクボタンの SVG アイコンは追加済みですが、見た目は今後さらに改善予定です
- 改善タスクは `docs/prompt/TODO.md` に記録しています