### PR TITLE
prompt-gen の出力オプションを 3値化し共通後付けへ整理

### DIFF
--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -121,17 +121,20 @@ limitations under the License.
           help-label="ラベル名を先頭に含める説明">
           ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
         </lht-switch-help>
-        <lht-switch-help
-          switch-id="hallucinationGuard"
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="hallucinationGuard"
           label="幻想防止"
-          help-label="幻想防止の説明">
-          ON の場合は、事実誤認や根拠のない補完を避けるための注意文を含めます。
-        </lht-switch-help>
+          help-text="幻想防止の強さを選択します。なし / 弱 / 強 の3段階です。">
+          <option value="none">なし</option>
+          <option value="low">弱</option>
+          <option value="high">強</option>
+        </lht-select-help>
         <lht-switch-help
           switch-id="outputMarkdown"
-          label="Markdownフェンス"
-          help-label="Markdownフェンスの説明">
-          ON の場合は、最終回答を `~~~~` で囲んで出力する指定を含めます。
+          label="Markdown出力"
+          help-label="Markdown出力の説明">
+          ON の場合は、最終回答を Markdown として出力し、外側を `~~~~` で囲む指定を含めます。
         </lht-switch-help>
         <a
           id="gitPseudoSquashLink"

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1263,8 +1263,28 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 .md-output-options {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
+}
+
+.md-output-options__select {
+  flex: 0 0 auto;
+  margin-right: 20px;
+}
+
+.md-output-options__select--compact {
+  min-width: 9rem;
+  max-width: 11rem;
+}
+
+.md-output-options__select--compact md-outlined-select,
+.md-output-options__select--compact .lht-select-help__fallback-wrap,
+.md-output-options__select--compact .lht-select-help__fallback {
+  width: 100%;
+}
+
+.md-output-options lht-switch-help {
+  flex: 0 0 auto;
 }
 
 @media (max-width: 720px) {
@@ -1531,17 +1551,20 @@ md-icon-button.md-copy-button--surface {
           help-label="ラベル名を先頭に含める説明">
           ON の場合は `[ボタンラベル] 本文` の形式で出力します。OFF の場合は本文のみを出力します。
         </lht-switch-help>
-        <lht-switch-help
-          switch-id="hallucinationGuard"
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="hallucinationGuard"
           label="幻想防止"
-          help-label="幻想防止の説明">
-          ON の場合は、事実誤認や根拠のない補完を避けるための注意文を含めます。
-        </lht-switch-help>
+          help-text="幻想防止の強さを選択します。なし / 弱 / 強 の3段階です。">
+          <option value="none">なし</option>
+          <option value="low">弱</option>
+          <option value="high">強</option>
+        </lht-select-help>
         <lht-switch-help
           switch-id="outputMarkdown"
-          label="Markdownフェンス"
-          help-label="Markdownフェンスの説明">
-          ON の場合は、最終回答を `~~~~` で囲んで出力する指定を含めます。
+          label="Markdown出力"
+          help-label="Markdown出力の説明">
+          ON の場合は、最終回答を Markdown として出力し、外側を `~~~~` で囲む指定を含めます。
         </lht-switch-help>
         <a
           id="gitPseudoSquashLink"
@@ -3700,14 +3723,14 @@ const softHallucinationPreventionInstruction = `○事実誤認を避けるた�
 - 根拠がある事実と、推測・評価・提案は区別して記載してください。
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
-const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+const markdownFenceInstruction = "○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
 let currentPromptOutputOptions = {
-    hallucinationGuardEnabled: true,
+    hallucinationGuardLevel: "high",
     outputMarkdownEnabled: true
 };
 function setPromptOutputOptions(options) {
     currentPromptOutputOptions = {
-        hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+        hallucinationGuardLevel: options.hallucinationGuardLevel || "none",
         outputMarkdownEnabled: options.outputMarkdownEnabled !== false
     };
 }
@@ -3718,6 +3741,57 @@ function getPromptOutputInstructionTemplates() {
         markdownFenceInstruction
     };
 }
+function trimTrailingPromptSeparators(value) {
+    return String(value || "").replace(/(?:\s*\n\s*)+$/g, "").trimEnd();
+}
+function inferPromptOutputInstructionProfile(body) {
+    const templates = getPromptOutputInstructionTemplates();
+    const normalizedBody = String(body || "");
+    return {
+        hallucinationGuardMode: normalizedBody.includes(templates.strictHallucinationPreventionInstruction)
+            ? "high"
+            : normalizedBody.includes(templates.softHallucinationPreventionInstruction)
+                ? "low"
+                : "none",
+        outputMarkdown: normalizedBody.includes(templates.markdownFenceInstruction)
+    };
+}
+function stripPromptOutputInstructions(body) {
+    const templates = getPromptOutputInstructionTemplates();
+    let normalizedBody = trimTrailingPromptSeparators(body);
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const template of [
+            templates.markdownFenceInstruction,
+            templates.strictHallucinationPreventionInstruction,
+            templates.softHallucinationPreventionInstruction
+        ]) {
+            if (!template || !normalizedBody.endsWith(template)) {
+                continue;
+            }
+            normalizedBody = trimTrailingPromptSeparators(normalizedBody.slice(0, normalizedBody.length - template.length));
+            changed = true;
+        }
+    }
+    return normalizedBody;
+}
+function appendPromptOutputInstructions(body, options, hallucinationGuardMode = "high") {
+    const normalizedBody = trimTrailingPromptSeparators(body);
+    if (!normalizedBody) {
+        return "";
+    }
+    const segments = [normalizedBody];
+    if (options.hallucinationGuardLevel !== "none") {
+        segments.push((options.hallucinationGuardLevel || hallucinationGuardMode) === "low"
+            ? softHallucinationPreventionInstruction
+            : strictHallucinationPreventionInstruction);
+    }
+    if (options.outputMarkdownEnabled) {
+        segments.push(markdownFenceInstruction);
+    }
+    return segments.join("\n\n");
+}
 function getMarkdownFenceInstruction() {
     return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
 }
@@ -3726,10 +3800,10 @@ function appendMarkdownFenceInstruction(body) {
     return instruction ? `${body}\n\n${instruction}` : body;
 }
 function getStrictHallucinationPreventionInstruction() {
-    return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+    return currentPromptOutputOptions.hallucinationGuardLevel === "high" ? strictHallucinationPreventionInstruction : "";
 }
 function getSoftHallucinationPreventionInstruction() {
-    return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
+    return currentPromptOutputOptions.hallucinationGuardLevel === "low" ? softHallucinationPreventionInstruction : "";
 }
 function getTodoReflectionInstruction() {
     return "必要に応じて、今回の作業結果を TODO.md に反映してください。関連する既存の TODO があれば補強・更新し、該当する記述がなければ新規の TODO を追加してください。";
@@ -8396,6 +8470,19 @@ async function initializePromptPage() {
     const popularDefinitions = Array.isArray(popularPromptDefinitions) ? popularPromptDefinitions : [];
     if (window.customElements && window.customElements.whenDefined) {
         await window.customElements.whenDefined("lht-text-field-help");
+        await window.customElements.whenDefined("lht-select-help");
+    }
+    async function waitForElementById(id, maxFrames = 4) {
+        for (let index = 0; index < maxFrames; index += 1) {
+            const element = document.getElementById(id);
+            if (element) {
+                return element;
+            }
+            await new Promise((resolve) => {
+                requestAnimationFrame(() => resolve());
+            });
+        }
+        return document.getElementById(id);
     }
     const promptSearch = document.getElementById("promptSearch");
     const promptCandidateArea = document.getElementById("promptCandidateArea");
@@ -8406,7 +8493,7 @@ async function initializePromptPage() {
     const promptOutputHelp = document.getElementById("promptOutputHelp");
     const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
-    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const hallucinationGuard = await waitForElementById("hallucinationGuard");
     const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
@@ -8958,14 +9045,14 @@ async function initializePromptPage() {
     }
     function getPromptOutputOptions() {
         return {
-            hallucinationGuardEnabled: hallucinationGuard.checked,
+            hallucinationGuardLevel: (hallucinationGuard.value || "none"),
             outputMarkdownEnabled: outputMarkdown.checked
         };
     }
     function inferPromptOutputOptionDefaults(definition) {
         if (!definition) {
             return {
-                hallucinationGuard: false,
+                hallucinationGuard: "none",
                 outputMarkdown: false
             };
         }
@@ -8973,9 +9060,13 @@ async function initializePromptPage() {
         if (cached) {
             return cached;
         }
-        if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+        if (typeof definition.hallucinationGuard === "string" || typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
             const explicitDefaults = {
-                hallucinationGuard: definition.hallucinationGuard === true,
+                hallucinationGuard: typeof definition.hallucinationGuard === "string"
+                    ? definition.hallucinationGuard
+                    : definition.hallucinationGuard === true
+                        ? "high"
+                        : "none",
                 outputMarkdown: definition.outputMarkdown === true
             };
             promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
@@ -8983,7 +9074,7 @@ async function initializePromptPage() {
         }
         const originalOptions = getPromptOutputOptions();
         setPromptOutputOptions({
-            hallucinationGuardEnabled: true,
+            hallucinationGuardLevel: "high",
             outputMarkdownEnabled: true
         });
         const argsForInference = {};
@@ -8993,18 +9084,17 @@ async function initializePromptPage() {
         }
         const body = definition.buildBody(sanitizePromptVariableInput(argsForInference.commitId || ""), sanitizePromptVariableInput(argsForInference.subject || ""));
         setPromptOutputOptions(originalOptions);
-        const templates = getPromptOutputInstructionTemplates();
+        const instructionProfile = inferPromptOutputInstructionProfile(body);
         const defaults = {
-            hallucinationGuard: body.includes(templates.strictHallucinationPreventionInstruction) ||
-                body.includes(templates.softHallucinationPreventionInstruction),
-            outputMarkdown: body.includes(templates.markdownFenceInstruction)
+            hallucinationGuard: instructionProfile.hallucinationGuardMode,
+            outputMarkdown: instructionProfile.outputMarkdown
         };
         promptOutputOptionDefaultsById.set(definition.id, defaults);
         return defaults;
     }
     function applyPromptOutputOptionDefaults(definition) {
         const defaults = inferPromptOutputOptionDefaults(definition);
-        hallucinationGuard.checked = defaults.hallucinationGuard;
+        hallucinationGuard.value = defaults.hallucinationGuard;
         outputMarkdown.checked = defaults.outputMarkdown;
     }
     function renderSelectedPromptHelp() {
@@ -9161,8 +9251,15 @@ async function initializePromptPage() {
         const argumentValues = getPromptArgumentValues();
         const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
         const subject = sanitizePromptVariableInput(argumentValues.subject || "");
-        setPromptOutputOptions(getPromptOutputOptions());
-        const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        const currentOptions = getPromptOutputOptions();
+        setPromptOutputOptions({
+            hallucinationGuardLevel: "high",
+            outputMarkdownEnabled: true
+        });
+        const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        setPromptOutputOptions(currentOptions);
+        const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
+        const body = appendPromptOutputInstructions(stripPromptOutputInstructions(rawBody), currentOptions, instructionProfile.hallucinationGuardMode || "high");
         if (!body || !label) {
             return "";
         }

--- a/docs/prompt/src/prompt-gen/css/app.css
+++ b/docs/prompt/src/prompt-gen/css/app.css
@@ -187,8 +187,28 @@ lht-text-field-help .lht-text-field-help__fallback::placeholder {
 .md-output-options {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
+}
+
+.md-output-options__select {
+  flex: 0 0 auto;
+  margin-right: 20px;
+}
+
+.md-output-options__select--compact {
+  min-width: 9rem;
+  max-width: 11rem;
+}
+
+.md-output-options__select--compact md-outlined-select,
+.md-output-options__select--compact .lht-select-help__fallback-wrap,
+.md-output-options__select--compact .lht-select-help__fallback {
+  width: 100%;
+}
+
+.md-output-options lht-switch-help {
+  flex: 0 0 auto;
 }
 
 @media (max-width: 720px) {

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -33,6 +33,19 @@ async function initializePromptPage() {
     const popularDefinitions = Array.isArray(popularPromptDefinitions) ? popularPromptDefinitions : [];
     if (window.customElements && window.customElements.whenDefined) {
         await window.customElements.whenDefined("lht-text-field-help");
+        await window.customElements.whenDefined("lht-select-help");
+    }
+    async function waitForElementById(id, maxFrames = 4) {
+        for (let index = 0; index < maxFrames; index += 1) {
+            const element = document.getElementById(id);
+            if (element) {
+                return element;
+            }
+            await new Promise((resolve) => {
+                requestAnimationFrame(() => resolve());
+            });
+        }
+        return document.getElementById(id);
     }
     const promptSearch = document.getElementById("promptSearch");
     const promptCandidateArea = document.getElementById("promptCandidateArea");
@@ -43,7 +56,7 @@ async function initializePromptPage() {
     const promptOutputHelp = document.getElementById("promptOutputHelp");
     const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink");
     const includeLabelPrefix = document.getElementById("includeLabelPrefix");
-    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const hallucinationGuard = await waitForElementById("hallucinationGuard");
     const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
@@ -595,14 +608,14 @@ async function initializePromptPage() {
     }
     function getPromptOutputOptions() {
         return {
-            hallucinationGuardEnabled: hallucinationGuard.checked,
+            hallucinationGuardLevel: (hallucinationGuard.value || "none"),
             outputMarkdownEnabled: outputMarkdown.checked
         };
     }
     function inferPromptOutputOptionDefaults(definition) {
         if (!definition) {
             return {
-                hallucinationGuard: false,
+                hallucinationGuard: "none",
                 outputMarkdown: false
             };
         }
@@ -610,9 +623,13 @@ async function initializePromptPage() {
         if (cached) {
             return cached;
         }
-        if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+        if (typeof definition.hallucinationGuard === "string" || typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
             const explicitDefaults = {
-                hallucinationGuard: definition.hallucinationGuard === true,
+                hallucinationGuard: typeof definition.hallucinationGuard === "string"
+                    ? definition.hallucinationGuard
+                    : definition.hallucinationGuard === true
+                        ? "high"
+                        : "none",
                 outputMarkdown: definition.outputMarkdown === true
             };
             promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
@@ -620,7 +637,7 @@ async function initializePromptPage() {
         }
         const originalOptions = getPromptOutputOptions();
         setPromptOutputOptions({
-            hallucinationGuardEnabled: true,
+            hallucinationGuardLevel: "high",
             outputMarkdownEnabled: true
         });
         const argsForInference = {};
@@ -630,18 +647,17 @@ async function initializePromptPage() {
         }
         const body = definition.buildBody(sanitizePromptVariableInput(argsForInference.commitId || ""), sanitizePromptVariableInput(argsForInference.subject || ""));
         setPromptOutputOptions(originalOptions);
-        const templates = getPromptOutputInstructionTemplates();
+        const instructionProfile = inferPromptOutputInstructionProfile(body);
         const defaults = {
-            hallucinationGuard: body.includes(templates.strictHallucinationPreventionInstruction) ||
-                body.includes(templates.softHallucinationPreventionInstruction),
-            outputMarkdown: body.includes(templates.markdownFenceInstruction)
+            hallucinationGuard: instructionProfile.hallucinationGuardMode,
+            outputMarkdown: instructionProfile.outputMarkdown
         };
         promptOutputOptionDefaultsById.set(definition.id, defaults);
         return defaults;
     }
     function applyPromptOutputOptionDefaults(definition) {
         const defaults = inferPromptOutputOptionDefaults(definition);
-        hallucinationGuard.checked = defaults.hallucinationGuard;
+        hallucinationGuard.value = defaults.hallucinationGuard;
         outputMarkdown.checked = defaults.outputMarkdown;
     }
     function renderSelectedPromptHelp() {
@@ -798,8 +814,15 @@ async function initializePromptPage() {
         const argumentValues = getPromptArgumentValues();
         const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
         const subject = sanitizePromptVariableInput(argumentValues.subject || "");
-        setPromptOutputOptions(getPromptOutputOptions());
-        const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        const currentOptions = getPromptOutputOptions();
+        setPromptOutputOptions({
+            hallucinationGuardLevel: "high",
+            outputMarkdownEnabled: true
+        });
+        const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        setPromptOutputOptions(currentOptions);
+        const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
+        const body = appendPromptOutputInstructions(stripPromptOutputInstructions(rawBody), currentOptions, instructionProfile.hallucinationGuardMode || "high");
         if (!body || !label) {
             return "";
         }

--- a/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
@@ -16,14 +16,14 @@ const softHallucinationPreventionInstruction = `○事実誤認を避けるた�
 - 根拠がある事実と、推測・評価・提案は区別して記載してください。
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
-const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+const markdownFenceInstruction = "○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
 let currentPromptOutputOptions = {
-    hallucinationGuardEnabled: true,
+    hallucinationGuardLevel: "high",
     outputMarkdownEnabled: true
 };
 function setPromptOutputOptions(options) {
     currentPromptOutputOptions = {
-        hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+        hallucinationGuardLevel: options.hallucinationGuardLevel || "none",
         outputMarkdownEnabled: options.outputMarkdownEnabled !== false
     };
 }
@@ -34,6 +34,57 @@ function getPromptOutputInstructionTemplates() {
         markdownFenceInstruction
     };
 }
+function trimTrailingPromptSeparators(value) {
+    return String(value || "").replace(/(?:\s*\n\s*)+$/g, "").trimEnd();
+}
+function inferPromptOutputInstructionProfile(body) {
+    const templates = getPromptOutputInstructionTemplates();
+    const normalizedBody = String(body || "");
+    return {
+        hallucinationGuardMode: normalizedBody.includes(templates.strictHallucinationPreventionInstruction)
+            ? "high"
+            : normalizedBody.includes(templates.softHallucinationPreventionInstruction)
+                ? "low"
+                : "none",
+        outputMarkdown: normalizedBody.includes(templates.markdownFenceInstruction)
+    };
+}
+function stripPromptOutputInstructions(body) {
+    const templates = getPromptOutputInstructionTemplates();
+    let normalizedBody = trimTrailingPromptSeparators(body);
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const template of [
+            templates.markdownFenceInstruction,
+            templates.strictHallucinationPreventionInstruction,
+            templates.softHallucinationPreventionInstruction
+        ]) {
+            if (!template || !normalizedBody.endsWith(template)) {
+                continue;
+            }
+            normalizedBody = trimTrailingPromptSeparators(normalizedBody.slice(0, normalizedBody.length - template.length));
+            changed = true;
+        }
+    }
+    return normalizedBody;
+}
+function appendPromptOutputInstructions(body, options, hallucinationGuardMode = "high") {
+    const normalizedBody = trimTrailingPromptSeparators(body);
+    if (!normalizedBody) {
+        return "";
+    }
+    const segments = [normalizedBody];
+    if (options.hallucinationGuardLevel !== "none") {
+        segments.push((options.hallucinationGuardLevel || hallucinationGuardMode) === "low"
+            ? softHallucinationPreventionInstruction
+            : strictHallucinationPreventionInstruction);
+    }
+    if (options.outputMarkdownEnabled) {
+        segments.push(markdownFenceInstruction);
+    }
+    return segments.join("\n\n");
+}
 function getMarkdownFenceInstruction() {
     return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
 }
