### PR TITLE
git-work-list のモバイル UI を改善し、リポジトリ情報ダイアログに git status コピー導線を追加

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,7 @@
 - [lht-cmn] `lht-input-mode-toggle`（file/source 切替）を追加し、music系で反復しているラジオUIを共通化する
 - [lht-cmn] `lht-preview-output`（プレビュー + コピー導線）を追加し、`previewText` 周辺の反復UIを共通化する
 - [lht-cmn] `lht-text-field-help` の trailing action を正式設計する。現在は `prompt-gen` 向けに `clearable` を暫定追加しているが、`lht-cmn` チームの更新版を受領したら、slot / action API を含めてちゃんとした実装へ置き換える
+- [lht-cmn][git-work-list] Material Web の `md-outlined-text-field` / `md-outlined-select` が DevTools で `translateY(NaNpx) scale(NaN)` 警告を出す件を調査し、非表示時初期化の回避または fallback 利用へ寄せる方針を決める
 - [prompt-gen][仕様検討] JSON から追加ボタン定義を投入し、`localStorage` に保存して再表示できる仕組みを初版スコープで整理する
 - [prompt-gen][仕様検討] 初版は「固定文面ボタンのみ追加可能」とし、`commitId` 差し込みや任意ロジックは対象外と明記する
 - [prompt-gen][仕様検討] 追加ボタン定義の JSON schema を固定する（初版: `id` / `label` / `keywords` / `body`。`requiresCommitId` は常に `false` 扱い）

--- a/docs/diagram/graphviz-dot-to-svg.html
+++ b/docs/diagram/graphviz-dot-to-svg.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/diagram/mermaid-to-svg.html
+++ b/docs/diagram/mermaid-to-svg.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-audio-convert-cmdline-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-concat-cmdline-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -301,6 +301,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-mp4-to-wav-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
+++ b/docs/ffmpeg/ffmpeg-replace-audio-with-wav-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-silence-detect-gen.html
+++ b/docs/ffmpeg/ffmpeg-silence-detect-gen.html
@@ -301,6 +301,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
+++ b/docs/ffmpeg/ffmpeg-youtube-mkv-gen.html
@@ -311,6 +311,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/git/git-config-advanced-setup.html
+++ b/docs/git/git-config-advanced-setup.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/git/git-config-setup.html
+++ b/docs/git/git-config-setup.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -316,6 +316,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -124,6 +124,7 @@ limitations under the License.
         </div>
 
         <div class="md-dialog__footer">
