### PR TITLE
生成AI導線を内部リンクへ統一し Git 作業一覧 連携を整理

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@
 - [lht-cmn] `lht-text-field-help` の trailing action を正式設計する。現在は `prompt-gen` 向けに `clearable` を暫定追加しているが、`lht-cmn` チームの更新版を受領したら、slot / action API を含めてちゃんとした実装へ置き換える
 - [lht-cmn][git-work-list] Material Web の `md-outlined-text-field` / `md-outlined-select` が DevTools で `translateY(NaNpx) scale(NaN)` 警告を出す件を調査し、非表示時初期化の回避または fallback 利用へ寄せる方針を決める
 - [prompt-gen][仕様検討] JSON から追加ボタン定義を投入し、`localStorage` に保存して再表示できる仕組みを初版スコープで整理する
+- [prompt-gen][導線整理] `生成AIで整理` ボタンは外部 URL 扱いではなく `local-html-tools` 内部導線として扱えるよう、遷移方式と UI 表現を見直す
 - [prompt-gen][仕様検討] 初版は「固定文面ボタンのみ追加可能」とし、`commitId` 差し込みや任意ロジックは対象外と明記する
 - [prompt-gen][仕様検討] 追加ボタン定義の JSON schema を固定する（初版: `id` / `label` / `keywords` / `body`。`requiresCommitId` は常に `false` 扱い）
 - [prompt-gen][仕様検討] JSON schema の妥当性チェック方針を決める（必須項目欠落・重複 `id`・不正 JSON の扱い）

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -201,12 +201,6 @@ limitations under the License.
               <circle cx="12" cy="7.5" r="0.9" fill="currentColor" stroke="none"></circle>
             </svg>
           </button>
-          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="https://igapyon.github.io/local-html-tools/prompt/prompt-gen.html?q=A501&id=A501" target="_blank" rel="noopener noreferrer" title="生成AIで整理" aria-label="生成AIで整理">
-            <span>生成AIで整理</span>
-            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
-            </svg>
-          </a>
         </span>
       </div>
       <div class="md-form-row">