@@ -42,10 +93,10 @@ function appendMarkdownFenceInstruction(body) {
     return instruction ? `${body}\n\n${instruction}` : body;
 }
 function getStrictHallucinationPreventionInstruction() {
-    return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+    return currentPromptOutputOptions.hallucinationGuardLevel === "high" ? strictHallucinationPreventionInstruction : "";
 }
 function getSoftHallucinationPreventionInstruction() {
-    return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
+    return currentPromptOutputOptions.hallucinationGuardLevel === "low" ? softHallucinationPreventionInstruction : "";
 }
 function getTodoReflectionInstruction() {
     return "必要に応じて、今回の作業結果を TODO.md に反映してください。関連する既存の TODO があれば補強・更新し、該当する記述がなければ新規の TODO を追加してください。";

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -9,7 +9,7 @@ type PromptDefinition = {
   subjectHelpText?: string;
   subjectDefaultValue?: string;
   args?: PromptArgumentDefinition[];
-  hallucinationGuard?: boolean;
+  hallucinationGuard?: "none" | "low" | "high" | boolean;
   outputMarkdown?: boolean;
   buildBody: (commitId: string, subject?: string) => string;
 };
@@ -25,7 +25,7 @@ type PromptArgumentDefinition = {
 };
 
 type PromptOutputOptionDefaults = {
-  hallucinationGuard: boolean;
+  hallucinationGuard: "none" | "low" | "high";
   outputMarkdown: boolean;
 };
 
@@ -91,6 +91,20 @@ async function initializePromptPage() {
 
   if (window.customElements && window.customElements.whenDefined) {
     await window.customElements.whenDefined("lht-text-field-help");
+    await window.customElements.whenDefined("lht-select-help");
+  }
+
+  async function waitForElementById<T extends HTMLElement>(id: string, maxFrames = 4): Promise<T | null> {
+    for (let index = 0; index < maxFrames; index += 1) {
+      const element = document.getElementById(id) as T | null;
+      if (element) {
+        return element;
+      }
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    }
+    return document.getElementById(id) as T | null;
   }
 
   const promptSearch = document.getElementById("promptSearch") as HTMLInputElement | null;
@@ -102,7 +116,7 @@ async function initializePromptPage() {
   const promptOutputHelp = document.getElementById("promptOutputHelp") as HTMLDivElement | null;
   const gitPseudoSquashLink = document.getElementById("gitPseudoSquashLink") as HTMLAnchorElement | null;
   const includeLabelPrefix = document.getElementById("includeLabelPrefix") as HTMLInputElement | null;
-  const hallucinationGuard = document.getElementById("hallucinationGuard") as HTMLInputElement | null;
+  const hallucinationGuard = await waitForElementById<HTMLSelectElement>("hallucinationGuard");
   const outputMarkdown = document.getElementById("outputMarkdown") as HTMLInputElement | null;
   const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
@@ -753,7 +767,7 @@ async function initializePromptPage() {
 
   function getPromptOutputOptions() {
     return {
-      hallucinationGuardEnabled: hallucinationGuard.checked,
+      hallucinationGuardLevel: ((hallucinationGuard.value || "none") as "none" | "low" | "high"),
       outputMarkdownEnabled: outputMarkdown.checked
     };
   }
@@ -761,7 +775,7 @@ async function initializePromptPage() {
   function inferPromptOutputOptionDefaults(definition: PromptDefinition | null): PromptOutputOptionDefaults {
     if (!definition) {
       return {
-        hallucinationGuard: false,
+        hallucinationGuard: "none",
         outputMarkdown: false
       };
     }
@@ -771,9 +785,13 @@ async function initializePromptPage() {
       return cached;
     }
 
-    if (typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
+    if (typeof definition.hallucinationGuard === "string" || typeof definition.hallucinationGuard === "boolean" || typeof definition.outputMarkdown === "boolean") {
       const explicitDefaults = {
-        hallucinationGuard: definition.hallucinationGuard === true,
+        hallucinationGuard: typeof definition.hallucinationGuard === "string"
+          ? definition.hallucinationGuard
+          : definition.hallucinationGuard === true
+            ? "high"
+            : "none",
         outputMarkdown: definition.outputMarkdown === true
       };
       promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
@@ -782,7 +800,7 @@ async function initializePromptPage() {
 
     const originalOptions = getPromptOutputOptions();
     setPromptOutputOptions({
-      hallucinationGuardEnabled: true,
+      hallucinationGuardLevel: "high",
       outputMarkdownEnabled: true
     });
     const argsForInference: Record<string, string> = {};
@@ -796,12 +814,10 @@ async function initializePromptPage() {
     );
     setPromptOutputOptions(originalOptions);
 
-    const templates = getPromptOutputInstructionTemplates();
+    const instructionProfile = inferPromptOutputInstructionProfile(body);
     const defaults = {
-      hallucinationGuard:
-        body.includes(templates.strictHallucinationPreventionInstruction) ||
-        body.includes(templates.softHallucinationPreventionInstruction),
-      outputMarkdown: body.includes(templates.markdownFenceInstruction)
+      hallucinationGuard: instructionProfile.hallucinationGuardMode,
+      outputMarkdown: instructionProfile.outputMarkdown
     };
     promptOutputOptionDefaultsById.set(definition.id, defaults);
     return defaults;
@@ -809,7 +825,7 @@ async function initializePromptPage() {
 
   function applyPromptOutputOptionDefaults(definition: PromptDefinition | null) {
     const defaults = inferPromptOutputOptionDefaults(definition);
-    hallucinationGuard.checked = defaults.hallucinationGuard;
+    hallucinationGuard.value = defaults.hallucinationGuard;
     outputMarkdown.checked = defaults.outputMarkdown;
   }
 
@@ -990,8 +1006,19 @@ async function initializePromptPage() {
     const argumentValues = getPromptArgumentValues();
     const commitId = sanitizePromptVariableInput(argumentValues.commitId || "");
     const subject = sanitizePromptVariableInput(argumentValues.subject || "");
-    setPromptOutputOptions(getPromptOutputOptions());
-    const body = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+    const currentOptions = getPromptOutputOptions();
+    setPromptOutputOptions({
+      hallucinationGuardLevel: "high",
+      outputMarkdownEnabled: true
+    });
+    const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+    setPromptOutputOptions(currentOptions);
+    const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
+    const body = appendPromptOutputInstructions(
+      stripPromptOutputInstructions(rawBody),
+      currentOptions,
+      instructionProfile.hallucinationGuardMode || "high"
+    );
 
     if (!body || !label) {
       return "";

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -19,7 +19,7 @@ type PromptDefinition = {
   subjectHelpText?: string;
   subjectDefaultValue?: string;
   args?: PromptArgumentDefinition[];
-  hallucinationGuard?: boolean;
+  hallucinationGuard?: "none" | "low" | "high" | boolean;
   outputMarkdown?: boolean;
   buildBody: (commitId: string, subject?: string) => string;
 };

--- a/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
@@ -1,6 +1,13 @@
 type PromptOutputOptions = {
-  hallucinationGuardEnabled: boolean;
+  hallucinationGuardLevel: "none" | "low" | "high";
   outputMarkdownEnabled: boolean;
+};
+
+type PromptHallucinationGuardMode = "none" | "low" | "high";
+
+type PromptOutputInstructionProfile = {
+  hallucinationGuardMode: PromptHallucinationGuardMode | null;
+  outputMarkdown: boolean;
 };
 
 const strictHallucinationPreventionInstruction = `○ハルシネーション防止のため、次のルールに従ってください。
@@ -23,16 +30,16 @@ const softHallucinationPreventionInstruction = `○事実誤認を避けるた�
 - 推測や評価を書く場合は、断定を避け、根拠や前提が分かるようにしてください。
 - 不明点が残る場合は、不明のまま扱ってください。`;
 
-const markdownFenceInstruction = "○最終的な回答は ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
+const markdownFenceInstruction = "○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。markdown 内に backtick による code fence が含まれる場合があるため、外側の囲みは tilde を使ってください。";
 
 let currentPromptOutputOptions: PromptOutputOptions = {
-  hallucinationGuardEnabled: true,
+  hallucinationGuardLevel: "high",
   outputMarkdownEnabled: true
 };
 
 function setPromptOutputOptions(options: PromptOutputOptions): void {
   currentPromptOutputOptions = {
-    hallucinationGuardEnabled: options.hallucinationGuardEnabled !== false,
+    hallucinationGuardLevel: options.hallucinationGuardLevel || "none",
     outputMarkdownEnabled: options.outputMarkdownEnabled !== false
   };
 }
@@ -45,6 +52,72 @@ function getPromptOutputInstructionTemplates() {
   };
 }
 
+function trimTrailingPromptSeparators(value: string): string {
+  return String(value || "").replace(/(?:\s*\n\s*)+$/g, "").trimEnd();
+}
+
+function inferPromptOutputInstructionProfile(body: string): PromptOutputInstructionProfile {
+  const templates = getPromptOutputInstructionTemplates();
+  const normalizedBody = String(body || "");
+  return {
+    hallucinationGuardMode: normalizedBody.includes(templates.strictHallucinationPreventionInstruction)
+      ? "high"
+      : normalizedBody.includes(templates.softHallucinationPreventionInstruction)
+        ? "low"
+        : "none",
+    outputMarkdown: normalizedBody.includes(templates.markdownFenceInstruction)
+  };
+}
+
+function stripPromptOutputInstructions(body: string): string {
+  const templates = getPromptOutputInstructionTemplates();
+  let normalizedBody = trimTrailingPromptSeparators(body);
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    for (const template of [
+      templates.markdownFenceInstruction,
+      templates.strictHallucinationPreventionInstruction,
+      templates.softHallucinationPreventionInstruction
+    ]) {
+      if (!template || !normalizedBody.endsWith(template)) {
+        continue;
+      }
+      normalizedBody = trimTrailingPromptSeparators(normalizedBody.slice(0, normalizedBody.length - template.length));
+      changed = true;
+    }
+  }
+
+  return normalizedBody;
+}
+
+function appendPromptOutputInstructions(
+  body: string,
+  options: PromptOutputOptions,
+  hallucinationGuardMode: PromptHallucinationGuardMode = "high"
+): string {
+  const normalizedBody = trimTrailingPromptSeparators(body);
+  if (!normalizedBody) {
+    return "";
+  }
+
+  const segments = [normalizedBody];
+
+  if (options.hallucinationGuardLevel !== "none") {
+    segments.push(
+      (options.hallucinationGuardLevel || hallucinationGuardMode) === "low"
+        ? softHallucinationPreventionInstruction
+        : strictHallucinationPreventionInstruction
+    );
+  }
+  if (options.outputMarkdownEnabled) {
+    segments.push(markdownFenceInstruction);
+  }
+
+  return segments.join("\n\n");
+}
+
 function getMarkdownFenceInstruction(): string {
   return currentPromptOutputOptions.outputMarkdownEnabled ? markdownFenceInstruction : "";
 }
@@ -55,11 +128,11 @@ function appendMarkdownFenceInstruction(body: string): string {
 }
 
 function getStrictHallucinationPreventionInstruction(): string {
-  return currentPromptOutputOptions.hallucinationGuardEnabled ? strictHallucinationPreventionInstruction : "";
+  return currentPromptOutputOptions.hallucinationGuardLevel === "high" ? strictHallucinationPreventionInstruction : "";
 }
 
 function getSoftHallucinationPreventionInstruction(): string {
-  return currentPromptOutputOptions.hallucinationGuardEnabled ? softHallucinationPreventionInstruction : "";
+  return currentPromptOutputOptions.hallucinationGuardLevel === "low" ? softHallucinationPreventionInstruction : "";
 }
 
 function getTodoReflectionInstruction(): string {

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -62,6 +62,42 @@ function defineElementIfNeeded(tagName) {
       });
       return;
     }
+    if (tagName === "lht-select-help") {
+      customElements.define(tagName, class extends HTMLElement {
+        connectedCallback() {
+          if (this.dataset.initialized === "true") return;
+          this.dataset.initialized = "true";
+          const selectId = (this.getAttribute("select-id") || "").trim();
+          const labelText = (this.getAttribute("label") || "").trim();
+          const helpText = this.getAttribute("help-text") || "";
+          const sourceOptions = Array.from(this.querySelectorAll("option")).map((option) => ({
+            value: option.getAttribute("value") || "",
+            label: option.textContent || "",
+            selected: option.hasAttribute("selected")
+          }));
+          this.textContent = "";
+          const label = document.createElement("label");
+          const span = document.createElement("span");
+          span.textContent = labelText;
+          const select = document.createElement("select");
+          select.id = selectId;
+          select.title = helpText;
+          for (const entry of sourceOptions) {
+            const option = document.createElement("option");
+            option.value = entry.value;
+            option.textContent = entry.label;
+            if (entry.selected) {
+              option.selected = true;
+            }
+            select.appendChild(option);
+          }
+          label.appendChild(span);
+          label.appendChild(select);
+          this.appendChild(label);
+        }
+      });
+      return;
+    }
     if (tagName === "lht-switch-help") {
       customElements.define(tagName, class extends HTMLElement {
         connectedCallback() {
@@ -102,7 +138,11 @@ function mountPromptDom() {
       <div id="promptOutputHelp"></div>
     </div>
     <input id="includeLabelPrefix" type="checkbox" />
-    <input id="hallucinationGuard" type="checkbox" />
+    <select id="hallucinationGuard">
+      <option value="none">なし</option>
+      <option value="low">弱</option>
+      <option value="high">強</option>
+    </select>
     <input id="outputMarkdown" type="checkbox" />
     <button id="copyShareLinkButton" type="button"></button>
     <a id="gitPseudoSquashLink" class="md-hidden" href="../git/git-work-list.html"></a>
@@ -143,6 +183,7 @@ function setRawInputValue(element, value) {
 
 async function bootPromptPage(urlSearch = "") {
   defineElementIfNeeded("lht-text-field-help");
+  defineElementIfNeeded("lht-select-help");
   defineElementIfNeeded("lht-switch-help");
   defineElementIfNeeded("lht-help-tooltip");
   ensureLocalStorageMock();
@@ -259,10 +300,10 @@ describe("prompt-gen main", () => {
     const outputMarkdown = document.getElementById("outputMarkdown");
     const promptOutput = document.getElementById("promptOutput");
 
-    expect(hallucinationGuard.checked).toBe(true);
+    expect(hallucinationGuard.value).toBe("high");
     expect(outputMarkdown.checked).toBe(true);
     expect(promptOutput.textContent).toContain("○ハルシネーション防止のため");
-    expect(promptOutput.textContent).toContain("○最終的な回答は ~~~~ で囲まれた一塊として出力してください。");
+    expect(promptOutput.textContent).toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
   });
 
   it("updates output when hallucinationGuard and outputMarkdown are toggled", async () => {
@@ -272,13 +313,13 @@ describe("prompt-gen main", () => {
     const outputMarkdown = document.getElementById("outputMarkdown");
     const promptOutput = document.getElementById("promptOutput");
 
-    hallucinationGuard.checked = false;
+    hallucinationGuard.value = "none";
     hallucinationGuard.dispatchEvent(new Event("change"));
     outputMarkdown.checked = false;
     outputMarkdown.dispatchEvent(new Event("change"));
 
     expect(promptOutput.textContent).not.toContain("○ハルシネーション防止のため");
-    expect(promptOutput.textContent).not.toContain("○最終的な回答は ~~~~ で囲まれた一塊として出力してください。");
+    expect(promptOutput.textContent).not.toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
   });
 
   it("resets hallucinationGuard and outputMarkdown to prompt defaults when switching prompts", async () => {
@@ -290,7 +331,7 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "A501";
     promptSearch.dispatchEvent(new Event("input"));
-    hallucinationGuard.checked = false;
+    hallucinationGuard.value = "none";
     hallucinationGuard.dispatchEvent(new Event("change"));
     outputMarkdown.checked = false;
     outputMarkdown.dispatchEvent(new Event("change"));
@@ -300,8 +341,29 @@ describe("prompt-gen main", () => {
     promptSearch.value = "A501";
     promptSearch.dispatchEvent(new Event("input"));
 
-    expect(hallucinationGuard.checked).toBe(true);
+    expect(hallucinationGuard.value).toBe("high");
     expect(outputMarkdown.checked).toBe(true);
+  });
+
+  it("applies hallucinationGuard and outputMarkdown to prompts without embedded instructions", async () => {
+    await bootPromptPage("?q=P1803-004");
+
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
+    const promptOutput = document.getElementById("promptOutput");
+
+    expect(hallucinationGuard.value).toBe("none");
+    expect(outputMarkdown.checked).toBe(false);
+    expect(promptOutput.textContent).not.toContain("○ハルシネーション防止のため");
+    expect(promptOutput.textContent).not.toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
+
+    hallucinationGuard.value = "high";
+    hallucinationGuard.dispatchEvent(new Event("change"));
+    outputMarkdown.checked = true;
+    outputMarkdown.dispatchEvent(new Event("change"));
+
+    expect(promptOutput.textContent).toContain("○ハルシネーション防止のため");
+    expect(promptOutput.textContent).toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
   });
 
   it("uses docs as the default docs path for A150", async () => {


### PR DESCRIPTION
## 概要
`docs/prompt/prompt-gen` に対して、`幻想防止` を 2値スイッチから 3値選択へ変更し、出力オプションの適用を `main.ts` 側で一律後付けする形に整理した変更です。あわせて、`lht-select-help` 導入に伴う初期化不具合の修正と、関連UIのレイアウト調整、テスト更新が含まれます。

## 主な変更点
- `幻想防止` を `none / low / high` の 3値で扱えるように変更
- UI 上の `幻想防止` をスイッチからドロップダウンに変更
- `Markdown出力` の文言を維持しつつ、共通出力指示を `main.ts` 側で本文生成後に一律後付けする方式へ変更
- 既存プロンプト本文に含まれる出力指示を推定・除去し、現在の UI 設定に応じて再付与する処理を追加
- `lht-select-help` の初期化待ちと `field-id` 修正により、画面が動作しなくなる不具合を修正
- `幻想防止` ドロップダウンの幅と右余白、出力オプション列のレイアウトを調整
- 関連ユニットテストを更新し、固定本文プロンプトでも出力オプションが効くことを検証

## 変更ファイル
- `docs/prompt/prompt-gen-src.html`
- `docs/prompt/prompt-gen.html`
- `docs/prompt/src/prompt-gen/css/app.css`
- `docs/prompt/src/prompt-gen/ts/main.ts`
- `docs/prompt/src/prompt-gen/js/main.js`
- `docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts`
- `docs/prompt/src/prompt-gen/js/prompt-markdown-util.js`
- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
- `docs/prompt/tests/prompt-gen-main.test.js`

## テスト / 確認
- `npm run build:prompt`
- `npm test -- docs/prompt/tests/prompt-gen-main.test.js`

## 注意点
- `hallucinationGuard` は型上 `boolean` 互換を残しつつ、実質的には `"none" | "low" | "high"` の運用へ寄せています
- `main.ts` 側で既存の注意文・Markdown指示を末尾から除去して再付与するため、本文末尾の共通指示の扱いが従来と変わっています