+          <button id="copyGitStatusCommandBtn" type="button" class="md-button md-button--secondary">cd + git status</button>
           <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
         </div>
       </form>

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }
@@ -1501,6 +1538,7 @@ lht-index-card-link {
 
 .md-dialog__surface {
   width: min(1040px, calc(100vw - 3rem));
+  max-width: calc(100vw - 3rem);
   max-height: calc(100vh - 2rem);
   overflow: auto;
   border: 1px solid #ddd6e7;
@@ -1631,8 +1669,59 @@ lht-index-card-link {
 
   .md-dialog__surface {
     width: calc(100vw - 1.5rem);
+    max-width: calc(100vw - 1.5rem);
     max-height: calc(100vh - 1rem);
     padding: 0.9rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .md-dialog {
+    max-width: 100vw;
+  }
+
+  .md-dialog__surface,
+  .md-dialog__surface--compact {
+    width: calc(100vw - 1rem);
+    max-width: calc(100vw - 1rem);
+    padding: 0.8rem;
+    border-radius: 18px;
+  }
+
+  .md-dialog__header,
+  .md-dialog__footer {
+    align-items: stretch;
+  }
+
+  .md-dialog__header > *,
+  .md-dialog__footer > * {
+    min-width: 0;
+  }
+
+  .md-dialog__header .md-button,
+  .md-dialog__footer .md-button {
+    width: 100%;
+  }
+
+  .md-dialog__title {
+    font-size: 1.02rem;
+    line-height: 1.3;
+  }
+
+  .md-dialog__subtitle {
+    font-size: 0.88rem;
+    line-height: 1.5;
+  }
+
+  .md-dialog__body {
+    min-width: 0;
+  }
+
+  .md-dialog__body lht-text-field-help,
+  .md-dialog__body lht-select-help,
+  .md-dialog__body md-outlined-text-field.md-outlined-field,
+  .md-dialog__body md-outlined-select.md-outlined-field {
+    min-width: 0;
   }
 }
   </style>
@@ -1737,6 +1826,7 @@ lht-index-card-link {
         </div>
 
         <div class="md-dialog__footer">
+          <button id="copyGitStatusCommandBtn" type="button" class="md-button md-button--secondary">cd + git status</button>
           <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
         </div>
       </form>
@@ -4423,6 +4513,26 @@ if (!customElements.get("lht-page-menu")) {
       showToast("メモを保存しました");
     }
 
+    function quoteShellPath(value) {
+      const text = String(value || "");
+      if (!text) return "''";
+      return `'${text.replace(/'/g, `'\"'\"'`)}'`;
+    }
+
+    async function copyGitStatusCommand() {
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
+      if (!gitCurrentDir) {
+        showToast("git カレントディレクトリを入力してください");
+        return;
+      }
+      const commandText = `cd ${quoteShellPath(gitCurrentDir)}\ngit status -sb`;
+      const copied = await copyTextToClipboard(commandText);
+      if (copied) {
+        showToast("cd + git status をコピーしました");
+      }
+    }
+
     async function copyTextToClipboard(text) {
       const normalizedText = String(text || "");
       if (!normalizedText) return false;
@@ -4623,6 +4733,12 @@ if (!customElements.get("lht-page-menu")) {
       const saveMemoButton = document.getElementById("saveMemoBtn");
       if (saveMemoButton) {
         saveMemoButton.addEventListener("click", saveMemo);
+      }
+      const copyGitStatusCommandButton = document.getElementById("copyGitStatusCommandBtn");
+      if (copyGitStatusCommandButton) {
+        copyGitStatusCommandButton.addEventListener("click", () => {
+          copyGitStatusCommand();
+        });
       }
       const memoDialog = getMemoDialog();
       if (memoDialog && !memoDialog.dataset.boundOutsideClose) {

--- a/docs/git/src/git-work-list/css/app.css
+++ b/docs/git/src/git-work-list/css/app.css
@@ -462,6 +462,7 @@
 
 .md-dialog__surface {
   width: min(1040px, calc(100vw - 3rem));
+  max-width: calc(100vw - 3rem);
   max-height: calc(100vh - 2rem);
   overflow: auto;
   border: 1px solid #ddd6e7;
@@ -592,7 +593,58 @@
 
   .md-dialog__surface {
     width: calc(100vw - 1.5rem);
+    max-width: calc(100vw - 1.5rem);
     max-height: calc(100vh - 1rem);
     padding: 0.9rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .md-dialog {
+    max-width: 100vw;
+  }
+
+  .md-dialog__surface,
+  .md-dialog__surface--compact {
+    width: calc(100vw - 1rem);
+    max-width: calc(100vw - 1rem);
+    padding: 0.8rem;
+    border-radius: 18px;
+  }
+
+  .md-dialog__header,
+  .md-dialog__footer {
+    align-items: stretch;
+  }
+
+  .md-dialog__header > *,
+  .md-dialog__footer > * {
+    min-width: 0;
+  }
+
+  .md-dialog__header .md-button,
+  .md-dialog__footer .md-button {
+    width: 100%;
+  }
+
+  .md-dialog__title {
+    font-size: 1.02rem;
+    line-height: 1.3;
+  }
+
+  .md-dialog__subtitle {
+    font-size: 0.88rem;
+    line-height: 1.5;
+  }
+
+  .md-dialog__body {
+    min-width: 0;
+  }
+
+  .md-dialog__body lht-text-field-help,
+  .md-dialog__body lht-select-help,
+  .md-dialog__body md-outlined-text-field.md-outlined-field,
+  .md-dialog__body md-outlined-select.md-outlined-field {
+    min-width: 0;
   }
 }

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -557,6 +557,26 @@
       showToast("メモを保存しました");
     }
 
+    function quoteShellPath(value) {
+      const text = String(value || "");
+      if (!text) return "''";
+      return `'${text.replace(/'/g, `'\"'\"'`)}'`;
+    }
+
+    async function copyGitStatusCommand() {
+      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
+      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
+      if (!gitCurrentDir) {
+        showToast("git カレントディレクトリを入力してください");
+        return;
+      }
+      const commandText = `cd ${quoteShellPath(gitCurrentDir)}\ngit status -sb`;
+      const copied = await copyTextToClipboard(commandText);
+      if (copied) {
+        showToast("cd + git status をコピーしました");
+      }
+    }
+
     async function copyTextToClipboard(text) {
       const normalizedText = String(text || "");
       if (!normalizedText) return false;
@@ -757,6 +777,12 @@
       const saveMemoButton = document.getElementById("saveMemoBtn");
       if (saveMemoButton) {
         saveMemoButton.addEventListener("click", saveMemo);
+      }
+      const copyGitStatusCommandButton = document.getElementById("copyGitStatusCommandBtn");
+      if (copyGitStatusCommandButton) {
+        copyGitStatusCommandButton.addEventListener("click", () => {
+          copyGitStatusCommand();
+        });
       }
       const memoDialog = getMemoDialog();
       if (memoDialog && !memoDialog.dataset.boundOutsideClose) {

--- a/docs/grep/find-gen.html
+++ b/docs/grep/find-gen.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/img/img2svg.html
+++ b/docs/img/img2svg.html
@@ -1319,6 +1319,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1328,6 +1328,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/life/forgot-items-check.html
+++ b/docs/life/forgot-items-check.html
@@ -1228,6 +1228,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/life/japan-weather.html
+++ b/docs/life/japan-weather.html
@@ -1253,6 +1253,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/link/amazon-dp-extract.html
+++ b/docs/link/amazon-dp-extract.html
@@ -1313,6 +1313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/link/facebook-fbclid-remove.html
+++ b/docs/link/facebook-fbclid-remove.html
@@ -1313,6 +1313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/link/mime-base64.html
+++ b/docs/link/mime-base64.html
@@ -1343,6 +1343,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/link/url-encode-decode.html
+++ b/docs/link/url-encode-decode.html
@@ -1314,6 +1314,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/link/utm-remove.html
+++ b/docs/link/utm-remove.html
@@ -1313,6 +1313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/music/abc-to-musicxml.html
+++ b/docs/music/abc-to-musicxml.html
@@ -313,6 +313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/music/midi-to-musicxml.html
+++ b/docs/music/midi-to-musicxml.html
@@ -313,6 +313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/music/musicxml-to-abc.html
+++ b/docs/music/musicxml-to-abc.html
@@ -313,6 +313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/music/musicxml-to-midi.html
+++ b/docs/music/musicxml-to-midi.html
@@ -313,6 +313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/music/musicxml-to-svg.html
+++ b/docs/music/musicxml-to-svg.html
@@ -313,6 +313,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/password/password-gen.html
+++ b/docs/password/password-gen.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -315,6 +315,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/text/file-rename-cmdline-gen.html
+++ b/docs/text/file-rename-cmdline-gen.html
@@ -845,6 +845,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/text/japanese-romaji-guide.html
+++ b/docs/text/japanese-romaji-guide.html
@@ -925,6 +925,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/text/text-processing.html
+++ b/docs/text/text-processing.html
@@ -1399,6 +1399,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/docs/text/text-viewer.html
+++ b/docs/text/text-viewer.html
@@ -1287,6 +1287,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/lht-cmn/css/components.css
+++ b/lht-cmn/css/components.css
@@ -289,6 +289,43 @@ lht-page-hero .md-menu-panel {
   }
 }
 
+@media (max-width: 430px) {
+  lht-page-hero .lht-page-hero__title-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.4rem;
+  }
+
+  lht-page-hero .lht-page-hero__title-main {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__title {
+    font-size: clamp(1rem, 4vw, 1.18rem);
+    max-width: 100%;
+  }
+
+  lht-page-hero .lht-page-hero__actions {
+    width: auto;
+    min-width: 0;
+    margin-left: auto;
+    gap: 0.3rem;
+    justify-content: flex-end;
+    align-self: start;
+  }
+
+  lht-page-hero .md-menu-button,
+  lht-page-hero .lht-page-hero__actions .md-icon-btn,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button,
+  lht-page-hero .lht-page-hero__actions .md-help-icon-button--fallback {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
 lht-command-block {
   display: block;
 }

--- a/llmdocs/TODO.md
+++ b/llmdocs/TODO.md
@@ -4,6 +4,7 @@
 
 - [ ] toast、error、ファイル選択、プレビュー、コマンドブロック UI がまだ重複しているアプリに対して、`lht-cmn` コンポーネント展開を継続する。
 - [ ] 狭幅画面でのはみ出し問題の残件を確認し、個別パッチの前に共有 `lht` ルールで修正する。
+- [ ] `git-work-list` で Material Web の `md-outlined-text-field` / `md-outlined-select` が `translateY(NaNpx) scale(NaN)` 警告を出す件を切り分け、無視継続か初期化タイミング修正かを判断する。
 - [ ] 既存のルート [`TODO.md`](/Users/igapyon/Documents/git/local-html-tools/TODO.md) バックログから、次に着手すべき最優先実装対象を明確化する。
 
 ## 最近完了した項目


### PR DESCRIPTION
## 概要
`git-work-list` について、iPhone SE 相当の狭幅画面で発生していたレイアウト崩れを修正し、リポジトリ情報ダイアログから `cd` + `git status -sb` コマンドを直接コピーできるようにしました。あわせて、Material Web の `NaN` 警告調査タスクを TODO に記録しています。

## 変更内容
- `git-work-list` のリポジトリ情報ダイアログに `cd + git status` ボタンを追加
- `git カレントディレクトリ` をもとに、以下の 2 行をクリップボードへコピーする処理を追加
  - `cd '<git カレントディレクトリ>'`
  - `git status -sb`
- パス中のシングルクォートを壊さないよう、シェル向けのエスケープ処理を追加
- iPhone SE 相当の狭幅画面でもダイアログが横にはみ出しにくいよう、`git-work-list` のダイアログ幅・余白・内部フィールドの `min-width` を調整
- 共通 `lht-page-hero` の狭幅レイアウトを見直し、タイトル右側のメニューが下段へ折れないように調整
- DevTools 上で確認した Material Web の `translateY(NaNpx) scale(NaN)` 警告について、後続調査用の TODO を追加
- 関連する単一 HTML 配布ファイルを再生成

## 背景
- iPhone SE3 幅で `git-work-list` のモーダルが横にはみ出していた
- 同じく狭幅時に、ヒーロー右上のメニューがタイトル行から折れて下段に移動していた
- リポジトリ情報ダイアログから、作業ディレクトリに移動して `git status -sb` を実行するためのコマンドをすぐ取り出したかった

## 確認観点
- iPhone SE 相当の幅で `git-work-list` のダイアログが横にはみ出さないこと
- iPhone SE 相当の幅でヒーロー右上メニューがタイトル行内に収まること
- リポジトリ情報ダイアログの `cd + git status` ボタン押下で、期待する 2 行のコマンドがコピーされること
- `git カレントディレクトリ` 未入力時にトーストで案内されること

## 補足
- Material Web の `md-outlined-text-field` / `md-outlined-select` が DevTools で `translateY(NaNpx) scale(NaN)` 警告を出す件は、この PR では解消していません。後続調査用に TODO へ記録しています。