### PR TITLE
prompt-gen の出力オプション追加と引数入力の一般化

### DIFF
--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -93,35 +93,25 @@ limitations under the License.
       <div id="promptCandidateArea" class="md-chip-row" aria-live="polite"></div>
     </section>
 
-    <section id="commitInputSection" class="md-section md-stack-md md-hidden">
-      <div class="md-form-grid md-form-grid-2">
-        <lht-text-field-help
-          field-id="commitId"
-          label="コミットID"
-          required
-          placeholder="例: abc1234"
-          help-text="PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。">
-        </lht-text-field-help>
-      </div>
-    </section>
-
-    <section id="subjectInputSection" class="md-section md-stack-md md-hidden">
-      <div class="md-form-grid md-form-grid-2">
-        <lht-text-field-help
-          id="subjectInputField"
-          field-id="subjectInput"
-          label="subject"
-          required
-          placeholder="例: a small fox"
-          help-text="プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。">
-        </lht-text-field-help>
+    <section id="promptArgsSection" class="md-section md-stack-md md-hidden">
+      <div id="promptArgsContainer" class="md-form-grid md-form-grid-2">
       </div>
     </section>
 
     <section id="promptOutputSection" class="md-section md-stack-md md-hidden">
       <div class="md-output-header">
-        <p id="promptOutputTitle" class="md-output-title">生成結果</p>
-        <div id="promptOutputHelp" class="md-output-help"></div>
+        <div class="md-output-header__main">
+          <p id="promptOutputTitle" class="md-output-title">生成結果</p>
+          <div id="promptOutputHelp" class="md-output-help"></div>
+        </div>
+        <div class="md-output-header__actions">
+          <button id="copyShareLinkButton" type="button" class="md-secondary-button">
+            <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
+            </svg>
+            <span>共有リンクをコピー</span>
+          </button>
+        </div>
       </div>
       <lht-command-block command-id="promptOutput" copy-buttons="dual"></lht-command-block>
       <div class="md-output-options">
@@ -131,12 +121,18 @@ limitations under the License.
           help-label="ラベル名を先頭に含める説明">
           ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
         </lht-switch-help>
