### PR TITLE
prompt-gen に A150 を追加し docs ルート可変化と出力UI改善を実施

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2084,7 +2084,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-11</div>
+        <div class="md-app-meta">更新日: 2026-03-12</div>
       </div>
     </header>
 

--- a/docs/prompt/prompt-gen-search-and-keywords.md
+++ b/docs/prompt/prompt-gen-search-and-keywords.md
@@ -123,3 +123,9 @@
 - `requiresCommitId` が `true` の候補は、commit ID 未入力の可能性があるため自動コピーしない
 - コピー成功時は `コピーしました`、失敗時は `コピーに失敗しました` の toast を表示する
 - Clipboard API が使えない環境では、`textarea` を一時生成して `execCommand("copy")` にフォールバックする
+
+## A501 の特記事項
+
+- `A501: GitHub PR 文面の作成` を選択したときだけ、出力オプション行に `Git pseudo-squash で整理` の外部リンクを表示する
+- リンク先は `https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html` 固定とする
+- この導線は他ページからの連携前提でも使うため、A501 向けのリンク先パスは不用意に変更しない

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -43,6 +43,11 @@ limitations under the License.
         <path d="M9.88 14.12a3 3 0 0 1 0-4.24l2-2a3 3 0 1 1 4.24 4.24l-.71.71"/>
         <path d="M14.12 9.88a3 3 0 0 1 0 4.24l-2 2a3 3 0 1 1-4.24-4.24l.71-.71"/>
       </symbol>
+      <symbol id="md-icon-open-in-new" viewBox="0 0 24 24">
+        <path d="M14 5h5v5"/>
+        <path d="M10 14 19 5"/>
+        <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -98,6 +103,7 @@ limitations under the License.
     <section id="subjectInputSection" class="md-section md-stack-md md-hidden">
       <div class="md-form-grid md-form-grid-2">
         <lht-text-field-help
+          id="subjectInputField"
           field-id="subjectInput"
           label="subject"
           required
@@ -112,7 +118,7 @@ limitations under the License.
         <p id="promptOutputTitle" class="md-output-title">生成結果</p>
         <div id="promptOutputHelp" class="md-output-help"></div>
       </div>
-      <lht-command-block command-id="promptOutput"></lht-command-block>
+      <lht-command-block command-id="promptOutput" copy-buttons="dual"></lht-command-block>
       <div class="md-output-options">
         <lht-switch-help
           switch-id="includeLabelPrefix"
@@ -126,6 +132,18 @@ limitations under the License.
           </svg>
           <span>共有リンクをコピー</span>
         </button>
+        <a
+          id="gitPseudoSquashLink"
+          class="md-secondary-button md-hidden"
+          href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Git pseudo-squash で整理">
+          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+          </svg>
+          <span>Git pseudo-squash で整理</span>
+        </a>
       </div>
     </section>
 

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1273,6 +1273,12 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   right: 0.5rem;
 }
 
