### PR TITLE
git-work-list に JSON エクスポート/インポートを追加し、Git ツール名と操作ラベルを整理

### DIFF
--- a/docs/git/git-branch-diff-src.html
+++ b/docs/git/git-branch-diff-src.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Git ブランチ比較コマンドジェネレータ</title>
+  <title>Git ブランチ比較</title>
     <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
   <link rel="stylesheet" href="src/git-branch-diff/css/app.css" />
   <script src="../../lht-cmn/vendor/material-web-outlined-text-field.bundle.js"></script>
@@ -44,10 +44,10 @@ limitations under the License.
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="Git ブランチ比較コマンドジェネレータ"
+      title="Git ブランチ比較"
       subtitle="2つのブランチ差分を表示するコマンドを生成します。"
       icon="🧰"
-      help-label="Git ブランチ比較コマンドジェネレータの説明"
+      help-label="Git ブランチ比較の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">

--- a/docs/git/git-branch-diff.html
+++ b/docs/git/git-branch-diff.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Git ブランチ比較コマンドジェネレータ</title>
+  <title>Git ブランチ比較</title>
     
   
   
@@ -2185,10 +2185,10 @@ lht-index-card-link {
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="Git ブランチ比較コマンドジェネレータ"
+      title="Git ブランチ比較"
       subtitle="2つのブランチ差分を表示するコマンドを生成します。"
       icon="🧰"
-      help-label="Git ブランチ比較コマンドジェネレータの説明"
+      help-label="Git ブランチ比較の説明"
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Git pseudo-squash コマンドジェネレータ</title>
+  <title>Git pseudo-squash</title>
 
   <link rel="stylesheet" href="../../lht-cmn/css/components.css" />
   <link rel="stylesheet" href="src/git-pseudo-squash/css/app.css" />
@@ -62,7 +62,7 @@ limitations under the License.
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="Git pseudo-squash コマンドジェネレータ"
+      title="Git pseudo-squash"
       subtitle="履歴を1コミットにまとめるコマンドを生成します。"
       icon="🧩"
       help-label="Git pseudo-squash の説明"

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -18,7 +18,7 @@ limitations under the License.
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Git pseudo-squash コマンドジェネレータ</title>
+  <title>Git pseudo-squash</title>
 
   
   
@@ -2531,7 +2531,7 @@ lht-index-card-link {
   </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
-      title="Git pseudo-squash コマンドジェネレータ"
+      title="Git pseudo-squash"
       subtitle="履歴を1コミットにまとめるコマンドを生成します。"
       icon="🧩"
       help-label="Git pseudo-squash の説明"

--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -47,6 +47,23 @@ limitations under the License.
             </svg>
             <span>追加</span>
           </button>
+          <button id="exportEntriesBtn" type="button" class="md-button md-button--surface">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3v12"></path>
+              <path d="m7 10 5 5 5-5"></path>
+              <path d="M5 21h14"></path>
+            </svg>
+            <span>Export</span>
+          </button>
+          <button id="importEntriesBtn" type="button" class="md-button md-button--surface">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 21V9"></path>
+              <path d="m7 14 5-5 5 5"></path>
+              <path d="M5 3h14"></path>
+            </svg>
+            <span>Import</span>
+          </button>
+          <input id="importEntriesInput" type="file" accept="application/json,.json" class="md-hidden" />
         </div>
       </div>
 

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1749,6 +1749,23 @@ lht-index-card-link {
             </svg>
             <span>追加</span>
           </button>
+          <button id="exportEntriesBtn" type="button" class="md-button md-button--surface">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 3v12"></path>
+              <path d="m7 10 5 5 5-5"></path>
+              <path d="M5 21h14"></path>
+            </svg>
+            <span>Export</span>
+          </button>
+          <button id="importEntriesBtn" type="button" class="md-button md-button--surface">
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="md-button__icon" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 21V9"></path>
+              <path d="m7 14 5-5 5 5"></path>
+              <path d="M5 3h14"></path>
+            </svg>
+            <span>Import</span>
+          </button>
+          <input id="importEntriesInput" type="file" accept="application/json,.json" class="md-hidden" />
         </div>
       </div>
 
@@ -3957,6 +3974,7 @@ if (!customElements.get("lht-page-menu")) {
     const STORAGE_KEY = "gitWorkList.entries";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
     const MEMO_STORAGE_KEY = "gitWorkList.memos";
+    const EXPORT_VERSION = 1;
     let entries = [];
     let recentActions = [];
     let memos = {};
@@ -4173,6 +4191,93 @@ if (!customElements.get("lht-page-menu")) {
 
     function saveMemos() {
       localStorage.setItem(MEMO_STORAGE_KEY, JSON.stringify(memos));
+    }
+
+    function createExportPayload() {
+      return {
+        version: EXPORT_VERSION,
+        exportedAt: new Date().toISOString(),
+        entries,
+        memos
+      };
+    }
+
+    function buildExportFilename() {
+      const now = new Date();
+      const yyyy = String(now.getFullYear());
+      const mm = String(now.getMonth() + 1).padStart(2, "0");
+      const dd = String(now.getDate()).padStart(2, "0");
+      const hh = String(now.getHours()).padStart(2, "0");
+      const mi = String(now.getMinutes()).padStart(2, "0");
+      const ss = String(now.getSeconds()).padStart(2, "0");
+      return `git-work-list-export-${yyyy}${mm}${dd}-${hh}${mi}${ss}.json`;
+    }
+
+    function downloadTextFile(text, filename, contentType) {
+      const blob = new Blob([text], { type: contentType });
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.setTimeout(() => {
+        URL.revokeObjectURL(objectUrl);
+      }, 0);
+    }
+
+    function exportEntriesAndMemos() {
+      const payload = createExportPayload();
+      downloadTextFile(
+        `${JSON.stringify(payload, null, 2)}\n`,
+        buildExportFilename(),
+        "application/json;charset=utf-8"
+      );
+      showToast("一覧を JSON でエクスポートしました");
+    }
+
+    function normalizeImportedPayload(rawPayload) {
+      if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+        return null;
+      }
+      if (Number(rawPayload.version) !== EXPORT_VERSION) {
+        return null;
+      }
+      if (typeof rawPayload.exportedAt !== "string" || !rawPayload.exportedAt.trim()) {
+        return null;
+      }
+      if (!Array.isArray(rawPayload.entries)) {
+        return null;
+      }
+      return {
+        entries: rawPayload.entries
+          .map((entry) => normalizeEntry(entry))
+          .filter((entry) => entry.repoUrl && entry.baseBranch && entry.compareBranch),
+        memos: normalizeMemos(rawPayload.memos || {})
+      };
+    }
+
+    async function importEntriesAndMemosFromFile(file) {
+      if (!file) return;
+      try {
+        const rawText = await file.text();
+        const parsed = JSON.parse(rawText);
+        const normalized = normalizeImportedPayload(parsed);
+        if (!normalized) {
+          showToast("JSON の読み込みに失敗しました");
+          return;
+        }
+        entries = normalized.entries;
+        memos = normalized.memos;
+        saveEntries();
+        saveMemos();
+        renderEntries();
+        updatePrimaryActionsState();
+        showToast("一覧を JSON から取り込みました");
+      } catch (_) {
+        showToast("JSON の読み込みに失敗しました");
+      }
     }
 
     function normalizeScope(value) {
@@ -4567,7 +4672,7 @@ if (!customElements.get("lht-page-menu")) {
             </div>
           </div>
           <div class="md-entry-actions md-work-row__actions">
-            <button type="button" class="md-button ${getToolButtonClass(entry.id, "pseudo-squash")}" data-action="open-pseudo-squash">${getButtonIconSvg("pseudo-squash")}<span>squash</span></button>
+            <button type="button" class="md-button ${getToolButtonClass(entry.id, "pseudo-squash")}" data-action="open-pseudo-squash">${getButtonIconSvg("pseudo-squash")}<span>Squash</span></button>
             <button type="button" class="md-button ${getToolButtonClass(entry.id, "branch-diff")}" data-action="open-branch-diff">${getButtonIconSvg("branch-diff")}<span>比較</span></button>
             <button type="button" class="md-button md-button--surface" data-action="edit-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("edit")}<span>変更</span></button>
             <button type="button" class="md-button md-button--danger" data-action="delete-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("delete")}<span>削除</span></button>
@@ -4702,6 +4807,25 @@ if (!customElements.get("lht-page-menu")) {
       const openCreateButton = document.getElementById("openCreateDialogBtn");
       if (openCreateButton) {
         openCreateButton.addEventListener("click", openCreateDialog);
+      }
+      const exportEntriesButton = document.getElementById("exportEntriesBtn");
+      if (exportEntriesButton) {
+        exportEntriesButton.addEventListener("click", exportEntriesAndMemos);
+      }
+      const importEntriesButton = document.getElementById("importEntriesBtn");
+      const importEntriesInput = document.getElementById("importEntriesInput");
+      if (importEntriesButton && importEntriesInput) {
+        importEntriesButton.addEventListener("click", () => {
+          importEntriesInput.value = "";
+          importEntriesInput.click();
+        });
+        importEntriesInput.addEventListener("change", async () => {
+          const file = importEntriesInput.files && importEntriesInput.files[0]
+            ? importEntriesInput.files[0]
+            : null;
+          await importEntriesAndMemosFromFile(file);
+          importEntriesInput.value = "";
+        });
       }
       const saveButton = document.getElementById("saveEntryBtn");
       if (saveButton) {

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -1,6 +1,7 @@
     const STORAGE_KEY = "gitWorkList.entries";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
     const MEMO_STORAGE_KEY = "gitWorkList.memos";
+    const EXPORT_VERSION = 1;
     let entries = [];
     let recentActions = [];
     let memos = {};
@@ -217,6 +218,93 @@
 
     function saveMemos() {
       localStorage.setItem(MEMO_STORAGE_KEY, JSON.stringify(memos));
+    }
+
+    function createExportPayload() {
+      return {
+        version: EXPORT_VERSION,
+        exportedAt: new Date().toISOString(),
+        entries,
+        memos
+      };
+    }
+
+    function buildExportFilename() {
+      const now = new Date();
+      const yyyy = String(now.getFullYear());
+      const mm = String(now.getMonth() + 1).padStart(2, "0");
+      const dd = String(now.getDate()).padStart(2, "0");
+      const hh = String(now.getHours()).padStart(2, "0");
+      const mi = String(now.getMinutes()).padStart(2, "0");
+      const ss = String(now.getSeconds()).padStart(2, "0");
+      return `git-work-list-export-${yyyy}${mm}${dd}-${hh}${mi}${ss}.json`;
+    }
+
+    function downloadTextFile(text, filename, contentType) {
+      const blob = new Blob([text], { type: contentType });
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.setTimeout(() => {
+        URL.revokeObjectURL(objectUrl);
+      }, 0);
+    }
+
+    function exportEntriesAndMemos() {
+      const payload = createExportPayload();
+      downloadTextFile(
+        `${JSON.stringify(payload, null, 2)}\n`,
+        buildExportFilename(),
+        "application/json;charset=utf-8"
+      );
+      showToast("一覧を JSON でエクスポートしました");
+    }
+
+    function normalizeImportedPayload(rawPayload) {
+      if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+        return null;
+      }
+      if (Number(rawPayload.version) !== EXPORT_VERSION) {
+        return null;
+      }
+      if (typeof rawPayload.exportedAt !== "string" || !rawPayload.exportedAt.trim()) {
+        return null;
+      }
+      if (!Array.isArray(rawPayload.entries)) {
+        return null;
+      }
+      return {
+        entries: rawPayload.entries
+          .map((entry) => normalizeEntry(entry))
+          .filter((entry) => entry.repoUrl && entry.baseBranch && entry.compareBranch),
+        memos: normalizeMemos(rawPayload.memos || {})
+      };
+    }
+
+    async function importEntriesAndMemosFromFile(file) {
+      if (!file) return;
+      try {
+        const rawText = await file.text();
+        const parsed = JSON.parse(rawText);
+        const normalized = normalizeImportedPayload(parsed);
+        if (!normalized) {
+          showToast("JSON の読み込みに失敗しました");
+          return;
+        }
+        entries = normalized.entries;
+        memos = normalized.memos;
+        saveEntries();
+        saveMemos();
+        renderEntries();
+        updatePrimaryActionsState();
+        showToast("一覧を JSON から取り込みました");
+      } catch (_) {
+        showToast("JSON の読み込みに失敗しました");
+      }
     }
 
     function normalizeScope(value) {
@@ -611,7 +699,7 @@
             </div>
           </div>
           <div class="md-entry-actions md-work-row__actions">
-            <button type="button" class="md-button ${getToolButtonClass(entry.id, "pseudo-squash")}" data-action="open-pseudo-squash">${getButtonIconSvg("pseudo-squash")}<span>squash</span></button>
+            <button type="button" class="md-button ${getToolButtonClass(entry.id, "pseudo-squash")}" data-action="open-pseudo-squash">${getButtonIconSvg("pseudo-squash")}<span>Squash</span></button>
             <button type="button" class="md-button ${getToolButtonClass(entry.id, "branch-diff")}" data-action="open-branch-diff">${getButtonIconSvg("branch-diff")}<span>比較</span></button>
             <button type="button" class="md-button md-button--surface" data-action="edit-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("edit")}<span>変更</span></button>
             <button type="button" class="md-button md-button--danger" data-action="delete-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("delete")}<span>削除</span></button>
@@ -746,6 +834,25 @@
       const openCreateButton = document.getElementById("openCreateDialogBtn");
       if (openCreateButton) {
         openCreateButton.addEventListener("click", openCreateDialog);
+      }
+      const exportEntriesButton = document.getElementById("exportEntriesBtn");
+      if (exportEntriesButton) {
+        exportEntriesButton.addEventListener("click", exportEntriesAndMemos);
+      }
+      const importEntriesButton = document.getElementById("importEntriesBtn");
+      const importEntriesInput = document.getElementById("importEntriesInput");
+      if (importEntriesButton && importEntriesInput) {
+        importEntriesButton.addEventListener("click", () => {
+          importEntriesInput.value = "";
+          importEntriesInput.click();
+        });
+        importEntriesInput.addEventListener("change", async () => {
+          const file = importEntriesInput.files && importEntriesInput.files[0]
+            ? importEntriesInput.files[0]
+            : null;
+          await importEntriesAndMemosFromFile(file);
+          importEntriesInput.value = "";
+        });
       }
       const saveButton = document.getElementById("saveEntryBtn");
       if (saveButton) {


### PR DESCRIPTION
## 概要
`git-work-list` に JSON エクスポート/インポート機能を追加し、リポジトリ情報ダイアログから `cd + git status -sb` をコピーできる導線を追加しました。あわせて、Git 系ツールのタイトル文言と `git-work-list` 内の操作ラベルを整理しています。

## 変更内容
- `git-work-list` 上部に `Export` / `Import` ボタンを追加
- `entries` と `memos` を対象に JSON エクスポートできるように実装
- エクスポート JSON に `version: 1` と `exportedAt` を付与
- JSON インポートを追加し、初版仕様として「全置換のみ」を実装
- インポート失敗時は既存データを変更せず、トースト通知のみ行うように実装
- リポジトリ情報ダイアログに `cd + git status` ボタンを追加
- `git カレントディレクトリ` から以下のコマンドをクリップボードへコピーできるように実装
  - `cd '<git カレントディレクトリ>'`
  - `git status -sb`
- `git-work-list` 内の `squash` ボタン表記を `Squash` に変更
- `Export` / `Import` ボタンに SVG アイコンを追加
- `git-pseudo-squash` のタイトルを `Git pseudo-squash` に変更
- `git-branch-diff` のタイトルを `Git ブランチ比較` に変更
- 上記変更を単一 HTML 配布ファイルへ反映

## 仕様
### エクスポート
- 対象は `entries` と `memos` のみ
- 出力 JSON には以下を含める
  - `version`
  - `exportedAt`
  - `entries`
  - `memos`

### インポート
- 初版は「全置換のみ」
- `version` と `exportedAt` を持つ JSON のみ受け付ける
- 形式不正、JSON パース失敗、必須項目不足時は取り込みを中止
- 失敗時はトースト表示のみで、既存データは変更しない

## 背景
- `git-work-list` の内容を端末間やブラウザ間で持ち運びたい
- `git カレントディレクトリ` から、そのままターミナルへ貼れるコマンドをすぐ取得したい
- 画面上のタイトルやボタン文言を、現在の実態に合わせて簡潔にしたい

## 確認観点
- `Export` ボタンで `version` / `exportedAt` / `entries` / `memos` を含む JSON がダウンロードされること
- `Import` ボタンで有効な JSON を取り込むと一覧とメモが全置換されること
- 不正な JSON を選んだ場合、既存データが維持されてトースト通知されること
- リポジトリ情報ダイアログの `cd + git status` ボタンで 2 行のコマンドがコピーされること
- 一覧カードの `Squash` 表記、`Export` / `Import` アイコン、各 Git 画面タイトルが期待どおり反映されていること

## 補足
- インポート対象は初版では `recentActions` を含めていません
- マージ取り込みは今回は実装せず、置換のみです