-        <button id="copyShareLinkButton" type="button" class="md-secondary-button">
-          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
-          </svg>
-          <span>共有リンクをコピー</span>
-        </button>
+        <lht-switch-help
+          switch-id="hallucinationGuard"
+          label="幻想防止"
+          help-label="幻想防止の説明">
+          ON の場合は、事実誤認や根拠のない補完を避けるための注意文を含めます。
+        </lht-switch-help>
+        <lht-switch-help
+          switch-id="outputMarkdown"
+          label="Markdownフェンス"
+          help-label="Markdownフェンスの説明">
+          ON の場合は、最終回答を `~~~~` で囲んで出力する指定を含めます。
+        </lht-switch-help>
         <a
           id="gitPseudoSquashLink"
           class="md-secondary-button md-hidden"

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1230,9 +1230,24 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 }
 
 .md-output-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.md-output-header__main {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.md-output-header__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
 .md-output-help {
@@ -1250,6 +1265,13 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .md-output-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .md-secondary-button {
@@ -1481,35 +1503,25 @@ md-icon-button.md-copy-button--surface {
       <div id="promptCandidateArea" class="md-chip-row" aria-live="polite"></div>
     </section>
 
-    <section id="commitInputSection" class="md-section md-stack-md md-hidden">
-      <div class="md-form-grid md-form-grid-2">
-        <lht-text-field-help
-          field-id="commitId"
-          label="コミットID"
-          required
-          placeholder="例: abc1234"
-          help-text="PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。">
-        </lht-text-field-help>
-      </div>
-    </section>
-
-    <section id="subjectInputSection" class="md-section md-stack-md md-hidden">
-      <div class="md-form-grid md-form-grid-2">
-        <lht-text-field-help
-          id="subjectInputField"
-          field-id="subjectInput"
-          label="subject"
-          required
-          placeholder="例: a small fox"
-          help-text="プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。">
-        </lht-text-field-help>
+    <section id="promptArgsSection" class="md-section md-stack-md md-hidden">
+      <div id="promptArgsContainer" class="md-form-grid md-form-grid-2">
       </div>
     </section>
 
     <section id="promptOutputSection" class="md-section md-stack-md md-hidden">
       <div class="md-output-header">
-        <p id="promptOutputTitle" class="md-output-title">生成結果</p>
-        <div id="promptOutputHelp" class="md-output-help"></div>
+        <div class="md-output-header__main">
+          <p id="promptOutputTitle" class="md-output-title">生成結果</p>
+          <div id="promptOutputHelp" class="md-output-help"></div>
+        </div>
+        <div class="md-output-header__actions">
+          <button id="copyShareLinkButton" type="button" class="md-secondary-button">
+            <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
+            </svg>
+            <span>共有リンクをコピー</span>
+          </button>
+        </div>
       </div>
       <lht-command-block command-id="promptOutput" copy-buttons="dual"></lht-command-block>
       <div class="md-output-options">
@@ -1519,12 +1531,18 @@ md-icon-button.md-copy-button--surface {
           help-label="ラベル名を先頭に含める説明">
           ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
         </lht-switch-help>
-        <button id="copyShareLinkButton" type="button" class="md-secondary-button">
-          <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
-          </svg>
-          <span>共有リンクをコピー</span>
-        </button>
+        <lht-switch-help
+          switch-id="hallucinationGuard"
+          label="幻想防止"
+          help-label="幻想防止の説明">
+          ON の場合は、事実誤認や根拠のない補完を避けるための注意文を含めます。
+        </lht-switch-help>
+        <lht-switch-help
+          switch-id="outputMarkdown"
+          label="Markdownフェンス"
+          help-label="Markdownフェンスの説明">
+          ON の場合は、最終回答を `~~~~` で囲んで出力する指定を含めます。
+        </lht-switch-help>
         <a
           id="gitPseudoSquashLink"
           class="md-secondary-button md-hidden"
@@ -3664,20 +3682,11 @@ if (!customElements.get("lht-page-menu")) {
   </script>
 
   <script>
-function getMarkdownFenceInstruction() {
-    return "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
-}
-function appendMarkdownFenceInstruction(body) {
-    return `${body}\n\n${getMarkdownFenceInstruction()}`;
-}
-function getStrictHallucinationPreventionInstruction() {
-    return `○ハルシネーション防止のため、次のルールに従ってください。
+const strictHallucinationPreventionInstruction = `○ハルシネーション防止のため、次のルールに従ってください。
 - 禁止: (1)今回のこの会話（セッション）および入力内容に明示されていない情報を、補完して記入してはいけません。 (2)会話にない情報を、もっともらしく埋めてはいけません。 (3)根拠がない内容を、確定情報として記載してはいけません。
 - 代替行動: (1)情報不足の項目がある場合は、必要な追加質問を行ってください。 (2)追加質問できない場合、または質問後も根拠が不足する場合は、"不明" "未確認" "要確認" などと明示してください。 (3)判断材料が不足している場合は、無理に結論を書かず、不足している点を明示してください。
 - 出力規則: (1)各項目は、今回のこの会話（セッション）および入力内容に根拠があるものだけを記入してください。 (2)推測を書く場合は、事実として断定せず、"推測:" と明示してください。 (3)未確認事項は事実として書かないでください。 (4)要約や整理を行う場合も、新しい事実を追加せず、与えられた情報の範囲内で表現してください。`;
-}
-function getSoftHallucinationPreventionInstruction() {
-    return `○事実誤認を避けるため、次のルールを意識してください。
+const softHallucinationPreventionInstruction = `○事実誤認を避けるため、次のルールを意識してください。
 
 注意:
 - 今回のこの会話（セッション）および入力内容に明示されていない事実は、断定して記載しないでください。
@@ -3691,6 +3700,36 @@ function getSoftHallucinationPreventionInstruction() {
 - 根拠がある事実と、推測・評価・提案は区別して記載してください。
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
+const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+let currentPromptOutputOptions = {
+    hallucinationGuardEnabled: true,
+    outputMarkdownEnabled: true
+};
+function setPromptOutputOptions(options) {
+    currentPromptOutputOptions = {
+        hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+        outputMarkdownEnabled: options.outputMarkdownEnabled !== false
+    };
+}
+function getPromptOutputInstructionTemplates() {
+    return {
+        strictHallucinationPreventionInstruction,
+        softHallucinationPreventionInstruction,
+        markdownFenceInstruction
+    };
+}
+function getMarkdownFenceInstruction() {
+    return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
+}
+function appendMarkdownFenceInstruction(body) {
+    const instruction = getMarkdownFenceInstruction();
+    return instruction ? `${body}\n\n${instruction}` : body;
+}
+function getStrictHallucinationPreventionInstruction() {
+    return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+}
+function getSoftHallucinationPreventionInstruction() {
+    return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
 }
 function getTodoReflectionInstruction() {
     return "必要に応じて、今回の作業結果を TODO.md に反映してください。関連する既存の TODO があれば補強・更新し、該当する記述がなければ新規の TODO を追加してください。";
@@ -8360,19 +8399,18 @@ async function initializePromptPage() {
     }
     const promptSearch = document.getElementById("promptSearch");
     const promptCandidateArea = document.getElementById("promptCandidateArea");
-    const commitInputSection = document.getElementById("commitInputSection");
-    const subjectInputSection = document.getElementById("subjectInputSection");
-    let subjectInputFieldHost = document.getElementById("subjectInputField");
+    const promptArgsSection = document.getElementById("promptArgsSection");
+    const promptArgsContainer = document.getElementById("promptArgsContainer");
     const promptOutputSection = document.getElementById("promptOutputSection");
     const promptOutputTitle = document.getElementById("promptOutputTitle");
     const promptOutputHelp = document.getElementById("promptOutputHelp");
     const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
-    const commitIdInput = document.getElementById("commitId");
-    let subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !includeLabelPrefix || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -8412,13 +8450,44 @@ async function initializePromptPage() {
         storage.removeItem(SERIES_VISIBILITY_STORAGE_KEY);
     }
     let seriesVisibilitySettings = loadSeriesVisibilitySettings();
+    function getLegacyPromptArguments(definition) {
+        const args = [];
+        if (definition.requiresCommitId) {
+            args.push({
+                id: "commitId",
+                label: "コミットID",
+                required: true,
+                placeholder: "例: abc1234",
+                helpText: "PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。",
+                inputMode: "latin"
+            });
+        }
+        if (definition.requiresSubject) {
+            args.push({
+                id: "subject",
+                label: definition.subjectLabel || "subject",
+                required: true,
+                placeholder: definition.subjectPlaceholder || "例: a small fox",
+                helpText: definition.subjectHelpText || "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。",
+                defaultValue: definition.subjectDefaultValue,
+                inputMode: "text"
+            });
+        }
+        return args;
+    }
+    function normalizePromptDefinition(definition) {
+        return {
+            ...definition,
+            args: Array.isArray(definition.args) ? definition.args : getLegacyPromptArguments(definition)
+        };
+    }
     function getVisiblePromptDefinitions() {
         return [
             ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
             ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
             ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
             ...(seriesVisibilitySettings.showP ? popularDefinitions : [])
-        ];
+        ].map(normalizePromptDefinition);
     }
     let visiblePromptDefinitions = [];
     let promptSearchIndexes = [];
@@ -8435,13 +8504,9 @@ async function initializePromptPage() {
         }
     }
     applyLatinInputHints(promptSearch, "search");
-    applyLatinInputHints(commitIdInput, "done");
     const MAX_EMBED_INPUT_LENGTH = 1024;
-    const defaultSubjectFieldConfig = {
-        label: "subject",
-        placeholder: "例: a small fox",
-        helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
-    };
+    let activeArgumentDefinitions = [];
+    let promptArgumentInputs = new Map();
     function sanitizePromptVariableInput(value) {
         const normalizedWhitespace = String(value || "")
             .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
@@ -8454,76 +8519,118 @@ async function initializePromptPage() {
         const normalizedQuotes = truncatedValue.replace(/`/g, "'");
         return `\`${normalizedQuotes}\``;
     }
-    function getSubjectFieldConfig(definition) {
-        return {
-            label: (definition === null || definition === void 0 ? void 0 : definition.subjectLabel) || defaultSubjectFieldConfig.label,
-            placeholder: (definition === null || definition === void 0 ? void 0 : definition.subjectPlaceholder) || defaultSubjectFieldConfig.placeholder,
-            helpText: (definition === null || definition === void 0 ? void 0 : definition.subjectHelpText) || defaultSubjectFieldConfig.helpText
-        };
-    }
-    function handleSubjectInput() {
+    function handleArgumentInput() {
         updateOutput();
     }
-    function refreshSubjectInputReference() {
-        subjectInput = document.getElementById("subjectInput");
-        if (subjectInput) {
-            subjectInput.addEventListener("input", handleSubjectInput);
+    function getSelectedPromptArguments(definition) {
+        return Array.isArray(definition === null || definition === void 0 ? void 0 : definition.args) ? definition.args : [];
+    }
+    function getArgumentInput(argumentId) {
+        return promptArgumentInputs.get(argumentId) || null;
+    }
+    function getArgumentDomId(argumentId) {
+        if (argumentId === "subject") {
+            return "subjectInput";
+        }
+        return argumentId;
+    }
+    function getArgumentValue(argumentId) {
+        var _a;
+        return ((_a = getArgumentInput(argumentId)) === null || _a === void 0 ? void 0 : _a.value) || "";
+    }
+    function getArgumentQueryParamName(argumentId) {
+        if (argumentId === "commitId") {
+            return "commit";
+        }
+        if (argumentId === "subject") {
+            return "subject";
+        }
+        return `arg_${argumentId}`;
+    }
+    function getPromptArgumentValues() {
+        const values = {};
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            values[argumentDefinition.id] = getArgumentValue(argumentDefinition.id);
+        }
+        return values;
+    }
+    function setPromptArgumentValues(values) {
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const input = getArgumentInput(argumentDefinition.id);
+            if (!input) {
+                continue;
+            }
+            input.value = values[argumentDefinition.id] || "";
         }
     }
-    function renderSubjectInputField(definition) {
-        const config = getSubjectFieldConfig(definition);
-        const currentValue = (subjectInput === null || subjectInput === void 0 ? void 0 : subjectInput.value) || "";
-        if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
-            const nextField = document.createElement("lht-text-field-help");
-            nextField.id = "subjectInputField";
-            nextField.setAttribute("field-id", "subjectInput");
-            nextField.setAttribute("label", config.label);
-            nextField.setAttribute("placeholder", config.placeholder);
-            nextField.setAttribute("help-text", config.helpText);
-            nextField.setAttribute("required", "");
-            subjectInputFieldHost.replaceWith(nextField);
-            subjectInputFieldHost = nextField;
-        }
-        else if (subjectInput) {
-            subjectInput.setAttribute("aria-label", config.label);
-            subjectInput.setAttribute("placeholder", config.placeholder);
-            subjectInput.setAttribute("title", config.helpText);
-        }
-        refreshSubjectInputReference();
-        if (subjectInput) {
-            subjectInput.value = currentValue;
+    function refreshArgumentInputReferences(definition) {
+        promptArgumentInputs = new Map();
+        for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+            const input = document.getElementById(getArgumentDomId(argumentDefinition.id));
+            if (!input) {
+                continue;
+            }
+            promptArgumentInputs.set(argumentDefinition.id, input);
+            input.addEventListener("input", handleArgumentInput);
+            if (argumentDefinition.inputMode === "latin") {
+                applyLatinInputHints(input, "done");
+            }
         }
     }
-    function applyDefaultSubjectValue(selectedDefinition) {
-        if (!(selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) || !subjectInput) {
+    function renderArgumentFields(definition) {
+        const currentValues = getPromptArgumentValues();
+        activeArgumentDefinitions = getSelectedPromptArguments(definition).map((argumentDefinition) => ({ ...argumentDefinition }));
+        promptArgsContainer.innerHTML = "";
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const field = document.createElement("lht-text-field-help");
+            field.id = `${getArgumentDomId(argumentDefinition.id)}Field`;
+            field.setAttribute("field-id", getArgumentDomId(argumentDefinition.id));
+            field.setAttribute("label", argumentDefinition.label);
+            if (argumentDefinition.placeholder) {
+                field.setAttribute("placeholder", argumentDefinition.placeholder);
+            }
+            if (argumentDefinition.helpText) {
+                field.setAttribute("help-text", argumentDefinition.helpText);
+            }
+            if (argumentDefinition.required !== false) {
+                field.setAttribute("required", "");
+            }
+            promptArgsContainer.appendChild(field);
+        }
+        refreshArgumentInputReferences(definition);
+        setPromptArgumentValues(currentValues);
+    }
+    function applyDefaultArgumentValues(selectedDefinition) {
+        if (!selectedDefinition) {
             return;
         }
-        if ((subjectInput.value || "").trim()) {
-            return;
+        for (const argumentDefinition of getSelectedPromptArguments(selectedDefinition)) {
+            const input = getArgumentInput(argumentDefinition.id);
+            if (!input) {
+                continue;
+            }
+            if ((input.value || "").trim()) {
+                continue;
+            }
+            if (!argumentDefinition.defaultValue) {
+                continue;
+            }
+            input.value = argumentDefinition.defaultValue;
         }
-        if (!selectedDefinition.subjectDefaultValue) {
-            return;
-        }
-        subjectInput.value = selectedDefinition.subjectDefaultValue;
     }
     function syncInputSections(selectedDefinition) {
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
-            commitInputSection.classList.remove("md-hidden");
+        if (getSelectedPromptArguments(selectedDefinition).length > 0) {
+            promptArgsSection.classList.remove("md-hidden");
         }
         else {
-            commitInputSection.classList.add("md-hidden");
-        }
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) {
-            subjectInputSection.classList.remove("md-hidden");
-        }
-        else {
-            subjectInputSection.classList.add("md-hidden");
+            promptArgsSection.classList.add("md-hidden");
         }
     }
     let selectedPrompt = "";
     let lastSearchQuery = "";
     let pendingInitialPromptCode = "";
     let suppressSearchResetOnce = false;
+    const promptOutputOptionDefaultsById = new Map();
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
         ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
@@ -8849,6 +8956,57 @@ async function initializePromptPage() {
         }
         return visiblePromptDefinitions.find((definition) => definition.id === selectedPrompt) || null;
     }
+    function getPromptOutputOptions() {
+        return {
+            hallucinationGuardEnabled: hallucinationGuard.checked,
+            outputMarkdownEnabled: outputMarkdown.checked
+        };
+    }
+    function inferPromptOutputOptionDefaults(definition) {
+        if (!definition) {
+            return {
+                hallucinationGuard: false,
+                outputMarkdown: false
+            };
+        }
+        const cached = promptOutputOptionDefaultsById.get(definition.id);
+        if (cached) {
+            return cached;
+        }
+        if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+            const explicitDefaults = {
+                hallucinationGuard: definition.hallucinationGuard === true,
+                outputMarkdown: definition.outputMarkdown === true
+            };
+            promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
+            return explicitDefaults;
+        }
+        const originalOptions = getPromptOutputOptions();
+        setPromptOutputOptions({
+            hallucinationGuardEnabled: true,
+            outputMarkdownEnabled: true
+        });
+        const argsForInference = {};
+        for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+            const rawValue = getArgumentValue(argumentDefinition.id) || argumentDefinition.defaultValue || `dummy-${argumentDefinition.id}`;
+            argsForInference[argumentDefinition.id] = rawValue;
+        }
+        const body = definition.buildBody(sanitizePromptVariableInput(argsForInference.commitId || ""), sanitizePromptVariableInput(argsForInference.subject || ""));
+        setPromptOutputOptions(originalOptions);
+        const templates = getPromptOutputInstructionTemplates();
+        const defaults = {
+            hallucinationGuard: body.includes(templates.strictHallucinationPreventionInstruction) ||
+                body.includes(templates.softHallucinationPreventionInstruction),
+            outputMarkdown: body.includes(templates.markdownFenceInstruction)
+        };
+        promptOutputOptionDefaultsById.set(definition.id, defaults);
+        return defaults;
+    }
+    function applyPromptOutputOptionDefaults(definition) {
+        const defaults = inferPromptOutputOptionDefaults(definition);
+        hallucinationGuard.checked = defaults.hallucinationGuard;
+        outputMarkdown.checked = defaults.outputMarkdown;
+    }
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
         promptOutputHelp.innerHTML = "";
@@ -8913,11 +9071,9 @@ async function initializePromptPage() {
             else {
                 selectedPrompt = "";
                 syncInputSections(null);
+                renderArgumentFields(null);
                 promptOutputSection.classList.add("md-hidden");
-                commitIdInput.value = "";
-                if (subjectInput) {
-                    subjectInput.value = "";
-                }
+                applyPromptOutputOptionDefaults(null);
                 promptOutput.textContent = "";
             }
         }
@@ -8932,7 +9088,7 @@ async function initializePromptPage() {
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
-                commitInputSection.classList.add("md-hidden");
+                promptArgsSection.classList.add("md-hidden");
                 promptOutputSection.classList.add("md-hidden");
                 updateOutput();
             }
@@ -8958,14 +9114,16 @@ async function initializePromptPage() {
             if (selectedButton) {
                 selectedButton.classList.add("is-active");
             }
-            renderSubjectInputField(selectedDefinition);
+            renderArgumentFields(selectedDefinition);
             syncInputSections(selectedDefinition);
-            applyDefaultSubjectValue(selectedDefinition);
+            applyDefaultArgumentValues(selectedDefinition);
+            applyPromptOutputOptionDefaults(selectedDefinition);
             revealOutputSection();
             updateOutput();
         }
     }
     async function selectPrompt(id, button, options) {
+        var _a;
         selectedPrompt = id;
         for (const element of promptCandidateArea.querySelectorAll(".md-chip-button")) {
             element.classList.remove("is-active");
@@ -8982,16 +9140,15 @@ async function initializePromptPage() {
             }
         }
         syncInputSections(selectedDefinition || null);
-        renderSubjectInputField(selectedDefinition || null);
-        applyDefaultSubjectValue(selectedDefinition || null);
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
-            commitIdInput.focus();
-        }
-        else if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) {
-            subjectInput.focus();
+        renderArgumentFields(selectedDefinition || null);
+        applyDefaultArgumentValues(selectedDefinition || null);
+        applyPromptOutputOptionDefaults(selectedDefinition || null);
+        const firstArgument = getSelectedPromptArguments(selectedDefinition || null)[0];
+        if (firstArgument) {
+            (_a = getArgumentInput(firstArgument.id)) === null || _a === void 0 ? void 0 : _a.focus();
         }
         updateOutput();
-        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && !selectedDefinition.requiresCommitId && !selectedDefinition.requiresSubject) {
+        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && getSelectedPromptArguments(selectedDefinition).length === 0) {
             await copyText(promptOutput.textContent || "");
         }
     }
@@ -9001,13 +9158,16 @@ async function initializePromptPage() {
             return "";
         }
         const label = selectedDefinition ? selectedDefinition.label : "";
-        const commitId = sanitizePromptVariableInput(commitIdInput.value || "");
-        const subject = sanitizePromptVariableInput(subjectInput.value || "");
+        const argumentValues = getPromptArgumentValues();
+        const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
+        const subject = sanitizePromptVariableInput(argumentValues.subject || "");
+        setPromptOutputOptions(getPromptOutputOptions());
         const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
         if (!body || !label) {
             return "";
         }
-        return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
+        const normalizedBody = body.trim().replace(/\n{3,}/g, "\n\n");
+        return includeLabelPrefix.checked ? `[${label}] ${normalizedBody}` : normalizedBody;
     }
     function getDefinitionLabelCode(definition) {
         const label = String((definition === null || definition === void 0 ? void 0 : definition.label) || "");
@@ -9023,8 +9183,6 @@ async function initializePromptPage() {
         const url = new URL(window.location.href);
         url.search = "";
         const query = (promptSearch.value || "").trim();
-        const subject = subjectInput.value || "";
-        const commitId = commitIdInput.value || "";
         const selectedDefinition = getSelectedPromptDefinition();
         const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
         if (query) {
@@ -9033,11 +9191,12 @@ async function initializePromptPage() {
         if (selectedDefinitionCode) {
             url.searchParams.set("id", selectedDefinitionCode);
         }
-        if (subject) {
-            url.searchParams.set("subject", subject);
-        }
-        if (commitId) {
-            url.searchParams.set("commit", commitId);
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const value = getArgumentValue(argumentDefinition.id);
+            if (!value) {
+                continue;
+            }
+            url.searchParams.set(getArgumentQueryParamName(argumentDefinition.id), value);
         }
         return url.toString();
     }
@@ -9112,22 +9271,26 @@ async function initializePromptPage() {
         section.appendChild(resetButton);
     }
     promptSearch.addEventListener("input", renderCandidates);
-    commitIdInput.addEventListener("input", updateOutput);
-    renderSubjectInputField(null);
     includeLabelPrefix.addEventListener("change", updateOutput);
+    hallucinationGuard.addEventListener("change", updateOutput);
+    outputMarkdown.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
     let initialPromptCode = "";
-    let initialSubject = "";
-    let initialCommitId = "";
+    const initialArgumentValues = {};
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
         initialPromptCode = (url.searchParams.get("id") || "").trim();
-        initialSubject = url.searchParams.get("subject") || "";
-        initialCommitId = url.searchParams.get("commit") || "";
+        initialArgumentValues.subject = url.searchParams.get("subject") || "";
+        initialArgumentValues.commitId = url.searchParams.get("commit") || "";
+        for (const [key, value] of url.searchParams.entries()) {
+            if (key.startsWith("arg_")) {
+                initialArgumentValues[key.slice(4)] = value;
+            }
+        }
         if (initialQuery) {
             promptSearch.value = initialQuery;
         }
@@ -9135,17 +9298,15 @@ async function initializePromptPage() {
     catch (_error) {
         // Ignore invalid or unavailable location values.
     }
+    applyPromptOutputOptionDefaults(null);
     createSeriesVisibilityMenu();
+    renderArgumentFields(null);
     if (initialPromptCode) {
         pendingInitialPromptCode = initialPromptCode;
     }
     renderCandidates();
-    if (initialSubject) {
-        subjectInput.value = initialSubject;
-    }
-    if (initialCommitId) {
-        commitIdInput.value = initialCommitId;
-    }
+    setPromptArgumentValues(initialArgumentValues);
+    applyDefaultArgumentValues(getSelectedPromptDefinition());
     updateOutput();
     requestAnimationFrame(() => {
         promptSearch.focus();

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -154,9 +154,24 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 }
 
 .md-output-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.md-output-header__main {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+
+.md-output-header__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
 .md-output-help {
@@ -174,6 +189,13 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+}
+
+@media (max-width: 720px) {
+  .md-output-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .md-secondary-button {

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -36,19 +36,18 @@ async function initializePromptPage() {
     }
     const promptSearch = document.getElementById("promptSearch");
     const promptCandidateArea = document.getElementById("promptCandidateArea");
-    const commitInputSection = document.getElementById("commitInputSection");
-    const subjectInputSection = document.getElementById("subjectInputSection");
-    let subjectInputFieldHost = document.getElementById("subjectInputField");
+    const promptArgsSection = document.getElementById("promptArgsSection");
+    const promptArgsContainer = document.getElementById("promptArgsContainer");
     const promptOutputSection = document.getElementById("promptOutputSection");
     const promptOutputTitle = document.getElementById("promptOutputTitle");
     const promptOutputHelp = document.getElementById("promptOutputHelp");
     const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
-    const commitIdInput = document.getElementById("commitId");
-    let subjectInput = document.getElementById("subjectInput");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !includeLabelPrefix || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -88,13 +87,44 @@ async function initializePromptPage() {
         storage.removeItem(SERIES_VISIBILITY_STORAGE_KEY);
     }
     let seriesVisibilitySettings = loadSeriesVisibilitySettings();
+    function getLegacyPromptArguments(definition) {
+        const args = [];
+        if (definition.requiresCommitId) {
+            args.push({
+                id: "commitId",
+                label: "コミットID",
+                required: true,
+                placeholder: "例: abc1234",
+                helpText: "PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。",
+                inputMode: "latin"
+            });
+        }
+        if (definition.requiresSubject) {
+            args.push({
+                id: "subject",
+                label: definition.subjectLabel || "subject",
+                required: true,
+                placeholder: definition.subjectPlaceholder || "例: a small fox",
+                helpText: definition.subjectHelpText || "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。",
+                defaultValue: definition.subjectDefaultValue,
+                inputMode: "text"
+            });
+        }
+        return args;
+    }
+    function normalizePromptDefinition(definition) {
+        return {
+            ...definition,
+            args: Array.isArray(definition.args) ? definition.args : getLegacyPromptArguments(definition)
+        };
+    }
     function getVisiblePromptDefinitions() {
         return [
             ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
             ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
             ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
             ...(seriesVisibilitySettings.showP ? popularDefinitions : [])
-        ];
+        ].map(normalizePromptDefinition);
     }
     let visiblePromptDefinitions = [];
     let promptSearchIndexes = [];
@@ -111,13 +141,9 @@ async function initializePromptPage() {
         }
     }
     applyLatinInputHints(promptSearch, "search");
-    applyLatinInputHints(commitIdInput, "done");
     const MAX_EMBED_INPUT_LENGTH = 1024;
-    const defaultSubjectFieldConfig = {
-        label: "subject",
-        placeholder: "例: a small fox",
-        helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
-    };
+    let activeArgumentDefinitions = [];
+    let promptArgumentInputs = new Map();
     function sanitizePromptVariableInput(value) {
         const normalizedWhitespace = String(value || "")
             .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
@@ -130,76 +156,118 @@ async function initializePromptPage() {
         const normalizedQuotes = truncatedValue.replace(/`/g, "'");
         return `\`${normalizedQuotes}\``;
     }
-    function getSubjectFieldConfig(definition) {
-        return {
-            label: (definition === null || definition === void 0 ? void 0 : definition.subjectLabel) || defaultSubjectFieldConfig.label,
-            placeholder: (definition === null || definition === void 0 ? void 0 : definition.subjectPlaceholder) || defaultSubjectFieldConfig.placeholder,
-            helpText: (definition === null || definition === void 0 ? void 0 : definition.subjectHelpText) || defaultSubjectFieldConfig.helpText
-        };
-    }
-    function handleSubjectInput() {
+    function handleArgumentInput() {
         updateOutput();
     }
-    function refreshSubjectInputReference() {
-        subjectInput = document.getElementById("subjectInput");
-        if (subjectInput) {
-            subjectInput.addEventListener("input", handleSubjectInput);
+    function getSelectedPromptArguments(definition) {
+        return Array.isArray(definition === null || definition === void 0 ? void 0 : definition.args) ? definition.args : [];
+    }
+    function getArgumentInput(argumentId) {
+        return promptArgumentInputs.get(argumentId) || null;
+    }
+    function getArgumentDomId(argumentId) {
+        if (argumentId === "subject") {
+            return "subjectInput";
+        }
+        return argumentId;
+    }
+    function getArgumentValue(argumentId) {
+        var _a;
+        return ((_a = getArgumentInput(argumentId)) === null || _a === void 0 ? void 0 : _a.value) || "";
+    }
+    function getArgumentQueryParamName(argumentId) {
+        if (argumentId === "commitId") {
+            return "commit";
+        }
+        if (argumentId === "subject") {
+            return "subject";
+        }
+        return `arg_${argumentId}`;
+    }
+    function getPromptArgumentValues() {
+        const values = {};
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            values[argumentDefinition.id] = getArgumentValue(argumentDefinition.id);
+        }
+        return values;
+    }
+    function setPromptArgumentValues(values) {
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const input = getArgumentInput(argumentDefinition.id);
+            if (!input) {
+                continue;
+            }
+            input.value = values[argumentDefinition.id] || "";
         }
     }
-    function renderSubjectInputField(definition) {
-        const config = getSubjectFieldConfig(definition);
-        const currentValue = (subjectInput === null || subjectInput === void 0 ? void 0 : subjectInput.value) || "";
-        if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
-            const nextField = document.createElement("lht-text-field-help");
-            nextField.id = "subjectInputField";
-            nextField.setAttribute("field-id", "subjectInput");
-            nextField.setAttribute("label", config.label);
-            nextField.setAttribute("placeholder", config.placeholder);
-            nextField.setAttribute("help-text", config.helpText);
-            nextField.setAttribute("required", "");
-            subjectInputFieldHost.replaceWith(nextField);
-            subjectInputFieldHost = nextField;
-        }
-        else if (subjectInput) {
-            subjectInput.setAttribute("aria-label", config.label);
-            subjectInput.setAttribute("placeholder", config.placeholder);
-            subjectInput.setAttribute("title", config.helpText);
-        }
-        refreshSubjectInputReference();
-        if (subjectInput) {
-            subjectInput.value = currentValue;
+    function refreshArgumentInputReferences(definition) {
+        promptArgumentInputs = new Map();
+        for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+            const input = document.getElementById(getArgumentDomId(argumentDefinition.id));
+            if (!input) {
+                continue;
+            }
+            promptArgumentInputs.set(argumentDefinition.id, input);
+            input.addEventListener("input", handleArgumentInput);
+            if (argumentDefinition.inputMode === "latin") {
+                applyLatinInputHints(input, "done");
+            }
         }
     }
-    function applyDefaultSubjectValue(selectedDefinition) {
-        if (!(selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) || !subjectInput) {
+    function renderArgumentFields(definition) {
+        const currentValues = getPromptArgumentValues();
+        activeArgumentDefinitions = getSelectedPromptArguments(definition).map((argumentDefinition) => ({ ...argumentDefinition }));
+        promptArgsContainer.innerHTML = "";
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const field = document.createElement("lht-text-field-help");
+            field.id = `${getArgumentDomId(argumentDefinition.id)}Field`;
+            field.setAttribute("field-id", getArgumentDomId(argumentDefinition.id));
+            field.setAttribute("label", argumentDefinition.label);
+            if (argumentDefinition.placeholder) {
+                field.setAttribute("placeholder", argumentDefinition.placeholder);
+            }
+            if (argumentDefinition.helpText) {
+                field.setAttribute("help-text", argumentDefinition.helpText);
+            }
+            if (argumentDefinition.required !== false) {
+                field.setAttribute("required", "");
+            }
+            promptArgsContainer.appendChild(field);
+        }
+        refreshArgumentInputReferences(definition);
+        setPromptArgumentValues(currentValues);
+    }
+    function applyDefaultArgumentValues(selectedDefinition) {
+        if (!selectedDefinition) {
             return;
         }
-        if ((subjectInput.value || "").trim()) {
-            return;
+        for (const argumentDefinition of getSelectedPromptArguments(selectedDefinition)) {
+            const input = getArgumentInput(argumentDefinition.id);
+            if (!input) {
+                continue;
+            }
+            if ((input.value || "").trim()) {
+                continue;
+            }
+            if (!argumentDefinition.defaultValue) {
+                continue;
+            }
+            input.value = argumentDefinition.defaultValue;
         }
-        if (!selectedDefinition.subjectDefaultValue) {
-            return;
-        }
-        subjectInput.value = selectedDefinition.subjectDefaultValue;
     }
     function syncInputSections(selectedDefinition) {
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
-            commitInputSection.classList.remove("md-hidden");
+        if (getSelectedPromptArguments(selectedDefinition).length > 0) {
+            promptArgsSection.classList.remove("md-hidden");
         }
         else {
-            commitInputSection.classList.add("md-hidden");
-        }
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) {
-            subjectInputSection.classList.remove("md-hidden");
-        }
-        else {
-            subjectInputSection.classList.add("md-hidden");
+            promptArgsSection.classList.add("md-hidden");
         }
     }
     let selectedPrompt = "";
     let lastSearchQuery = "";
     let pendingInitialPromptCode = "";
     let suppressSearchResetOnce = false;
+    const promptOutputOptionDefaultsById = new Map();
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
         ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"],
@@ -525,6 +593,57 @@ async function initializePromptPage() {
         }
         return visiblePromptDefinitions.find((definition) => definition.id === selectedPrompt) || null;
     }
+    function getPromptOutputOptions() {
+        return {
+            hallucinationGuardEnabled: hallucinationGuard.checked,
+            outputMarkdownEnabled: outputMarkdown.checked
+        };
+    }
+    function inferPromptOutputOptionDefaults(definition) {
+        if (!definition) {
+            return {
+                hallucinationGuard: false,
+                outputMarkdown: false
+            };
+        }
+        const cached = promptOutputOptionDefaultsById.get(definition.id);
+        if (cached) {
+            return cached;
+        }
+        if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+            const explicitDefaults = {
+                hallucinationGuard: definition.hallucinationGuard === true,
+                outputMarkdown: definition.outputMarkdown === true
+            };
+            promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
+            return explicitDefaults;
+        }
+        const originalOptions = getPromptOutputOptions();
+        setPromptOutputOptions({
+            hallucinationGuardEnabled: true,
+            outputMarkdownEnabled: true
+        });
+        const argsForInference = {};
+        for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+            const rawValue = getArgumentValue(argumentDefinition.id) || argumentDefinition.defaultValue || `dummy-${argumentDefinition.id}`;
+            argsForInference[argumentDefinition.id] = rawValue;
+        }
+        const body = definition.buildBody(sanitizePromptVariableInput(argsForInference.commitId || ""), sanitizePromptVariableInput(argsForInference.subject || ""));
+        setPromptOutputOptions(originalOptions);
+        const templates = getPromptOutputInstructionTemplates();
+        const defaults = {
+            hallucinationGuard: body.includes(templates.strictHallucinationPreventionInstruction) ||
+                body.includes(templates.softHallucinationPreventionInstruction),
+            outputMarkdown: body.includes(templates.markdownFenceInstruction)
+        };
+        promptOutputOptionDefaultsById.set(definition.id, defaults);
+        return defaults;
+    }
+    function applyPromptOutputOptionDefaults(definition) {
+        const defaults = inferPromptOutputOptionDefaults(definition);
+        hallucinationGuard.checked = defaults.hallucinationGuard;
+        outputMarkdown.checked = defaults.outputMarkdown;
+    }
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
         promptOutputHelp.innerHTML = "";
@@ -589,11 +708,9 @@ async function initializePromptPage() {
             else {
                 selectedPrompt = "";
                 syncInputSections(null);
+                renderArgumentFields(null);
                 promptOutputSection.classList.add("md-hidden");
-                commitIdInput.value = "";
-                if (subjectInput) {
-                    subjectInput.value = "";
-                }
+                applyPromptOutputOptionDefaults(null);
                 promptOutput.textContent = "";
             }
         }
@@ -608,7 +725,7 @@ async function initializePromptPage() {
         if (matchedDefinitions.length === 0) {
             if (selectedPrompt) {
                 selectedPrompt = "";
-                commitInputSection.classList.add("md-hidden");
+                promptArgsSection.classList.add("md-hidden");
                 promptOutputSection.classList.add("md-hidden");
                 updateOutput();
             }
@@ -634,14 +751,16 @@ async function initializePromptPage() {
             if (selectedButton) {
                 selectedButton.classList.add("is-active");
             }
-            renderSubjectInputField(selectedDefinition);
+            renderArgumentFields(selectedDefinition);
             syncInputSections(selectedDefinition);
-            applyDefaultSubjectValue(selectedDefinition);
+            applyDefaultArgumentValues(selectedDefinition);
+            applyPromptOutputOptionDefaults(selectedDefinition);
             revealOutputSection();
             updateOutput();
         }
     }
     async function selectPrompt(id, button, options) {
+        var _a;
         selectedPrompt = id;
         for (const element of promptCandidateArea.querySelectorAll(".md-chip-button")) {
             element.classList.remove("is-active");
@@ -658,16 +777,15 @@ async function initializePromptPage() {
             }
         }
         syncInputSections(selectedDefinition || null);
-        renderSubjectInputField(selectedDefinition || null);
-        applyDefaultSubjectValue(selectedDefinition || null);
-        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresCommitId) {
-            commitIdInput.focus();
-        }
-        else if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.requiresSubject) {
-            subjectInput.focus();
+        renderArgumentFields(selectedDefinition || null);
+        applyDefaultArgumentValues(selectedDefinition || null);
+        applyPromptOutputOptionDefaults(selectedDefinition || null);
+        const firstArgument = getSelectedPromptArguments(selectedDefinition || null)[0];
+        if (firstArgument) {
+            (_a = getArgumentInput(firstArgument.id)) === null || _a === void 0 ? void 0 : _a.focus();
         }
         updateOutput();
-        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && !selectedDefinition.requiresCommitId && !selectedDefinition.requiresSubject) {
+        if ((options === null || options === void 0 ? void 0 : options.autoCopy) && selectedDefinition && getSelectedPromptArguments(selectedDefinition).length === 0) {
             await copyText(promptOutput.textContent || "");
         }
     }
@@ -677,13 +795,16 @@ async function initializePromptPage() {
             return "";
         }
         const label = selectedDefinition ? selectedDefinition.label : "";
-        const commitId = sanitizePromptVariableInput(commitIdInput.value || "");
-        const subject = sanitizePromptVariableInput(subjectInput.value || "");
+        const argumentValues = getPromptArgumentValues();
+        const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
+        const subject = sanitizePromptVariableInput(argumentValues.subject || "");
+        setPromptOutputOptions(getPromptOutputOptions());
         const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
         if (!body || !label) {
             return "";
         }
-        return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
+        const normalizedBody = body.trim().replace(/\n{3,}/g, "\n\n");
+        return includeLabelPrefix.checked ? `[${label}] ${normalizedBody}` : normalizedBody;
     }
     function getDefinitionLabelCode(definition) {
         const label = String((definition === null || definition === void 0 ? void 0 : definition.label) || "");
@@ -699,8 +820,6 @@ async function initializePromptPage() {
         const url = new URL(window.location.href);
         url.search = "";
         const query = (promptSearch.value || "").trim();
-        const subject = subjectInput.value || "";
-        const commitId = commitIdInput.value || "";
         const selectedDefinition = getSelectedPromptDefinition();
         const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
         if (query) {
@@ -709,11 +828,12 @@ async function initializePromptPage() {
         if (selectedDefinitionCode) {
             url.searchParams.set("id", selectedDefinitionCode);
         }
-        if (subject) {
-            url.searchParams.set("subject", subject);
-        }
-        if (commitId) {
-            url.searchParams.set("commit", commitId);
+        for (const argumentDefinition of activeArgumentDefinitions) {
+            const value = getArgumentValue(argumentDefinition.id);
+            if (!value) {
+                continue;
+            }
+            url.searchParams.set(getArgumentQueryParamName(argumentDefinition.id), value);
         }
         return url.toString();
     }
@@ -788,22 +908,26 @@ async function initializePromptPage() {
         section.appendChild(resetButton);
     }
     promptSearch.addEventListener("input", renderCandidates);
-    commitIdInput.addEventListener("input", updateOutput);
-    renderSubjectInputField(null);
     includeLabelPrefix.addEventListener("change", updateOutput);
+    hallucinationGuard.addEventListener("change", updateOutput);
+    outputMarkdown.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
     let initialPromptCode = "";
-    let initialSubject = "";
-    let initialCommitId = "";
+    const initialArgumentValues = {};
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
         initialPromptCode = (url.searchParams.get("id") || "").trim();
-        initialSubject = url.searchParams.get("subject") || "";
-        initialCommitId = url.searchParams.get("commit") || "";
+        initialArgumentValues.subject = url.searchParams.get("subject") || "";
+        initialArgumentValues.commitId = url.searchParams.get("commit") || "";
+        for (const [key, value] of url.searchParams.entries()) {
+            if (key.startsWith("arg_")) {
+                initialArgumentValues[key.slice(4)] = value;
+            }
+        }
         if (initialQuery) {
             promptSearch.value = initialQuery;
         }
@@ -811,17 +935,15 @@ async function initializePromptPage() {
     catch (_error) {
         // Ignore invalid or unavailable location values.
     }
+    applyPromptOutputOptionDefaults(null);
     createSeriesVisibilityMenu();
+    renderArgumentFields(null);
     if (initialPromptCode) {
         pendingInitialPromptCode = initialPromptCode;
     }
     renderCandidates();
-    if (initialSubject) {
-        subjectInput.value = initialSubject;
-    }
-    if (initialCommitId) {
-        commitIdInput.value = initialCommitId;
-    }
+    setPromptArgumentValues(initialArgumentValues);
+    applyDefaultArgumentValues(getSelectedPromptDefinition());
     updateOutput();
     requestAnimationFrame(() => {
         promptSearch.focus();

--- a/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
@@ -1,17 +1,8 @@
-function getMarkdownFenceInstruction() {
-    return "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
-}
-function appendMarkdownFenceInstruction(body) {
-    return `${body}\n\n${getMarkdownFenceInstruction()}`;
-}
-function getStrictHallucinationPreventionInstruction() {
-    return `○ハルシネーション防止のため、次のルールに従ってください。
+const strictHallucinationPreventionInstruction = `○ハルシネーション防止のため、次のルールに従ってください。
 - 禁止: (1)今回のこの会話（セッション）および入力内容に明示されていない情報を、補完して記入してはいけません。 (2)会話にない情報を、もっともらしく埋めてはいけません。 (3)根拠がない内容を、確定情報として記載してはいけません。
 - 代替行動: (1)情報不足の項目がある場合は、必要な追加質問を行ってください。 (2)追加質問できない場合、または質問後も根拠が不足する場合は、"不明" "未確認" "要確認" などと明示してください。 (3)判断材料が不足している場合は、無理に結論を書かず、不足している点を明示してください。
 - 出力規則: (1)各項目は、今回のこの会話（セッション）および入力内容に根拠があるものだけを記入してください。 (2)推測を書く場合は、事実として断定せず、"推測:" と明示してください。 (3)未確認事項は事実として書かないでください。 (4)要約や整理を行う場合も、新しい事実を追加せず、与えられた情報の範囲内で表現してください。`;
-}
-function getSoftHallucinationPreventionInstruction() {
-    return `○事実誤認を避けるため、次のルールを意識してください。
+const softHallucinationPreventionInstruction = `○事実誤認を避けるため、次のルールを意識してください。
 
 注意:
 - 今回のこの会話（セッション）および入力内容に明示されていない事実は、断定して記載しないでください。
@@ -25,6 +16,36 @@ function getSoftHallucinationPreventionInstruction() {
 - 根拠がある事実と、推測・評価・提案は区別して記載してください。
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
+const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+let currentPromptOutputOptions = {
+    hallucinationGuardEnabled: true,
+    outputMarkdownEnabled: true
+};
+function setPromptOutputOptions(options) {
+    currentPromptOutputOptions = {
+        hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+        outputMarkdownEnabled: options.outputMarkdownEnabled !== false
+    };
+}
+function getPromptOutputInstructionTemplates() {
+    return {
+        strictHallucinationPreventionInstruction,
+        softHallucinationPreventionInstruction,
+        markdownFenceInstruction
+    };
+}
+function getMarkdownFenceInstruction() {
+    return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
+}
+function appendMarkdownFenceInstruction(body) {
+    const instruction = getMarkdownFenceInstruction();
+    return instruction ? `${body}\n\n${instruction}` : body;
+}
+function getStrictHallucinationPreventionInstruction() {
+    return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+}
+function getSoftHallucinationPreventionInstruction() {
+    return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
 }
 function getTodoReflectionInstruction() {
     return "必要に応じて、今回の作業結果を TODO.md に反映してください。関連する既存の TODO があれば補強・更新し、該当する記述がなければ新規の TODO を追加してください。";

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -2,13 +2,31 @@ type PromptDefinition = {
   id: string;
   label: string;
   keywords: string[];
-  requiresCommitId: boolean;
+  requiresCommitId?: boolean;
   requiresSubject?: boolean;
   subjectLabel?: string;
   subjectPlaceholder?: string;
   subjectHelpText?: string;
   subjectDefaultValue?: string;
+  args?: PromptArgumentDefinition[];
+  hallucinationGuard?: boolean;
+  outputMarkdown?: boolean;
   buildBody: (commitId: string, subject?: string) => string;
+};
+
+type PromptArgumentDefinition = {
+  id: string;
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  helpText?: string;
+  defaultValue?: string;
+  inputMode?: "text" | "latin";
+};
+
+type PromptOutputOptionDefaults = {
+  hallucinationGuard: boolean;
+  outputMarkdown: boolean;
 };
 
 type PromptSearchIndex = {
@@ -77,20 +95,19 @@ async function initializePromptPage() {
 
   const promptSearch = document.getElementById("promptSearch") as HTMLInputElement | null;
   const promptCandidateArea = document.getElementById("promptCandidateArea") as HTMLDivElement | null;
-  const commitInputSection = document.getElementById("commitInputSection") as HTMLElement | null;
-  const subjectInputSection = document.getElementById("subjectInputSection") as HTMLElement | null;
-  let subjectInputFieldHost = document.getElementById("subjectInputField") as HTMLElement | null;
+  const promptArgsSection = document.getElementById("promptArgsSection") as HTMLElement | null;
+  const promptArgsContainer = document.getElementById("promptArgsContainer") as HTMLDivElement | null;
   const promptOutputSection = document.getElementById("promptOutputSection") as HTMLElement | null;
   const promptOutputTitle = document.getElementById("promptOutputTitle") as HTMLElement | null;
   const promptOutputHelp = document.getElementById("promptOutputHelp") as HTMLDivElement | null;
   const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink") as HTMLAnchorElement | null;
-  const commitIdInput = document.getElementById("commitId") as HTMLInputElement | null;
-  let subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
   const includeLabelPrefix = document.getElementById("includeLabelPrefix") as HTMLInputElement | null;
+  const hallucinationGuard = document.getElementById("hallucinationGuard") as HTMLInputElement | null;
+  const outputMarkdown = document.getElementById("outputMarkdown") as HTMLInputElement | null;
   const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
 
-  if (!promptSearch || !commitIdInput || !subjectInput || !includeLabelPrefix || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !commitInputSection || !subjectInputSection || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+  if (!promptSearch || !includeLabelPrefix || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
     return;
   }
 
@@ -134,13 +151,49 @@ async function initializePromptPage() {
 
   let seriesVisibilitySettings = loadSeriesVisibilitySettings();
 
+  function getLegacyPromptArguments(definition: PromptDefinition): PromptArgumentDefinition[] {
+    const args: PromptArgumentDefinition[] = [];
+
+    if (definition.requiresCommitId) {
+      args.push({
+        id: "commitId",
+        label: "コミットID",
+        required: true,
+        placeholder: "例: abc1234",
+        helpText: "PR 文面の作成対象にしたいコミット ID を入力します。短縮 SHA でも構いません。",
+        inputMode: "latin"
+      });
+    }
+
+    if (definition.requiresSubject) {
+      args.push({
+        id: "subject",
+        label: definition.subjectLabel || "subject",
+        required: true,
+        placeholder: definition.subjectPlaceholder || "例: a small fox",
+        helpText: definition.subjectHelpText || "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。",
+        defaultValue: definition.subjectDefaultValue,
+        inputMode: "text"
+      });
+    }
+
+    return args;
+  }
+
+  function normalizePromptDefinition(definition: PromptDefinition): PromptDefinition {
+    return {
+      ...definition,
+      args: Array.isArray(definition.args) ? definition.args : getLegacyPromptArguments(definition)
+    };
+  }
+
   function getVisiblePromptDefinitions() {
     return [
       ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
       ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
       ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
       ...(seriesVisibilitySettings.showP ? popularDefinitions : [])
-    ];
+    ].map(normalizePromptDefinition);
   }
 
   let visiblePromptDefinitions: PromptDefinition[] = [];
@@ -160,14 +213,9 @@ async function initializePromptPage() {
   }
 
   applyLatinInputHints(promptSearch, "search");
-  applyLatinInputHints(commitIdInput, "done");
-
   const MAX_EMBED_INPUT_LENGTH = 1024;
-  const defaultSubjectFieldConfig = {
-    label: "subject",
-    placeholder: "例: a small fox",
-    helpText: "プロンプト内の [subject] に差し込む対象を入力します。英語でも日本語でも構いません。"
-  };
+  let activeArgumentDefinitions: PromptArgumentDefinition[] = [];
+  let promptArgumentInputs = new Map<string, HTMLInputElement>();
 
   function sanitizePromptVariableInput(value: string) {
     const normalizedWhitespace = String(value || "")
@@ -183,75 +231,123 @@ async function initializePromptPage() {
     return `\`${normalizedQuotes}\``;
   }
 
-  function getSubjectFieldConfig(definition: PromptDefinition | null) {
-    return {
-      label: definition?.subjectLabel || defaultSubjectFieldConfig.label,
-      placeholder: definition?.subjectPlaceholder || defaultSubjectFieldConfig.placeholder,
-      helpText: definition?.subjectHelpText || defaultSubjectFieldConfig.helpText
-    };
-  }
-
-  function handleSubjectInput() {
+  function handleArgumentInput() {
     updateOutput();
   }
 
-  function refreshSubjectInputReference() {
-    subjectInput = document.getElementById("subjectInput") as HTMLInputElement | null;
-    if (subjectInput) {
-      subjectInput.addEventListener("input", handleSubjectInput);
+  function getSelectedPromptArguments(definition: PromptDefinition | null): PromptArgumentDefinition[] {
+    return Array.isArray(definition?.args) ? definition.args : [];
+  }
+
+  function getArgumentInput(argumentId: string) {
+    return promptArgumentInputs.get(argumentId) || null;
+  }
+
+  function getArgumentDomId(argumentId: string) {
+    if (argumentId === "subject") {
+      return "subjectInput";
+    }
+    return argumentId;
+  }
+
+  function getArgumentValue(argumentId: string) {
+    return getArgumentInput(argumentId)?.value || "";
+  }
+
+  function getArgumentQueryParamName(argumentId: string) {
+    if (argumentId === "commitId") {
+      return "commit";
+    }
+    if (argumentId === "subject") {
+      return "subject";
+    }
+    return `arg_${argumentId}`;
+  }
+
+  function getPromptArgumentValues() {
+    const values: Record<string, string> = {};
+    for (const argumentDefinition of activeArgumentDefinitions) {
+      values[argumentDefinition.id] = getArgumentValue(argumentDefinition.id);
+    }
+    return values;
+  }
+
+  function setPromptArgumentValues(values: Record<string, string>) {
+    for (const argumentDefinition of activeArgumentDefinitions) {
+      const input = getArgumentInput(argumentDefinition.id);
+      if (!input) {
+        continue;
+      }
+      input.value = values[argumentDefinition.id] || "";
     }
   }
 
-  function renderSubjectInputField(definition: PromptDefinition | null) {
-    const config = getSubjectFieldConfig(definition);
-    const currentValue = subjectInput?.value || "";
-
-    if (subjectInputFieldHost && subjectInputFieldHost.parentElement) {
-      const nextField = document.createElement("lht-text-field-help");
-      nextField.id = "subjectInputField";
-      nextField.setAttribute("field-id", "subjectInput");
-      nextField.setAttribute("label", config.label);
-      nextField.setAttribute("placeholder", config.placeholder);
-      nextField.setAttribute("help-text", config.helpText);
-      nextField.setAttribute("required", "");
-      subjectInputFieldHost.replaceWith(nextField);
-      subjectInputFieldHost = nextField;
-    } else if (subjectInput) {
-      subjectInput.setAttribute("aria-label", config.label);
-      subjectInput.setAttribute("placeholder", config.placeholder);
-      subjectInput.setAttribute("title", config.helpText);
-    }
-
-    refreshSubjectInputReference();
-    if (subjectInput) {
-      subjectInput.value = currentValue;
+  function refreshArgumentInputReferences(definition: PromptDefinition | null) {
+    promptArgumentInputs = new Map();
+    for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+      const input = document.getElementById(getArgumentDomId(argumentDefinition.id)) as HTMLInputElement | null;
+      if (!input) {
+        continue;
+      }
+      promptArgumentInputs.set(argumentDefinition.id, input);
+      input.addEventListener("input", handleArgumentInput);
+      if (argumentDefinition.inputMode === "latin") {
+        applyLatinInputHints(input, "done");
+      }
     }
   }
 
-  function applyDefaultSubjectValue(selectedDefinition: PromptDefinition | null) {
-    if (!selectedDefinition?.requiresSubject || !subjectInput) {
+  function renderArgumentFields(definition: PromptDefinition | null) {
+    const currentValues = getPromptArgumentValues();
+    activeArgumentDefinitions = getSelectedPromptArguments(definition).map((argumentDefinition) => ({ ...argumentDefinition }));
+    promptArgsContainer.innerHTML = "";
+
+    for (const argumentDefinition of activeArgumentDefinitions) {
+      const field = document.createElement("lht-text-field-help");
+      field.id = `${getArgumentDomId(argumentDefinition.id)}Field`;
+      field.setAttribute("field-id", getArgumentDomId(argumentDefinition.id));
+      field.setAttribute("label", argumentDefinition.label);
+      if (argumentDefinition.placeholder) {
+        field.setAttribute("placeholder", argumentDefinition.placeholder);
+      }
+      if (argumentDefinition.helpText) {
+        field.setAttribute("help-text", argumentDefinition.helpText);
+      }
+      if (argumentDefinition.required !== false) {
+        field.setAttribute("required", "");
+      }
+      promptArgsContainer.appendChild(field);
+    }
+
+    refreshArgumentInputReferences(definition);
+    setPromptArgumentValues(currentValues);
+  }
+
+  function applyDefaultArgumentValues(selectedDefinition: PromptDefinition | null) {
+    if (!selectedDefinition) {
       return;
     }
-    if ((subjectInput.value || "").trim()) {
-      return;
+
+    for (const argumentDefinition of getSelectedPromptArguments(selectedDefinition)) {
+      const input = getArgumentInput(argumentDefinition.id);
+      if (!input) {
+        continue;
+      }
+      if ((input.value || "").trim()) {
+        continue;
+      }
+      if (!argumentDefinition.defaultValue) {
+        continue;
+      }
+      input.value = argumentDefinition.defaultValue;
     }
-    if (!selectedDefinition.subjectDefaultValue) {
-      return;
-    }
-    subjectInput.value = selectedDefinition.subjectDefaultValue;
   }
 
   function syncInputSections(selectedDefinition: PromptDefinition | null) {
-    if (selectedDefinition?.requiresCommitId) {
-      commitInputSection.classList.remove("md-hidden");
+    if (getSelectedPromptArguments(selectedDefinition).length > 0) {
+      promptArgsSection.classList.remove("md-hidden");
     } else {
-      commitInputSection.classList.add("md-hidden");
-    }
-
-    if (selectedDefinition?.requiresSubject) {
-      subjectInputSection.classList.remove("md-hidden");
-    } else {
-      subjectInputSection.classList.add("md-hidden");
+      promptArgsSection.classList.add("md-hidden");
     }
   }
 
@@ -259,6 +355,7 @@ async function initializePromptPage() {
   let lastSearchQuery = "";
   let pendingInitialPromptCode = "";
   let suppressSearchResetOnce = false;
+  const promptOutputOptionDefaultsById = new Map<string, PromptOutputOptionDefaults>();
 
   const kanaToRomajiMap = new Map<string, string>([
     ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
@@ -654,6 +751,68 @@ async function initializePromptPage() {
     return visiblePromptDefinitions.find((definition) => definition.id === selectedPrompt) || null;
   }
 
+  function getPromptOutputOptions() {
+    return {
+      hallucinationGuardEnabled: hallucinationGuard.checked,
+      outputMarkdownEnabled: outputMarkdown.checked
+    };
+  }
+
+  function inferPromptOutputOptionDefaults(definition: PromptDefinition | null): PromptOutputOptionDefaults {
+    if (!definition) {
+      return {
+        hallucinationGuard: false,
+        outputMarkdown: false
+      };
+    }
+
+    const cached = promptOutputOptionDefaultsById.get(definition.id);
+    if (cached) {
+      return cached;
+    }
+
+    if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+      const explicitDefaults = {
+        hallucinationGuard: definition.hallucinationGuard === true,
+        outputMarkdown: definition.outputMarkdown === true
+      };
+      promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
+      return explicitDefaults;
+    }
+
+    const originalOptions = getPromptOutputOptions();
+    setPromptOutputOptions({
+      hallucinationGuardEnabled: true,
+      outputMarkdownEnabled: true
+    });
+    const argsForInference: Record<string, string> = {};
+    for (const argumentDefinition of getSelectedPromptArguments(definition)) {
+      const rawValue = getArgumentValue(argumentDefinition.id) || argumentDefinition.defaultValue || `dummy-${argumentDefinition.id}`;
+      argsForInference[argumentDefinition.id] = rawValue;
+    }
+    const body = definition.buildBody(
+      sanitizePromptVariableInput(argsForInference.commitId || ""),
+      sanitizePromptVariableInput(argsForInference.subject || "")
+    );
+    setPromptOutputOptions(originalOptions);
+
+    const templates = getPromptOutputInstructionTemplates();
+    const defaults = {
+      hallucinationGuard:
+        body.includes(templates.strictHallucinationPreventionInstruction) ||
+        body.includes(templates.softHallucinationPreventionInstruction),
+      outputMarkdown: body.includes(templates.markdownFenceInstruction)
+    };
+    promptOutputOptionDefaultsById.set(definition.id, defaults);
+    return defaults;
+  }
+
+  function applyPromptOutputOptionDefaults(definition: PromptDefinition | null) {
+    const defaults = inferPromptOutputOptionDefaults(definition);
+    hallucinationGuard.checked = defaults.hallucinationGuard;
+    outputMarkdown.checked = defaults.outputMarkdown;
+  }
+
   function renderSelectedPromptHelp() {
     const selectedDefinition = getSelectedPromptDefinition();
     promptOutputHelp.innerHTML = "";
@@ -723,11 +882,9 @@ async function initializePromptPage() {
       } else {
         selectedPrompt = "";
         syncInputSections(null);
+        renderArgumentFields(null);
         promptOutputSection.classList.add("md-hidden");
-        commitIdInput.value = "";
-        if (subjectInput) {
-          subjectInput.value = "";
-        }
+        applyPromptOutputOptionDefaults(null);
         promptOutput.textContent = "";
       }
     }
@@ -751,7 +908,7 @@ async function initializePromptPage() {
     if (matchedDefinitions.length === 0) {
       if (selectedPrompt) {
         selectedPrompt = "";
-        commitInputSection.classList.add("md-hidden");
+        promptArgsSection.classList.add("md-hidden");
         promptOutputSection.classList.add("md-hidden");
         updateOutput();
       }
@@ -781,9 +938,10 @@ async function initializePromptPage() {
       if (selectedButton) {
         selectedButton.classList.add("is-active");
       }
-      renderSubjectInputField(selectedDefinition);
+      renderArgumentFields(selectedDefinition);
       syncInputSections(selectedDefinition);
-      applyDefaultSubjectValue(selectedDefinition);
+      applyDefaultArgumentValues(selectedDefinition);
+      applyPromptOutputOptionDefaults(selectedDefinition);
       revealOutputSection();
       updateOutput();
     }
@@ -808,17 +966,17 @@ async function initializePromptPage() {
       }
     }
     syncInputSections(selectedDefinition || null);
-    renderSubjectInputField(selectedDefinition || null);
-    applyDefaultSubjectValue(selectedDefinition || null);
-    if (selectedDefinition?.requiresCommitId) {
-      commitIdInput.focus();
-    } else if (selectedDefinition?.requiresSubject) {
-      subjectInput.focus();
+    renderArgumentFields(selectedDefinition || null);
+    applyDefaultArgumentValues(selectedDefinition || null);
+    applyPromptOutputOptionDefaults(selectedDefinition || null);
+    const firstArgument = getSelectedPromptArguments(selectedDefinition || null)[0];
+    if (firstArgument) {
+      getArgumentInput(firstArgument.id)?.focus();
     }
 
     updateOutput();
 
-    if (options?.autoCopy && selectedDefinition && !selectedDefinition.requiresCommitId && !selectedDefinition.requiresSubject) {
+    if (options?.autoCopy && selectedDefinition && getSelectedPromptArguments(selectedDefinition).length === 0) {
       await copyText(promptOutput.textContent || "");
     }
   }
@@ -829,15 +987,18 @@ async function initializePromptPage() {
       return "";
     }
     const label = selectedDefinition ? selectedDefinition.label : "";
-    const commitId = sanitizePromptVariableInput(commitIdInput.value || "");
-    const subject = sanitizePromptVariableInput(subjectInput.value || "");
+    const argumentValues = getPromptArgumentValues();
+    const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
+    const subject = sanitizePromptVariableInput(argumentValues.subject || "");
+    setPromptOutputOptions(getPromptOutputOptions());
     const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
 
     if (!body || !label) {
       return "";
     }
 
-    return includeLabelPrefix.checked ? `[${label}] ${body}` : body;
+    const normalizedBody = body.trim().replace(/\n{3,}/g, "\n\n");
+    return includeLabelPrefix.checked ? `[${label}] ${normalizedBody}` : normalizedBody;
   }
 
   function getDefinitionLabelCode(definition: PromptDefinition | null) {
@@ -857,8 +1018,6 @@ async function initializePromptPage() {
     url.search = "";
 
     const query = (promptSearch.value || "").trim();
-    const subject = subjectInput.value || "";
-    const commitId = commitIdInput.value || "";
     const selectedDefinition = getSelectedPromptDefinition();
     const selectedDefinitionCode = getDefinitionLabelCode(selectedDefinition);
 
@@ -868,11 +1027,12 @@ async function initializePromptPage() {
     if (selectedDefinitionCode) {
       url.searchParams.set("id", selectedDefinitionCode);
     }
-    if (subject) {
-      url.searchParams.set("subject", subject);
-    }
-    if (commitId) {
-      url.searchParams.set("commit", commitId);
+    for (const argumentDefinition of activeArgumentDefinitions) {
+      const value = getArgumentValue(argumentDefinition.id);
+      if (!value) {
+        continue;
+      }
+      url.searchParams.set(getArgumentQueryParamName(argumentDefinition.id), value);
     }
 
     return url.toString();
@@ -960,23 +1120,27 @@ async function initializePromptPage() {
   }
 
   promptSearch.addEventListener("input", renderCandidates);
-  commitIdInput.addEventListener("input", updateOutput);
-  renderSubjectInputField(null);
   includeLabelPrefix.addEventListener("change", updateOutput);
+  hallucinationGuard.addEventListener("change", updateOutput);
+  outputMarkdown.addEventListener("change", updateOutput);
   copyShareLinkButton.addEventListener("click", () => {
     void copyText(buildShareLink());
   });
 
   let initialQuery = "";
   let initialPromptCode = "";
-  let initialSubject = "";
-  let initialCommitId = "";
+  const initialArgumentValues: Record<string, string> = {};
   try {
     const url = new URL(window.location.href);
     initialQuery = (url.searchParams.get("q") || "").trim();
     initialPromptCode = (url.searchParams.get("id") || "").trim();
-    initialSubject = url.searchParams.get("subject") || "";
-    initialCommitId = url.searchParams.get("commit") || "";
+    initialArgumentValues.subject = url.searchParams.get("subject") || "";
+    initialArgumentValues.commitId = url.searchParams.get("commit") || "";
+    for (const [key, value] of url.searchParams.entries()) {
+      if (key.startsWith("arg_")) {
+        initialArgumentValues[key.slice(4)] = value;
+      }
+    }
     if (initialQuery) {
       promptSearch.value = initialQuery;
     }
@@ -984,17 +1148,15 @@ async function initializePromptPage() {
     // Ignore invalid or unavailable location values.
   }
 
+  applyPromptOutputOptionDefaults(null);
   createSeriesVisibilityMenu();
+  renderArgumentFields(null);
   if (initialPromptCode) {
     pendingInitialPromptCode = initialPromptCode;
   }
   renderCandidates();
-  if (initialSubject) {
-    subjectInput.value = initialSubject;
-  }
-  if (initialCommitId) {
-    commitIdInput.value = initialCommitId;
-  }
+  setPromptArgumentValues(initialArgumentValues);
+  applyDefaultArgumentValues(getSelectedPromptDefinition());
   updateOutput();
 
   requestAnimationFrame(() => {

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -1,13 +1,26 @@
+type PromptArgumentDefinition = {
+  id: string;
+  label: string;
+  required?: boolean;
+  placeholder?: string;
+  helpText?: string;
+  defaultValue?: string;
+  inputMode?: "text" | "latin";
+};
+
 type PromptDefinition = {
   id: string;
   label: string;
   keywords: string[];
-  requiresCommitId: boolean;
+  requiresCommitId?: boolean;
   requiresSubject?: boolean;
   subjectLabel?: string;
   subjectPlaceholder?: string;
   subjectHelpText?: string;
   subjectDefaultValue?: string;
+  args?: PromptArgumentDefinition[];
+  hallucinationGuard?: boolean;
+  outputMarkdown?: boolean;
   buildBody: (commitId: string, subject?: string) => string;
 };
 

--- a/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
@@ -1,20 +1,14 @@
-function getMarkdownFenceInstruction(): string {
-  return "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
-}
+type PromptOutputOptions = {
+  hallucinationGuardEnabled: boolean;
+  outputMarkdownEnabled: boolean;
+};
 
-function appendMarkdownFenceInstruction(body: string): string {
-  return `${body}\n\n${getMarkdownFenceInstruction()}`;
-}
-
-function getStrictHallucinationPreventionInstruction(): string {
-  return `○ハルシネーション防止のため、次のルールに従ってください。
+const strictHallucinationPreventionInstruction = `○ハルシネーション防止のため、次のルールに従ってください。
 - 禁止: (1)今回のこの会話（セッション）および入力内容に明示されていない情報を、補完して記入してはいけません。 (2)会話にない情報を、もっともらしく埋めてはいけません。 (3)根拠がない内容を、確定情報として記載してはいけません。
 - 代替行動: (1)情報不足の項目がある場合は、必要な追加質問を行ってください。 (2)追加質問できない場合、または質問後も根拠が不足する場合は、"不明" "未確認" "要確認" などと明示してください。 (3)判断材料が不足している場合は、無理に結論を書かず、不足している点を明示してください。
 - 出力規則: (1)各項目は、今回のこの会話（セッション）および入力内容に根拠があるものだけを記入してください。 (2)推測を書く場合は、事実として断定せず、"推測:" と明示してください。 (3)未確認事項は事実として書かないでください。 (4)要約や整理を行う場合も、新しい事実を追加せず、与えられた情報の範囲内で表現してください。`;
-}
 
-function getSoftHallucinationPreventionInstruction(): string {
-  return `○事実誤認を避けるため、次のルールを意識してください。
+const softHallucinationPreventionInstruction = `○事実誤認を避けるため、次のルールを意識してください。
 
 注意:
 - 今回のこの会話（セッション）および入力内容に明示されていない事実は、断定して記載しないでください。
@@ -28,6 +22,44 @@ function getSoftHallucinationPreventionInstruction(): string {
 - 根拠がある事実と、推測・評価・提案は区別して記載してください。
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
+
+const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+
+let currentPromptOutputOptions: PromptOutputOptions = {
+  hallucinationGuardEnabled: true,
+  outputMarkdownEnabled: true
+};
+
+function setPromptOutputOptions(options: PromptOutputOptions): void {
+  currentPromptOutputOptions = {
+    hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+    outputMarkdownEnabled: options.outputMarkdownEnabled !== false
+  };
+}
+
+function getPromptOutputInstructionTemplates() {
+  return {
+    strictHallucinationPreventionInstruction,
+    softHallucinationPreventionInstruction,
+    markdownFenceInstruction
+  };
+}
+
+function getMarkdownFenceInstruction(): string {
+  return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
+}
+
+function appendMarkdownFenceInstruction(body: string): string {
+  const instruction = getMarkdownFenceInstruction();
+  return instruction ? `${body}\n\n${instruction}` : body;
+}
+
+function getStrictHallucinationPreventionInstruction(): string {
+  return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+}
+
+function getSoftHallucinationPreventionInstruction(): string {
+  return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
 }
 
 function getTodoReflectionInstruction(): string {

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -36,6 +36,32 @@ const mainCode = readFileSync(
 
 function defineElementIfNeeded(tagName) {
   if (!customElements.get(tagName)) {
+    if (tagName === "lht-text-field-help") {
+      customElements.define(tagName, class extends HTMLElement {
+        connectedCallback() {
+          if (this.dataset.initialized === "true") return;
+          this.dataset.initialized = "true";
+          const fieldId = (this.getAttribute("field-id") || "").trim();
+          const labelText = (this.getAttribute("label") || "").trim();
+          const placeholder = this.getAttribute("placeholder") || "";
+          const helpText = this.getAttribute("help-text") || "";
+          const isRequired = this.hasAttribute("required");
+          this.textContent = "";
+          const label = document.createElement("label");
+          const span = document.createElement("span");
+          span.textContent = labelText;
+          const input = document.createElement("input");
+          input.id = fieldId;
+          input.placeholder = placeholder;
+          input.title = helpText;
+          input.required = isRequired;
+          label.appendChild(span);
+          label.appendChild(input);
+          this.appendChild(label);
+        }
+      });
+      return;
+    }
     if (tagName === "lht-switch-help") {
       customElements.define(tagName, class extends HTMLElement {
         connectedCallback() {
@@ -68,15 +94,16 @@ function mountPromptDom() {
     <lht-page-menu><div class="md-menu-panel"></div></lht-page-menu>
     <input id="promptSearch" />
     <div id="promptCandidateArea"></div>
-    <div id="commitInputSection" class="md-hidden"></div>
-    <div id="subjectInputSection" class="md-hidden"></div>
+    <div id="promptArgsSection" class="md-hidden">
+      <div id="promptArgsContainer"></div>
+    </div>
     <div id="promptOutputSection" class="md-hidden">
       <p id="promptOutputTitle">生成結果</p>
       <div id="promptOutputHelp"></div>
     </div>
-    <input id="commitId" />
-    <input id="subjectInput" />
     <input id="includeLabelPrefix" type="checkbox" />
+    <input id="hallucinationGuard" type="checkbox" />
+    <input id="outputMarkdown" type="checkbox" />
     <button id="copyShareLinkButton" type="button"></button>
     <a id="gitPseudoSquashLink" class="md-hidden" href="../git/git-work-list.html"></a>
     <div id="promptOutput"></div>
@@ -184,16 +211,16 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const subjectInput = document.getElementById("subjectInput");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
-    const buttons = [...document.querySelectorAll(".md-chip-button")];
 
     promptSearch.value = "和";
     promptSearch.dispatchEvent(new Event("input"));
+    const buttons = [...document.querySelectorAll(".md-chip-button")];
     const targetButton = buttons.find((button) =>
       button.querySelector(".md-chip-label").textContent.includes("A852: 和紙切絵作品")
     );
     targetButton.click();
+    const subjectInput = document.getElementById("subjectInput");
     subjectInput.value = "a small fox";
     subjectInput.dispatchEvent(new Event("input"));
     copyShareLinkButton.click();
@@ -206,13 +233,13 @@ describe("prompt-gen main", () => {
     await bootPromptPage("?q=A852");
 
     const promptSearch = document.getElementById("promptSearch");
-    const subjectInputSection = document.getElementById("subjectInputSection");
+    const promptArgsSection = document.getElementById("promptArgsSection");
     const buttons = [...document.querySelectorAll(".md-chip-button")];
 
     expect(promptSearch.value).toBe("A852");
     expect(buttons).toHaveLength(1);
     expect(buttons[0].querySelector(".md-chip-label").textContent).toContain("和紙切絵作品");
-    expect(subjectInputSection.classList.contains("md-hidden")).toBe(false);
+    expect(promptArgsSection.classList.contains("md-hidden")).toBe(false);
   });
 
   it("applies subject query parameter and generates output on load", async () => {
@@ -223,6 +250,58 @@ describe("prompt-gen main", () => {
 
     expect(subjectInput.value).toBe("a small fox");
     expect(promptOutput.textContent).toContain("A simplified cute illustration of `a small fox`");
+  });
+
+  it("applies prompt defaults to hallucinationGuard and outputMarkdown", async () => {
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(hallucinationGuard.checked).toBe(true);
+    expect(outputMarkdown.checked).toBe(true);
+    expect(promptOutput.textContent).toContain("○ハルシネーション防止のため");
+    expect(promptOutput.textContent).toContain("○最終的な回答は ~~~~ で囲まれた一塊として出力してください。");
+  });
+
+  it("updates output when hallucinationGuard and outputMarkdown are toggled", async () => {
+    await bootPromptPage("?q=A501");
+
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
+    const promptOutput = document.getElementById("promptOutput");
+
+    hallucinationGuard.checked = false;
+    hallucinationGuard.dispatchEvent(new Event("change"));
+    outputMarkdown.checked = false;
+    outputMarkdown.dispatchEvent(new Event("change"));
+
+    expect(promptOutput.textContent).not.toContain("○ハルシネーション防止のため");
+    expect(promptOutput.textContent).not.toContain("○最終的な回答は ~~~~ で囲まれた一塊として出力してください。");
+  });
+
+  it("resets hallucinationGuard and outputMarkdown to prompt defaults when switching prompts", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
+
+    promptSearch.value = "A501";
+    promptSearch.dispatchEvent(new Event("input"));
+    hallucinationGuard.checked = false;
+    hallucinationGuard.dispatchEvent(new Event("change"));
+    outputMarkdown.checked = false;
+    outputMarkdown.dispatchEvent(new Event("change"));
+
+    promptSearch.value = "A503";
+    promptSearch.dispatchEvent(new Event("input"));
+    promptSearch.value = "A501";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(hallucinationGuard.checked).toBe(true);
+    expect(outputMarkdown.checked).toBe(true);
   });
 
   it("uses docs as the default docs path for A150", async () => {
@@ -317,8 +396,7 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const commitId = document.getElementById("commitId");
-    const commitInputSection = document.getElementById("commitInputSection");
+    const promptArgsSection = document.getElementById("promptArgsSection");
     const promptOutputSection = document.getElementById("promptOutputSection");
     const promptOutput = document.getElementById("promptOutput");
 
@@ -329,10 +407,11 @@ describe("prompt-gen main", () => {
     expect(buttons).toHaveLength(1);
     expect(buttons[0].querySelector(".md-chip-label").textContent).toContain("GitHub PR 文面の作成");
     expect(buttons[0].classList.contains("is-active")).toBe(true);
-    expect(commitInputSection.classList.contains("md-hidden")).toBe(false);
+    expect(promptArgsSection.classList.contains("md-hidden")).toBe(false);
     expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
     expect(promptOutput.textContent).toBe("");
 
+    const commitId = document.getElementById("commitId");
     commitId.value = "abc1234";
     commitId.dispatchEvent(new Event("input"));
 
@@ -363,14 +442,14 @@ describe("prompt-gen main", () => {
 
     const promptSearch = document.getElementById("promptSearch");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
-    const commitInputSection = document.getElementById("commitInputSection");
+    const promptArgsSection = document.getElementById("promptArgsSection");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A701";
     promptSearch.dispatchEvent(new Event("input"));
 
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
-    expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
+    expect(promptArgsSection.classList.contains("md-hidden")).toBe(true);
     expect(promptOutput.textContent).toBe(
       "このアプリは原則として Single-file Web App であるようにしてください。変更の過程でこれが崩れていることがたまにあります。ビルド後の html ファイルは、CDN や別ファイルの CSS / JS ファイルを利用していないことを確認してください。"
     );
@@ -387,17 +466,17 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const subjectInput = document.getElementById("subjectInput");
-    const subjectInputSection = document.getElementById("subjectInputSection");
+    const promptArgsSection = document.getElementById("promptArgsSection");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A852";
     promptSearch.dispatchEvent(new Event("input"));
 
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
-    expect(subjectInputSection.classList.contains("md-hidden")).toBe(false);
+    expect(promptArgsSection.classList.contains("md-hidden")).toBe(false);
     expect(promptOutput.textContent).toBe("");
 
+    const subjectInput = document.getElementById("subjectInput");
     subjectInput.value = "a small fox";
     subjectInput.dispatchEvent(new Event("input"));
 
@@ -409,12 +488,12 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const commitId = document.getElementById("commitId");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A501";
     promptSearch.dispatchEvent(new Event("input"));
 
+    const commitId = document.getElementById("commitId");
     commitId.value = `ab\`cd${"x".repeat(1100)}`;
     commitId.dispatchEvent(new Event("input"));
 
@@ -429,12 +508,12 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const subjectInput = document.getElementById("subjectInput");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A852";
     promptSearch.dispatchEvent(new Event("input"));
 
+    const subjectInput = document.getElementById("subjectInput");
     subjectInput.value = `small \`fox\`${"y".repeat(1100)}`;
     subjectInput.dispatchEvent(new Event("input"));
 
@@ -449,12 +528,12 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const commitId = document.getElementById("commitId");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A501";
     promptSearch.dispatchEvent(new Event("input"));
 
+    const commitId = document.getElementById("commitId");
     setRawInputValue(commitId, "ab\tcd\nef\u0000gh\u200Biz");
     commitId.dispatchEvent(new Event("input"));
 
@@ -465,12 +544,12 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const subjectInput = document.getElementById("subjectInput");
     const promptOutput = document.getElementById("promptOutput");
 
     promptSearch.value = "A852";
     promptSearch.dispatchEvent(new Event("input"));
 
+    const subjectInput = document.getElementById("subjectInput");
     setRawInputValue(subjectInput, "small\tfox\nwith\u200Bhat");
     subjectInput.dispatchEvent(new Event("input"));
 
@@ -481,13 +560,13 @@ describe("prompt-gen main", () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
-    const commitId = document.getElementById("commitId");
     const promptOutput = document.getElementById("promptOutput");
-    const commitInputSection = document.getElementById("commitInputSection");
+    const promptArgsSection = document.getElementById("promptArgsSection");
     const promptOutputSection = document.getElementById("promptOutputSection");
 
     promptSearch.value = "A501";
     promptSearch.dispatchEvent(new Event("input"));
+    const commitId = document.getElementById("commitId");
     commitId.value = "abc1234";
     commitId.dispatchEvent(new Event("input"));
     expect(promptOutput.textContent).toContain("abc1234");
@@ -495,10 +574,10 @@ describe("prompt-gen main", () => {
     promptSearch.value = "A703";
     promptSearch.dispatchEvent(new Event("input"));
 
-    expect(commitId.value).toBe("");
+    expect(document.getElementById("commitId")).toBeNull();
     expect(promptOutput.textContent).not.toContain("abc1234");
     expect(promptOutput.textContent).toContain("今からの作業は仕様の検討です。");
-    expect(commitInputSection.classList.contains("md-hidden")).toBe(true);
+    expect(promptArgsSection.classList.contains("md-hidden")).toBe(true);
     expect(promptOutputSection.classList.contains("md-hidden")).toBe(false);
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
   });


### PR DESCRIPTION
## 概要
`docs/prompt/prompt-gen` に対して、出力オプションの切り替え UI を追加し、従来の固定入力欄を `args` ベースの動的入力欄へ整理した変更です。あわせて、共有リンクボタンの配置調整、関連ロジックの整理、テスト更新が含まれます。

## 主な変更点
- `prompt-gen` の出力オプションとして `幻想防止` と `Markdownフェンス` を追加
- 内部の出力オプション名を `markdownFence` から `outputMarkdown` へ整理
- プロンプト定義に `args`, `hallucinationGuard`, `outputMarkdown` を持てるよう型を拡張
- 既存の `requiresCommitId` / `requiresSubject` ベース定義を `args` に正規化する互換処理を追加
- `commitId` / `subject` 固定前提の入力UIを廃止し、動的な引数入力欄描画に変更
- 共有リンク生成・復元処理を動的引数に対応させ、既存の `commit` / `subject` パラメータ互換も維持
- `共有リンクをコピー` ボタンを出力ヘッダ右側へ移動
- `prompt-gen` のテストを新UI/新オプション構成に合わせて更新

## 変更ファイル
- `docs/prompt/prompt-gen-src.html`
- `docs/prompt/prompt-gen.html`
- `docs/prompt/src/prompt-gen/css/app.css`
- `docs/prompt/src/prompt-gen/ts/main.ts`
- `docs/prompt/src/prompt-gen/js/main.js`
- `docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts`
- `docs/prompt/src/prompt-gen/js/prompt-markdown-util.js`
- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
- `docs/prompt/tests/prompt-gen-main.test.js`

## テスト / 確認
- テストコードの更新は含まれています
- 実行結果: 不明
- 未確認事項:
  - このコミット時点で `npm test -- docs/prompt/tests/prompt-gen-main.test.js` を実行したか
  - ビルド生成物の確認をどこまで行ったか

## 注意点
- 既存プロンプト定義は全面的に `args` へ移行されたわけではなく、互換変換で動かす構成です
- `buildBody` のシグネチャ自体は `commitId` / `subject` のままであり、入力モデルと本文生成APIの完全統一は今後の余地があります