### PR TITLE
Git 作業一覧の基準・作業表示を調整し、HEAD 状態を補助ラベル化

### DIFF
--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1188,6 +1188,10 @@ lht-index-card-link {
   max-width: 100%;
 }
 
+.md-entry-base-box .md-ref-value {
+  margin-left: 0;
+}
+
 .md-entry-title {
   margin: 0;
   display: inline-flex;
@@ -1332,12 +1336,36 @@ lht-index-card-link {
   color: #6d28d9;
 }
 
+.md-head-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  background: #e7f8f5;
+  color: #0f766e;
+  line-height: 1;
+}
+
 .md-ref-value {
-  font-size: 0.89rem;
+  font-size: 0.96rem;
   font-weight: 500;
   color: #475569;
   white-space: nowrap;
   margin-left: 1.25rem;
+}
+
+.md-ref-value-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.md-ref-value-row .md-ref-value {
+  margin-left: 0;
 }
 
 .md-work-row-list {
@@ -4156,13 +4184,16 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function renderWorkRow(entry) {
-      const workRef = entry.compareUseHead ? "HEAD" : buildRef(entry.compareBranch, entry.compareScope, entry.remoteName);
+      const workRef = buildRef(entry.compareBranch, entry.compareScope, entry.remoteName);
       return `
         <section class="md-work-row" data-entry-id="${escapeHtml(entry.id)}">
           <div class="md-work-row__main">
             <div class="md-ref-box md-ref-box--work">
               <div class="md-ref-label">${entry.locked ? `<span class="md-entry-lock-icon" aria-label="ロック中">${getButtonIconSvg("lock")}</span>` : ""}作業 <span class="md-scope-badge" data-scope="${escapeHtml(entry.compareScope)}">${escapeHtml(entry.compareScope)}</span></div>
-              <div class="md-ref-value">${escapeHtml(workRef)}</div>
+              <div class="md-ref-value-row">
+                <div class="md-ref-value">${escapeHtml(workRef)}</div>
+                ${entry.compareUseHead ? '<span class="md-head-badge">HEAD</span>' : ""}
+              </div>
             </div>
           </div>
           <div class="md-entry-actions md-work-row__actions">

--- a/docs/git/src/git-work-list/css/app.css
+++ b/docs/git/src/git-work-list/css/app.css
@@ -149,6 +149,10 @@
   max-width: 100%;
 }
 
+.md-entry-base-box .md-ref-value {
+  margin-left: 0;
+}
+
 .md-entry-title {
   margin: 0;
   display: inline-flex;
@@ -293,12 +297,36 @@
   color: #6d28d9;
 }
 
+.md-head-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  background: #e7f8f5;
+  color: #0f766e;
+  line-height: 1;
+}
+
 .md-ref-value {
-  font-size: 0.89rem;
+  font-size: 0.96rem;
   font-weight: 500;
   color: #475569;
   white-space: nowrap;
   margin-left: 1.25rem;
+}
+
+.md-ref-value-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.md-ref-value-row .md-ref-value {
+  margin-left: 0;
 }
 
 .md-work-row-list {

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -438,13 +438,16 @@
     }
 
     function renderWorkRow(entry) {
-      const workRef = entry.compareUseHead ? "HEAD" : buildRef(entry.compareBranch, entry.compareScope, entry.remoteName);
+      const workRef = buildRef(entry.compareBranch, entry.compareScope, entry.remoteName);
       return `
         <section class="md-work-row" data-entry-id="${escapeHtml(entry.id)}">
           <div class="md-work-row__main">
             <div class="md-ref-box md-ref-box--work">
               <div class="md-ref-label">${entry.locked ? `<span class="md-entry-lock-icon" aria-label="ロック中">${getButtonIconSvg("lock")}</span>` : ""}作業 <span class="md-scope-badge" data-scope="${escapeHtml(entry.compareScope)}">${escapeHtml(entry.compareScope)}</span></div>
-              <div class="md-ref-value">${escapeHtml(workRef)}</div>
+              <div class="md-ref-value-row">
+                <div class="md-ref-value">${escapeHtml(workRef)}</div>
+                ${entry.compareUseHead ? '<span class="md-head-badge">HEAD</span>' : ""}
+              </div>
             </div>
           </div>
           <div class="md-entry-actions md-work-row__actions">


### PR DESCRIPTION
## 概要

`Git 作業一覧` の表示を見直し、基準情報の配置と作業行の視認性を改善しました。
あわせて、`HEAD` 比較状態を作業ブランチ名そのものとして表示するのをやめ、実ブランチ名の右に補助ラベルとして表示するようにしています。

## 変更内容

### 基準表示の配置調整

- 親カード内の `基準` 情報を右側へ配置
- 見た目は従来の基準ボックスを維持しつつ、位置だけ右へ移動
- 基準セクションと作業リストの間に水平線を追加し、親情報と子行の区切りを明確化

### 作業行の表示調整

- `作業 / local` とブランチ名の間隔を詰め、より自然なフローに調整
- `基準 / remote` 側も同様に、ブランチ名との間隔を詰めた
- 基準ブランチ名と作業ブランチ名のフォントサイズを少し大きくした

### `HEAD` 表示の改善

- `compareUseHead=true` のときも、作業ブランチ欄には実ブランチ名を表示するように変更
- `HEAD` はブランチ名の右側に小さな補助ラベルとして表示
- `HEAD` ラベルのスタイルを調整
  - `local` バッジより控えめなサイズ
  - ティール系の配色
    - 背景: `#e7f8f5`
    - 文字: `#0f766e`

## 目的

- 基準情報と作業情報の視線移動を減らし、一覧として読みやすくする
- `HEAD` 状態を「作業ブランチ名」ではなく「比較モードの補助状態」として表現する
- ブランチ名を主役にしつつ、状態ラベルは控えめに見せる

## 補足

- 生成済みの `docs/git/git-work-list.html` も更新済み
- 今回の変更は `Git 作業一覧` の表示調整が中心で、保存キーや一覧の一意性は変更していない

## テスト

- 実施: `vitest run docs/git/tests/git-work-list-main.test.js`
- 実施: `npm run build:git`
- 結果: 成功