### PR TITLE
Git 作業一覧から pseudo-squash へ渡す current branch 設定の復元不具合を修正

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -5672,6 +5672,7 @@ if (!customElements.get("lht-page-menu")) {
       const remoteName = String(params.get("remoteName") || "").trim();
       const useHeadWork = String(params.get("useHeadWork") || "").trim();
       const useCurrentBranch = String(params.get("useCurrentBranch") || "").trim();
+      const hasUseCurrentBranchParam = params.has("useCurrentBranch") || params.has("useHeadWork");
       const repoUrlField = document.getElementById("repoUrl");
       const baseBranchField = document.getElementById("squashBaseBranch");
       const workBranchField = document.getElementById("workBranch");
@@ -5695,8 +5696,14 @@ if (!customElements.get("lht-page-menu")) {
       if (defaultCommitMessage && commitMessageField && !String(commitMessageField.value || "").trim()) {
         commitMessageField.value = defaultCommitMessage;
       }
-      if (useHeadWork === "1" || useHeadWork === "true" || useCurrentBranch === "1" || useCurrentBranch === "true") {
-        setUseCurrentBranchSelected(true);
+      if (hasUseCurrentBranchParam) {
+        const useCurrentBranchEnabled = (
+          useHeadWork === "1" ||
+          useHeadWork === "true" ||
+          useCurrentBranch === "1" ||
+          useCurrentBranch === "true"
+        );
+        setUseCurrentBranchSelected(useCurrentBranchEnabled);
       }
       if ((baseScope === "remote" || baseScope === "local") && baseScopeField) {
         baseScopeField.value = baseScope;
@@ -5914,6 +5921,8 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function loadPersistedUiPreferences() {
+      const params = readCurrentQueryParams();
+      const hasUseCurrentBranchParam = params.has("useCurrentBranch") || params.has("useHeadWork");
       const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
       const lockOrigin = document.getElementById("lockOrigin");
       const squashBaseScope = document.getElementById("squashBaseScope");
@@ -5934,7 +5943,7 @@ if (!customElements.get("lht-page-menu")) {
       if (lockOrigin && lockOriginValue !== null) {
         setSwitchSelected("lockOrigin", lockOriginValue);
       }
-      if (useCurrentBranch && useCurrentBranchValue !== null) {
+      if (!hasUseCurrentBranchParam && useCurrentBranch && useCurrentBranchValue !== null) {
         setUseCurrentBranchSelected(useCurrentBranchValue);
       }
       if (squashBaseScope && (scopeValue === "remote" || scopeValue === "local")) {

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -4380,11 +4380,9 @@ if (!customElements.get("lht-page-menu")) {
       params.set("baseScope", entry.baseScope);
       params.set("workBranch", entry.compareBranch);
       params.set("remoteName", entry.remoteName);
+      params.set("useCurrentBranch", entry.compareUseHead ? "true" : "false");
       if (memoText) {
         params.set("defaultCommitMessage", memoText);
-      }
-      if (entry.compareUseHead) {
-        params.set("useHeadWork", "1");
       }
       return `git-pseudo-squash.html?${params.toString()}`;
     }

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -749,6 +749,7 @@
       const remoteName = String(params.get("remoteName") || "").trim();
       const useHeadWork = String(params.get("useHeadWork") || "").trim();
       const useCurrentBranch = String(params.get("useCurrentBranch") || "").trim();
+      const hasUseCurrentBranchParam = params.has("useCurrentBranch") || params.has("useHeadWork");
       const repoUrlField = document.getElementById("repoUrl");
       const baseBranchField = document.getElementById("squashBaseBranch");
       const workBranchField = document.getElementById("workBranch");
@@ -772,8 +773,14 @@
       if (defaultCommitMessage && commitMessageField && !String(commitMessageField.value || "").trim()) {
         commitMessageField.value = defaultCommitMessage;
       }
-      if (useHeadWork === "1" || useHeadWork === "true" || useCurrentBranch === "1" || useCurrentBranch === "true") {
-        setUseCurrentBranchSelected(true);
+      if (hasUseCurrentBranchParam) {
+        const useCurrentBranchEnabled = (
+          useHeadWork === "1" ||
+          useHeadWork === "true" ||
+          useCurrentBranch === "1" ||
+          useCurrentBranch === "true"
+        );
+        setUseCurrentBranchSelected(useCurrentBranchEnabled);
       }
       if ((baseScope === "remote" || baseScope === "local") && baseScopeField) {
         baseScopeField.value = baseScope;
@@ -991,6 +998,8 @@
     }
 
     function loadPersistedUiPreferences() {
+      const params = readCurrentQueryParams();
+      const hasUseCurrentBranchParam = params.has("useCurrentBranch") || params.has("useHeadWork");
       const shellEnvPowerShell = document.getElementById("shellEnvPowerShell");
       const lockOrigin = document.getElementById("lockOrigin");
       const squashBaseScope = document.getElementById("squashBaseScope");
@@ -1011,7 +1020,7 @@
       if (lockOrigin && lockOriginValue !== null) {
         setSwitchSelected("lockOrigin", lockOriginValue);
       }
-      if (useCurrentBranch && useCurrentBranchValue !== null) {
+      if (!hasUseCurrentBranchParam && useCurrentBranch && useCurrentBranchValue !== null) {
         setUseCurrentBranchSelected(useCurrentBranchValue);
       }
       if (squashBaseScope && (scopeValue === "remote" || scopeValue === "local")) {

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -407,11 +407,9 @@
       params.set("baseScope", entry.baseScope);
       params.set("workBranch", entry.compareBranch);
       params.set("remoteName", entry.remoteName);
+      params.set("useCurrentBranch", entry.compareUseHead ? "true" : "false");
       if (memoText) {
         params.set("defaultCommitMessage", memoText);
-      }
-      if (entry.compareUseHead) {
-        params.set("useHeadWork", "1");
       }
       return `git-pseudo-squash.html?${params.toString()}`;
     }

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -449,6 +449,54 @@ window.__gitPseudoSquashTest = {
     expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
   });
 
+  it("turns off current-branch mode when useCurrentBranch=false is passed from the list", () => {
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel&workBranch=feature-a&useCurrentBranch=false"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
+  });
+
+  it("prioritizes query useCurrentBranch=false over persisted current-branch preference", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitPseudoSquash.ui.useCurrentBranch", "true");
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel&workBranch=feature-a&useCurrentBranch=false"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
+  });
+
   it("builds branch-diff URL with HEAD when current branch mode is enabled", () => {
     bootGitPseudoSquashPage();
 

--- a/docs/git/tests/git-work-list-main.test.js
+++ b/docs/git/tests/git-work-list-main.test.js
@@ -232,8 +232,22 @@ describe("git-work-list main", () => {
       compareScope: "local",
       compareUseHead: true,
       remoteName: "origin"
-    })).toBe("git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature%2Flogin&remoteName=origin&defaultCommitMessage=default+memo&useHeadWork=1");
+    })).toBe("git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature%2Flogin&remoteName=origin&useCurrentBranch=true&defaultCommitMessage=default+memo");
   });
+
+  it("builds git-pseudo-squash URL params with current-branch mode off", () => {
+    bootPage();
+
+    expect(window.__gitWorkListTest.buildPseudoSquashUrl({
+      repoUrl: "https://example.com/repo-a",
+      baseBranch: "devel",
+      baseScope: "remote",
+      compareBranch: "feature/login",
+      compareScope: "local",
+      compareUseHead: false,
+      remoteName: "origin"
+    })).toBe("git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&baseScope=remote&workBranch=feature%2Flogin&remoteName=origin&useCurrentBranch=false");
+    });
 
   it("renders stored entries in reverse created order", () => {
     localStorage.setItem("gitWorkList.entries", JSON.stringify([
@@ -267,7 +281,7 @@ describe("git-work-list main", () => {
     expect(entriesHtml).toContain("repo-b");
     expect(entriesHtml.indexOf("repo-b")).toBeLessThan(entriesHtml.indexOf("repo-a"));
     expect(entriesHtml).toContain("比較");
-    expect(entriesHtml).toContain("squash");
+    expect(entriesHtml).toContain("Squash");
     expect(entriesHtml).toContain("ロック");
   });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-14</div>
+        <div class="md-app-meta">更新日: 2026-03-15</div>
       </div>
     </header>
 


### PR DESCRIPTION
### 概要

`Git 作業一覧` から `Git pseudo-squash` へ遷移した際に、`HEAD` を使わない項目でも `現在ブランチで作業` が有効化され、一覧へ戻したあとに `HEAD` バッジが付いてしまう問題を修正しました。あわせて、URL パラメータの表現を `true/false` に整理し、設定復元まわりのテストを補強しています。

### 変更内容

- `git-work-list` から `git-pseudo-squash` へ遷移する URL に `useCurrentBranch=true/false` を常に付与するよう変更
- `git-pseudo-squash` 側で `useCurrentBranch` / `useHeadWork` の query が存在する場合は、その値を優先して `現在ブランチで作業` を復元するよう変更
- `git-pseudo-squash` の `localStorage` 復元処理で、query 指定があるときに保存済み設定が上書きしないよう修正
- `true/false` 指定、および query が保存済み設定より優先されることを確認するテストを追加
- 関連する生成HTMLとテスト期待値を更新
- docs index の生成物も再ビルドして反映

### 原因

これまでは `HEAD` を使う場合だけ遷移パラメータを付ける実装だったため、`HEAD` を使わない項目では明示的な `false` が渡されていませんでした。さらに `git-pseudo-squash` の初期化順で query 適用後に `localStorage` の保存設定が復元されるため、保存済みの `現在ブランチで作業=true` が再度有効になり、一覧へ戻した際に `compareUseHead=true` として保存されていました。

### 期待される効果

- `HEAD` を使わない作業項目を `Squash` へ開いて戻っても、意図せず `HEAD` バッジが付かなくなる
- `Git 作業一覧` と `Git pseudo-squash` の間で current branch 設定が一貫して引き継がれる
- URL パラメータの意味が `true/false` で読みやすくなる

### テスト

- `npm test -- docs/git/tests/git-work-list-main.test.js docs/git/tests/git-pseudo-squash-main.test.js`
- `npm run build:git`