### PR TITLE
Git pseudo-squash の作業ブランチ命名規則を調整し Git 作業一覧との連携を追加

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -4957,8 +4957,8 @@ if (!customElements.get("lht-page-menu")) {
 
     function convertTimeToThreeChars(hours, minutes) {
       const s1 = String.fromCharCode(97 + hours);
-      const s2 = String.fromCharCode(97 + Math.floor(minutes / 26));
-      const s3 = String.fromCharCode(97 + (minutes % 26));
+      const s2 = String.fromCharCode(97 + Math.floor(minutes / 10));
+      const s3 = String.fromCharCode(97 + (minutes % 10));
       return s1 + s2 + s3;
     }
 
@@ -5109,6 +5109,14 @@ if (!customElements.get("lht-page-menu")) {
       const timeStr = convertTimeToThreeChars(hh, min);
       input.value = `tiga${mm}${dd}${timeStr}`;
       regenerateAllCommands();
+      const saved = upsertWorkBranchListEntry({
+        requireRepoUrl: false,
+        showAlertOnInvalid: false,
+        updateRecentActions: false
+      });
+      if (saved) {
+        showToast("作業ブランチ名を更新し、Git 作業一覧へ反映しました");
+      }
     }
 
     function generateRebaseCommand(options = {}) {
@@ -5822,22 +5830,32 @@ if (!customElements.get("lht-page-menu")) {
       window.location.href = url;
     }
 
-    function saveToWorkBranchListAndOpen() {
+    function upsertWorkBranchListEntry(options = {}) {
+      const requireRepoUrl = options.requireRepoUrl !== false;
+      const showAlertOnInvalid = options.showAlertOnInvalid !== false;
+      const updateRecent = options.updateRecentActions !== false;
       const repoUrlField = document.getElementById("repoUrl");
       const repoUrl = repoUrlField ? normalizeRepoUrl(repoUrlField.value) : "";
       if (!repoUrl) {
-        alert("リポジトリ URL を入力してください。");
+        if (!requireRepoUrl) {
+          return null;
+        }
+        if (showAlertOnInvalid) {
+          alert("リポジトリ URL を入力してください。");
+        }
         if (repoUrlField && typeof repoUrlField.focus === "function") {
           repoUrlField.focus();
         }
-        return;
+        return null;
       }
 
       const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
       const compareBranch = document.getElementById("workBranch")?.value.trim() || "";
       if (!baseBranch || !compareBranch) {
-        alert("基点ブランチと作業ブランチを入力してください。");
-        return;
+        if (showAlertOnInvalid) {
+          alert("基点ブランチと作業ブランチを入力してください。");
+        }
+        return null;
       }
 
       const baseScope = document.getElementById("squashBaseScope")?.value === "local" ? "local" : "remote";
@@ -5871,8 +5889,25 @@ if (!customElements.get("lht-page-menu")) {
         entries.push(nextEntry);
       }
       saveWorkBranchListEntries(entries);
-      saveRecentActions(updateRecentActions(loadRecentActions(), nextEntry.id, "pseudo-squash"));
-      showToast(existingIndex >= 0 ? "Git 作業一覧を更新しました" : "Git 作業一覧へ追加しました");
+      if (updateRecent) {
+        saveRecentActions(updateRecentActions(loadRecentActions(), nextEntry.id, "pseudo-squash"));
+      }
+      return {
+        entry: nextEntry,
+        existed: existingIndex >= 0
+      };
+    }
+
+    function saveToWorkBranchListAndOpen() {
+      const saved = upsertWorkBranchListEntry({
+        requireRepoUrl: true,
+        showAlertOnInvalid: true,
+        updateRecentActions: true
+      });
+      if (!saved) {
+        return;
+      }
+      showToast(saved.existed ? "Git 作業一覧を更新しました" : "Git 作業一覧へ追加しました");
       navigateTo("git-work-list.html");
     }
 

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -34,8 +34,8 @@
 
     function convertTimeToThreeChars(hours, minutes) {
       const s1 = String.fromCharCode(97 + hours);
-      const s2 = String.fromCharCode(97 + Math.floor(minutes / 26));
-      const s3 = String.fromCharCode(97 + (minutes % 26));
+      const s2 = String.fromCharCode(97 + Math.floor(minutes / 10));
+      const s3 = String.fromCharCode(97 + (minutes % 10));
       return s1 + s2 + s3;
     }
 
@@ -186,6 +186,14 @@
       const timeStr = convertTimeToThreeChars(hh, min);
       input.value = `tiga${mm}${dd}${timeStr}`;
       regenerateAllCommands();
+      const saved = upsertWorkBranchListEntry({
+        requireRepoUrl: false,
+        showAlertOnInvalid: false,
+        updateRecentActions: false
+      });
+      if (saved) {
+        showToast("作業ブランチ名を更新し、Git 作業一覧へ反映しました");
+      }
     }
 
     function generateRebaseCommand(options = {}) {
@@ -899,22 +907,32 @@
       window.location.href = url;
     }
 
-    function saveToWorkBranchListAndOpen() {
+    function upsertWorkBranchListEntry(options = {}) {
+      const requireRepoUrl = options.requireRepoUrl !== false;
+      const showAlertOnInvalid = options.showAlertOnInvalid !== false;
+      const updateRecent = options.updateRecentActions !== false;
       const repoUrlField = document.getElementById("repoUrl");
       const repoUrl = repoUrlField ? normalizeRepoUrl(repoUrlField.value) : "";
       if (!repoUrl) {
-        alert("リポジトリ URL を入力してください。");
+        if (!requireRepoUrl) {
+          return null;
+        }
+        if (showAlertOnInvalid) {
+          alert("リポジトリ URL を入力してください。");
+        }
         if (repoUrlField && typeof repoUrlField.focus === "function") {
           repoUrlField.focus();
         }
-        return;
+        return null;
       }
 
       const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
       const compareBranch = document.getElementById("workBranch")?.value.trim() || "";
       if (!baseBranch || !compareBranch) {
-        alert("基点ブランチと作業ブランチを入力してください。");
-        return;
+        if (showAlertOnInvalid) {
+          alert("基点ブランチと作業ブランチを入力してください。");
+        }
+        return null;
       }
 
       const baseScope = document.getElementById("squashBaseScope")?.value === "local" ? "local" : "remote";
@@ -948,8 +966,25 @@
         entries.push(nextEntry);
       }
       saveWorkBranchListEntries(entries);
-      saveRecentActions(updateRecentActions(loadRecentActions(), nextEntry.id, "pseudo-squash"));
-      showToast(existingIndex >= 0 ? "Git 作業一覧を更新しました" : "Git 作業一覧へ追加しました");
+      if (updateRecent) {
+        saveRecentActions(updateRecentActions(loadRecentActions(), nextEntry.id, "pseudo-squash"));
+      }
+      return {
+        entry: nextEntry,
+        existed: existingIndex >= 0
+      };
+    }
+
+    function saveToWorkBranchListAndOpen() {
+      const saved = upsertWorkBranchListEntry({
+        requireRepoUrl: true,
+        showAlertOnInvalid: true,
+        updateRecentActions: true
+      });
+      if (!saved) {
+        return;
+      }
+      showToast(saved.existed ? "Git 作業一覧を更新しました" : "Git 作業一覧へ追加しました");
       navigateTo("git-work-list.html");
     }
 


### PR DESCRIPTION
### 概要
`git-pseudo-squash` の作業ブランチ自動命名ルールを見直し、あわせて作業ブランチ更新時に Git 作業一覧へ反映できるようにしました。

### 変更内容
- `docs/git/src/git-pseudo-squash/js/main.js` の `convertTimeToThreeChars()` を変更
- 分の変換方式を `26` 基準から、十の位 / 一の位ベースの文字変換へ変更
- `updateWorkBranchWithCurrentTime()` 実行時に、Git 作業一覧への追加・更新処理を呼ぶように変更
- Git 作業一覧への保存処理を `upsertWorkBranchListEntry()` として共通化
- 既存の `saveToWorkBranchListAndOpen()` は共通化した保存処理を利用する構成へ整理
- 生成物 `docs/git/git-pseudo-squash.html` に変更を反映

### 期待される効果
- 自動生成される作業ブランチ名の分部分が読み取りやすくなる
- 作業ブランチ名の更新操作と Git 作業一覧の内容がずれにくくなる
- 一覧への保存ロジックを共通化し、今後の保守性を上げる

### 影響範囲
- `docs/git/src/git-pseudo-squash/js/main.js`
- `docs/git/git-pseudo-squash.html`

### 確認事項
- 対象コミットの差分上は `git-pseudo-squash` 関連 2 ファイルのみ変更されています
- `git-work-list` 側のソースファイル変更はこのコミットには含まれていません