### PR TITLE
Git 作業一覧にリポジトリ情報メモを追加し、squash への初期文言連携を実装

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -5630,6 +5630,7 @@ if (!customElements.get("lht-page-menu")) {
       const repoUrl = String(params.get("repoUrl") || "").trim();
       const baseBranch = String(params.get("baseBranch") || "").trim();
       const workBranch = String(params.get("workBranch") || "").trim();
+      const defaultCommitMessage = String(params.get("defaultCommitMessage") || "").trim();
       const baseScope = String(params.get("baseScope") || "").trim();
       const remoteName = String(params.get("remoteName") || "").trim();
       const useHeadWork = String(params.get("useHeadWork") || "").trim();
@@ -5637,6 +5638,7 @@ if (!customElements.get("lht-page-menu")) {
       const repoUrlField = document.getElementById("repoUrl");
       const baseBranchField = document.getElementById("squashBaseBranch");
       const workBranchField = document.getElementById("workBranch");
+      const commitMessageField = document.getElementById("commitMessage");
       const baseScopeField = document.getElementById("squashBaseScope");
       const baseRemoteField = document.getElementById("baseRemote");
       const squashRemoteField = document.getElementById("squashRemote");
@@ -5652,6 +5654,9 @@ if (!customElements.get("lht-page-menu")) {
       }
       if (workBranch && workBranchField) {
         workBranchField.value = workBranch;
+      }
+      if (defaultCommitMessage && commitMessageField && !String(commitMessageField.value || "").trim()) {
+        commitMessageField.value = defaultCommitMessage;
       }
       if (useHeadWork === "1" || useHeadWork === "true" || useCurrentBranch === "1" || useCurrentBranch === "true") {
         setUseCurrentBranchSelected(true);

--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -104,6 +104,31 @@ limitations under the License.
       </form>
     </dialog>
 
+    <dialog id="memoDialog" class="md-dialog">
+      <form method="dialog" class="md-dialog__surface md-dialog__surface--compact" id="memoForm">
+        <div class="md-dialog__header">
+          <div>
+            <h2 class="md-dialog__title">リポジトリ情報</h2>
+            <p class="md-dialog__subtitle">このリポジトリと基準ブランチの組み合わせ向け情報を入力します。</p>
+          </div>
+          <button id="closeMemoDialogBtn" type="button" class="md-button md-button--surface md-button--compact">閉じる</button>
+        </div>
+
+        <div class="md-dialog__body md-stack-md">
+          <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
+          </div>
+          <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="gitCurrentDirectory" label="git カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+          </div>
+        </div>
+
+        <div class="md-dialog__footer">
+          <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
+        </div>
+      </form>
+    </dialog>
+
     <lht-toast id="toast"></lht-toast>
   </div>
 

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1182,6 +1182,14 @@ lht-index-card-link {
   gap: 0.35rem;
 }
 
+.md-entry-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
 .md-entry-base-box {
   flex: 0 0 auto;
   min-width: 250px;
@@ -1244,6 +1252,89 @@ lht-index-card-link {
   color: #64748b;
   cursor: pointer;
   flex: 0 0 auto;
+}
+
+.md-entry-memo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6deea;
+  background: #f8fafc;
+  color: #64748b;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.md-entry-memo-btn:hover {
+  background: #eef2f7;
+}
+
+.md-entry-memo-btn .md-button__icon {
+  width: 0.92rem;
+  height: 0.92rem;
+}
+
+.md-entry-copy-dir-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6deea;
+  background: #f8fafc;
+  color: #64748b;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.md-entry-copy-dir-btn:hover {
+  background: #eef2f7;
+}
+
+.md-entry-copy-dir-btn .md-button__icon {
+  width: 0.92rem;
+  height: 0.92rem;
+}
+
+.md-entry-memo-preview {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 18ch;
+  padding: 0.22rem 0.55rem;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 1px solid #d6deea;
+  color: #64748b;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.md-entry-memo-preview::after {
+  content: attr(data-full-text);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.45rem);
+  display: none;
+  max-width: min(40ch, 70vw);
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  background: #111827;
+  color: #f9fafb;
+  font-size: 0.76rem;
+  line-height: 1.4;
+  white-space: normal;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+  z-index: 10;
+}
+
+.md-entry-memo-preview:hover::after {
+  display: block;
 }
 
 .md-entry-link-btn:hover {
@@ -1420,6 +1511,10 @@ lht-index-card-link {
   box-sizing: border-box;
   display: grid;
   gap: 1rem;
+}
+
+.md-dialog__surface--compact {
+  width: min(640px, calc(100vw - 3rem));
 }
 
 .md-dialog__header,
@@ -1618,6 +1713,31 @@ lht-index-card-link {
             </svg>
             <span>追加</span>
           </button>
+        </div>
+      </form>
+    </dialog>
+
+    <dialog id="memoDialog" class="md-dialog">
+      <form method="dialog" class="md-dialog__surface md-dialog__surface--compact" id="memoForm">
+        <div class="md-dialog__header">
+          <div>
+            <h2 class="md-dialog__title">リポジトリ情報</h2>
+            <p class="md-dialog__subtitle">このリポジトリと基準ブランチの組み合わせ向け情報を入力します。</p>
+          </div>
+          <button id="closeMemoDialogBtn" type="button" class="md-button md-button--surface md-button--compact">閉じる</button>
+        </div>
+
+        <div class="md-dialog__body md-stack-md">
+          <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
+          </div>
+          <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="gitCurrentDirectory" label="git カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+          </div>
+        </div>
+
+        <div class="md-dialog__footer">
+          <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
         </div>
       </form>
     </dialog>
@@ -3746,10 +3866,13 @@ if (!customElements.get("lht-page-menu")) {
   <script>
     const STORAGE_KEY = "gitWorkList.entries";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
+    const MEMO_STORAGE_KEY = "gitWorkList.memos";
     let entries = [];
     let recentActions = [];
+    let memos = {};
     let editingId = "";
     let dialogMode = "create";
+    let editingMemoKey = "";
 
     function readText(id) {
       const field = document.getElementById(id);
@@ -3846,6 +3969,9 @@ if (!customElements.get("lht-page-menu")) {
       if (kind === "open-external") {
         return '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 5h5v5"></path><path d="M10 14 19 5"></path><path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path></svg>';
       }
+      if (kind === "copy-directory") {
+        return '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><rect x="13" y="3" width="8" height="8" rx="2"></rect><path d="M15.5 7h3"></path><path d="M17 5.5v3"></path></svg>';
+      }
       return "";
     }
 
@@ -3910,6 +4036,55 @@ if (!customElements.get("lht-page-menu")) {
       localStorage.setItem(RECENT_ACTIONS_KEY, JSON.stringify(recentActions));
     }
 
+    function buildMemoKey(repoUrl, baseBranch) {
+      return `${normalizeRepoUrl(repoUrl)}::${String(baseBranch || "").trim()}`;
+    }
+
+    function normalizeMemos(rawMemos) {
+      if (!rawMemos || typeof rawMemos !== "object" || Array.isArray(rawMemos)) {
+        return {};
+      }
+      const nextMemos = {};
+      Object.entries(rawMemos).forEach(([key, value]) => {
+        const normalizedKey = String(key || "").trim();
+        if (!normalizedKey) return;
+        if (typeof value === "string") {
+          const normalizedMemo = value.trim();
+          if (normalizedMemo) {
+            nextMemos[normalizedKey] = {
+              memo: normalizedMemo,
+              gitCurrentDir: ""
+            };
+          }
+          return;
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) return;
+        const normalizedMemo = String(value.memo || "").trim();
+        const normalizedGitCurrentDir = String(value.gitCurrentDir || "").trim();
+        if (normalizedMemo || normalizedGitCurrentDir) {
+          nextMemos[normalizedKey] = {
+            memo: normalizedMemo,
+            gitCurrentDir: normalizedGitCurrentDir
+          };
+        }
+      });
+      return nextMemos;
+    }
+
+    function loadMemos() {
+      try {
+        const raw = localStorage.getItem(MEMO_STORAGE_KEY);
+        if (!raw) return {};
+        return normalizeMemos(JSON.parse(raw));
+      } catch (_) {
+        return {};
+      }
+    }
+
+    function saveMemos() {
+      localStorage.setItem(MEMO_STORAGE_KEY, JSON.stringify(memos));
+    }
+
     function normalizeScope(value) {
       return value === "local" ? "local" : "remote";
     }
@@ -3957,6 +4132,7 @@ if (!customElements.get("lht-page-menu")) {
       const groupedMap = new Map();
       visibleEntries.forEach((entry) => {
         const key = buildGroupKey(entry);
+        const memoKey = buildMemoKey(entry.repoUrl, entry.baseBranch);
         const existing = groupedMap.get(key);
         if (existing) {
           existing.entries.push(entry);
@@ -3969,6 +4145,9 @@ if (!customElements.get("lht-page-menu")) {
           baseBranch: entry.baseBranch,
           baseScope: entry.baseScope,
           remoteName: entry.remoteName,
+          memoKey,
+          memo: String(memos[memoKey]?.memo || "").trim(),
+          gitCurrentDir: String(memos[memoKey]?.gitCurrentDir || "").trim(),
           entries: [entry]
         });
       });
@@ -3999,11 +4178,16 @@ if (!customElements.get("lht-page-menu")) {
 
     function buildPseudoSquashUrl(entry) {
       const params = new URLSearchParams();
+      const memoKey = buildMemoKey(entry.repoUrl, entry.baseBranch);
+      const memoText = String(memos[memoKey]?.memo || "").trim();
       params.set("repoUrl", entry.repoUrl);
       params.set("baseBranch", entry.baseBranch);
       params.set("baseScope", entry.baseScope);
       params.set("workBranch", entry.compareBranch);
       params.set("remoteName", entry.remoteName);
+      if (memoText) {
+        params.set("defaultCommitMessage", memoText);
+      }
       if (entry.compareUseHead) {
         params.set("useHeadWork", "1");
       }
@@ -4158,11 +4342,17 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function renderGroup(group) {
+      const memoPreview = group.memo.length > 16 ? `${group.memo.slice(0, 16)}...` : group.memo;
       return `
         <article class="md-entry-card md-entry-group" data-group-key="${escapeHtml(group.key)}">
           <div class="md-entry-head">
             <div class="md-entry-title-wrap">
-              <h3 class="md-entry-title">${escapeHtml(group.displayName)}</h3>
+              <div class="md-entry-title-row">
+                <h3 class="md-entry-title">${escapeHtml(group.displayName)}</h3>
+                <button type="button" class="md-entry-memo-btn" data-action="edit-memo" data-memo-key="${escapeHtml(group.memoKey)}" data-repo-url="${escapeHtml(group.repoUrl)}" data-base-branch="${escapeHtml(group.baseBranch)}" aria-label="メモを編集" title="メモを編集">${getButtonIconSvg("edit")}</button>
+                ${group.memo ? `<span class="md-entry-memo-preview" data-full-text="${escapeHtml(group.memo)}">${escapeHtml(memoPreview)}</span>` : ""}
+                ${group.gitCurrentDir ? `<button type="button" class="md-entry-copy-dir-btn" data-action="copy-git-current-dir" data-git-current-dir="${escapeHtml(group.gitCurrentDir)}" aria-label="git カレントディレクトリをコピー" title="${escapeHtml(group.gitCurrentDir)}">${getButtonIconSvg("copy-directory")}</button>` : ""}
+              </div>
               <div class="md-entry-url-row">
                 <div class="md-entry-url">${escapeHtml(group.repoUrl)}</div>
                 ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
@@ -4181,6 +4371,76 @@ if (!customElements.get("lht-page-menu")) {
           </div>
         </article>
       `;
+    }
+
+    function getMemoDialog() {
+      return document.getElementById("memoDialog");
+    }
+
+    function openMemoDialog(repoUrl, baseBranch) {
+      editingMemoKey = buildMemoKey(repoUrl, baseBranch);
+      const memoField = document.getElementById("memoText");
+      if (memoField) {
+        memoField.value = String(memos[editingMemoKey]?.memo || "");
+      }
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      if (gitCurrentDirectoryField) {
+        gitCurrentDirectoryField.value = String(memos[editingMemoKey]?.gitCurrentDir || "");
+      }
+      const dialog = getMemoDialog();
+      if (!dialog) return;
+      if (typeof dialog.showModal === "function") {
+        dialog.showModal();
+      }
+    }
+
+    function closeMemoDialog() {
+      const dialog = getMemoDialog();
+      if (!dialog) return;
+      if (dialog.open && typeof dialog.close === "function") {
+        dialog.close();
+      }
+      editingMemoKey = "";
+    }
+
+    function saveMemo() {
+      if (!editingMemoKey) return;
+      const memoField = document.getElementById("memoText");
+      const memoText = memoField ? String(memoField.value || "").trim() : "";
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
+      if (memoText || gitCurrentDir) {
+        memos[editingMemoKey] = {
+          memo: memoText,
+          gitCurrentDir
+        };
+      } else {
+        delete memos[editingMemoKey];
+      }
+      saveMemos();
+      renderEntries();
+      closeMemoDialog();
+      showToast("メモを保存しました");
+    }
+
+    async function copyTextToClipboard(text) {
+      const normalizedText = String(text || "");
+      if (!normalizedText) return false;
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        try {
+          await navigator.clipboard.writeText(normalizedText);
+          return true;
+        } catch (_) {
+          // fallback below
+        }
+      }
+      const temp = document.createElement("textarea");
+      temp.value = normalizedText;
+      document.body.appendChild(temp);
+      temp.select();
+      const copied = document.execCommand("copy");
+      document.body.removeChild(temp);
+      return !!copied;
     }
 
     function renderWorkRow(entry) {
@@ -4277,6 +4537,18 @@ if (!customElements.get("lht-page-menu")) {
       const button = event.target.closest("[data-action]");
       if (!button) return;
       const action = button.getAttribute("data-action");
+      if (action === "edit-memo") {
+        openMemoDialog(button.getAttribute("data-repo-url"), button.getAttribute("data-base-branch"));
+        return;
+      }
+      if (action === "copy-git-current-dir") {
+        const gitCurrentDir = button.getAttribute("data-git-current-dir");
+        const copied = await copyTextToClipboard(gitCurrentDir);
+        if (copied) {
+          showToast("git カレントディレクトリをコピーしました");
+        }
+        return;
+      }
       if (action === "open-repo-url") {
         const repoUrl = button.getAttribute("data-repo-url");
         if (!isOpenableExternalUrl(repoUrl)) return;
@@ -4344,11 +4616,29 @@ if (!customElements.get("lht-page-menu")) {
         });
         dialog.dataset.boundOutsideClose = "true";
       }
+      const closeMemoButton = document.getElementById("closeMemoDialogBtn");
+      if (closeMemoButton) {
+        closeMemoButton.addEventListener("click", closeMemoDialog);
+      }
+      const saveMemoButton = document.getElementById("saveMemoBtn");
+      if (saveMemoButton) {
+        saveMemoButton.addEventListener("click", saveMemo);
+      }
+      const memoDialog = getMemoDialog();
+      if (memoDialog && !memoDialog.dataset.boundOutsideClose) {
+        memoDialog.addEventListener("click", (event) => {
+          if (event.target === memoDialog) {
+            closeMemoDialog();
+          }
+        });
+        memoDialog.dataset.boundOutsideClose = "true";
+      }
     }
 
     function bootstrap() {
       entries = loadEntries();
       recentActions = loadRecentActions();
+      memos = loadMemos();
       resetForm();
       setupEvents();
       renderEntries();

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -744,6 +744,7 @@
       const repoUrl = String(params.get("repoUrl") || "").trim();
       const baseBranch = String(params.get("baseBranch") || "").trim();
       const workBranch = String(params.get("workBranch") || "").trim();
+      const defaultCommitMessage = String(params.get("defaultCommitMessage") || "").trim();
       const baseScope = String(params.get("baseScope") || "").trim();
       const remoteName = String(params.get("remoteName") || "").trim();
       const useHeadWork = String(params.get("useHeadWork") || "").trim();
@@ -751,6 +752,7 @@
       const repoUrlField = document.getElementById("repoUrl");
       const baseBranchField = document.getElementById("squashBaseBranch");
       const workBranchField = document.getElementById("workBranch");
+      const commitMessageField = document.getElementById("commitMessage");
       const baseScopeField = document.getElementById("squashBaseScope");
       const baseRemoteField = document.getElementById("baseRemote");
       const squashRemoteField = document.getElementById("squashRemote");
@@ -766,6 +768,9 @@
       }
       if (workBranch && workBranchField) {
         workBranchField.value = workBranch;
+      }
+      if (defaultCommitMessage && commitMessageField && !String(commitMessageField.value || "").trim()) {
+        commitMessageField.value = defaultCommitMessage;
       }
       if (useHeadWork === "1" || useHeadWork === "true" || useCurrentBranch === "1" || useCurrentBranch === "true") {
         setUseCurrentBranchSelected(true);

--- a/docs/git/src/git-work-list/css/app.css
+++ b/docs/git/src/git-work-list/css/app.css
@@ -143,6 +143,14 @@
   gap: 0.35rem;
 }
 
+.md-entry-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
 .md-entry-base-box {
   flex: 0 0 auto;
   min-width: 250px;
@@ -205,6 +213,89 @@
   color: #64748b;
   cursor: pointer;
   flex: 0 0 auto;
+}
+
+.md-entry-memo-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6deea;
+  background: #f8fafc;
+  color: #64748b;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.md-entry-memo-btn:hover {
+  background: #eef2f7;
+}
+
+.md-entry-memo-btn .md-button__icon {
+  width: 0.92rem;
+  height: 0.92rem;
+}
+
+.md-entry-copy-dir-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid #d6deea;
+  background: #f8fafc;
+  color: #64748b;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.md-entry-copy-dir-btn:hover {
+  background: #eef2f7;
+}
+
+.md-entry-copy-dir-btn .md-button__icon {
+  width: 0.92rem;
+  height: 0.92rem;
+}
+
+.md-entry-memo-preview {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 18ch;
+  padding: 0.22rem 0.55rem;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 1px solid #d6deea;
+  color: #64748b;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.md-entry-memo-preview::after {
+  content: attr(data-full-text);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 0.45rem);
+  display: none;
+  max-width: min(40ch, 70vw);
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  background: #111827;
+  color: #f9fafb;
+  font-size: 0.76rem;
+  line-height: 1.4;
+  white-space: normal;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+  z-index: 10;
+}
+
+.md-entry-memo-preview:hover::after {
+  display: block;
 }
 
 .md-entry-link-btn:hover {
@@ -381,6 +472,10 @@
   box-sizing: border-box;
   display: grid;
   gap: 1rem;
+}
+
+.md-dialog__surface--compact {
+  width: min(640px, calc(100vw - 3rem));
 }
 
 .md-dialog__header,

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -1,9 +1,12 @@
     const STORAGE_KEY = "gitWorkList.entries";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
+    const MEMO_STORAGE_KEY = "gitWorkList.memos";
     let entries = [];
     let recentActions = [];
+    let memos = {};
     let editingId = "";
     let dialogMode = "create";
+    let editingMemoKey = "";
 
     function readText(id) {
       const field = document.getElementById(id);
@@ -100,6 +103,9 @@
       if (kind === "open-external") {
         return '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 5h5v5"></path><path d="M10 14 19 5"></path><path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path></svg>';
       }
+      if (kind === "copy-directory") {
+        return '<svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><rect x="13" y="3" width="8" height="8" rx="2"></rect><path d="M15.5 7h3"></path><path d="M17 5.5v3"></path></svg>';
+      }
       return "";
     }
 
@@ -164,6 +170,55 @@
       localStorage.setItem(RECENT_ACTIONS_KEY, JSON.stringify(recentActions));
     }
 
+    function buildMemoKey(repoUrl, baseBranch) {
+      return `${normalizeRepoUrl(repoUrl)}::${String(baseBranch || "").trim()}`;
+    }
+
+    function normalizeMemos(rawMemos) {
+      if (!rawMemos || typeof rawMemos !== "object" || Array.isArray(rawMemos)) {
+        return {};
+      }
+      const nextMemos = {};
+      Object.entries(rawMemos).forEach(([key, value]) => {
+        const normalizedKey = String(key || "").trim();
+        if (!normalizedKey) return;
+        if (typeof value === "string") {
+          const normalizedMemo = value.trim();
+          if (normalizedMemo) {
+            nextMemos[normalizedKey] = {
+              memo: normalizedMemo,
+              gitCurrentDir: ""
+            };
+          }
+          return;
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) return;
+        const normalizedMemo = String(value.memo || "").trim();
+        const normalizedGitCurrentDir = String(value.gitCurrentDir || "").trim();
+        if (normalizedMemo || normalizedGitCurrentDir) {
+          nextMemos[normalizedKey] = {
+            memo: normalizedMemo,
+            gitCurrentDir: normalizedGitCurrentDir
+          };
+        }
+      });
+      return nextMemos;
+    }
+
+    function loadMemos() {
+      try {
+        const raw = localStorage.getItem(MEMO_STORAGE_KEY);
+        if (!raw) return {};
+        return normalizeMemos(JSON.parse(raw));
+      } catch (_) {
+        return {};
+      }
+    }
+
+    function saveMemos() {
+      localStorage.setItem(MEMO_STORAGE_KEY, JSON.stringify(memos));
+    }
+
     function normalizeScope(value) {
       return value === "local" ? "local" : "remote";
     }
@@ -211,6 +266,7 @@
       const groupedMap = new Map();
       visibleEntries.forEach((entry) => {
         const key = buildGroupKey(entry);
+        const memoKey = buildMemoKey(entry.repoUrl, entry.baseBranch);
         const existing = groupedMap.get(key);
         if (existing) {
           existing.entries.push(entry);
@@ -223,6 +279,9 @@
           baseBranch: entry.baseBranch,
           baseScope: entry.baseScope,
           remoteName: entry.remoteName,
+          memoKey,
+          memo: String(memos[memoKey]?.memo || "").trim(),
+          gitCurrentDir: String(memos[memoKey]?.gitCurrentDir || "").trim(),
           entries: [entry]
         });
       });
@@ -253,11 +312,16 @@
 
     function buildPseudoSquashUrl(entry) {
       const params = new URLSearchParams();
+      const memoKey = buildMemoKey(entry.repoUrl, entry.baseBranch);
+      const memoText = String(memos[memoKey]?.memo || "").trim();
       params.set("repoUrl", entry.repoUrl);
       params.set("baseBranch", entry.baseBranch);
       params.set("baseScope", entry.baseScope);
       params.set("workBranch", entry.compareBranch);
       params.set("remoteName", entry.remoteName);
+      if (memoText) {
+        params.set("defaultCommitMessage", memoText);
+      }
       if (entry.compareUseHead) {
         params.set("useHeadWork", "1");
       }
@@ -412,11 +476,17 @@
     }
 
     function renderGroup(group) {
+      const memoPreview = group.memo.length > 16 ? `${group.memo.slice(0, 16)}...` : group.memo;
       return `
         <article class="md-entry-card md-entry-group" data-group-key="${escapeHtml(group.key)}">
           <div class="md-entry-head">
             <div class="md-entry-title-wrap">
-              <h3 class="md-entry-title">${escapeHtml(group.displayName)}</h3>
+              <div class="md-entry-title-row">
+                <h3 class="md-entry-title">${escapeHtml(group.displayName)}</h3>
+                <button type="button" class="md-entry-memo-btn" data-action="edit-memo" data-memo-key="${escapeHtml(group.memoKey)}" data-repo-url="${escapeHtml(group.repoUrl)}" data-base-branch="${escapeHtml(group.baseBranch)}" aria-label="メモを編集" title="メモを編集">${getButtonIconSvg("edit")}</button>
+                ${group.memo ? `<span class="md-entry-memo-preview" data-full-text="${escapeHtml(group.memo)}">${escapeHtml(memoPreview)}</span>` : ""}
+                ${group.gitCurrentDir ? `<button type="button" class="md-entry-copy-dir-btn" data-action="copy-git-current-dir" data-git-current-dir="${escapeHtml(group.gitCurrentDir)}" aria-label="git カレントディレクトリをコピー" title="${escapeHtml(group.gitCurrentDir)}">${getButtonIconSvg("copy-directory")}</button>` : ""}
+              </div>
               <div class="md-entry-url-row">
                 <div class="md-entry-url">${escapeHtml(group.repoUrl)}</div>
                 ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
@@ -435,6 +505,76 @@
           </div>
         </article>
       `;
+    }
+
+    function getMemoDialog() {
+      return document.getElementById("memoDialog");
+    }
+
+    function openMemoDialog(repoUrl, baseBranch) {
+      editingMemoKey = buildMemoKey(repoUrl, baseBranch);
+      const memoField = document.getElementById("memoText");
+      if (memoField) {
+        memoField.value = String(memos[editingMemoKey]?.memo || "");
+      }
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      if (gitCurrentDirectoryField) {
+        gitCurrentDirectoryField.value = String(memos[editingMemoKey]?.gitCurrentDir || "");
+      }
+      const dialog = getMemoDialog();
+      if (!dialog) return;
+      if (typeof dialog.showModal === "function") {
+        dialog.showModal();
+      }
+    }
+
+    function closeMemoDialog() {
+      const dialog = getMemoDialog();
+      if (!dialog) return;
+      if (dialog.open && typeof dialog.close === "function") {
+        dialog.close();
+      }
+      editingMemoKey = "";
+    }
+
+    function saveMemo() {
+      if (!editingMemoKey) return;
+      const memoField = document.getElementById("memoText");
+      const memoText = memoField ? String(memoField.value || "").trim() : "";
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
+      if (memoText || gitCurrentDir) {
+        memos[editingMemoKey] = {
+          memo: memoText,
+          gitCurrentDir
+        };
+      } else {
+        delete memos[editingMemoKey];
+      }
+      saveMemos();
+      renderEntries();
+      closeMemoDialog();
+      showToast("メモを保存しました");
+    }
+
+    async function copyTextToClipboard(text) {
+      const normalizedText = String(text || "");
+      if (!normalizedText) return false;
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+        try {
+          await navigator.clipboard.writeText(normalizedText);
+          return true;
+        } catch (_) {
+          // fallback below
+        }
+      }
+      const temp = document.createElement("textarea");
+      temp.value = normalizedText;
+      document.body.appendChild(temp);
+      temp.select();
+      const copied = document.execCommand("copy");
+      document.body.removeChild(temp);
+      return !!copied;
     }
 
     function renderWorkRow(entry) {
@@ -531,6 +671,18 @@
       const button = event.target.closest("[data-action]");
       if (!button) return;
       const action = button.getAttribute("data-action");
+      if (action === "edit-memo") {
+        openMemoDialog(button.getAttribute("data-repo-url"), button.getAttribute("data-base-branch"));
+        return;
+      }
+      if (action === "copy-git-current-dir") {
+        const gitCurrentDir = button.getAttribute("data-git-current-dir");
+        const copied = await copyTextToClipboard(gitCurrentDir);
+        if (copied) {
+          showToast("git カレントディレクトリをコピーしました");
+        }
+        return;
+      }
       if (action === "open-repo-url") {
         const repoUrl = button.getAttribute("data-repo-url");
         if (!isOpenableExternalUrl(repoUrl)) return;
@@ -598,11 +750,29 @@
         });
         dialog.dataset.boundOutsideClose = "true";
       }
