### PR TITLE
prompt-gen の共有リンク再現性を改善

### DIFF
--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -6847,6 +6847,7 @@ async function initializePromptPage() {
     }
     let selectedPrompt = "";
     let lastSearchQuery = "";
+    let pendingInitialPromptCode = "";
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
         ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
@@ -7225,6 +7226,13 @@ async function initializePromptPage() {
             promptOutput.textContent = "";
         }
         const { matchedDefinitions, prioritizedSingleDefinition } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
+        if (pendingInitialPromptCode) {
+            const pendingDefinition = matchedDefinitions.find((definition) => getDefinitionLabelCode(definition) === pendingInitialPromptCode);
+            if (pendingDefinition) {
+                selectedPrompt = pendingDefinition.id;
+            }
+            pendingInitialPromptCode = "";
+        }
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
@@ -7243,24 +7251,20 @@ async function initializePromptPage() {
         }
         for (const definition of matchedDefinitions) {
             const button = createCandidateButton(definition);
-            if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
+            if (selectedPrompt === definition.id) {
                 button.classList.add("is-active");
             }
             promptCandidateArea.appendChild(button);
         }
-        if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
-            const selectedDefinition = prioritizedSingleDefinition;
-            if (selectedDefinition.requiresCommitId) {
-                syncInputSections(selectedDefinition);
+        const selectedDefinition = matchedDefinitions.find((definition) => definition.id === selectedPrompt) || null;
+        if (selectedDefinition) {
+            const selectedButton = promptCandidateArea.querySelector(`[data-prompt-id="${selectedDefinition.id}"]`);
+            if (selectedButton) {
+                selectedButton.classList.add("is-active");
             }
-            else if (selectedDefinition.requiresSubject) {
-                syncInputSections(selectedDefinition);
-            }
-            else {
-                syncInputSections(selectedDefinition);
-            }
+            syncInputSections(selectedDefinition);
             revealOutputSection({
-                scrollIntoView: queryChanged && query.length > 0
+                scrollIntoView: queryChanged && query.length > 0 && !!prioritizedSingleDefinition
             });
             updateOutput();
         }
@@ -7299,14 +7303,24 @@ async function initializePromptPage() {
         }
         return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
     }