+.md-copy-button--bottom-right {
+  top: auto;
+  right: 0.5rem;
+  bottom: 0.5rem;
+}
+
 md-icon-button.md-copy-button {
   width: 32px;
   height: 32px;
@@ -1387,6 +1393,11 @@ md-icon-button.md-copy-button--surface {
         <path d="M9.88 14.12a3 3 0 0 1 0-4.24l2-2a3 3 0 1 1 4.24 4.24l-.71.71"/>
         <path d="M14.12 9.88a3 3 0 0 1 0 4.24l-2 2a3 3 0 1 1-4.24-4.24l.71-.71"/>
       </symbol>
+      <symbol id="md-icon-open-in-new" viewBox="0 0 24 24">
+        <path d="M14 5h5v5"/>
+        <path d="M10 14 19 5"/>
+        <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -1442,6 +1453,7 @@ md-icon-button.md-copy-button--surface {
     <section id="subjectInputSection" class="md-section md-stack-md md-hidden">
       <div class="md-form-grid md-form-grid-2">
         <lht-text-field-help
+          id="subjectInputField"
           field-id="subjectInput"
           label="subject"
           required
@@ -1456,7 +1468,7 @@ md-icon-button.md-copy-button--surface {
         <p id="promptOutputTitle" class="md-output-title">生成結果</p>
         <div id="promptOutputHelp" class="md-output-help"></div>
       </div>
-      <lht-command-block command-id="promptOutput"></lht-command-block>
+      <lht-command-block command-id="promptOutput" copy-buttons="dual"></lht-command-block>
       <div class="md-output-options">
         <lht-switch-help
           switch-id="includeLabelPrefix"
@@ -1470,6 +1482,18 @@ md-icon-button.md-copy-button--surface {
           </svg>
           <span>共有リンクをコピー</span>
         </button>
+        <a
+          id="gitPseudoSquashLink"
+          class="md-secondary-button md-hidden"
+          href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Git pseudo-squash で整理">
+          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+          </svg>
+          <span>Git pseudo-squash で整理</span>
+        </a>
       </div>
     </section>
 
@@ -3611,6 +3635,23 @@ function getTodoReflectionInstruction() {
   </script>
 
   <script>
+function unwrapPromptVariable(value) {
+    const normalized = String(value || "").trim();
+    const match = normalized.match(/^`([\s\S]*)`$/);
+    return match ? match[1] : normalized;
+}
+function normalizeRelativeDocPath(value) {
+    const unwrapped = unwrapPromptVariable(value)
+        .replace(/\\/g, "/")
+        .replace(/^\/+/, "")
+        .replace(/^\.\/+/, "")
+        .replace(/\/{2,}/g, "/")
+        .trim();
+    if (!unwrapped || unwrapped === "." || unwrapped.includes("..")) {
+        return "";
+    }
+    return unwrapped.replace(/\/+$/, "");
+}
 const promptDefinitions = [
     {
         id: "pr-request",
@@ -3692,6 +3733,268 @@ const promptDefinitions = [
         keywords: ["readme", "markdown", "directory", "ディレクトリ", "内容", "確認", "把握", "内容確認", "md確認", "りーどみー", "でぃれくとり", "ないよう", "かくにん", "はあく", "まーくだうん", "えむでぃー"],
         requiresCommitId: false,
         buildBody: () => "README.md などこのディレクトリの内容をあらわす markdown の内容を確認してください。"
+    },
+    {
+        id: "llm-docs-workflow-init-request",
+        label: "A150: LLM開発用 docs ワークフロー初期化",
+        keywords: ["A150", "llm workflow", "docs workflow", "docs initialization", "docs bootstrap", "documentation scaffold", "markdown workflow", "persistent memory", "repo docs", "context", "architecture", "plan", "todo", "state", "session", "rules", "docs path", "doc root", "LLM開発", "docs初期化", "文書初期化", "markdown運用", "永続メモリ", "開発文書", "どきゅめんとぱす", "こんてきすと", "あーきてくちゃ", "とぅーどぅー", "せっしょん", "るーるず"],
+        requiresCommitId: false,
+        requiresSubject: true,
+        subjectLabel: "docs ルート相対パス",
+        subjectPlaceholder: "例: docs / llm-docs / project-memory/docs",
+        subjectHelpText: "LLM 用ドキュメントを配置する相対パスを入力します。既定値は docs です。先頭スラッシュや .. を含むパスは避けてください。",
+        subjectDefaultValue: "docs",
+        buildBody: (_commitId, subject) => {
+            const docsPath = normalizeRelativeDocPath(subject || "docs");
+            if (!docsPath) {
+                return "";
+            }
+            const docsRoot = `/${docsPath}`;
+            return `# LLM Workflow Initialization Prompt
+
+You are assisting in initializing a repository that uses a **Markdown-based workflow for LLM-assisted development**.
+
+This workflow treats Markdown documents as the **persistent knowledge and task memory** of the project.  
+All planning, reasoning, and task tracking should be reflected in the documentation.
+
+Your task is to **create or update a \`${docsRoot}\` directory** with a structured documentation system and follow the rules below.
+
+---
+
+# Objectives
+
+1. Ensure the repository contains the following documentation files:
+
+\`${docsRoot}\`
+- \`CONTEXT.md\`
+- \`ARCHITECTURE.md\`
+- \`PLAN.md\`
+- \`TODO.md\`
+- \`STATE.md\`
+- \`SESSION.md\`
+- \`RULES.md\`
+
+2. If a file **does not exist**, create it with an appropriate template.
+
+3. If a file **already exists**:
+- preserve useful content
+- update structure if necessary
+- avoid deleting meaningful information
+
+4. Keep documents **structured, concise, and easy for both humans and LLMs to read**.
+
+---
+
+# Concept of This Workflow
+
+The \`${docsRoot}\` directory acts as the **persistent memory layer** for development.
+
+Human instructions -> update markdown -> perform work.
+
+Markdown documents store:
+
+- project context
+- architecture
+- plans
+- task queues
+- current understanding
+- session focus
+- development rules
+
+This allows future LLM sessions to quickly understand the repository.
+
+---
+
+# File Roles
+
+## CONTEXT.md
+Stable project background information.
+
+Include:
+- project purpose
+- high-level goals
+- technology stack
+- constraints
+- development philosophy
+
+---
+
+## ARCHITECTURE.md
+High-level structure of the system.
+
+Include:
+- major components
+- module responsibilities
+- dependencies
+- system relationships
+
+Example structure:
+
+\`\`\`
+# Architecture
+
+## System Overview
+
+## Core Modules
+module -> responsibility
+
+## External Dependencies
+\`\`\`
+
+---
+
+## PLAN.md
+Long-term direction and milestones.
+
+Example:
+
+\`\`\`
+# Project Plan
+
+## Goals
+
+## Milestones
+
+## Future Work
+\`\`\`
+
+This file should change infrequently.
+
+---
+
+## TODO.md
+Active task queue.
+
+Example:
+
+\`\`\`
+# Task List
+
+## Current Tasks
+
+- [ ] example task
+
+## Backlog
+
+- [ ] future work
+\`\`\`
+
+Tasks should be checked off as they are completed.
+
+---
+
+## STATE.md
+Current understanding of the system.
+
+Use this file to record:
+
+- discoveries
+- known problems
+- recent architectural decisions
+- investigation results
+
+Example:
+
+\`\`\`
+# Current State
+
+## Overview
+
+## Known Issues
+
+## Recent Changes
+\`\`\`
+
+---
+
+## SESSION.md
+Short-term working memory for the current development session.
+
+Example:
+
+\`\`\`
+# Current Session
+
+## Focus
+
+## Next Step
+
+## Notes
+\`\`\`
+
+This file may change frequently during development.
+
+---
+
+## RULES.md
+Development and editing principles.
+
+Example structure:
+
+\`\`\`
+# Development Rules
+
+## General Principles
+- prefer minimal changes
+- follow existing coding style
+- keep documentation updated
+
+## Documentation Guidelines
+- preserve document structure
+- prefer small edits instead of rewrites
+- update affected sections only
+\`\`\`
+
+---
+
+# Editing Guidelines
+
+When modifying documentation:
+
+- preserve headings and structure
+- prefer incremental edits
+- avoid rewriting entire documents unnecessarily
+- keep information concise and structured
+- maintain consistency across documents
+
+---
+
+# Workflow Loop
+
+When performing development work:
+
+1. Read the following files first:
+
+   CONTEXT.md  
+   ARCHITECTURE.md  
+   STATE.md  
+   TODO.md  
+   SESSION.md  
+
+2. Understand the current system state.
+
+3. If a new task is required, update **TODO.md** first.
+
+4. Record current work focus in **SESSION.md**.
+
+5. Perform implementation or analysis.
+
+6. After completing work:
+   - update TODO.md
+   - update STATE.md if new understanding emerged
+   - update SESSION.md
+
+7. If architecture changes, update **ARCHITECTURE.md**.
+
+---
+
+# Final Step
+
+After creating or updating the documentation system:
+
+1. Summarize the \`${docsRoot}\` structure.
+2. Explain briefly how future LLM sessions should use these documents.`;
+        }
     },
     {
         id: "conversation-handover-request",
@@ -7002,11 +7305,13 @@ async function initializePromptPage() {
     const promptCandidateArea = document.getElementById("promptCandidateArea");
     const commitInputSection = document.getElementById("commitInputSection");
     const subjectInputSection = document.getElementById("subjectInputSection");
+    let subjectInputFieldHost = document.getElementById("subjectInputField");
     const promptOutputSection = document.getElementById("promptOutputSection");
     const promptOutputTitle = document.getElementById("promptOutputTitle");
     const promptOutputHelp = document.getElementById("promptOutputHelp");
+    const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
     const commitIdInput = document.getElementById("commitId");
-    const subjectInput = document.getElementById("subjectInput");
+    let subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
@@ -7075,6 +7380,11 @@ async function initializePromptPage() {
     applyLatinInputHints(promptSearch, "search");
     applyLatinInputHints(commitIdInput, "done");
     const MAX_EMBED_INPUT_LENGTH = 1024;
+    const defaultSubjectFieldConfig = {
+        label: "subject",
+        placeholder: "例: a small fox",
+        helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
+    };
     function sanitizePromptVariableInput(value) {
         const normalizedWhitespace = String(value || "")
             .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
@@ -7086,6 +7396,58 @@ async function initializePromptPage() {
         const truncatedValue = trimmedValue.slice(0, MAX_EMBED_INPUT_LENGTH);
         const normalizedQuotes = truncatedValue.replace(/`/g, "'");
         return `\`${normalizedQuotes}\``;
+    }
+    function getSubjectFieldConfig(definition) {
+        return {
+            label: (definition === null || definition === void 0 ? void 0 : definition.subjectLabel) || defaultSubjectFieldConfig.label,
+            placeholder: (definition === null || definition === void 0 ? void 0 : definition.subjectPlaceholder) || defaultSubjectFieldConfig.placeholder,
+            helpText: (definition === null || definition === void 0 ? void 0 : definition.subjectHelpText) || defaultSubjectFieldConfig.helpText
+        };
+    }
+    function handleSubjectInput() {
+        updateOutput();
+    }
+    function refreshSubjectInputReference() {
+        subjectInput = document.getElementById("subjectInput");
+        if (subjectInput) {
+            subjectInput.addEventListener("input", handleSubjectInput);
+        }
+    }
+    function renderSubjectInputField(definition) {
+        const config = getSubjectFieldConfig(definition);
+        const currentValue = (subjectInput === null || subjectInput === void 0 ? void 0 : subjectInput.value) || "";
+        if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
+            const nextField = document.createElement("lht-text-field-help");
+            nextField.id = "subjectInputField";
+            nextField.setAttribute("field-id", "subjectInput");
+            nextField.setAttribute("label", config.label);
+            nextField.setAttribute("placeholder", config.placeholder);
+            nextField.setAttribute("help-text", config.helpText);
+            nextField.setAttribute("required", "");
+            subjectInputFieldHost.replaceWith(nextField);
+            subjectInputFieldHost = nextField;
+        }
+        else if (subjectInput) {
+            subjectInput.setAttribute("aria-label", config.label);
+            subjectInput.setAttribute("placeholder", config.placeholder);
+            subjectInput.setAttribute("title", config.helpText);
+        }
+        refreshSubjectInputReference();
+        if (subjectInput) {
+            subjectInput.value = currentValue;
+        }
+    }
+    function applyDefaultSubjectValue(selectedDefinition) {
+        if (!(selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) || !subjectInput) {
+            return;
+        }
+        if ((subjectInput.value || "").trim()) {
+            return;
+        }
+        if (!selectedDefinition.subjectDefaultValue) {
+            return;
+        }
+        subjectInput.value = selectedDefinition.subjectDefaultValue;
     }
     function syncInputSections(selectedDefinition) {
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
@@ -7433,11 +7795,15 @@ async function initializePromptPage() {
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
         promptOutputHelp.innerHTML = "";
+        gitPseudoSquashLink === null || gitPseudoSquashLink === void 0 ? void 0 : gitPseudoSquashLink.classList.add("md-hidden");
         if (!selectedDefinition) {
             promptOutputTitle.textContent = "生成結果";
             return;
         }
         promptOutputTitle.textContent = selectedDefinition.label;
+        if (getDefinitionLabelCode(selectedDefinition) === "A501") {
+            gitPseudoSquashLink === null || gitPseudoSquashLink === void 0 ? void 0 : gitPseudoSquashLink.classList.remove("md-hidden");
+        }
         const help = document.createElement("lht-help-tooltip");
         help.setAttribute("label", "キーワード");
         help.setAttribute("placement", "right");
@@ -7492,7 +7858,9 @@ async function initializePromptPage() {
                 syncInputSections(null);
                 promptOutputSection.classList.add("md-hidden");
                 commitIdInput.value = "";
-                subjectInput.value = "";
+                if (subjectInput) {
+                    subjectInput.value = "";
+                }
                 promptOutput.textContent = "";
             }
         }
@@ -7533,7 +7901,9 @@ async function initializePromptPage() {
             if (selectedButton) {
                 selectedButton.classList.add("is-active");
             }
+            renderSubjectInputField(selectedDefinition);
             syncInputSections(selectedDefinition);
+            applyDefaultSubjectValue(selectedDefinition);
             revealOutputSection();
             updateOutput();
         }
@@ -7555,6 +7925,8 @@ async function initializePromptPage() {
             }
         }
         syncInputSections(selectedDefinition || null);
+        renderSubjectInputField(selectedDefinition || null);
+        applyDefaultSubjectValue(selectedDefinition || null);
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
             commitIdInput.focus();
         }
@@ -7684,7 +8056,7 @@ async function initializePromptPage() {
     }
     promptSearch.addEventListener("input", renderCandidates);
     commitIdInput.addEventListener("input", updateOutput);
-    subjectInput.addEventListener("input", updateOutput);
+    renderSubjectInputField(null);
     includeLabelPrefix.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -234,6 +234,12 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   right: 0.5rem;
 }
 
+.md-copy-button--bottom-right {
+  top: auto;
+  right: 0.5rem;
+  bottom: 0.5rem;
+}
+
 md-icon-button.md-copy-button {
   width: 32px;
   height: 32px;

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -38,11 +38,13 @@ async function initializePromptPage() {
     const promptCandidateArea = document.getElementById("promptCandidateArea");
     const commitInputSection = document.getElementById("commitInputSection");
     const subjectInputSection = document.getElementById("subjectInputSection");
+    let subjectInputFieldHost = document.getElementById("subjectInputField");
     const promptOutputSection = document.getElementById("promptOutputSection");
     const promptOutputTitle = document.getElementById("promptOutputTitle");
     const promptOutputHelp = document.getElementById("promptOutputHelp");
+    const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
     const commitIdInput = document.getElementById("commitId");
-    const subjectInput = document.getElementById("subjectInput");
+    let subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
@@ -111,6 +113,11 @@ async function initializePromptPage() {
     applyLatinInputHints(promptSearch, "search");
     applyLatinInputHints(commitIdInput, "done");
     const MAX_EMBED_INPUT_LENGTH = 1024;
+    const defaultSubjectFieldConfig = {
+        label: "subject",
+        placeholder: "例: a small fox",
+        helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
+    };
     function sanitizePromptVariableInput(value) {
         const normalizedWhitespace = String(value || "")
             .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
@@ -122,6 +129,58 @@ async function initializePromptPage() {
         const truncatedValue = trimmedValue.slice(0, MAX_EMBED_INPUT_LENGTH);
         const normalizedQuotes = truncatedValue.replace(/`/g, "'");
         return `\`${normalizedQuotes}\``;
+    }
+    function getSubjectFieldConfig(definition) {
+        return {
+            label: (definition === null || definition === void 0 ? void 0 : definition.subjectLabel) || defaultSubjectFieldConfig.label,
+            placeholder: (definition === null || definition === void 0 ? void 0 : definition.subjectPlaceholder) || defaultSubjectFieldConfig.placeholder,
+            helpText: (definition === null || definition === void 0 ? void 0 : definition.subjectHelpText) || defaultSubjectFieldConfig.helpText
+        };
+    }
+    function handleSubjectInput() {
+        updateOutput();
+    }
+    function refreshSubjectInputReference() {
+        subjectInput = document.getElementById("subjectInput");
+        if (subjectInput) {
+            subjectInput.addEventListener("input", handleSubjectInput);
+        }
+    }
+    function renderSubjectInputField(definition) {
+        const config = getSubjectFieldConfig(definition);
+        const currentValue = (subjectInput === null || subjectInput === void 0 ? void 0 : subjectInput.value) || "";
+        if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
+            const nextField = document.createElement("lht-text-field-help");
+            nextField.id = "subjectInputField";
+            nextField.setAttribute("field-id", "subjectInput");
+            nextField.setAttribute("label", config.label);
+            nextField.setAttribute("placeholder", config.placeholder);
+            nextField.setAttribute("help-text", config.helpText);
+            nextField.setAttribute("required", "");
+            subjectInputFieldHost.replaceWith(nextField);
+            subjectInputFieldHost = nextField;
+        }
+        else if (subjectInput) {
+            subjectInput.setAttribute("aria-label", config.label);
+            subjectInput.setAttribute("placeholder", config.placeholder);
+            subjectInput.setAttribute("title", config.helpText);
+        }
+        refreshSubjectInputReference();
+        if (subjectInput) {
+            subjectInput.value = currentValue;
+        }
+    }
+    function applyDefaultSubjectValue(selectedDefinition) {
+        if (!(selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) || !subjectInput) {
+            return;
+        }
+        if ((subjectInput.value || "").trim()) {
+            return;
+        }
+        if (!selectedDefinition.subjectDefaultValue) {
+            return;
+        }
+        subjectInput.value = selectedDefinition.subjectDefaultValue;
     }
     function syncInputSections(selectedDefinition) {
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
@@ -469,11 +528,15 @@ async function initializePromptPage() {
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
         promptOutputHelp.innerHTML = "";
+        gitPseudoSquashLink === null || gitPseudoSquashLink === void 0 ? void 0 : gitPseudoSquashLink.classList.add("md-hidden");
         if (!selectedDefinition) {
             promptOutputTitle.textContent = "生成結果";
             return;
         }
         promptOutputTitle.textContent = selectedDefinition.label;
+        if (getDefinitionLabelCode(selectedDefinition) === "A501") {
+            gitPseudoSquashLink === null || gitPseudoSquashLink === void 0 ? void 0 : gitPseudoSquashLink.classList.remove("md-hidden");
+        }
         const help = document.createElement("lht-help-tooltip");
         help.setAttribute("label", "キーワード");
         help.setAttribute("placement", "right");
@@ -528,7 +591,9 @@ async function initializePromptPage() {
                 syncInputSections(null);
                 promptOutputSection.classList.add("md-hidden");
                 commitIdInput.value = "";
-                subjectInput.value = "";
+                if (subjectInput) {
+                    subjectInput.value = "";
+                }
                 promptOutput.textContent = "";
             }
         }
@@ -569,7 +634,9 @@ async function initializePromptPage() {
             if (selectedButton) {
                 selectedButton.classList.add("is-active");
             }
+            renderSubjectInputField(selectedDefinition);
             syncInputSections(selectedDefinition);
+            applyDefaultSubjectValue(selectedDefinition);
             revealOutputSection();
             updateOutput();
         }
@@ -591,6 +658,8 @@ async function initializePromptPage() {
             }
         }
         syncInputSections(selectedDefinition || null);
+        renderSubjectInputField(selectedDefinition || null);
+        applyDefaultSubjectValue(selectedDefinition || null);
         if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
             commitIdInput.focus();
         }
@@ -720,7 +789,7 @@ async function initializePromptPage() {
     }
     promptSearch.addEventListener("input", renderCandidates);
     commitIdInput.addEventListener("input", updateOutput);
-    subjectInput.addEventListener("input", updateOutput);
+    renderSubjectInputField(null);
     includeLabelPrefix.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -1,3 +1,20 @@
+function unwrapPromptVariable(value) {
+    const normalized = String(value || "").trim();
+    const match = normalized.match(/^`([\s\S]*)`$/);
+    return match ? match[1] : normalized;
+}
+function normalizeRelativeDocPath(value) {
+    const unwrapped = unwrapPromptVariable(value)
+        .replace(/\\/g, "/")
+        .replace(/^\/+/, "")
+        .replace(/^\.\/+/, "")
+        .replace(/\/{2,}/g, "/")
+        .trim();
+    if (!unwrapped || unwrapped === "." || unwrapped.includes("..")) {
+        return "";
+    }
+    return unwrapped.replace(/\/+$/, "");
+}
 const promptDefinitions = [
     {
         id: "pr-request",
@@ -79,6 +96,268 @@ const promptDefinitions = [
         keywords: ["readme", "markdown", "directory", "ディレクトリ", "内容", "確認", "把握", "内容確認", "md確認", "りーどみー", "でぃれくとり", "ないよう", "かくにん", "はあく", "まーくだうん", "えむでぃー"],
         requiresCommitId: false,
         buildBody: () => "README.md などこのディレクトリの内容をあらわす markdown の内容を確認してください。"
+    },
+    {
+        id: "llm-docs-workflow-init-request",
+        label: "A150: LLM開発用 docs ワークフロー初期化",
+        keywords: ["A150", "llm workflow", "docs workflow", "docs initialization", "docs bootstrap", "documentation scaffold", "markdown workflow", "persistent memory", "repo docs", "context", "architecture", "plan", "todo", "state", "session", "rules", "docs path", "doc root", "LLM開発", "docs初期化", "文書初期化", "markdown運用", "永続メモリ", "開発文書", "どきゅめんとぱす", "こんてきすと", "あーきてくちゃ", "とぅーどぅー", "せっしょん", "るーるず"],
+        requiresCommitId: false,
+        requiresSubject: true,
+        subjectLabel: "docs ルート相対パス",
+        subjectPlaceholder: "例: docs / llm-docs / project-memory/docs",
+        subjectHelpText: "LLM 用ドキュメントを配置する相対パスを入力します。既定値は docs です。先頭スラッシュや .. を含むパスは避けてください。",
+        subjectDefaultValue: "docs",
+        buildBody: (_commitId, subject) => {
+            const docsPath = normalizeRelativeDocPath(subject || "docs");
+            if (!docsPath) {
+                return "";
+            }
+            const docsRoot = `/${docsPath}`;
+            return `# LLM Workflow Initialization Prompt
+
+You are assisting in initializing a repository that uses a **Markdown-based workflow for LLM-assisted development**.
+
+This workflow treats Markdown documents as the **persistent knowledge and task memory** of the project.  
+All planning, reasoning, and task tracking should be reflected in the documentation.
+
+Your task is to **create or update a \`${docsRoot}\` directory** with a structured documentation system and follow the rules below.
+
+---
+
+# Objectives
+
+1. Ensure the repository contains the following documentation files:
+
+\`${docsRoot}\`
+- \`CONTEXT.md\`
+- \`ARCHITECTURE.md\`
+- \`PLAN.md\`
+- \`TODO.md\`
+- \`STATE.md\`
+- \`SESSION.md\`
+- \`RULES.md\`
+
+2. If a file **does not exist**, create it with an appropriate template.
+
+3. If a file **already exists**:
+- preserve useful content
+- update structure if necessary
+- avoid deleting meaningful information
+
+4. Keep documents **structured, concise, and easy for both humans and LLMs to read**.
+
+---
+
+# Concept of This Workflow
+
+The \`${docsRoot}\` directory acts as the **persistent memory layer** for development.
+
+Human instructions -> update markdown -> perform work.
+
+Markdown documents store:
+
+- project context
+- architecture
+- plans
+- task queues
+- current understanding
+- session focus
+- development rules
+
+This allows future LLM sessions to quickly understand the repository.
+
+---
+
+# File Roles
+
+## CONTEXT.md
+Stable project background information.
+
+Include:
+- project purpose
+- high-level goals
+- technology stack
+- constraints
+- development philosophy
+
+---
+
+## ARCHITECTURE.md
+High-level structure of the system.
+
+Include:
+- major components
+- module responsibilities
+- dependencies
+- system relationships
+
+Example structure:
+
+\`\`\`
+# Architecture
+
+## System Overview
+
+## Core Modules
+module -> responsibility
+
+## External Dependencies
+\`\`\`
+
+---
+
+## PLAN.md
+Long-term direction and milestones.
+
+Example:
+
+\`\`\`
+# Project Plan
+
+## Goals
+
+## Milestones
+
+## Future Work
+\`\`\`
+
+This file should change infrequently.
+
+---
+
+## TODO.md
+Active task queue.
+
+Example:
+
+\`\`\`
+# Task List
+
+## Current Tasks
+
+- [ ] example task
+
+## Backlog
+
+- [ ] future work
+\`\`\`
+
+Tasks should be checked off as they are completed.
+
+---
+
+## STATE.md
+Current understanding of the system.
+
+Use this file to record:
+
+- discoveries
+- known problems
+- recent architectural decisions
+- investigation results
+
+Example:
+
+\`\`\`
+# Current State
+
+## Overview
+
+## Known Issues
+
+## Recent Changes
+\`\`\`
+
+---
+
+## SESSION.md
+Short-term working memory for the current development session.
+
+Example:
+
+\`\`\`
+# Current Session
+
+## Focus
+
+## Next Step
+
+## Notes
+\`\`\`
+
+This file may change frequently during development.
+
+---
+
+## RULES.md
+Development and editing principles.
+
+Example structure:
+
+\`\`\`
+# Development Rules
+
+## General Principles
+- prefer minimal changes
+- follow existing coding style
+- keep documentation updated
+
+## Documentation Guidelines
+- preserve document structure
+- prefer small edits instead of rewrites
+- update affected sections only
+\`\`\`
+
+---
+
+# Editing Guidelines
+
+When modifying documentation:
+
+- preserve headings and structure
+- prefer incremental edits
+- avoid rewriting entire documents unnecessarily
+- keep information concise and structured
+- maintain consistency across documents
+
+---
+
+# Workflow Loop
+
+When performing development work:
+
+1. Read the following files first:
+
+   CONTEXT.md  
+   ARCHITECTURE.md  
+   STATE.md  
+   TODO.md  
+   SESSION.md  
+
+2. Understand the current system state.
+
+3. If a new task is required, update **TODO.md** first.
+
+4. Record current work focus in **SESSION.md**.
+
+5. Perform implementation or analysis.
+
+6. After completing work:
+   - update TODO.md
+   - update STATE.md if new understanding emerged
+   - update SESSION.md
+
+7. If architecture changes, update **ARCHITECTURE.md**.
+
+---
+
+# Final Step
+
+After creating or updating the documentation system:
+
+1. Summarize the \`${docsRoot}\` structure.
+2. Explain briefly how future LLM sessions should use these documents.`;
+        }
     },
     {
         id: "conversation-handover-request",

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -4,6 +4,10 @@ type PromptDefinition = {
   keywords: string[];
   requiresCommitId: boolean;
   requiresSubject?: boolean;
+  subjectLabel?: string;
+  subjectPlaceholder?: string;
+  subjectHelpText?: string;
+  subjectDefaultValue?: string;
   buildBody: (commitId: string, subject?: string) => string;
 };
 
@@ -75,11 +79,13 @@ async function initializePromptPage() {
   const promptCandidateArea = document.getElementById("promptCandidateArea") as HTMLDivElement | null;
   const commitInputSection = document.getElementById("commitInputSection") as HTMLElement | null;
   const subjectInputSection = document.getElementById("subjectInputSection") as HTMLElement | null;
+  let subjectInputFieldHost = document.getElementById("subjectInputField") as HTMLElement | null;
   const promptOutputSection = document.getElementById("promptOutputSection") as HTMLElement | null;
   const promptOutputTitle = document.getElementById("promptOutputTitle") as HTMLElement | null;
   const promptOutputHelp = document.getElementById("promptOutputHelp") as HTMLDivElement | null;
+  const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink") as HTMLAnchorElement | null;
   const commitIdInput = document.getElementById("commitId") as HTMLInputElement | null;
-  const subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
+  let subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
   const includeLabelPrefix = document.getElementById("includeLabelPrefix") as HTMLInputElement | null;
   const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
@@ -157,6 +163,11 @@ async function initializePromptPage() {
   applyLatinInputHints(commitIdInput, "done");
 
   const MAX_EMBED_INPUT_LENGTH = 1024;
+  const defaultSubjectFieldConfig = {
+    label: "subject",
+    placeholder: "例: a small fox",
+    helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
+  };
 
   function sanitizePromptVariableInput(value: string) {
     const normalizedWhitespace = String(value || "")
@@ -170,6 +181,64 @@ async function initializePromptPage() {
     const truncatedValue = trimmedValue.slice(0, MAX_EMBED_INPUT_LENGTH);
     const normalizedQuotes = truncatedValue.replace(/`/g, "'");
     return `\`${normalizedQuotes}\``;
+  }
+
+  function getSubjectFieldConfig(definition: PromptDefinition | null) {
+    return {
+      label: definition?.subjectLabel || defaultSubjectFieldConfig.label,
+      placeholder: definition?.subjectPlaceholder || defaultSubjectFieldConfig.placeholder,
+      helpText: definition?.subjectHelpText || defaultSubjectFieldConfig.helpText
+    };
+  }
+
+  function handleSubjectInput() {
+    updateOutput();
+  }
+
+  function refreshSubjectInputReference() {
+    subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
+    if (subjectInput) {
+      subjectInput.addEventListener("input", handleSubjectInput);
+    }
+  }
+
+  function renderSubjectInputField(definition: PromptDefinition | null) {
+    const config = getSubjectFieldConfig(definition);
+    const currentValue = subjectInput?.value || "";
+
+    if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
+      const nextField = document.createElement("lht-text-field-help");
+      nextField.id = "subjectInputField";
+      nextField.setAttribute("field-id", "subjectInput");
+      nextField.setAttribute("label", config.label);
+      nextField.setAttribute("placeholder", config.placeholder);
+      nextField.setAttribute("help-text", config.helpText);
+      nextField.setAttribute("required", "");
+      subjectInputFieldHost.replaceWith(nextField);
+      subjectInputFieldHost = nextField;
+    } else if (subjectInput) {
+      subjectInput.setAttribute("aria-label", config.label);
+      subjectInput.setAttribute("placeholder", config.placeholder);
+      subjectInput.setAttribute("title", config.helpText);
+    }
+
+    refreshSubjectInputReference();
+    if (subjectInput) {
+      subjectInput.value = currentValue;
+    }
+  }
+
+  function applyDefaultSubjectValue(selectedDefinition: PromptDefinition | null) {
+    if (!selectedDefinition?.requiresSubject || !subjectInput) {
+      return;
+    }
+    if ((subjectInput.value || "").trim()) {
+      return;
+    }
+    if (!selectedDefinition.subjectDefaultValue) {
+      return;
+    }
+    subjectInput.value = selectedDefinition.subjectDefaultValue;
   }
 
   function syncInputSections(selectedDefinition: PromptDefinition | null) {
@@ -588,6 +657,7 @@ async function initializePromptPage() {
   function renderSelectedPromptHelp() {
     const selectedDefinition = getSelectedPromptDefinition();
     promptOutputHelp.innerHTML = "";
+    gitPseudoSquashLink?.classList.add("md-hidden");
 
     if (!selectedDefinition) {
       promptOutputTitle.textContent = "生成結果";
@@ -595,6 +665,9 @@ async function initializePromptPage() {
     }
 
     promptOutputTitle.textContent = selectedDefinition.label;
+    if (getDefinitionLabelCode(selectedDefinition) === "A501") {
+      gitPseudoSquashLink?.classList.remove("md-hidden");
+    }
 
     const help = document.createElement("lht-help-tooltip");
     help.setAttribute("label", "キーワード");
@@ -652,7 +725,9 @@ async function initializePromptPage() {
         syncInputSections(null);
         promptOutputSection.classList.add("md-hidden");
         commitIdInput.value = "";
-        subjectInput.value = "";
+        if (subjectInput) {
+          subjectInput.value = "";
+        }
         promptOutput.textContent = "";
       }
     }
@@ -706,7 +781,9 @@ async function initializePromptPage() {
       if (selectedButton) {
         selectedButton.classList.add("is-active");
       }
+      renderSubjectInputField(selectedDefinition);
       syncInputSections(selectedDefinition);
+      applyDefaultSubjectValue(selectedDefinition);
       revealOutputSection();
       updateOutput();
     }
@@ -731,6 +808,8 @@ async function initializePromptPage() {
       }
     }
     syncInputSections(selectedDefinition || null);
+    renderSubjectInputField(selectedDefinition || null);
+    applyDefaultSubjectValue(selectedDefinition || null);
     if (selectedDefinition?.requiresCommitId) {
       commitIdInput.focus();
     } else if (selectedDefinition?.requiresSubject) {
@@ -882,7 +961,7 @@ async function initializePromptPage() {
 
   promptSearch.addEventListener("input", renderCandidates);
   commitIdInput.addEventListener("input", updateOutput);
-  subjectInput.addEventListener("input", updateOutput);
+  renderSubjectInputField(null);
   includeLabelPrefix.addEventListener("change", updateOutput);
   copyShareLinkButton.addEventListener("click", () => {
     void copyText(buildShareLink());

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -4,8 +4,31 @@ type PromptDefinition = {
   keywords: string[];
   requiresCommitId: boolean;
   requiresSubject?: boolean;
+  subjectLabel?: string;
+  subjectPlaceholder?: string;
+  subjectHelpText?: string;
+  subjectDefaultValue?: string;
   buildBody: (commitId: string, subject?: string) => string;
 };
+
+function unwrapPromptVariable(value: string): string {
+  const normalized = String(value || "").trim();
+  const match = normalized.match(/^`([\s\S]*)`$/);
+  return match ? match[1] : normalized;
+}
+
+function normalizeRelativeDocPath(value: string): string {
+  const unwrapped = unwrapPromptVariable(value)
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/^\.\/+/, "")
+    .replace(/\/{2,}/g, "/")
+    .trim();
+  if (!unwrapped || unwrapped === "." || unwrapped.includes("..")) {
+    return "";
+  }
+  return unwrapped.replace(/\/+$/, "");
+}
 
 const promptDefinitions: PromptDefinition[] = [
   {
@@ -88,6 +111,268 @@ const promptDefinitions: PromptDefinition[] = [
     keywords: ["readme", "markdown", "directory", "ディレクトリ", "内容", "確認", "把握", "内容確認", "md確認", "りーどみー", "でぃれくとり", "ないよう", "かくにん", "はあく", "まーくだうん", "えむでぃー"],
     requiresCommitId: false,
     buildBody: () => "README.md などこのディレクトリの内容をあらわす markdown の内容を確認してください。"
+  },
+  {
+    id: "llm-docs-workflow-init-request",
+    label: "A150: LLM開発用 docs ワークフロー初期化",
+    keywords: ["A150", "llm workflow", "docs workflow", "docs initialization", "docs bootstrap", "documentation scaffold", "markdown workflow", "persistent memory", "repo docs", "context", "architecture", "plan", "todo", "state", "session", "rules", "docs path", "doc root", "LLM開発", "docs初期化", "文書初期化", "markdown運用", "永続メモリ", "開発文書", "どきゅめんとぱす", "こんてきすと", "あーきてくちゃ", "とぅーどぅー", "せっしょん", "るーるず"],
+    requiresCommitId: false,
+    requiresSubject: true,
+    subjectLabel: "docs ルート相対パス",
+    subjectPlaceholder: "例: docs / llm-docs / project-memory/docs",
+    subjectHelpText: "LLM 用ドキュメントを配置する相対パスを入力します。既定値は docs です。先頭スラッシュや .. を含むパスは避けてください。",
+    subjectDefaultValue: "docs",
+    buildBody: (_commitId, subject) => {
+      const docsPath = normalizeRelativeDocPath(subject || "docs");
+      if (!docsPath) {
+        return "";
+      }
+      const docsRoot = `/${docsPath}`;
+      return `# LLM Workflow Initialization Prompt
+
+You are assisting in initializing a repository that uses a **Markdown-based workflow for LLM-assisted development**.
+
+This workflow treats Markdown documents as the **persistent knowledge and task memory** of the project.  
+All planning, reasoning, and task tracking should be reflected in the documentation.
+
+Your task is to **create or update a \`${docsRoot}\` directory** with a structured documentation system and follow the rules below.
+
+---
+
+# Objectives
+
+1. Ensure the repository contains the following documentation files:
+
+\`${docsRoot}\`
+- \`CONTEXT.md\`
+- \`ARCHITECTURE.md\`
+- \`PLAN.md\`
+- \`TODO.md\`
+- \`STATE.md\`
+- \`SESSION.md\`
+- \`RULES.md\`
+
+2. If a file **does not exist**, create it with an appropriate template.
+
+3. If a file **already exists**:
+- preserve useful content
+- update structure if necessary
+- avoid deleting meaningful information
+
+4. Keep documents **structured, concise, and easy for both humans and LLMs to read**.
+
+---
+
+# Concept of This Workflow
+
+The \`${docsRoot}\` directory acts as the **persistent memory layer** for development.
+
+Human instructions -> update markdown -> perform work.
+
+Markdown documents store:
+
+- project context
+- architecture
+- plans
+- task queues
+- current understanding
+- session focus
+- development rules
+
+This allows future LLM sessions to quickly understand the repository.
+
+---
+
+# File Roles
+
+## CONTEXT.md
+Stable project background information.
+
+Include:
+- project purpose
+- high-level goals
+- technology stack
+- constraints
+- development philosophy
+
+---
+
+## ARCHITECTURE.md
+High-level structure of the system.
+
+Include:
+- major components
+- module responsibilities
+- dependencies
+- system relationships
+
+Example structure:
+
+\`\`\`
+# Architecture
+
+## System Overview
+
+## Core Modules
+module -> responsibility
+
+## External Dependencies
+\`\`\`
+
+---
+
+## PLAN.md
+Long-term direction and milestones.
+
+Example:
+
+\`\`\`
+# Project Plan
+
+## Goals
+
+## Milestones
+
+## Future Work
+\`\`\`
+
+This file should change infrequently.
+
+---
+
+## TODO.md
+Active task queue.
+
+Example:
+
+\`\`\`
+# Task List
+
+## Current Tasks
+
+- [ ] example task
+
+## Backlog
+
+- [ ] future work
+\`\`\`
+
+Tasks should be checked off as they are completed.
+
+---
+
+## STATE.md
+Current understanding of the system.
+
+Use this file to record:
+
+- discoveries
+- known problems
+- recent architectural decisions
+- investigation results
+
+Example:
+
+\`\`\`
+# Current State
+
+## Overview
+
+## Known Issues
+
+## Recent Changes
+\`\`\`
+
+---
+
+## SESSION.md
+Short-term working memory for the current development session.
+
+Example:
+
+\`\`\`
+# Current Session
+
+## Focus
+
+## Next Step
+
+## Notes
+\`\`\`
+
+This file may change frequently during development.
+
+---
+
+## RULES.md
+Development and editing principles.
+
+Example structure:
+
+\`\`\`
+# Development Rules
+
+## General Principles
+- prefer minimal changes
+- follow existing coding style
+- keep documentation updated
+
+## Documentation Guidelines
+- preserve document structure
+- prefer small edits instead of rewrites
+- update affected sections only
+\`\`\`
+
+---
+
+# Editing Guidelines
+
+When modifying documentation:
+
+- preserve headings and structure
+- prefer incremental edits
+- avoid rewriting entire documents unnecessarily
+- keep information concise and structured
+- maintain consistency across documents
+
+---
+
+# Workflow Loop
+
+When performing development work:
+
+1. Read the following files first:
+
+   CONTEXT.md  
+   ARCHITECTURE.md  
+   STATE.md  
+   TODO.md  
+   SESSION.md  
+
+2. Understand the current system state.
+
+3. If a new task is required, update **TODO.md** first.
+
+4. Record current work focus in **SESSION.md**.
+
+5. Perform implementation or analysis.
+
+6. After completing work:
+   - update TODO.md
+   - update STATE.md if new understanding emerged
+   - update SESSION.md
+
+7. If architecture changes, update **ARCHITECTURE.md**.
+
+---
+
+# Final Step
+
+After creating or updating the documentation system:
+
+1. Summarize the \`${docsRoot}\` structure.
+2. Explain briefly how future LLM sessions should use these documents.`;
+    }
   },
   {
     id: "conversation-handover-request",

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -78,6 +78,7 @@ function mountPromptDom() {
     <input id="subjectInput" />
     <input id="includeLabelPrefix" type="checkbox" />
     <button id="copyShareLinkButton" type="button"></button>
+    <a id="gitPseudoSquashLink" class="md-hidden" href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"></a>
     <div id="promptOutput"></div>
   `;
 }
@@ -224,6 +225,30 @@ describe("prompt-gen main", () => {
     expect(promptOutput.textContent).toContain("A simplified cute illustration of `a small fox`");
   });
 
+  it("uses docs as the default docs path for A150", async () => {
+    await bootPromptPage("?q=A150");
+
+    const subjectInput = document.getElementById("subjectInput");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(subjectInput.value).toBe("docs");
+    expect(promptOutput.textContent).toContain("create or update a `/docs` directory");
+    expect(promptOutput.textContent).toContain("The `/docs` directory acts as the **persistent memory layer**");
+  });
+
+  it("updates A150 output when the docs path input changes", async () => {
+    await bootPromptPage("?q=A150");
+
+    const subjectInput = document.getElementById("subjectInput");
+    const promptOutput = document.getElementById("promptOutput");
+
+    subjectInput.value = "project-memory/docs";
+    subjectInput.dispatchEvent(new Event("input"));
+
+    expect(promptOutput.textContent).toContain("create or update a `/project-memory/docs` directory");
+    expect(promptOutput.textContent).toContain("Summarize the `/project-memory/docs` structure.");
+  });
+
   it("applies id query parameter to restore a selected prompt among multiple matches", async () => {
     await bootPromptPage("?q=%E5%92%8C&id=A852&subject=%E3%81%B6%E3%81%A9%E3%81%86");
 
@@ -313,6 +338,24 @@ describe("prompt-gen main", () => {
 
     expect(promptOutput.textContent).toContain("対象コミット `abc1234` における変更内容について");
     expect(promptOutput.textContent).toContain("PRタイトルとPR本文");
+  });
+
+  it("shows Git pseudo-squash link only for A501", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
+
+    promptSearch.value = "A501";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(gitPseudoSquashLink.classList.contains("md-hidden")).toBe(false);
+    expect(gitPseudoSquashLink.getAttribute("href")).toBe("https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html");
+
+    promptSearch.value = "A701";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(gitPseudoSquashLink.classList.contains("md-hidden")).toBe(true);
   });
 
   it("adds label prefix for fixed prompt when switch is enabled", async () => {


### PR DESCRIPTION
## 概要
`docs/prompt/prompt-gen` に、LLM 開発向けの docs ワークフロー初期化プロンプト `A150` を追加しました。あわせて、`A150` で docs ルート相対パスを可変入力できるようにし、`A501` 向けの Git pseudo-squash 導線と、生成結果の二重コピーボタン表示を整備しました。

## 変更点
- `A150: LLM開発用 docs ワークフロー初期化` を追加
- `A150` で docs ルート相対パスを入力できるようにし、既定値を `docs` に設定
- `subject` 入力欄を定義ごとにラベル・プレースホルダ・説明文・既定値を差し替えられるよう拡張
- docs ルート相対パスの正規化処理を追加し、先頭 `/` や `..` を含む不正なパスを抑止
- `A501` 選択時のみ `Git pseudo-squash で整理` リンクを表示するよう修正
- 生成結果の `lht-command-block` を `copy-buttons="dual"` に変更
- 右下コピー ボタン用の CSS を追加し、上下2か所のコピー導線を正しく表示
- `prompt-gen-search-and-keywords.md` に A501 の特記事項を追記
- `docs/index.html` の更新日を `2026-03-12` に更新
- `A150` の既定 docs パス、可変パス反映、A501 専用リンク表示のテストを追加

## 影響
- `prompt-gen` の出力UIと可変入力仕様が拡張されます
- `A150` により、`docs/` が製品本体であるリポジトリでも、別のドキュメントルートを指定して安全に初期化プロンプトを生成できます
- `A501` 利用時の関連導線が明確になり、生成結果のコピー操作性も向上します