@@ -220,6 +214,12 @@ limitations under the License.
           <lht-switch-help switch-id="useCurrentBranch" label="現在ブランチで作業" help-label="現在ブランチで作業の説明" checked on-change="toggleCurrentBranch">
             現在チェックアウト中のブランチを作業ブランチとして扱います。チェックを外すと、作業ブランチ名で switch するコマンドが含まれます。
           </lht-switch-help>
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで整理" aria-label="生成AIで整理">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
+            </svg>
+            <span>生成AIで整理</span>
+          </a>
         </span>
       </div>
     </div>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -2670,12 +2670,6 @@ lht-index-card-link {
               <circle cx="12" cy="7.5" r="0.9" fill="currentColor" stroke="none"></circle>
             </svg>
           </button>
-          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="https://igapyon.github.io/local-html-tools/prompt/prompt-gen.html?q=A501&id=A501" target="_blank" rel="noopener noreferrer" title="生成AIで整理" aria-label="生成AIで整理">
-            <span>生成AIで整理</span>
-            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
-            </svg>
-          </a>
         </span>
       </div>
       <div class="md-form-row">
@@ -2689,6 +2683,12 @@ lht-index-card-link {
           <lht-switch-help switch-id="useCurrentBranch" label="現在ブランチで作業" help-label="現在ブランチで作業の説明" checked on-change="toggleCurrentBranch">
             現在チェックアウト中のブランチを作業ブランチとして扱います。チェックを外すと、作業ブランチ名で switch するコマンドが含まれます。
           </lht-switch-help>
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで整理" aria-label="生成AIで整理">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
+            </svg>
+            <span>生成AIで整理</span>
+          </a>
         </span>
       </div>
     </div>

--- a/docs/prompt/prompt-gen-search-and-keywords.md
+++ b/docs/prompt/prompt-gen-search-and-keywords.md
@@ -126,6 +126,6 @@
 
 ## A501 の特記事項
 
-- `A501: GitHub PR 文面の作成` を選択したときだけ、出力オプション行に `Git pseudo-squash で整理` の外部リンクを表示する
-- リンク先は `https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html` 固定とする
+- `A501: GitHub PR 文面の作成` を選択したときだけ、出力オプション行に `Git 作業一覧` の内部リンクを表示する
+- リンク先は `../git/git-work-list.html` 固定とする
 - この導線は他ページからの連携前提でも使うため、A501 向けのリンク先パスは不用意に変更しない

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -48,6 +48,11 @@ limitations under the License.
         <path d="M10 14 19 5"/>
         <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
       </symbol>
+      <symbol id="md-icon-auto-fix" viewBox="0 0 24 24">
+        <path d="m6 4 .8 2.2L9 7l-2.2.8L6 10l-.8-2.2L3 7l2.2-.8L6 4"/>
+        <path d="m16 11 1.1 3 2.9 1.1-2.9 1.1L16 19l-1.1-2.9L12 15l2.9-1.1L16 11"/>
+        <path d="M10 19h8"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -135,14 +140,12 @@ limitations under the License.
         <a
           id="gitPseudoSquashLink"
           class="md-secondary-button md-hidden"
-          href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Git pseudo-squash で整理">
+          href="../git/git-work-list.html"
+          aria-label="Git 作業一覧">
           <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+            <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
           </svg>
-          <span>Git pseudo-squash で整理</span>
+          <span>Git 作業一覧</span>
         </a>
       </div>
     </section>

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1265,6 +1265,7 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   font-size: 0.8rem;
   font-weight: 600;
   line-height: 1.1;
+  text-decoration: none;
   cursor: pointer;
   transition: background 150ms ease, border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
 }
@@ -1435,6 +1436,11 @@ md-icon-button.md-copy-button--surface {
         <path d="M10 14 19 5"/>
         <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"/>
       </symbol>
+      <symbol id="md-icon-auto-fix" viewBox="0 0 24 24">
+        <path d="m6 4 .8 2.2L9 7l-2.2.8L6 10l-.8-2.2L3 7l2.2-.8L6 4"/>
+        <path d="m16 11 1.1 3 2.9 1.1-2.9 1.1L16 19l-1.1-2.9L12 15l2.9-1.1L16 11"/>
+        <path d="M10 19h8"/>
+      </symbol>
       <symbol id="md-icon-trash" viewBox="0 0 24 24">
         <path d="M3 6h18"/>
         <path d="M8 6V4h8v2"/>
@@ -1522,14 +1528,12 @@ md-icon-button.md-copy-button--surface {
         <a
           id="gitPseudoSquashLink"
           class="md-secondary-button md-hidden"
-          href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Git pseudo-squash で整理">
+          href="../git/git-work-list.html"
+          aria-label="Git 作業一覧">
           <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <use href="#md-icon-open-in-new" xlink:href="#md-icon-open-in-new"></use>
+            <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
           </svg>
-          <span>Git pseudo-squash で整理</span>
+          <span>Git 作業一覧</span>
         </a>
       </div>
     </section>

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -189,6 +189,7 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   font-size: 0.8rem;
   font-weight: 600;
   line-height: 1.1;
+  text-decoration: none;
   cursor: pointer;
   transition: background 150ms ease, border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
 }

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -78,7 +78,7 @@ function mountPromptDom() {
     <input id="subjectInput" />
     <input id="includeLabelPrefix" type="checkbox" />
     <button id="copyShareLinkButton" type="button"></button>
-    <a id="gitPseudoSquashLink" class="md-hidden" href="https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html"></a>
+    <a id="gitPseudoSquashLink" class="md-hidden" href="../git/git-work-list.html"></a>
     <div id="promptOutput"></div>
   `;
 }
@@ -350,7 +350,7 @@ describe("prompt-gen main", () => {
     promptSearch.dispatchEvent(new Event("input"));
 
     expect(gitPseudoSquashLink.classList.contains("md-hidden")).toBe(false);
-    expect(gitPseudoSquashLink.getAttribute("href")).toBe("https://igapyon.github.io/local-html-tools/git/git-pseudo-squash.html");
+    expect(gitPseudoSquashLink.getAttribute("href")).toBe("../git/git-work-list.html");
 
     promptSearch.value = "A701";
     promptSearch.dispatchEvent(new Event("input"));

--- a/llmdocs/TODO.md
+++ b/llmdocs/TODO.md
@@ -5,6 +5,7 @@
 - [ ] toast、error、ファイル選択、プレビュー、コマンドブロック UI がまだ重複しているアプリに対して、`lht-cmn` コンポーネント展開を継続する。
 - [ ] 狭幅画面でのはみ出し問題の残件を確認し、個別パッチの前に共有 `lht` ルールで修正する。
 - [ ] `git-work-list` で Material Web の `md-outlined-text-field` / `md-outlined-select` が `translateY(NaNpx) scale(NaN)` 警告を出す件を切り分け、無視継続か初期化タイミング修正かを判断する。
+- [ ] `生成AIで整理` ボタンが外部 URL 扱いになっているが実態は `local-html-tools` 内部導線なので、内部遷移へ寄せる方針を検討する。
 - [ ] 既存のルート [`TODO.md`](/Users/igapyon/Documents/git/local-html-tools/TODO.md) バックログから、次に着手すべき最優先実装対象を明確化する。
 
 ## 最近完了した項目


### PR DESCRIPTION
### 概要

`git-pseudo-squash` と `prompt-gen` のあいだにある導線を見直し、外部公開URL依存をやめて `local-html-tools` 内の画面遷移として統一しました。あわせて、`prompt-gen` 側の補助導線を `Git 作業一覧` 向けに整理し、ラベル・配置・見た目を調整しています。

### 変更内容

- `git-pseudo-squash` の `生成AIで整理` ボタンを外部リンクから内部相対リンクへ変更
- `git-pseudo-squash` の `生成AIで整理` ボタンを `現在ブランチで作業` の右側へ移動
- `git-pseudo-squash` の `生成AIで整理` ボタンに SVG アイコンを付与
- `prompt-gen` の `Git pseudo-squash で整理` 導線を内部リンク化
- `prompt-gen` 側の導線ラベルを `Git Squash` を経て `Git 作業一覧` へ変更
- `prompt-gen` 側のリンク先を `../git/git-work-list.html` へ変更
- `prompt-gen` 側の導線に SVG アイコンを追加し、リンク下線が出ないようスタイルを調整
- 関連する仕様メモ、TODO、テスト期待値、生成HTMLを更新

### 期待される効果

- ローカル利用時でも導線が公開URLに依存せず、一貫して内部画面遷移として扱える
- `git-pseudo-squash` から生成AIプロンプト作成への導線が文脈に沿った位置へ移動し、使いやすさが向上する
- `prompt-gen` からは squash 単体ではなく `Git 作業一覧` へ遷移する構成となり、Git作業全体の管理導線として自然になる

### テスト

- `npm test -- docs/prompt/tests/prompt-gen-main.test.js`
- `npm run build:prompt`
- `npm run build:git`
- `npm run build:all`

### 補足

- 今回の変更は主に導線整理とUI調整であり、各ツールのコアロジック自体は変更していません
- `prompt-gen` の A501 向け補助導線は維持しつつ、遷移先だけを現行運用に合わせて見直しています