+      const closeMemoButton = document.getElementById("closeMemoDialogBtn");
+      if (closeMemoButton) {
+        closeMemoButton.addEventListener("click", closeMemoDialog);
+      }
+      const saveMemoButton = document.getElementById("saveMemoBtn");
+      if (saveMemoButton) {
+        saveMemoButton.addEventListener("click", saveMemo);
+      }
+      const memoDialog = getMemoDialog();
+      if (memoDialog && !memoDialog.dataset.boundOutsideClose) {
+        memoDialog.addEventListener("click", (event) => {
+          if (event.target === memoDialog) {
+            closeMemoDialog();
+          }
+        });
+        memoDialog.dataset.boundOutsideClose = "true";
+      }
     }
 
     function bootstrap() {
       entries = loadEntries();
       recentActions = loadRecentActions();
+      memos = loadMemos();
       resetForm();
       setupEvents();
       renderEntries();

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -399,7 +399,7 @@ PR本文:
     window.history.replaceState(
       {},
       "",
-      "/docs/git/git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature-a&remoteName=upstream"
+      "/docs/git/git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature-a&remoteName=upstream&defaultCommitMessage=hello+memo"
     );
     const instrumentedCode = `${mainCode}
 window.__gitPseudoSquashTest = {
@@ -418,6 +418,7 @@ window.__gitPseudoSquashTest = {
     expect(document.getElementById("repoUrl").readOnly).toBe(true);
     expect(document.getElementById("squashBaseBranch").value).toBe("devel");
     expect(document.getElementById("workBranch").value).toBe("feature-a");
+    expect(document.getElementById("commitMessage").value).toBe("hello memo");
     expect(document.getElementById("squashBaseScope").value).toBe("remote");
     expect(document.getElementById("lockOrigin").checked).toBe(false);
     expect(document.getElementById("baseRemote").value).toBe("upstream");

--- a/docs/git/tests/git-work-list-main.test.js
+++ b/docs/git/tests/git-work-list-main.test.js
@@ -31,11 +31,16 @@ function mountDom() {
     <input id="remoteName" value="origin" />
     <button id="closeDialogBtn" type="button">close</button>
     <button id="saveEntryBtn" type="button">save</button>
+    <input id="memoText" value="" />
+    <input id="gitCurrentDirectory" value="" />
+    <button id="closeMemoDialogBtn" type="button">close memo</button>
+    <button id="saveMemoBtn" type="button">save memo</button>
     <div id="entriesList"></div>
     <div id="emptyGuide" hidden></div>
     <div id="toast"></div>
     <div id="entryDialogTitle"></div>
     <dialog id="entryDialog"></dialog>
+    <dialog id="memoDialog"></dialog>
   `;
 
   const toast = document.getElementById("toast");
@@ -46,6 +51,13 @@ function mountDom() {
   });
   dialog.close = vi.fn(() => {
     dialog.open = false;
+  });
+  const memoDialog = document.getElementById("memoDialog");
+  memoDialog.showModal = vi.fn(() => {
+    memoDialog.open = true;
+  });
+  memoDialog.close = vi.fn(() => {
+    memoDialog.open = false;
   });
 }
 
