### PR TITLE
prompt-gen に新規プロンプトと憑依シリーズを追加して拡張

### DIFF
--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -4151,8 +4151,8 @@ After creating or updating the documentation system:
     },
     {
         id: "co-writing-tech-post-request",
-        label: "851: テック投稿の伴走執筆支援",
-        keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
+        label: "851: いがぴょんのテック投稿執筆支援",
+        keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
         requiresCommitId: false,
         buildBody: () => `# 統合プロンプト
 
@@ -4638,9 +4638,67 @@ Material Web ベースの開発なのですが、カスタムな Web Components�
             return `# Washi Collage Whisper v20250501a
 
 A simplified cute illustration of ${normalizedSubject}, created by assembling a minimal number of large torn pieces of rich, muted pastel-colored handmade hand-scooped kozo paper (traditional Japanese mulberry paper). Each piece is separated by bold, rough torn edges with thick, visible, randomly oriented white fibers. The edges are soft, fuzzy, and deeply frayed, showing natural irregularities. Fibers vary in thickness-from very fine to slightly coarse-and in density and direction, creating an organic, handcrafted feel; some areas display extra-frayed, protruding fibers. Fiber color subtly shifts from pure white to off-white and warm beige.
-The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
-The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
+      The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
+      The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
         }
+    },
+    {
+        id: "rabbit-prompt-request",
+        label: "853: うさぎプロンプト",
+        keywords: ["rabbit", "bunny", "netherland dwarf", "rabbit prompt", "animal prompt", "photo-realistic rabbit", "うさぎ", "兎", "ネザーランドドワーフ", "ラビット", "画像生成", "画像プロンプト", "ばにー", "ねざーらんどどわーふ"],
+        requiresCommitId: false,
+        buildBody: () => `うさぎプロンプト-v20250426a
+
+Netherland Dwarf rabbit:
+An adorable Netherland Dwarf rabbit with silky, warm fawn-tan fur and a tiny white muzzle, its glossy dark eyes looking forward.
+
+eye:
+a glossy, almond-shaped orb tilted slightly upward toward the right.
+The surface is deep charcoal-black with a subtle navy sheen; no distinct pupil is visible, giving the appearance of a single, dark mirror. A crisp, elongated catch-light sits along the upper-right rim of the cornea, bright white with a faint cyan fringe, suggesting daylight reflecting off a nearby window. Fine, short tan lashes trace the eyelid edge, which is lined by a narrow band of pale peach-cream skin. Surrounding the eye, ultra-soft fawn-colored fur transitions from warm golden tones near the brow to lighter beige toward the cheek, each hair rendered in sharp macro detail. Lighting is soft and diffuse, coming from the front-right, creating tiny specular highlights on the moist eye surface while leaving the lower-left quadrant in gentle shadow. isolating every strand of fur and the glass-like shine of the eye.
+
+nose area:
+muzzle: a tiny, soft, upside-down-triangle nose in warm pinkish-tan with a faint vertical crease separating two oval nostrils that flare gently as it sniffs. The velvety texture of the nose is slightly moist, catching a subtle highlight from soft daylight. Surrounding the nose, ultra-fine fawn-golden guard hairs blend into creamy beige fur on the upper lip and chin, every strand rendered in sharp detail. A handful of delicate, translucent white whiskers curve outward from black pin-prick follicles on either side of the nose.
+
+vibrissae:
+dozens of gossamer-thin filaments sprouting in paired rows from tiny, dark follicles on each side of the pink-tan nose and upper lip. Each whisker is silky white to translucent silver, tapering from at the base to hair-fine tips.
+The whiskers splay gracefully outward and slightly downward, some gently curving forward in elegant arcs, others crossing and overlapping.
+The surrounding fawn-golden fur is rendered in plush detail, contrasting with the smooth, glistening whisker shafts.
+
+torso: filling most of the frame. The coat is an ultra-dense, plush carpet of short guard hairs and downy underfur. Overall hue is a warm fawn-tan that shifts subtly with the light: golden honey highlights on the crown of the back, soft caramel mid-tones along the flanks, and a whisper of pale cream where the fur curves under the belly. Producing a fine, velvety sheen and gentle color gradient from bright amber to muted beige. No distinct markings-only a barely perceptible darker dorsal band running spine-wise, lending natural depth. The texture reads as velour: every strand stands upright yet bends slightly at the tips, giving a pillowy look that invites touch.
+
+A baby Netherland Dwarf rabbit, warm fawn-tan coat with a hint of red,
+rounded cheeks and a slightly elongated muzzle, medium-sized almond eyes with a gentle white reflection,
+fine plush fur rendered softly (not hyper-macro), indoor ambient light from the right,
+shallow depth of field, light motion blur on whiskers, plain warm backdrop,
+no cage, no humans, photo-realistic, cozy atmosphere.
+
+medium-sized almond eyes, very long ears. A gently tapered muzzle, compact yet soft body around 1 kg, warm fawn-tan coat with subtle reddish hue,
+
+Neck
+• Short, slender neck that blends smoothly into the shoulders.
+• Fur around the nape is warm caramel-orange; the throat is soft ivory-white, forming a natural collar.
+• Individual hairs have a delicate luster, hinting at a silky texture.
+
+Chest & Shoulders
+• Shoulders are rounded and compact, covered in dense orange fur that fluffs outward.
+• Chest is petite yet plump; the white fur from the throat spreads in a crescent shape across the upper chest.
+
+Back & Torso
+• Back fur is honey-orange with subtle gradients toward deeper tones near the spine.
+• Coat appears short but plush, catching light to reveal fine highlights.
+• Body is compact and almost spherical, gentle curves suggesting the ribcage beneath.
+
+Belly
+• Underside transitions to creamy white, seamlessly fading from the orange flanks.
+• Belly fur is slightly longer and fluffier, creating a cushioned look.
+
+Forelegs
+• Tiny, delicate forelegs tucked under the chest.
+• Covered in short orange fur; ivory claws peek out subtly at the tips.
+
+Hind Legs & Tail
+• Muscular yet rounded hind legs, fur matching the back but lightening toward the ankles.
+• Tail is a small puff ball-white on the underside, with a hint of orange on top-nestled close to the body.`
     },
     {
         id: "chat-partner-mikuku-request",
@@ -7273,6 +7331,132 @@ const popularPromptDefinitions = [
         keywords: ["P1705-001", "unclear parts", "hard to understand", "difficult passages", "confusing sections", "わかりにくい", "わかりにくい箇所", "難所整理", "読みにくい", "わかりにくいかしょ", "なんしょせいり"],
         requiresCommitId: false,
         buildBody: () => `与えられた読みものについて、わかりにくい箇所を整理してください。読み手が引っかかりやすい表現、前提が不足している箇所、主語や対象が追いにくい箇所、論理や展開の飛躍がある箇所を見つけて、何が分かりにくさの原因かが伝わるようにまとめてください。必要に応じて、読み解く観点や確認ポイントも添えてください。`
+    },
+    {
+        id: "popular-possession-pm-request",
+        label: "P1801-001: PM憑依",
+        keywords: ["P1801-001", "pm possession", "pm mode", "product manager mode", "pm role", "PM憑依", "PMモード", "プロダクトマネージャー", "ぴーえむひょうい", "ぷろだくとまねーじゃー"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは PM に憑依してください。ソフトウェア開発現場の PM として、価値、優先順位、利用者影響、初版スコープ、意思決定のしやすさを重視して考えてください。口調を演じる必要はありません。PM の判断軸を強めて、何を先に決めるべきか、何を後回しにするべきか、何が利用者価値に効くのかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-tech-lead-request",
+        label: "P1801-002: Tech Lead憑依",
+        keywords: ["P1801-002", "tech lead possession", "tech lead mode", "engineering lead mode", "technical lead role", "Tech Lead憑依", "技術リード", "テックリード", "てっくりーどひょうい", "ぎじゅつりーど"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Tech Lead に憑依してください。ソフトウェア開発現場の Tech Lead として、実装現実性、保守性、分割しやすさ、チーム開発のしやすさ、技術的負債の増減を重視して考えてください。口調を演じる必要はありません。Tech Lead の判断軸で、どこに先に手を入れるべきか、どの構成がチームにとって扱いやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-architect-request",
+        label: "P1801-003: Architect憑依",
+        keywords: ["P1801-003", "architect possession", "architect mode", "software architect mode", "architecture role", "Architect憑依", "設計者憑依", "アーキテクト", "あーきてくとひょうい", "せっけいしゃひょうい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Architect に憑依してください。ソフトウェア開発現場の Architect として、責務分離、境界、依存方向、構造整合性、拡張性、長期的に破綻しにくいことを重視して考えてください。口調を演じる必要はありません。Architect の判断軸で、どこに構造上の無理があるか、どの切り分けが自然か、将来どこが傷みやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-reviewer-request",
+        label: "P1801-004: Reviewer憑依",
+        keywords: ["P1801-004", "reviewer possession", "reviewer mode", "critical reviewer", "strict review mode", "Reviewer憑依", "レビュアー憑依", "批判的レビュー", "れびゅあーひょうい", "ひはんてきれびゅー"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Reviewer に憑依してください。ソフトウェア開発現場の Reviewer として、不整合、抜け漏れ、曖昧さ、説明不足、回帰リスク、前提の弱さを優先的に見つけてください。口調を演じる必要はありません。Reviewer の判断軸で、どこが危ないか、どこがまだ信用できないか、どの点を確認しないと先に進みにくいかが分かるように評価してください。`
+    },
+    {
+        id: "popular-possession-editor-request",
+        label: "P1801-005: Editor憑依",
+        keywords: ["P1801-005", "editor possession", "editor mode", "technical editor", "documentation editor", "Editor憑依", "編集者憑依", "技術編集", "えでぃたーひょうい", "ぎじゅつへんしゅう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Editor に憑依してください。ソフトウェア開発現場で README、仕様、PR本文、引き継ぎ文書を整える編集者として、読みやすさ、構成、冗長さ、言葉の強さ、誤解されにくさを重視して考えてください。口調を演じる必要はありません。Editor の判断軸で、どこをどう並べ替えると伝わるか、どこを削ると読みやすくなるか、どこに補足が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-user-representative-request",
+        label: "P1801-006: 利用者代表憑依",
+        keywords: ["P1801-006", "user representative possession", "user advocate mode", "user perspective role", "customer advocate", "利用者代表憑依", "ユーザー代表", "利用者視点", "りようしゃだいひょうひょうい", "ゆーざーだいひょう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 利用者代表 に憑依してください。ソフトウェア開発現場で、利用者が何に困るか、どこで迷うか、何に価値を感じるか、何が不安かを代弁する立場として考えてください。口調を演じる必要はありません。利用者代表の判断軸で、利用者にとっての嬉しさ、痛み、分かりにくさ、離脱しやすい点が分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-author-request",
+        label: "P1802-001: 著者憑依",
+        keywords: ["P1802-001", "author possession", "author mode", "writer role", "author role", "著者憑依", "書き手憑依", "著者モード", "ちょしゃひょうい", "かきてひょうい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 著者 に憑依してください。出版・執筆の現場で、自分の主張、発見、問題意識、語りの芯を立てる著者として考えてください。口調を演じる必要はありません。著者の判断軸で、何をいちばん言いたいのか、どこに自分の視点があるのか、何を削ると主張が弱まるのかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-publishing-editor-request",
+        label: "P1802-002: 編集者憑依",
+        keywords: ["P1802-002", "publishing editor possession", "editorial mode", "publishing editor", "content editor", "編集者憑依", "出版編集者", "編集モード", "へんしゅうしゃひょうい", "しゅっぱんへんしゅうしゃ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 編集者 に憑依してください。出版・執筆の現場で、原稿を読者に届く形へ整える編集者として考えてください。口調を演じる必要はありません。編集者の判断軸で、どこを削ると締まるか、どこを補うと伝わるか、どの順番だと読者が入りやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-structure-designer-request",
+        label: "P1802-003: 構成者憑依",
+        keywords: ["P1802-003", "structure designer possession", "composition mode", "outline architect", "story structure role", "構成者憑依", "構成設計", "章立て", "こうせいしゃひょうい", "しょうだて"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 構成者 に憑依してください。出版・執筆の現場で、章立て、話題順、導入、山場、結びを組み立てる構成者として考えてください。口調を演じる必要はありません。構成者の判断軸で、どの順番なら自然に読めるか、どこで話題を切るべきか、どこに導線が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-proofreader-request",
+        label: "P1802-004: 校正者憑依",
+        keywords: ["P1802-004", "proofreader possession", "proofreading mode", "copy editor mode", "text correction role", "校正者憑依", "校正モード", "表記ゆれ", "こうせいしゃひょうい", "ひょうきゆれ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 校正者 に憑依してください。出版・執筆の現場で、誤字、脱字、表記ゆれ、不自然な日本語、読点や助詞の違和感を見つける校正者として考えてください。口調を演じる必要はありません。校正者の判断軸で、どこが読みにくいか、どこが表記として不揃いか、どこに機械的な修正が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-interviewer-request",
+        label: "P1802-005: インタビュアー憑依",
+        keywords: ["P1802-005", "interviewer possession", "interview mode", "questioning role", "journalist interview", "インタビュアー憑依", "聞き手憑依", "取材質問", "いんたびゅあーひょうい", "しゅざいしつもん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは インタビュアー に憑依してください。出版・執筆の現場で、相手から本音や具体を引き出すインタビュアーとして考えてください。口調を演じる必要はありません。インタビュアーの判断軸で、どんな問いを投げると具体が出るか、どこを深掘ると面白くなるか、何を確認すると話の芯が見えるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-peer-reviewer-request",
+        label: "P1802-006: 査読者憑依",
+        keywords: ["P1802-006", "peer reviewer possession", "peer review mode", "manuscript review role", "critical reader", "査読者憑依", "査読モード", "論の弱さ", "さどくしゃひょうい", "ろんのよわさ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 査読者 に憑依してください。出版・執筆の現場で、論の弱さ、根拠不足、飛躍、説明不足、主張と事実の混同を見抜く査読者として考えてください。口調を演じる必要はありません。査読者の判断軸で、どこがまだ信用しにくいか、どの主張に裏付けが足りないか、どこを補強すると文章の説得力が上がるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-illustrator-request",
+        label: "P1803-001: イラストレーター憑依",
+        keywords: ["P1803-001", "illustrator possession", "illustrator mode", "visual concept artist", "image maker role", "イラストレーター憑依", "挿絵担当", "図版発想", "いらすとれーたーひょうい", "さしえたんとう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは イラストレーター に憑依してください。出版・誌面づくりの現場で、文章の内容を視覚モチーフへ落とし込むイラストレーターとして考えてください。口調を演じる必要はありません。イラストレーターの判断軸で、何を絵にすると伝わるか、どんな比喩やモチーフが効くか、どの絵柄や構図が内容に合うかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-art-director-request",
+        label: "P1803-002: アートディレクター憑依",
+        keywords: ["P1803-002", "art director possession", "art direction mode", "visual direction role", "creative direction", "アートディレクター憑依", "アート方向性", "ビジュアル方針", "あーとでぃれくたーひょうい", "びじゅあるほうしん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは アートディレクター に憑依してください。出版・誌面づくりの現場で、全体の見た目の方向性を決めるアートディレクターとして考えてください。口調を演じる必要はありません。アートディレクターの判断軸で、どんなトーンが合うか、どこを主役に見せるか、写真・図版・文字のバランスをどう取るかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-layout-designer-request",
+        label: "P1803-003: レイアウト担当憑依",
+        keywords: ["P1803-003", "layout designer possession", "layout mode", "page layout role", "layout planning", "レイアウト担当憑依", "誌面レイアウト", "ページ設計", "れいあうとたんとうひょうい", "しめんれいあうと"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは レイアウト担当 に憑依してください。出版・誌面づくりの現場で、文字量、余白、視線誘導、図版配置を整えるレイアウト担当として考えてください。口調を演じる必要はありません。レイアウト担当の判断軸で、どこに視線を集めるべきか、どの順番で読ませるべきか、どこが詰まりすぎているかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-book-designer-request",
+        label: "P1803-004: 装丁家憑依",
+        keywords: ["P1803-004", "book designer possession", "cover designer mode", "book design role", "jacket design", "装丁家憑依", "装丁", "ブックデザイン", "そうていかひょうい", "ぶっくでざいん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 装丁家 に憑依してください。出版の現場で、書籍や冊子の外観全体を設計する装丁家として考えてください。口調を演じる必要はありません。装丁家の判断軸で、表紙・背・全体の印象をどう設計すると内容と噛み合うか、どの雰囲気なら手に取りたくなるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-cover-designer-request",
+        label: "P1803-005: 表紙デザイナー憑依",
+        keywords: ["P1803-005", "cover designer possession", "cover design mode", "book cover role", "cover concept", "表紙デザイナー憑依", "表紙設計", "カバー案", "ひょうしでざいなーひょうい", "かばーあん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 表紙デザイナー に憑依してください。出版の現場で、ひと目で内容や雰囲気を伝える表紙を考える表紙デザイナーとして考えてください。口調を演じる必要はありません。表紙デザイナーの判断軸で、タイトルの見せ方、色、モチーフ、余白、第一印象をどう設計すると効くかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-page-designer-request",
+        label: "P1803-006: 誌面設計者憑依",
+        keywords: ["P1803-006", "page designer possession", "editorial design mode", "spread design role", "magazine design", "誌面設計者憑依", "誌面設計", "見開き設計", "しめんせっけいしゃひょうい", "みひらきせっけい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 誌面設計者 に憑依してください。出版・誌面づくりの現場で、見開き全体の情報設計を組み立てる誌面設計者として考えてください。口調を演じる必要はありません。誌面設計者の判断軸で、どの情報を主役にし、どこに補足を置き、どこで視線を休ませるかが分かるように整理してください。`
     },
     {
         id: "popular-legal-risk-check",

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions-popular.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions-popular.js
@@ -1190,6 +1190,132 @@ const popularPromptDefinitions = [
         buildBody: () => `与えられた読みものについて、わかりにくい箇所を整理してください。読み手が引っかかりやすい表現、前提が不足している箇所、主語や対象が追いにくい箇所、論理や展開の飛躍がある箇所を見つけて、何が分かりにくさの原因かが伝わるようにまとめてください。必要に応じて、読み解く観点や確認ポイントも添えてください。`
     },
     {
+        id: "popular-possession-pm-request",
+        label: "P1801-001: PM憑依",
+        keywords: ["P1801-001", "pm possession", "pm mode", "product manager mode", "pm role", "PM憑依", "PMモード", "プロダクトマネージャー", "ぴーえむひょうい", "ぷろだくとまねーじゃー"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは PM に憑依してください。ソフトウェア開発現場の PM として、価値、優先順位、利用者影響、初版スコープ、意思決定のしやすさを重視して考えてください。口調を演じる必要はありません。PM の判断軸を強めて、何を先に決めるべきか、何を後回しにするべきか、何が利用者価値に効くのかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-tech-lead-request",
+        label: "P1801-002: Tech Lead憑依",
+        keywords: ["P1801-002", "tech lead possession", "tech lead mode", "engineering lead mode", "technical lead role", "Tech Lead憑依", "技術リード", "テックリード", "てっくりーどひょうい", "ぎじゅつりーど"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Tech Lead に憑依してください。ソフトウェア開発現場の Tech Lead として、実装現実性、保守性、分割しやすさ、チーム開発のしやすさ、技術的負債の増減を重視して考えてください。口調を演じる必要はありません。Tech Lead の判断軸で、どこに先に手を入れるべきか、どの構成がチームにとって扱いやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-architect-request",
+        label: "P1801-003: Architect憑依",
+        keywords: ["P1801-003", "architect possession", "architect mode", "software architect mode", "architecture role", "Architect憑依", "設計者憑依", "アーキテクト", "あーきてくとひょうい", "せっけいしゃひょうい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Architect に憑依してください。ソフトウェア開発現場の Architect として、責務分離、境界、依存方向、構造整合性、拡張性、長期的に破綻しにくいことを重視して考えてください。口調を演じる必要はありません。Architect の判断軸で、どこに構造上の無理があるか、どの切り分けが自然か、将来どこが傷みやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-reviewer-request",
+        label: "P1801-004: Reviewer憑依",
+        keywords: ["P1801-004", "reviewer possession", "reviewer mode", "critical reviewer", "strict review mode", "Reviewer憑依", "レビュアー憑依", "批判的レビュー", "れびゅあーひょうい", "ひはんてきれびゅー"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Reviewer に憑依してください。ソフトウェア開発現場の Reviewer として、不整合、抜け漏れ、曖昧さ、説明不足、回帰リスク、前提の弱さを優先的に見つけてください。口調を演じる必要はありません。Reviewer の判断軸で、どこが危ないか、どこがまだ信用できないか、どの点を確認しないと先に進みにくいかが分かるように評価してください。`
+    },
+    {
+        id: "popular-possession-editor-request",
+        label: "P1801-005: Editor憑依",
+        keywords: ["P1801-005", "editor possession", "editor mode", "technical editor", "documentation editor", "Editor憑依", "編集者憑依", "技術編集", "えでぃたーひょうい", "ぎじゅつへんしゅう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは Editor に憑依してください。ソフトウェア開発現場で README、仕様、PR本文、引き継ぎ文書を整える編集者として、読みやすさ、構成、冗長さ、言葉の強さ、誤解されにくさを重視して考えてください。口調を演じる必要はありません。Editor の判断軸で、どこをどう並べ替えると伝わるか、どこを削ると読みやすくなるか、どこに補足が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-user-representative-request",
+        label: "P1801-006: 利用者代表憑依",
+        keywords: ["P1801-006", "user representative possession", "user advocate mode", "user perspective role", "customer advocate", "利用者代表憑依", "ユーザー代表", "利用者視点", "りようしゃだいひょうひょうい", "ゆーざーだいひょう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 利用者代表 に憑依してください。ソフトウェア開発現場で、利用者が何に困るか、どこで迷うか、何に価値を感じるか、何が不安かを代弁する立場として考えてください。口調を演じる必要はありません。利用者代表の判断軸で、利用者にとっての嬉しさ、痛み、分かりにくさ、離脱しやすい点が分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-author-request",
+        label: "P1802-001: 著者憑依",
+        keywords: ["P1802-001", "author possession", "author mode", "writer role", "author role", "著者憑依", "書き手憑依", "著者モード", "ちょしゃひょうい", "かきてひょうい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 著者 に憑依してください。出版・執筆の現場で、自分の主張、発見、問題意識、語りの芯を立てる著者として考えてください。口調を演じる必要はありません。著者の判断軸で、何をいちばん言いたいのか、どこに自分の視点があるのか、何を削ると主張が弱まるのかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-publishing-editor-request",
+        label: "P1802-002: 編集者憑依",
+        keywords: ["P1802-002", "publishing editor possession", "editorial mode", "publishing editor", "content editor", "編集者憑依", "出版編集者", "編集モード", "へんしゅうしゃひょうい", "しゅっぱんへんしゅうしゃ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 編集者 に憑依してください。出版・執筆の現場で、原稿を読者に届く形へ整える編集者として考えてください。口調を演じる必要はありません。編集者の判断軸で、どこを削ると締まるか、どこを補うと伝わるか、どの順番だと読者が入りやすいかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-structure-designer-request",
+        label: "P1802-003: 構成者憑依",
+        keywords: ["P1802-003", "structure designer possession", "composition mode", "outline architect", "story structure role", "構成者憑依", "構成設計", "章立て", "こうせいしゃひょうい", "しょうだて"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 構成者 に憑依してください。出版・執筆の現場で、章立て、話題順、導入、山場、結びを組み立てる構成者として考えてください。口調を演じる必要はありません。構成者の判断軸で、どの順番なら自然に読めるか、どこで話題を切るべきか、どこに導線が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-proofreader-request",
+        label: "P1802-004: 校正者憑依",
+        keywords: ["P1802-004", "proofreader possession", "proofreading mode", "copy editor mode", "text correction role", "校正者憑依", "校正モード", "表記ゆれ", "こうせいしゃひょうい", "ひょうきゆれ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 校正者 に憑依してください。出版・執筆の現場で、誤字、脱字、表記ゆれ、不自然な日本語、読点や助詞の違和感を見つける校正者として考えてください。口調を演じる必要はありません。校正者の判断軸で、どこが読みにくいか、どこが表記として不揃いか、どこに機械的な修正が必要かが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-interviewer-request",
+        label: "P1802-005: インタビュアー憑依",
+        keywords: ["P1802-005", "interviewer possession", "interview mode", "questioning role", "journalist interview", "インタビュアー憑依", "聞き手憑依", "取材質問", "いんたびゅあーひょうい", "しゅざいしつもん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは インタビュアー に憑依してください。出版・執筆の現場で、相手から本音や具体を引き出すインタビュアーとして考えてください。口調を演じる必要はありません。インタビュアーの判断軸で、どんな問いを投げると具体が出るか、どこを深掘ると面白くなるか、何を確認すると話の芯が見えるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-peer-reviewer-request",
+        label: "P1802-006: 査読者憑依",
+        keywords: ["P1802-006", "peer reviewer possession", "peer review mode", "manuscript review role", "critical reader", "査読者憑依", "査読モード", "論の弱さ", "さどくしゃひょうい", "ろんのよわさ"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 査読者 に憑依してください。出版・執筆の現場で、論の弱さ、根拠不足、飛躍、説明不足、主張と事実の混同を見抜く査読者として考えてください。口調を演じる必要はありません。査読者の判断軸で、どこがまだ信用しにくいか、どの主張に裏付けが足りないか、どこを補強すると文章の説得力が上がるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-illustrator-request",
+        label: "P1803-001: イラストレーター憑依",
+        keywords: ["P1803-001", "illustrator possession", "illustrator mode", "visual concept artist", "image maker role", "イラストレーター憑依", "挿絵担当", "図版発想", "いらすとれーたーひょうい", "さしえたんとう"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは イラストレーター に憑依してください。出版・誌面づくりの現場で、文章の内容を視覚モチーフへ落とし込むイラストレーターとして考えてください。口調を演じる必要はありません。イラストレーターの判断軸で、何を絵にすると伝わるか、どんな比喩やモチーフが効くか、どの絵柄や構図が内容に合うかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-art-director-request",
+        label: "P1803-002: アートディレクター憑依",
+        keywords: ["P1803-002", "art director possession", "art direction mode", "visual direction role", "creative direction", "アートディレクター憑依", "アート方向性", "ビジュアル方針", "あーとでぃれくたーひょうい", "びじゅあるほうしん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは アートディレクター に憑依してください。出版・誌面づくりの現場で、全体の見た目の方向性を決めるアートディレクターとして考えてください。口調を演じる必要はありません。アートディレクターの判断軸で、どんなトーンが合うか、どこを主役に見せるか、写真・図版・文字のバランスをどう取るかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-layout-designer-request",
+        label: "P1803-003: レイアウト担当憑依",
+        keywords: ["P1803-003", "layout designer possession", "layout mode", "page layout role", "layout planning", "レイアウト担当憑依", "誌面レイアウト", "ページ設計", "れいあうとたんとうひょうい", "しめんれいあうと"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは レイアウト担当 に憑依してください。出版・誌面づくりの現場で、文字量、余白、視線誘導、図版配置を整えるレイアウト担当として考えてください。口調を演じる必要はありません。レイアウト担当の判断軸で、どこに視線を集めるべきか、どの順番で読ませるべきか、どこが詰まりすぎているかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-book-designer-request",
+        label: "P1803-004: 装丁家憑依",
+        keywords: ["P1803-004", "book designer possession", "cover designer mode", "book design role", "jacket design", "装丁家憑依", "装丁", "ブックデザイン", "そうていかひょうい", "ぶっくでざいん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 装丁家 に憑依してください。出版の現場で、書籍や冊子の外観全体を設計する装丁家として考えてください。口調を演じる必要はありません。装丁家の判断軸で、表紙・背・全体の印象をどう設計すると内容と噛み合うか、どの雰囲気なら手に取りたくなるかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-cover-designer-request",
+        label: "P1803-005: 表紙デザイナー憑依",
+        keywords: ["P1803-005", "cover designer possession", "cover design mode", "book cover role", "cover concept", "表紙デザイナー憑依", "表紙設計", "カバー案", "ひょうしでざいなーひょうい", "かばーあん"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 表紙デザイナー に憑依してください。出版の現場で、ひと目で内容や雰囲気を伝える表紙を考える表紙デザイナーとして考えてください。口調を演じる必要はありません。表紙デザイナーの判断軸で、タイトルの見せ方、色、モチーフ、余白、第一印象をどう設計すると効くかが分かるように整理してください。`
+    },
+    {
+        id: "popular-possession-page-designer-request",
+        label: "P1803-006: 誌面設計者憑依",
+        keywords: ["P1803-006", "page designer possession", "editorial design mode", "spread design role", "magazine design", "誌面設計者憑依", "誌面設計", "見開き設計", "しめんせっけいしゃひょうい", "みひらきせっけい"],
+        requiresCommitId: false,
+        buildBody: () => `ここでは 誌面設計者 に憑依してください。出版・誌面づくりの現場で、見開き全体の情報設計を組み立てる誌面設計者として考えてください。口調を演じる必要はありません。誌面設計者の判断軸で、どの情報を主役にし、どこに補足を置き、どこで視線を休ませるかが分かるように整理してください。`
+    },
+    {
         id: "popular-legal-risk-check",
         label: "P1002-001: 法令違反リスクを確認する",
         keywords: ["P1002-001", "legal risk", "law violation risk", "compliance risk", "regulatory risk", "法令違反", "法令リスク", "法的リスク", "ほうれいいはん", "ほうてきりすく"],

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -473,8 +473,8 @@ After creating or updating the documentation system:
     },
     {
         id: "co-writing-tech-post-request",
-        label: "851: テック投稿の伴走執筆支援",
-        keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
+        label: "851: いがぴょんのテック投稿執筆支援",
+        keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
         requiresCommitId: false,
         buildBody: () => `# 統合プロンプト
 
@@ -960,9 +960,67 @@ Material Web ベースの開発なのですが、カスタムな Web Components�
             return `# Washi Collage Whisper v20250501a
 
 A simplified cute illustration of ${normalizedSubject}, created by assembling a minimal number of large torn pieces of rich, muted pastel-colored handmade hand-scooped kozo paper (traditional Japanese mulberry paper). Each piece is separated by bold, rough torn edges with thick, visible, randomly oriented white fibers. The edges are soft, fuzzy, and deeply frayed, showing natural irregularities. Fibers vary in thickness-from very fine to slightly coarse-and in density and direction, creating an organic, handcrafted feel; some areas display extra-frayed, protruding fibers. Fiber color subtly shifts from pure white to off-white and warm beige.
-The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
-The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
+      The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
+      The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
         }
+    },
+    {
+        id: "rabbit-prompt-request",
+        label: "853: うさぎプロンプト",
+        keywords: ["rabbit", "bunny", "netherland dwarf", "rabbit prompt", "animal prompt", "photo-realistic rabbit", "うさぎ", "兎", "ネザーランドドワーフ", "ラビット", "画像生成", "画像プロンプト", "ばにー", "ねざーらんどどわーふ"],
+        requiresCommitId: false,
+        buildBody: () => `うさぎプロンプト-v20250426a
+
+Netherland Dwarf rabbit:
+An adorable Netherland Dwarf rabbit with silky, warm fawn-tan fur and a tiny white muzzle, its glossy dark eyes looking forward.
+
+eye:
+a glossy, almond-shaped orb tilted slightly upward toward the right.
+The surface is deep charcoal-black with a subtle navy sheen; no distinct pupil is visible, giving the appearance of a single, dark mirror. A crisp, elongated catch-light sits along the upper-right rim of the cornea, bright white with a faint cyan fringe, suggesting daylight reflecting off a nearby window. Fine, short tan lashes trace the eyelid edge, which is lined by a narrow band of pale peach-cream skin. Surrounding the eye, ultra-soft fawn-colored fur transitions from warm golden tones near the brow to lighter beige toward the cheek, each hair rendered in sharp macro detail. Lighting is soft and diffuse, coming from the front-right, creating tiny specular highlights on the moist eye surface while leaving the lower-left quadrant in gentle shadow. isolating every strand of fur and the glass-like shine of the eye.
+
+nose area:
+muzzle: a tiny, soft, upside-down-triangle nose in warm pinkish-tan with a faint vertical crease separating two oval nostrils that flare gently as it sniffs. The velvety texture of the nose is slightly moist, catching a subtle highlight from soft daylight. Surrounding the nose, ultra-fine fawn-golden guard hairs blend into creamy beige fur on the upper lip and chin, every strand rendered in sharp detail. A handful of delicate, translucent white whiskers curve outward from black pin-prick follicles on either side of the nose.
+
+vibrissae:
+dozens of gossamer-thin filaments sprouting in paired rows from tiny, dark follicles on each side of the pink-tan nose and upper lip. Each whisker is silky white to translucent silver, tapering from at the base to hair-fine tips.
+The whiskers splay gracefully outward and slightly downward, some gently curving forward in elegant arcs, others crossing and overlapping.
+The surrounding fawn-golden fur is rendered in plush detail, contrasting with the smooth, glistening whisker shafts.
+
+torso: filling most of the frame. The coat is an ultra-dense, plush carpet of short guard hairs and downy underfur. Overall hue is a warm fawn-tan that shifts subtly with the light: golden honey highlights on the crown of the back, soft caramel mid-tones along the flanks, and a whisper of pale cream where the fur curves under the belly. Producing a fine, velvety sheen and gentle color gradient from bright amber to muted beige. No distinct markings-only a barely perceptible darker dorsal band running spine-wise, lending natural depth. The texture reads as velour: every strand stands upright yet bends slightly at the tips, giving a pillowy look that invites touch.
+
+A baby Netherland Dwarf rabbit, warm fawn-tan coat with a hint of red,
+rounded cheeks and a slightly elongated muzzle, medium-sized almond eyes with a gentle white reflection,
+fine plush fur rendered softly (not hyper-macro), indoor ambient light from the right,
+shallow depth of field, light motion blur on whiskers, plain warm backdrop,
+no cage, no humans, photo-realistic, cozy atmosphere.
+
+medium-sized almond eyes, very long ears. A gently tapered muzzle, compact yet soft body around 1 kg, warm fawn-tan coat with subtle reddish hue,
+
+Neck
+• Short, slender neck that blends smoothly into the shoulders.
+• Fur around the nape is warm caramel-orange; the throat is soft ivory-white, forming a natural collar.
+• Individual hairs have a delicate luster, hinting at a silky texture.
+
+Chest & Shoulders
+• Shoulders are rounded and compact, covered in dense orange fur that fluffs outward.
+• Chest is petite yet plump; the white fur from the throat spreads in a crescent shape across the upper chest.
+
+Back & Torso
+• Back fur is honey-orange with subtle gradients toward deeper tones near the spine.
+• Coat appears short but plush, catching light to reveal fine highlights.
+• Body is compact and almost spherical, gentle curves suggesting the ribcage beneath.
+
+Belly
+• Underside transitions to creamy white, seamlessly fading from the orange flanks.
+• Belly fur is slightly longer and fluffier, creating a cushioned look.
+
+Forelegs
+• Tiny, delicate forelegs tucked under the chest.
+• Covered in short orange fur; ivory claws peek out subtly at the tips.
+
+Hind Legs & Tail
+• Muscular yet rounded hind legs, fur matching the back but lightening toward the ankles.
+• Tail is a small puff ball-white on the underside, with a hint of orange on top-nestled close to the body.`
     },
     {
         id: "chat-partner-mikuku-request",

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions-popular.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions-popular.ts
@@ -1190,6 +1190,132 @@ const popularPromptDefinitions = [
     buildBody: () => `与えられた読みものについて、わかりにくい箇所を整理してください。読み手が引っかかりやすい表現、前提が不足している箇所、主語や対象が追いにくい箇所、論理や展開の飛躍がある箇所を見つけて、何が分かりにくさの原因かが伝わるようにまとめてください。必要に応じて、読み解く観点や確認ポイントも添えてください。`
   },
   {
+    id: "popular-possession-pm-request",
+    label: "P1801-001: PM憑依",
+    keywords: ["P1801-001", "pm possession", "pm mode", "product manager mode", "pm role", "PM憑依", "PMモード", "プロダクトマネージャー", "ぴーえむひょうい", "ぷろだくとまねーじゃー"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは PM に憑依してください。ソフトウェア開発現場の PM として、価値、優先順位、利用者影響、初版スコープ、意思決定のしやすさを重視して考えてください。口調を演じる必要はありません。PM の判断軸を強めて、何を先に決めるべきか、何を後回しにするべきか、何が利用者価値に効くのかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-tech-lead-request",
+    label: "P1801-002: Tech Lead憑依",
+    keywords: ["P1801-002", "tech lead possession", "tech lead mode", "engineering lead mode", "technical lead role", "Tech Lead憑依", "技術リード", "テックリード", "てっくりーどひょうい", "ぎじゅつりーど"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは Tech Lead に憑依してください。ソフトウェア開発現場の Tech Lead として、実装現実性、保守性、分割しやすさ、チーム開発のしやすさ、技術的負債の増減を重視して考えてください。口調を演じる必要はありません。Tech Lead の判断軸で、どこに先に手を入れるべきか、どの構成がチームにとって扱いやすいかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-architect-request",
+    label: "P1801-003: Architect憑依",
+    keywords: ["P1801-003", "architect possession", "architect mode", "software architect mode", "architecture role", "Architect憑依", "設計者憑依", "アーキテクト", "あーきてくとひょうい", "せっけいしゃひょうい"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは Architect に憑依してください。ソフトウェア開発現場の Architect として、責務分離、境界、依存方向、構造整合性、拡張性、長期的に破綻しにくいことを重視して考えてください。口調を演じる必要はありません。Architect の判断軸で、どこに構造上の無理があるか、どの切り分けが自然か、将来どこが傷みやすいかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-reviewer-request",
+    label: "P1801-004: Reviewer憑依",
+    keywords: ["P1801-004", "reviewer possession", "reviewer mode", "critical reviewer", "strict review mode", "Reviewer憑依", "レビュアー憑依", "批判的レビュー", "れびゅあーひょうい", "ひはんてきれびゅー"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは Reviewer に憑依してください。ソフトウェア開発現場の Reviewer として、不整合、抜け漏れ、曖昧さ、説明不足、回帰リスク、前提の弱さを優先的に見つけてください。口調を演じる必要はありません。Reviewer の判断軸で、どこが危ないか、どこがまだ信用できないか、どの点を確認しないと先に進みにくいかが分かるように評価してください。`
+  },
+  {
+    id: "popular-possession-editor-request",
+    label: "P1801-005: Editor憑依",
+    keywords: ["P1801-005", "editor possession", "editor mode", "technical editor", "documentation editor", "Editor憑依", "編集者憑依", "技術編集", "えでぃたーひょうい", "ぎじゅつへんしゅう"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは Editor に憑依してください。ソフトウェア開発現場で README、仕様、PR本文、引き継ぎ文書を整える編集者として、読みやすさ、構成、冗長さ、言葉の強さ、誤解されにくさを重視して考えてください。口調を演じる必要はありません。Editor の判断軸で、どこをどう並べ替えると伝わるか、どこを削ると読みやすくなるか、どこに補足が必要かが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-user-representative-request",
+    label: "P1801-006: 利用者代表憑依",
+    keywords: ["P1801-006", "user representative possession", "user advocate mode", "user perspective role", "customer advocate", "利用者代表憑依", "ユーザー代表", "利用者視点", "りようしゃだいひょうひょうい", "ゆーざーだいひょう"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 利用者代表 に憑依してください。ソフトウェア開発現場で、利用者が何に困るか、どこで迷うか、何に価値を感じるか、何が不安かを代弁する立場として考えてください。口調を演じる必要はありません。利用者代表の判断軸で、利用者にとっての嬉しさ、痛み、分かりにくさ、離脱しやすい点が分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-author-request",
+    label: "P1802-001: 著者憑依",
+    keywords: ["P1802-001", "author possession", "author mode", "writer role", "author role", "著者憑依", "書き手憑依", "著者モード", "ちょしゃひょうい", "かきてひょうい"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 著者 に憑依してください。出版・執筆の現場で、自分の主張、発見、問題意識、語りの芯を立てる著者として考えてください。口調を演じる必要はありません。著者の判断軸で、何をいちばん言いたいのか、どこに自分の視点があるのか、何を削ると主張が弱まるのかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-publishing-editor-request",
+    label: "P1802-002: 編集者憑依",
+    keywords: ["P1802-002", "publishing editor possession", "editorial mode", "publishing editor", "content editor", "編集者憑依", "出版編集者", "編集モード", "へんしゅうしゃひょうい", "しゅっぱんへんしゅうしゃ"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 編集者 に憑依してください。出版・執筆の現場で、原稿を読者に届く形へ整える編集者として考えてください。口調を演じる必要はありません。編集者の判断軸で、どこを削ると締まるか、どこを補うと伝わるか、どの順番だと読者が入りやすいかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-structure-designer-request",
+    label: "P1802-003: 構成者憑依",
+    keywords: ["P1802-003", "structure designer possession", "composition mode", "outline architect", "story structure role", "構成者憑依", "構成設計", "章立て", "こうせいしゃひょうい", "しょうだて"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 構成者 に憑依してください。出版・執筆の現場で、章立て、話題順、導入、山場、結びを組み立てる構成者として考えてください。口調を演じる必要はありません。構成者の判断軸で、どの順番なら自然に読めるか、どこで話題を切るべきか、どこに導線が必要かが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-proofreader-request",
+    label: "P1802-004: 校正者憑依",
+    keywords: ["P1802-004", "proofreader possession", "proofreading mode", "copy editor mode", "text correction role", "校正者憑依", "校正モード", "表記ゆれ", "こうせいしゃひょうい", "ひょうきゆれ"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 校正者 に憑依してください。出版・執筆の現場で、誤字、脱字、表記ゆれ、不自然な日本語、読点や助詞の違和感を見つける校正者として考えてください。口調を演じる必要はありません。校正者の判断軸で、どこが読みにくいか、どこが表記として不揃いか、どこに機械的な修正が必要かが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-interviewer-request",
+    label: "P1802-005: インタビュアー憑依",
+    keywords: ["P1802-005", "interviewer possession", "interview mode", "questioning role", "journalist interview", "インタビュアー憑依", "聞き手憑依", "取材質問", "いんたびゅあーひょうい", "しゅざいしつもん"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは インタビュアー に憑依してください。出版・執筆の現場で、相手から本音や具体を引き出すインタビュアーとして考えてください。口調を演じる必要はありません。インタビュアーの判断軸で、どんな問いを投げると具体が出るか、どこを深掘ると面白くなるか、何を確認すると話の芯が見えるかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-peer-reviewer-request",
+    label: "P1802-006: 査読者憑依",
+    keywords: ["P1802-006", "peer reviewer possession", "peer review mode", "manuscript review role", "critical reader", "査読者憑依", "査読モード", "論の弱さ", "さどくしゃひょうい", "ろんのよわさ"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 査読者 に憑依してください。出版・執筆の現場で、論の弱さ、根拠不足、飛躍、説明不足、主張と事実の混同を見抜く査読者として考えてください。口調を演じる必要はありません。査読者の判断軸で、どこがまだ信用しにくいか、どの主張に裏付けが足りないか、どこを補強すると文章の説得力が上がるかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-illustrator-request",
+    label: "P1803-001: イラストレーター憑依",
+    keywords: ["P1803-001", "illustrator possession", "illustrator mode", "visual concept artist", "image maker role", "イラストレーター憑依", "挿絵担当", "図版発想", "いらすとれーたーひょうい", "さしえたんとう"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは イラストレーター に憑依してください。出版・誌面づくりの現場で、文章の内容を視覚モチーフへ落とし込むイラストレーターとして考えてください。口調を演じる必要はありません。イラストレーターの判断軸で、何を絵にすると伝わるか、どんな比喩やモチーフが効くか、どの絵柄や構図が内容に合うかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-art-director-request",
+    label: "P1803-002: アートディレクター憑依",
+    keywords: ["P1803-002", "art director possession", "art direction mode", "visual direction role", "creative direction", "アートディレクター憑依", "アート方向性", "ビジュアル方針", "あーとでぃれくたーひょうい", "びじゅあるほうしん"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは アートディレクター に憑依してください。出版・誌面づくりの現場で、全体の見た目の方向性を決めるアートディレクターとして考えてください。口調を演じる必要はありません。アートディレクターの判断軸で、どんなトーンが合うか、どこを主役に見せるか、写真・図版・文字のバランスをどう取るかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-layout-designer-request",
+    label: "P1803-003: レイアウト担当憑依",
+    keywords: ["P1803-003", "layout designer possession", "layout mode", "page layout role", "layout planning", "レイアウト担当憑依", "誌面レイアウト", "ページ設計", "れいあうとたんとうひょうい", "しめんれいあうと"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは レイアウト担当 に憑依してください。出版・誌面づくりの現場で、文字量、余白、視線誘導、図版配置を整えるレイアウト担当として考えてください。口調を演じる必要はありません。レイアウト担当の判断軸で、どこに視線を集めるべきか、どの順番で読ませるべきか、どこが詰まりすぎているかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-book-designer-request",
+    label: "P1803-004: 装丁家憑依",
+    keywords: ["P1803-004", "book designer possession", "cover designer mode", "book design role", "jacket design", "装丁家憑依", "装丁", "ブックデザイン", "そうていかひょうい", "ぶっくでざいん"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 装丁家 に憑依してください。出版の現場で、書籍や冊子の外観全体を設計する装丁家として考えてください。口調を演じる必要はありません。装丁家の判断軸で、表紙・背・全体の印象をどう設計すると内容と噛み合うか、どの雰囲気なら手に取りたくなるかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-cover-designer-request",
+    label: "P1803-005: 表紙デザイナー憑依",
+    keywords: ["P1803-005", "cover designer possession", "cover design mode", "book cover role", "cover concept", "表紙デザイナー憑依", "表紙設計", "カバー案", "ひょうしでざいなーひょうい", "かばーあん"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 表紙デザイナー に憑依してください。出版の現場で、ひと目で内容や雰囲気を伝える表紙を考える表紙デザイナーとして考えてください。口調を演じる必要はありません。表紙デザイナーの判断軸で、タイトルの見せ方、色、モチーフ、余白、第一印象をどう設計すると効くかが分かるように整理してください。`
+  },
+  {
+    id: "popular-possession-page-designer-request",
+    label: "P1803-006: 誌面設計者憑依",
+    keywords: ["P1803-006", "page designer possession", "editorial design mode", "spread design role", "magazine design", "誌面設計者憑依", "誌面設計", "見開き設計", "しめんせっけいしゃひょうい", "みひらきせっけい"],
+    requiresCommitId: false,
+    buildBody: () => `ここでは 誌面設計者 に憑依してください。出版・誌面づくりの現場で、見開き全体の情報設計を組み立てる誌面設計者として考えてください。口調を演じる必要はありません。誌面設計者の判断軸で、どの情報を主役にし、どこに補足を置き、どこで視線を休ませるかが分かるように整理してください。`
+  },
+  {
     id: "popular-legal-risk-check",
     label: "P1002-001: 法令違反リスクを確認する",
     keywords: ["P1002-001", "legal risk", "law violation risk", "compliance risk", "regulatory risk", "法令違反", "法令リスク", "法的リスク", "ほうれいいはん", "ほうてきりすく"],

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -488,8 +488,8 @@ After creating or updating the documentation system:
   },
   {
     id: "co-writing-tech-post-request",
-    label: "851: テック投稿の伴走執筆支援",
-    keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
+    label: "851: いがぴょんのテック投稿執筆支援",
+    keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
     requiresCommitId: false,
     buildBody: () => `# 統合プロンプト
 
@@ -976,9 +976,67 @@ Material Web ベースの開発なのですが、カスタムな Web Components�
       return `# Washi Collage Whisper v20250501a
 
 A simplified cute illustration of ${normalizedSubject}, created by assembling a minimal number of large torn pieces of rich, muted pastel-colored handmade hand-scooped kozo paper (traditional Japanese mulberry paper). Each piece is separated by bold, rough torn edges with thick, visible, randomly oriented white fibers. The edges are soft, fuzzy, and deeply frayed, showing natural irregularities. Fibers vary in thickness-from very fine to slightly coarse-and in density and direction, creating an organic, handcrafted feel; some areas display extra-frayed, protruding fibers. Fiber color subtly shifts from pure white to off-white and warm beige.
-The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
-The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
+      The paper pieces are tinted in deep, smoky pastel tones-darker and thicker than ordinary pastels-avoiding vivid hues yet holding enough chroma to stay vibrant and prevent washed-out effects against the translucent handmade paper.
+      The overall texture is soft and fibrous, with bleeding fiber patterns radiating irregularly from the torn edges. Rendered in a flat 2-D style inspired by traditional Japanese torn-paper collage art, it features expansive colour fields, natural irregular edges, a warm and friendly mood, a simple unobtrusive background, and absolutely no strong shadows or dramatic lighting.`;
     }
+  },
+  {
+    id: "rabbit-prompt-request",
+    label: "853: うさぎプロンプト",
+    keywords: ["rabbit", "bunny", "netherland dwarf", "rabbit prompt", "animal prompt", "photo-realistic rabbit", "うさぎ", "兎", "ネザーランドドワーフ", "ラビット", "画像生成", "画像プロンプト", "ばにー", "ねざーらんどどわーふ"],
+    requiresCommitId: false,
+    buildBody: () => `うさぎプロンプト-v20250426a
+
+Netherland Dwarf rabbit:
+An adorable Netherland Dwarf rabbit with silky, warm fawn-tan fur and a tiny white muzzle, its glossy dark eyes looking forward.
+
+eye:
+a glossy, almond-shaped orb tilted slightly upward toward the right.
+The surface is deep charcoal-black with a subtle navy sheen; no distinct pupil is visible, giving the appearance of a single, dark mirror. A crisp, elongated catch-light sits along the upper-right rim of the cornea, bright white with a faint cyan fringe, suggesting daylight reflecting off a nearby window. Fine, short tan lashes trace the eyelid edge, which is lined by a narrow band of pale peach-cream skin. Surrounding the eye, ultra-soft fawn-colored fur transitions from warm golden tones near the brow to lighter beige toward the cheek, each hair rendered in sharp macro detail. Lighting is soft and diffuse, coming from the front-right, creating tiny specular highlights on the moist eye surface while leaving the lower-left quadrant in gentle shadow. isolating every strand of fur and the glass-like shine of the eye.
+
+nose area:
+muzzle: a tiny, soft, upside-down-triangle nose in warm pinkish-tan with a faint vertical crease separating two oval nostrils that flare gently as it sniffs. The velvety texture of the nose is slightly moist, catching a subtle highlight from soft daylight. Surrounding the nose, ultra-fine fawn-golden guard hairs blend into creamy beige fur on the upper lip and chin, every strand rendered in sharp detail. A handful of delicate, translucent white whiskers curve outward from black pin-prick follicles on either side of the nose.
+
+vibrissae:
+dozens of gossamer-thin filaments sprouting in paired rows from tiny, dark follicles on each side of the pink-tan nose and upper lip. Each whisker is silky white to translucent silver, tapering from at the base to hair-fine tips.
+The whiskers splay gracefully outward and slightly downward, some gently curving forward in elegant arcs, others crossing and overlapping.
+The surrounding fawn-golden fur is rendered in plush detail, contrasting with the smooth, glistening whisker shafts.
+
+torso: filling most of the frame. The coat is an ultra-dense, plush carpet of short guard hairs and downy underfur. Overall hue is a warm fawn-tan that shifts subtly with the light: golden honey highlights on the crown of the back, soft caramel mid-tones along the flanks, and a whisper of pale cream where the fur curves under the belly. Producing a fine, velvety sheen and gentle color gradient from bright amber to muted beige. No distinct markings-only a barely perceptible darker dorsal band running spine-wise, lending natural depth. The texture reads as velour: every strand stands upright yet bends slightly at the tips, giving a pillowy look that invites touch.
+
+A baby Netherland Dwarf rabbit, warm fawn-tan coat with a hint of red,
+rounded cheeks and a slightly elongated muzzle, medium-sized almond eyes with a gentle white reflection,
+fine plush fur rendered softly (not hyper-macro), indoor ambient light from the right,
+shallow depth of field, light motion blur on whiskers, plain warm backdrop,
+no cage, no humans, photo-realistic, cozy atmosphere.
+
+medium-sized almond eyes, very long ears. A gently tapered muzzle, compact yet soft body around 1 kg, warm fawn-tan coat with subtle reddish hue,
+
+Neck
+• Short, slender neck that blends smoothly into the shoulders.
+• Fur around the nape is warm caramel-orange; the throat is soft ivory-white, forming a natural collar.
+• Individual hairs have a delicate luster, hinting at a silky texture.
+
+Chest & Shoulders
+• Shoulders are rounded and compact, covered in dense orange fur that fluffs outward.
+• Chest is petite yet plump; the white fur from the throat spreads in a crescent shape across the upper chest.
+
+Back & Torso
+• Back fur is honey-orange with subtle gradients toward deeper tones near the spine.
+• Coat appears short but plush, catching light to reveal fine highlights.
+• Body is compact and almost spherical, gentle curves suggesting the ribcage beneath.
+
+Belly
+• Underside transitions to creamy white, seamlessly fading from the orange flanks.
+• Belly fur is slightly longer and fluffier, creating a cushioned look.
+
+Forelegs
+• Tiny, delicate forelegs tucked under the chest.
+• Covered in short orange fur; ivory claws peek out subtly at the tips.
+
+Hind Legs & Tail
+• Muscular yet rounded hind legs, fur matching the back but lightening toward the ankles.
+• Tail is a small puff ball-white on the underside, with a hint of orange on top-nestled close to the body.`
   },
   {
     id: "chat-partner-mikuku-request",


### PR DESCRIPTION
### 概要

`prompt-gen` に対して、既存の画像系・執筆系プロンプトの拡張と、新しい `憑依` 系シリーズの追加を行いました。 今回の変更では、開発現場向けの役割憑依、出版・執筆・査読向けの憑依、誌面・ビジュアル設計向けの憑依をまとめて追加し、あわせて新しい長文画像プロンプト `A853: うさぎプロンプト` を登録しています。

### 変更内容

- `A851` のラベルを `いがぴょんのテック投稿執筆支援` に変更
- `A851` のキーワードに `igapyon` `いがぴょん` `伊賀` を追加
- `A853: うさぎプロンプト` を新規追加
- `A853` は `うさぎプロンプト-v20250426a` を本文冒頭に置き、長文素材を 1 本の固定プロンプトとしてそのまま格納
- `P1801` として、ソフトウェア開発現場向けの憑依シリーズを追加
  - `PM憑依`
  - `Tech Lead憑依`
  - `Architect憑依`
  - `Reviewer憑依`
  - `Editor憑依`
  - `利用者代表憑依`
- `P1802` として、出版・執筆・査読向けの憑依シリーズを追加
  - `著者憑依`
  - `編集者憑依`
  - `構成者憑依`
  - `校正者憑依`
  - `インタビュアー憑依`
  - `査読者憑依`
- `P1803` として、出版アート・誌面設計向けの憑依シリーズを追加
  - `イラストレーター憑依`
  - `アートディレクター憑依`
  - `レイアウト担当憑依`
  - `装丁家憑依`
  - `表紙デザイナー憑依`
  - `誌面設計者憑依`
- TypeScript 定義から生成JSおよび `prompt-gen.html` を再生成し、配布物へ反映

### 期待される効果

- `prompt-gen` で役割ベースの思考モードをより幅広く呼び出せるようになる
- ソフトウェア開発向けだけでなく、執筆・編集・査読・誌面設計の文脈にも対応できる
- 長文の画像生成プロンプトを整理し直さずにそのまま定義化できるようになり、原本プロンプトの再利用がしやすくなる
- `A851` はいがぴょん向けの執筆伴走プロンプトとして検索しやすくなる

### 補足

- `A853` はあえて正規化せず、素材の重複や揺れも含めて 1 本の固定長文として保持しています
- `P1801` は開発現場寄り、`P1802` は出版・執筆・査読、`P1803` は誌面・ビジュアル設計という役割分担で整理しています