+    function getDefinitionLabelCode(definition) {
+        const label = String((definition === null || definition === void 0 ? void 0 : definition.label) || "");
+        const match = label.match(/^([^:]+):/);
+        return match ? match[1] : "";
+    }
     function buildShareLink() {
         const url = new URL(window.location.href);
         url.search = "";
         const query = (promptSearch.value || "").trim();
         const subject = subjectInput.value || "";
         const commitId = commitIdInput.value || "";
+        const selectedDefinition = getSelectedPromptDefinition();
+        const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
         if (query) {
             url.searchParams.set("q", query);
+        }
+        if (selectedDefinitionCode) {
+            url.searchParams.set("id", selectedDefinitionCode);
         }
         if (subject) {
             url.searchParams.set("subject", subject);
@@ -7394,11 +7408,13 @@ async function initializePromptPage() {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
+    let initialPromptCode = "";
     let initialSubject = "";
     let initialCommitId = "";
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
+        initialPromptCode = (url.searchParams.get("id") || "").trim();
         initialSubject = url.searchParams.get("subject") || "";
         initialCommitId = url.searchParams.get("commit") || "";
         if (initialQuery) {
@@ -7409,6 +7425,9 @@ async function initializePromptPage() {
         // Ignore invalid or unavailable location values.
     }
     createSeriesVisibilityMenu();
+    if (initialPromptCode) {
+        pendingInitialPromptCode = initialPromptCode;
+    }
     renderCandidates();
     if (initialSubject) {
         subjectInput.value = initialSubject;

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -139,6 +139,7 @@ async function initializePromptPage() {
     }
     let selectedPrompt = "";
     let lastSearchQuery = "";
+    let pendingInitialPromptCode = "";
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
         ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
@@ -517,6 +518,13 @@ async function initializePromptPage() {
             promptOutput.textContent = "";
         }
         const { matchedDefinitions, prioritizedSingleDefinition } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
+        if (pendingInitialPromptCode) {
+            const pendingDefinition = matchedDefinitions.find((definition) => getDefinitionLabelCode(definition) === pendingInitialPromptCode);
+            if (pendingDefinition) {
+                selectedPrompt = pendingDefinition.id;
+            }
+            pendingInitialPromptCode = "";
+        }
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
@@ -535,24 +543,20 @@ async function initializePromptPage() {
         }
         for (const definition of matchedDefinitions) {
             const button = createCandidateButton(definition);
-            if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
+            if (selectedPrompt === definition.id) {
                 button.classList.add("is-active");
             }
             promptCandidateArea.appendChild(button);
         }
-        if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
-            const selectedDefinition = prioritizedSingleDefinition;
-            if (selectedDefinition.requiresCommitId) {
-                syncInputSections(selectedDefinition);
+        const selectedDefinition = matchedDefinitions.find((definition) => definition.id === selectedPrompt) || null;
+        if (selectedDefinition) {
+            const selectedButton = promptCandidateArea.querySelector(`[data-prompt-id="${selectedDefinition.id}"]`);
+            if (selectedButton) {
+                selectedButton.classList.add("is-active");
             }
-            else if (selectedDefinition.requiresSubject) {
-                syncInputSections(selectedDefinition);
-            }
-            else {
-                syncInputSections(selectedDefinition);
-            }
+            syncInputSections(selectedDefinition);
             revealOutputSection({
-                scrollIntoView: queryChanged && query.length > 0
+                scrollIntoView: queryChanged && query.length > 0 && !!prioritizedSingleDefinition
             });
             updateOutput();
         }
@@ -591,14 +595,24 @@ async function initializePromptPage() {
         }
         return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
     }
+    function getDefinitionLabelCode(definition) {
+        const label = String((definition === null || definition === void 0 ? void 0 : definition.label) || "");
+        const match = label.match(/^([^:]+):/);
+        return match ? match[1] : "";
+    }
     function buildShareLink() {
         const url = new URL(window.location.href);
         url.search = "";
         const query = (promptSearch.value || "").trim();
         const subject = subjectInput.value || "";
         const commitId = commitIdInput.value || "";
+        const selectedDefinition = getSelectedPromptDefinition();
+        const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
         if (query) {
             url.searchParams.set("q", query);
+        }
+        if (selectedDefinitionCode) {
+            url.searchParams.set("id", selectedDefinitionCode);
         }
         if (subject) {
             url.searchParams.set("subject", subject);
@@ -686,11 +700,13 @@ async function initializePromptPage() {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
+    let initialPromptCode = "";
     let initialSubject = "";
     let initialCommitId = "";
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
+        initialPromptCode = (url.searchParams.get("id") || "").trim();
         initialSubject = url.searchParams.get("subject") || "";
         initialCommitId = url.searchParams.get("commit") || "";
         if (initialQuery) {
@@ -701,6 +717,9 @@ async function initializePromptPage() {
         // Ignore invalid or unavailable location values.
     }
     createSeriesVisibilityMenu();
+    if (initialPromptCode) {
+        pendingInitialPromptCode = initialPromptCode;
+    }
     renderCandidates();
     if (initialSubject) {
         subjectInput.value = initialSubject;

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -186,6 +186,7 @@ async function initializePromptPage() {
 
   let selectedPrompt = "";
   let lastSearchQuery = "";
+  let pendingInitialPromptCode = "";
 
   const kanaToRomajiMap = new Map<string, string>([
     ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
@@ -644,6 +645,16 @@ async function initializePromptPage() {
       prioritizedSingleDefinition
     } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
 
+    if (pendingInitialPromptCode) {
+      const pendingDefinition = matchedDefinitions.find((definition) =>
+        getDefinitionLabelCode(definition) === pendingInitialPromptCode
+      );
+      if (pendingDefinition) {
+        selectedPrompt = pendingDefinition.id;
+      }
+      pendingInitialPromptCode = "";
+    }
+
     if (matchedDefinitions.length === 0) {
       if (selectedPrompt) {
         selectedPrompt = "";
@@ -665,23 +676,21 @@ async function initializePromptPage() {
 
     for (const definition of matchedDefinitions) {
       const button = createCandidateButton(definition);
-      if (prioritizedSingleDefinition && selectedPrompt === definition.id) {
+      if (selectedPrompt === definition.id) {
         button.classList.add("is-active");
       }
       promptCandidateArea.appendChild(button);
     }
 
-    if (prioritizedSingleDefinition && selectedPrompt === prioritizedSingleDefinition.id) {
-      const selectedDefinition = prioritizedSingleDefinition;
-      if (selectedDefinition.requiresCommitId) {
-        syncInputSections(selectedDefinition);
-      } else if (selectedDefinition.requiresSubject) {
-        syncInputSections(selectedDefinition);
-      } else {
-        syncInputSections(selectedDefinition);
+    const selectedDefinition = matchedDefinitions.find((definition) => definition.id === selectedPrompt) || null;
+    if (selectedDefinition) {
+      const selectedButton = promptCandidateArea.querySelector(`[data-prompt-id="${selectedDefinition.id}"]`);
+      if (selectedButton) {
+        selectedButton.classList.add("is-active");
       }
+      syncInputSections(selectedDefinition);
       revealOutputSection({
-        scrollIntoView: queryChanged && query.length > 0
+        scrollIntoView: queryChanged && query.length > 0 && !!prioritizedSingleDefinition
       });
       updateOutput();
     }
@@ -728,6 +737,12 @@ async function initializePromptPage() {
     return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
   }
 
+  function getDefinitionLabelCode(definition: PromptDefinition | null) {
+    const label = String(definition?.label || "");
+    const match = label.match(/^([^:]+):/);
+    return match ? match[1] : "";
+  }
+
   function buildShareLink() {
     const url = new URL(window.location.href);
     url.search = "";
@@ -735,9 +750,14 @@ async function initializePromptPage() {
     const query = (promptSearch.value || "").trim();
     const subject = subjectInput.value || "";
     const commitId = commitIdInput.value || "";
+    const selectedDefinition = getSelectedPromptDefinition();
+    const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
 
     if (query) {
       url.searchParams.set("q", query);
+    }
+    if (selectedDefinitionCode) {
+      url.searchParams.set("id", selectedDefinitionCode);
     }
     if (subject) {
       url.searchParams.set("subject", subject);
@@ -839,11 +859,13 @@ async function initializePromptPage() {
   });
 
   let initialQuery = "";
+  let initialPromptCode = "";
   let initialSubject = "";
   let initialCommitId = "";
   try {
     const url = new URL(window.location.href);
     initialQuery = (url.searchParams.get("q") || "").trim();
+    initialPromptCode = (url.searchParams.get("id") || "").trim();
     initialSubject = url.searchParams.get("subject") || "";
     initialCommitId = url.searchParams.get("commit") || "";
     if (initialQuery) {
@@ -854,6 +876,9 @@ async function initializePromptPage() {
   }
 
   createSeriesVisibilityMenu();
+  if (initialPromptCode) {
+    pendingInitialPromptCode = initialPromptCode;
+  }
   renderCandidates();
   if (initialSubject) {
     subjectInput.value = initialSubject;

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -139,22 +139,27 @@ function ensureClipboardMock() {
 }
 
 describe("prompt-gen main", () => {
-  it("copies a share link with q and subject parameters", async () => {
+  it("copies a share link with q, id, and subject parameters", async () => {
     const getCopiedText = ensureClipboardMock();
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
     const subjectInput = document.getElementById("subjectInput");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
+    const buttons = [...document.querySelectorAll(".md-chip-button")];
 
-    promptSearch.value = "A852";
+    promptSearch.value = "和";
     promptSearch.dispatchEvent(new Event("input"));
+    const targetButton = buttons.find((button) =>
+      button.querySelector(".md-chip-label").textContent.includes("A852: 和紙切絵作品")
+    );
+    targetButton.click();
     subjectInput.value = "a small fox";
     subjectInput.dispatchEvent(new Event("input"));
     copyShareLinkButton.click();
     await Promise.resolve();
 
-    expect(getCopiedText()).toBe("http://localhost:3000/?q=A852&subject=a+small+fox");
+    expect(getCopiedText()).toBe("http://localhost:3000/?q=%E5%92%8C&id=A852&subject=a+small+fox");
   });
 
   it("applies q query parameter to the search field on load", async () => {
@@ -178,6 +183,21 @@ describe("prompt-gen main", () => {
 
     expect(subjectInput.value).toBe("a small fox");
     expect(promptOutput.textContent).toContain("A simplified cute illustration of `a small fox`");
+  });
+
+  it("applies id query parameter to restore a selected prompt among multiple matches", async () => {
+    await bootPromptPage("?q=%E5%92%8C&id=A852&subject=%E3%81%B6%E3%81%A9%E3%81%86");
+
+    const activeButton = document.querySelector(".md-chip-button.is-active");
+    const subjectInput = document.getElementById("subjectInput");
+    const promptOutputTitle = document.getElementById("promptOutputTitle");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(document.querySelectorAll(".md-chip-button")).toHaveLength(3);
+    expect(activeButton.querySelector(".md-chip-label").textContent).toContain("A852: 和紙切絵作品");
+    expect(subjectInput.value).toBe("ぶどう");
+    expect(promptOutputTitle.textContent).toContain("A852: 和紙切絵作品");
+    expect(promptOutput.textContent).toContain("A simplified cute illustration of `ぶどう`");
   });
 
   it("applies commit query parameter and generates output on load", async () => {


### PR DESCRIPTION
### 概要
`docs/prompt/prompt-gen` の共有リンク機能を改善し、複数候補が表示される検索結果から特定の候補を選んだ状態でも URL で再現できるようにしました。共有リンクに内部定義 ID ではなく表示コードの `id=A852` のような値を含めるようにし、初期表示時の復元処理とテストも強化しています。

### 主な変更点
- 共有リンク生成処理を改善
  - 現在の選択候補について、内部 ID ではなく表示ラベル先頭のコードを `id` パラメータとして URL に含めるよう変更
  - 例: `id=A852`
- 初期表示時の復元処理を調整
  - `q` による複数候補表示のあとに `id` を使って選択候補を復元
  - 選択済みボタンのアクティブ表示も再適用
  - `subject` や `commit` の初期値反映と組み合わせても再現できるよう更新
- 候補描画ロジックを改善
  - 一意候補だけでなく、複数候補時でも `selectedPrompt` が存在すれば選択状態を反映するよう調整
- テストを拡張
  - 共有リンクが `q` / `id` / `subject` を含むことを確認
  - `id=A852` のような URL から、複数候補の中で特定候補が選択済みの状態を復元できることを確認

### 期待される効果
- 検索結果が複数あるケースでも、利用者が選んだ候補を共有リンクで正確に再現できます
- URL 上の選択情報が `A852` のような表示コードになるため、人間にも意味が分かりやすくなります

### テスト
- `npm run build:prompt`
- `npm test -- docs/prompt/tests/prompt-gen-main.test.js`