@@ -87,6 +99,8 @@ window.__gitWorkListTest = {
   buildPseudoSquashUrl,
   openCreateDialog,
   openEditDialog,
+  openMemoDialog,
+  saveMemo,
   saveCurrentEntry,
   renderEntries,
   loadEntries,
@@ -105,6 +119,10 @@ describe("git-work-list main", () => {
     window.alert = vi.fn();
     window.confirm = vi.fn(() => true);
     window.open = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true
+    });
   });
 
   it("saves an entry from the form and renders it to the list", () => {
@@ -198,6 +216,12 @@ describe("git-work-list main", () => {
   });
 
   it("builds git-pseudo-squash URL params from an entry", () => {
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::devel": {
+        memo: "default memo",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    }));
     bootPage();
 
     expect(window.__gitWorkListTest.buildPseudoSquashUrl({
@@ -208,7 +232,7 @@ describe("git-work-list main", () => {
       compareScope: "local",
       compareUseHead: true,
       remoteName: "origin"
-    })).toBe("git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature%2Flogin&remoteName=origin&useHeadWork=1");
+    })).toBe("git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature%2Flogin&remoteName=origin&defaultCommitMessage=default+memo&useHeadWork=1");
   });
 
   it("renders stored entries in reverse created order", () => {
@@ -538,5 +562,107 @@ describe("git-work-list main", () => {
     openButton.click();
 
     expect(window.open).toHaveBeenCalledWith("https://example.com/repo-a", "_blank", "noopener,noreferrer");
+  });
+
+  it("saves memo by repoUrl and baseBranch and renders preview", () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "main",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "remote",
+        remoteName: "origin"
+      }
+    ]));
+
+    bootPage();
+    window.__gitWorkListTest.openMemoDialog("https://example.com/repo-a", "main");
+    document.getElementById("memoText").value = "this is a long memo text";
+    document.getElementById("gitCurrentDirectory").value = "/tmp/repo-a";
+    window.__gitWorkListTest.saveMemo();
+
+    const savedMemos = getSavedJsonByKey("gitWorkList.memos");
+    expect(savedMemos).toEqual({
+      "https://example.com/repo-a::main": {
+        memo: "this is a long memo text",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    });
+    const preview = document.querySelector(".md-entry-memo-preview");
+    expect(preview.textContent).toBe("this is a long m...");
+    expect(preview.getAttribute("data-full-text")).toBe("this is a long memo text");
+  });
+
+  it("loads legacy string memos and opens current directory field", () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "main",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "remote",
+        remoteName: "origin"
+      }
+    ]));
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::main": "legacy memo"
+    }));
+
+    bootPage();
+    window.__gitWorkListTest.openMemoDialog("https://example.com/repo-a", "main");
+
+    expect(document.getElementById("memoText").value).toBe("legacy memo");
+    expect(document.getElementById("gitCurrentDirectory").value).toBe("");
+  });
+
+  it("shows memo button without preview when memo is empty", () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "main",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "remote",
+        remoteName: "origin"
+      }
+    ]));
+
+    bootPage();
+
+    expect(document.querySelector(".md-entry-memo-btn")).not.toBeNull();
+    expect(document.querySelector(".md-entry-memo-preview")).toBeNull();
+  });
+
+  it("copies git current directory from the parent card action", async () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "main",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "remote",
+        remoteName: "origin"
+      }
+    ]));
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::main": {
+        memo: "memo",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    }));
+
+    bootPage();
+
+    const copyButton = document.querySelector('[data-action="copy-git-current-dir"]');
+    expect(copyButton).not.toBeNull();
+    copyButton.click();
+
+    await Promise.resolve();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("/tmp/repo-a");
   });
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -2084,7 +2084,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-13</div>
+        <div class="md-app-meta">更新日: 2026-03-14</div>
       </div>
     </header>
 


