### PR TITLE
git-pseudo-squash の squash セクションに生成AI整理リンクと整形アイコンを追加

### DIFF
--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -48,6 +48,16 @@ limitations under the License.
         <path d="M6 7l1 12h10l1-12"/>
         <path d="M9 7V5h6v2"/>
       </symbol>
+      <symbol id="md-icon-open-in-new" viewBox="0 0 24 24">
+        <path d="M14 5h5v5"/>
+        <path d="M10 14 19 5"/>
+        <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
+      </symbol>
+      <symbol id="md-icon-auto-fix" viewBox="0 0 24 24">
+        <path d="m6 4 .8 2.2L9 7l-2.2.8L6 10l-.8-2.2L3 7l2.2-.8L6 4"/>
+        <path d="m16 11 1.1 3 2.9 1.1-2.9 1.1L16 19l-1.1-2.9L12 15l2.9-1.1L16 11"/>
+        <path d="M10 19h8"/>
+      </symbol>
     </defs>
   </svg>
   <div class="md-surface-card md-card">
@@ -178,7 +188,12 @@ limitations under the License.
             ローカルの複数のコミットを1つにまとめます。
             reset --soft で履歴だけ戻し、変更は残したまま1コミット化します。
           </lht-help-tooltip>
-          <button type="button" class="md-button md-button--surface md-button--compact md-title-action-btn" onclick="normalizeCommitMessageForPr()" title="コミットメッセージをPRテキスト向けに整形" aria-label="コミットメッセージをPRテキスト向けに整形">PR整形</button>
+          <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" onclick="normalizeCommitMessageForPr()" title="コミットメッセージをPRテキスト向けに整形" aria-label="コミットメッセージをPRテキスト向けに整形">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
+            </svg>
+            <span>PR整形</span>
+          </button>
           <button type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-title-action-icon" onclick="openNormalizeDiffDialog()" title="整形差分を表示" aria-label="整形差分を表示">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="12" cy="12" r="9"></circle>
@@ -186,6 +201,12 @@ limitations under the License.
               <circle cx="12" cy="7.5" r="0.9" fill="currentColor" stroke="none"></circle>
             </svg>
           </button>
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="https://igapyon.github.io/local-html-tools/prompt/prompt-gen.html?q=A501&id=A501" target="_blank" rel="noopener noreferrer" title="生成AIで整理" aria-label="生成AIで整理">
+            <span>生成AIで整理</span>
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+            </svg>
+          </a>
         </span>
       </div>
       <div class="md-form-row">

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -1157,6 +1157,7 @@ lht-index-card-link {
     .md-button {
       border-radius: 999px;
       padding: 0.6rem 1.2rem;
+      font: inherit;
       font-weight: 600;
       font-size: 0.95rem;
       border: none;
@@ -2459,6 +2460,16 @@ lht-index-card-link {
         <path d="M6 7l1 12h10l1-12"/>
         <path d="M9 7V5h6v2"/>
       </symbol>
+      <symbol id="md-icon-open-in-new" viewBox="0 0 24 24">
+        <path d="M14 5h5v5"/>
+        <path d="M10 14 19 5"/>
+        <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
+      </symbol>
+      <symbol id="md-icon-auto-fix" viewBox="0 0 24 24">
+        <path d="m6 4 .8 2.2L9 7l-2.2.8L6 10l-.8-2.2L3 7l2.2-.8L6 4"/>
+        <path d="m16 11 1.1 3 2.9 1.1-2.9 1.1L16 19l-1.1-2.9L12 15l2.9-1.1L16 11"/>
+        <path d="M10 19h8"/>
+      </symbol>
     </defs>
   </svg>
   <div class="md-surface-card md-card">
@@ -2589,7 +2600,12 @@ lht-index-card-link {
             ローカルの複数のコミットを1つにまとめます。
             reset --soft で履歴だけ戻し、変更は残したまま1コミット化します。
           </lht-help-tooltip>
-          <button type="button" class="md-button md-button--surface md-button--compact md-title-action-btn" onclick="normalizeCommitMessageForPr()" title="コミットメッセージをPRテキスト向けに整形" aria-label="コミットメッセージをPRテキスト向けに整形">PR整形</button>
+          <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" onclick="normalizeCommitMessageForPr()" title="コミットメッセージをPRテキスト向けに整形" aria-label="コミットメッセージをPRテキスト向けに整形">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
+            </svg>
+            <span>PR整形</span>
+          </button>
           <button type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-title-action-icon" onclick="openNormalizeDiffDialog()" title="整形差分を表示" aria-label="整形差分を表示">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <circle cx="12" cy="12" r="9"></circle>
@@ -2597,6 +2613,12 @@ lht-index-card-link {
               <circle cx="12" cy="7.5" r="0.9" fill="currentColor" stroke="none"></circle>
             </svg>
           </button>
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="https://igapyon.github.io/local-html-tools/prompt/prompt-gen.html?q=A501&id=A501" target="_blank" rel="noopener noreferrer" title="生成AIで整理" aria-label="生成AIで整理">
+            <span>生成AIで整理</span>
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+            </svg>
+          </a>
         </span>
       </div>
       <div class="md-form-row">

--- a/docs/git/src/git-pseudo-squash/css/app.css
+++ b/docs/git/src/git-pseudo-squash/css/app.css
@@ -117,6 +117,7 @@
     .md-button {
       border-radius: 999px;
       padding: 0.6rem 1.2rem;
+      font: inherit;
       font-weight: 600;
       font-size: 0.95rem;
       border: none;


### PR DESCRIPTION
### 概要
`docs/git/git-pseudo-squash.html` の「作業をまとめる (squash)」セクションのアクションUIを改善しました。

### 変更内容
- `生成AIで整理` ボタンを squash セクション右側のアクション群に追加
- `生成AIで整理` から `prompt-gen.html?q=A501&id=A501` を別タブで開くよう変更
- `生成AIで整理` に外部リンクを示す SVG アイコンを追加
- `PR整形` ボタンをアイコン付き表示に変更し、整形アクションを想起しやすく改善
- `PR整形` のアイコンを左側配置にして、一般的なボタン表現に合わせて調整
- リンク要素でも既存ボタンと同じ見た目になるよう、`.md-button` に `font: inherit;` を追加

### 変更ファイル
- `docs/git/git-pseudo-squash-src.html`
- `docs/git/git-pseudo-squash.html`
- `docs/git/src/git-pseudo-squash/css/app.css`

### 期待される効果
- squash セクションから生成AI整理フローへ直接遷移できる
- PR整形ボタンの用途が視覚的に伝わりやすくなる
- ボタンとリンクの見た目が揃い、見出し右側アクションの一貫性が向上する