### PR DESCRIPTION
## 概要

`Git 作業一覧` に、親カード単位で保持する `リポジトリ情報` メモ機能を追加しました。
あわせて、入力したメモを `Git pseudo-squash コマンドジェネレータ` のコミットメッセージ初期値へ渡せるようにし、3 ツール間の連携を強化しています。

## 変更内容

### `Git 作業一覧` にリポジトリ情報ダイアログを追加

- 親カード単位で編集する `リポジトリ情報` ダイアログを追加
- 保存単位は `repoUrl + baseBranch`
- ダイアログで入力できる項目
  - `メモ`
  - `git カレントディレクトリ`
- 既存の編集ダイアログとは別に、小さめの専用ダイアログとして実装

### 親カード上部にメモ関連 UI を追加

- リポジトリ名の右に `メモ編集` ボタンを追加
- メモがある場合は、その右にメモ要約を表示
  - 一覧表示は最大 16 文字
  - 全文は hover tooltip で確認可能
- `git カレントディレクトリ` がある場合は、さらに右に `フォルダ + コピー` アイコンを表示
- コピー押下時は `git カレントディレクトリをコピーしました` の toast を表示

### 保存形式を拡張

- `gitWorkList.memos` を追加
- メモ保存形式を以下へ拡張
  - `{ memo, gitCurrentDir }`
- 既存の文字列メモも読み込める後方互換を保持

### `git-pseudo-squash` への連携

- `Git 作業一覧` から `squash` へ遷移する際、親カードのメモを `defaultCommitMessage` として URL 引数に追加
- `git-pseudo-squash` 側では、その値をコミットメッセージ欄の初期値として反映
- ただし、すでにコミットメッセージ欄に値がある場合は上書きしない

## 目的

- リポジトリ単位・基準ブランチ単位の補足情報を一覧側に保持できるようにする
- ローカルの作業ディレクトリを一覧からすぐ取り出せるようにする
- `Git 作業一覧` で管理している情報を、そのまま `squash` 作業の初期文脈として使えるようにする

## テスト

- `docs/git/tests/git-work-list-main.test.js`
  - メモ保存
  - 後方互換
  - コピー導線
- `docs/git/tests/git-pseudo-squash-main.test.js`
  - `defaultCommitMessage` の URL 初期反映

実施:
- `vitest run docs/git/tests/git-work-list-main.test.js docs/git/tests/git-pseudo-squash-main.test.js`
- `npm run build:git`

結果:
- 成功