### PR TITLE
prompt-gen に法令遵守・公序良俗の確認観点を追加

### DIFF
--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -203,6 +203,24 @@ limitations under the License.
           <option value="internal">内部レビュー</option>
           <option value="report">レビュー結果出力</option>
         </lht-select-help>
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="legalComplianceReview"
+          label="法令遵守"
+          help-text="法令遵守の観点で問題がないかを見直す方法を選択します。日本の法令を基準に、無指定 / 内部レビュー / レビュー結果出力 の3段階です。">
+          <option value="unspecified">無指定</option>
+          <option value="internal">内部レビュー</option>
+          <option value="report">レビュー結果出力</option>
+        </lht-select-help>
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="publicOrderReview"
+          label="公序良俗"
+          help-text="公序良俗の観点で問題がないかを見直す方法を選択します。日本を基準に、無指定 / 内部レビュー / レビュー結果出力 の3段階です。">
+          <option value="unspecified">無指定</option>
+          <option value="internal">内部レビュー</option>
+          <option value="report">レビュー結果出力</option>
+        </lht-select-help>
       </div>
     </section>
 

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1633,6 +1633,24 @@ md-icon-button.md-copy-button--surface {
           <option value="internal">内部レビュー</option>
           <option value="report">レビュー結果出力</option>
         </lht-select-help>
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="legalComplianceReview"
+          label="法令遵守"
+          help-text="法令遵守の観点で問題がないかを見直す方法を選択します。日本の法令を基準に、無指定 / 内部レビュー / レビュー結果出力 の3段階です。">
+          <option value="unspecified">無指定</option>
+          <option value="internal">内部レビュー</option>
+          <option value="report">レビュー結果出力</option>
+        </lht-select-help>
+        <lht-select-help
+          class="md-output-options__select md-output-options__select--compact"
+          field-id="publicOrderReview"
+          label="公序良俗"
+          help-text="公序良俗の観点で問題がないかを見直す方法を選択します。日本を基準に、無指定 / 内部レビュー / レビュー結果出力 の3段階です。">
+          <option value="unspecified">無指定</option>
+          <option value="internal">内部レビュー</option>
+          <option value="report">レビュー結果出力</option>
+        </lht-select-help>
       </div>
     </section>
 
@@ -3827,6 +3845,24 @@ const reportedSensitiveExpressionReviewInstruction = `○回答案を作成し�
 - 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
 - 最終回答の末尾に \`センシティブ表現レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
 - 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`法令遵守レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`公序良俗レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
 let currentPromptOutputOptions = {
     hallucinationGuardLevel: "high",
     outputMarkdownEnabled: true,
@@ -3836,7 +3872,9 @@ let currentPromptOutputOptions = {
     considerationRiskReview: "unspecified",
     discomfortRiskReview: "unspecified",
     aggressiveExpressionReview: "unspecified",
-    sensitiveExpressionReview: "unspecified"
+    sensitiveExpressionReview: "unspecified",
+    legalComplianceReview: "unspecified",
+    publicOrderReview: "unspecified"
 };
 function setPromptOutputOptions(options) {
     currentPromptOutputOptions = {
@@ -3848,7 +3886,9 @@ function setPromptOutputOptions(options) {
         considerationRiskReview: options.considerationRiskReview || "unspecified",
         discomfortRiskReview: options.discomfortRiskReview || "unspecified",
         aggressiveExpressionReview: options.aggressiveExpressionReview || "unspecified",
-        sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified"
+        sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified",
+        legalComplianceReview: options.legalComplianceReview || "unspecified",
+        publicOrderReview: options.publicOrderReview || "unspecified"
     };
 }
 function getPromptOutputInstructionTemplates() {
@@ -3869,7 +3909,11 @@ function getPromptOutputInstructionTemplates() {
         internalAggressiveExpressionReviewInstruction,
         reportedAggressiveExpressionReviewInstruction,
         internalSensitiveExpressionReviewInstruction,
-        reportedSensitiveExpressionReviewInstruction
+        reportedSensitiveExpressionReviewInstruction,
+        internalLegalComplianceReviewInstruction,
+        reportedLegalComplianceReviewInstruction,
+        internalPublicOrderReviewInstruction,
+        reportedPublicOrderReviewInstruction
     };
 }
 function trimTrailingPromptSeparators(value) {
@@ -3919,6 +3963,16 @@ function inferPromptOutputInstructionProfile(body) {
             ? "report"
             : normalizedBody.includes(templates.internalSensitiveExpressionReviewInstruction)
                 ? "internal"
+                : "unspecified",
+        legalComplianceReview: normalizedBody.includes(templates.reportedLegalComplianceReviewInstruction)
+            ? "report"
+            : normalizedBody.includes(templates.internalLegalComplianceReviewInstruction)
+                ? "internal"
+                : "unspecified",
+        publicOrderReview: normalizedBody.includes(templates.reportedPublicOrderReviewInstruction)
+            ? "report"
+            : normalizedBody.includes(templates.internalPublicOrderReviewInstruction)
+                ? "internal"
                 : "unspecified"
     };
 }
@@ -3929,6 +3983,10 @@ function stripPromptOutputInstructions(body) {
     while (changed) {
         changed = false;
         for (const template of [
+            templates.reportedPublicOrderReviewInstruction,
+            templates.internalPublicOrderReviewInstruction,
+            templates.reportedLegalComplianceReviewInstruction,
+            templates.internalLegalComplianceReviewInstruction,
             templates.reportedSensitiveExpressionReviewInstruction,
             templates.internalSensitiveExpressionReviewInstruction,
             templates.reportedAggressiveExpressionReviewInstruction,
@@ -4011,6 +4069,18 @@ function appendPromptOutputInstructions(body, options, hallucinationGuardMode = 
     }
     else if (options.sensitiveExpressionReview === "report") {
         segments.push(reportedSensitiveExpressionReviewInstruction);
+    }
+    if (options.legalComplianceReview === "internal") {
+        segments.push(internalLegalComplianceReviewInstruction);
+    }
+    else if (options.legalComplianceReview === "report") {
+        segments.push(reportedLegalComplianceReviewInstruction);
+    }
+    if (options.publicOrderReview === "internal") {
+        segments.push(internalPublicOrderReviewInstruction);
+    }
+    else if (options.publicOrderReview === "report") {
+        segments.push(reportedPublicOrderReviewInstruction);
     }
     return segments.join("\n\n");
 }
@@ -8199,6 +8269,20 @@ ${getMarkdownFenceInstruction()}`
         buildBody: () => `与えられた内容について、センシティブな表現がないか確認してください。属性、立場、背景、文化的事情などに関わる表現で、読み手や関係者に不必要な負荷や反発を生みそうな箇所があれば整理してください。断定しすぎず、どの観点で注意が必要そうかが分かるように示してください。`
     },
     {
+        id: "popular-legal-compliance-request",
+        label: "P1001-006: 法令遵守の観点で確認する",
+        keywords: ["P1001-006", "legal compliance", "law compliance", "regulatory compliance", "legal review", "法令遵守", "法律確認", "違法性確認", "ほうれいじゅんしゅ", "いほうせいかくにん"],
+        requiresCommitId: false,
+        buildBody: () => `与えられた内容について、法令遵守の観点で問題がないか確認してください。日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば整理してください。必要に応じて、より安全で適切な方向も示してください。`
+    },
+    {
+        id: "popular-public-order-review-request",
+        label: "P1001-007: 公序良俗の観点で確認する",
+        keywords: ["P1001-007", "public order and morals", "public morals", "social acceptability", "appropriateness review", "公序良俗", "社会通念", "不適切表現", "こうじょりょうぞく", "しゃかいつうねん"],
+        requiresCommitId: false,
+        buildBody: () => `与えられた内容について、公序良俗の観点で問題がないか確認してください。日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば整理してください。必要に応じて、より穏当で適切な方向も示してください。`
+    },
+    {
         id: "popular-clarify-request-request",
         label: "P1205-003: 曖昧な依頼を明確化する",
         keywords: ["P1205-003", "clarify request", "clarify vague request", "refine request", "request clarification", "依頼明確化", "曖昧な依頼", "依頼整理", "いらいめいかくか", "あいまいないらい"],
@@ -8728,12 +8812,16 @@ async function initializePromptPage() {
         (await waitForElementById("aggressiveExpressionReview"));
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview") ||
         (await waitForElementById("sensitiveExpressionReview"));
+    const legalComplianceReview = document.getElementById("legalComplianceReview") ||
+        (await waitForElementById("legalComplianceReview"));
+    const publicOrderReview = document.getElementById("publicOrderReview") ||
+        (await waitForElementById("publicOrderReview"));
     const hallucinationGuard = document.getElementById("hallucinationGuard") ||
         (await waitForElementById("hallucinationGuard"));
     const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -9289,7 +9377,9 @@ async function initializePromptPage() {
             considerationRiskReview: (considerationRiskReview.value || "unspecified"),
             discomfortRiskReview: (discomfortRiskReview.value || "unspecified"),
             aggressiveExpressionReview: (aggressiveExpressionReview.value || "unspecified"),
-            sensitiveExpressionReview: (sensitiveExpressionReview.value || "unspecified")
+            sensitiveExpressionReview: (sensitiveExpressionReview.value || "unspecified"),
+            legalComplianceReview: (legalComplianceReview.value || "unspecified"),
+            publicOrderReview: (publicOrderReview.value || "unspecified")
         };
     }
     function inferPromptOutputOptionDefaults(definition) {
@@ -9303,7 +9393,9 @@ async function initializePromptPage() {
                 considerationRiskReview: "unspecified",
                 discomfortRiskReview: "unspecified",
                 aggressiveExpressionReview: "unspecified",
-                sensitiveExpressionReview: "unspecified"
+                sensitiveExpressionReview: "unspecified",
+                legalComplianceReview: "unspecified",
+                publicOrderReview: "unspecified"
             };
         }
         const cached = promptOutputOptionDefaultsById.get(definition.id);
@@ -9324,7 +9416,9 @@ async function initializePromptPage() {
                 considerationRiskReview: "unspecified",
                 discomfortRiskReview: "unspecified",
                 aggressiveExpressionReview: "unspecified",
-                sensitiveExpressionReview: "unspecified"
+                sensitiveExpressionReview: "unspecified",
+                legalComplianceReview: "unspecified",
+                publicOrderReview: "unspecified"
             };
             promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
             return explicitDefaults;
@@ -9339,7 +9433,9 @@ async function initializePromptPage() {
             considerationRiskReview: "unspecified",
             discomfortRiskReview: "unspecified",
             aggressiveExpressionReview: "unspecified",
-            sensitiveExpressionReview: "unspecified"
+            sensitiveExpressionReview: "unspecified",
+            legalComplianceReview: "unspecified",
+            publicOrderReview: "unspecified"
         });
         const argsForInference = {};
         for (const argumentDefinition of getSelectedPromptArguments(definition)) {
@@ -9358,7 +9454,9 @@ async function initializePromptPage() {
             considerationRiskReview: instructionProfile.considerationRiskReview,
             discomfortRiskReview: instructionProfile.discomfortRiskReview,
             aggressiveExpressionReview: instructionProfile.aggressiveExpressionReview,
-            sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview
+            sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview,
+            legalComplianceReview: instructionProfile.legalComplianceReview,
+            publicOrderReview: instructionProfile.publicOrderReview
         };
         promptOutputOptionDefaultsById.set(definition.id, defaults);
         return defaults;
@@ -9374,6 +9472,8 @@ async function initializePromptPage() {
         discomfortRiskReview.value = defaults.discomfortRiskReview;
         aggressiveExpressionReview.value = defaults.aggressiveExpressionReview;
         sensitiveExpressionReview.value = defaults.sensitiveExpressionReview;
+        legalComplianceReview.value = defaults.legalComplianceReview;
+        publicOrderReview.value = defaults.publicOrderReview;
     }
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
@@ -9538,7 +9638,9 @@ async function initializePromptPage() {
             considerationRiskReview: "unspecified",
             discomfortRiskReview: "unspecified",
             aggressiveExpressionReview: "unspecified",
-            sensitiveExpressionReview: "unspecified"
+            sensitiveExpressionReview: "unspecified",
+            legalComplianceReview: "unspecified",
+            publicOrderReview: "unspecified"
         });
         const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
         setPromptOutputOptions(currentOptions);
@@ -9658,6 +9760,8 @@ async function initializePromptPage() {
     discomfortRiskReview.addEventListener("change", updateOutput);
     aggressiveExpressionReview.addEventListener("change", updateOutput);
     sensitiveExpressionReview.addEventListener("change", updateOutput);
+    legalComplianceReview.addEventListener("change", updateOutput);
+    publicOrderReview.addEventListener("change", updateOutput);
     hallucinationGuard.addEventListener("change", updateOutput);
     outputMarkdown.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -69,12 +69,16 @@ async function initializePromptPage() {
         (await waitForElementById("aggressiveExpressionReview"));
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview") ||
         (await waitForElementById("sensitiveExpressionReview"));
+    const legalComplianceReview = document.getElementById("legalComplianceReview") ||
+        (await waitForElementById("legalComplianceReview"));
+    const publicOrderReview = document.getElementById("publicOrderReview") ||
+        (await waitForElementById("publicOrderReview"));
     const hallucinationGuard = document.getElementById("hallucinationGuard") ||
         (await waitForElementById("hallucinationGuard"));
     const outputMarkdown = document.getElementById("outputMarkdown");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -630,7 +634,9 @@ async function initializePromptPage() {
             considerationRiskReview: (considerationRiskReview.value || "unspecified"),
             discomfortRiskReview: (discomfortRiskReview.value || "unspecified"),
             aggressiveExpressionReview: (aggressiveExpressionReview.value || "unspecified"),
-            sensitiveExpressionReview: (sensitiveExpressionReview.value || "unspecified")
+            sensitiveExpressionReview: (sensitiveExpressionReview.value || "unspecified"),
+            legalComplianceReview: (legalComplianceReview.value || "unspecified"),
+            publicOrderReview: (publicOrderReview.value || "unspecified")
         };
     }
     function inferPromptOutputOptionDefaults(definition) {
@@ -644,7 +650,9 @@ async function initializePromptPage() {
                 considerationRiskReview: "unspecified",
                 discomfortRiskReview: "unspecified",
                 aggressiveExpressionReview: "unspecified",
-                sensitiveExpressionReview: "unspecified"
+                sensitiveExpressionReview: "unspecified",
+                legalComplianceReview: "unspecified",
+                publicOrderReview: "unspecified"
             };
         }
         const cached = promptOutputOptionDefaultsById.get(definition.id);
@@ -665,7 +673,9 @@ async function initializePromptPage() {
                 considerationRiskReview: "unspecified",
                 discomfortRiskReview: "unspecified",
                 aggressiveExpressionReview: "unspecified",
-                sensitiveExpressionReview: "unspecified"
+                sensitiveExpressionReview: "unspecified",
+                legalComplianceReview: "unspecified",
+                publicOrderReview: "unspecified"
             };
             promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
             return explicitDefaults;
@@ -680,7 +690,9 @@ async function initializePromptPage() {
             considerationRiskReview: "unspecified",
             discomfortRiskReview: "unspecified",
             aggressiveExpressionReview: "unspecified",
-            sensitiveExpressionReview: "unspecified"
+            sensitiveExpressionReview: "unspecified",
+            legalComplianceReview: "unspecified",
+            publicOrderReview: "unspecified"
         });
         const argsForInference = {};
         for (const argumentDefinition of getSelectedPromptArguments(definition)) {
@@ -699,7 +711,9 @@ async function initializePromptPage() {
             considerationRiskReview: instructionProfile.considerationRiskReview,
             discomfortRiskReview: instructionProfile.discomfortRiskReview,
             aggressiveExpressionReview: instructionProfile.aggressiveExpressionReview,
-            sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview
+            sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview,
+            legalComplianceReview: instructionProfile.legalComplianceReview,
+            publicOrderReview: instructionProfile.publicOrderReview
         };
         promptOutputOptionDefaultsById.set(definition.id, defaults);
         return defaults;
@@ -715,6 +729,8 @@ async function initializePromptPage() {
         discomfortRiskReview.value = defaults.discomfortRiskReview;
         aggressiveExpressionReview.value = defaults.aggressiveExpressionReview;
         sensitiveExpressionReview.value = defaults.sensitiveExpressionReview;
+        legalComplianceReview.value = defaults.legalComplianceReview;
+        publicOrderReview.value = defaults.publicOrderReview;
     }
     function renderSelectedPromptHelp() {
         const selectedDefinition = getSelectedPromptDefinition();
@@ -879,7 +895,9 @@ async function initializePromptPage() {
             considerationRiskReview: "unspecified",
             discomfortRiskReview: "unspecified",
             aggressiveExpressionReview: "unspecified",
-            sensitiveExpressionReview: "unspecified"
+            sensitiveExpressionReview: "unspecified",
+            legalComplianceReview: "unspecified",
+            publicOrderReview: "unspecified"
         });
         const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
         setPromptOutputOptions(currentOptions);
@@ -999,6 +1017,8 @@ async function initializePromptPage() {
     discomfortRiskReview.addEventListener("change", updateOutput);
     aggressiveExpressionReview.addEventListener("change", updateOutput);
     sensitiveExpressionReview.addEventListener("change", updateOutput);
+    legalComplianceReview.addEventListener("change", updateOutput);
+    publicOrderReview.addEventListener("change", updateOutput);
     hallucinationGuard.addEventListener("change", updateOutput);
     outputMarkdown.addEventListener("change", updateOutput);
     copyShareLinkButton.addEventListener("click", () => {

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions-popular.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions-popular.js
@@ -1201,6 +1201,20 @@ ${getMarkdownFenceInstruction()}`
         buildBody: () => `与えられた内容について、センシティブな表現がないか確認してください。属性、立場、背景、文化的事情などに関わる表現で、読み手や関係者に不必要な負荷や反発を生みそうな箇所があれば整理してください。断定しすぎず、どの観点で注意が必要そうかが分かるように示してください。`
     },
     {
+        id: "popular-legal-compliance-request",
+        label: "P1001-006: 法令遵守の観点で確認する",
+        keywords: ["P1001-006", "legal compliance", "law compliance", "regulatory compliance", "legal review", "法令遵守", "法律確認", "違法性確認", "ほうれいじゅんしゅ", "いほうせいかくにん"],
+        requiresCommitId: false,
+        buildBody: () => `与えられた内容について、法令遵守の観点で問題がないか確認してください。日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば整理してください。必要に応じて、より安全で適切な方向も示してください。`
+    },
+    {
+        id: "popular-public-order-review-request",
+        label: "P1001-007: 公序良俗の観点で確認する",
+        keywords: ["P1001-007", "public order and morals", "public morals", "social acceptability", "appropriateness review", "公序良俗", "社会通念", "不適切表現", "こうじょりょうぞく", "しゃかいつうねん"],
+        requiresCommitId: false,
+        buildBody: () => `与えられた内容について、公序良俗の観点で問題がないか確認してください。日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば整理してください。必要に応じて、より穏当で適切な方向も示してください。`
+    },
+    {
         id: "popular-clarify-request-request",
         label: "P1205-003: 曖昧な依頼を明確化する",
         keywords: ["P1205-003", "clarify request", "clarify vague request", "refine request", "request clarification", "依頼明確化", "曖昧な依頼", "依頼整理", "いらいめいかくか", "あいまいないらい"],

--- a/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-markdown-util.js
@@ -63,6 +63,24 @@ const reportedSensitiveExpressionReviewInstruction = `○回答案を作成し�
 - 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
 - 最終回答の末尾に \`センシティブ表現レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
 - 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`法令遵守レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`公序良俗レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
 let currentPromptOutputOptions = {
     hallucinationGuardLevel: "high",
     outputMarkdownEnabled: true,
@@ -72,7 +90,9 @@ let currentPromptOutputOptions = {
     considerationRiskReview: "unspecified",
     discomfortRiskReview: "unspecified",
     aggressiveExpressionReview: "unspecified",
-    sensitiveExpressionReview: "unspecified"
+    sensitiveExpressionReview: "unspecified",
+    legalComplianceReview: "unspecified",
+    publicOrderReview: "unspecified"
 };
 function setPromptOutputOptions(options) {
     currentPromptOutputOptions = {
@@ -84,7 +104,9 @@ function setPromptOutputOptions(options) {
         considerationRiskReview: options.considerationRiskReview || "unspecified",
         discomfortRiskReview: options.discomfortRiskReview || "unspecified",
         aggressiveExpressionReview: options.aggressiveExpressionReview || "unspecified",
-        sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified"
+        sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified",
+        legalComplianceReview: options.legalComplianceReview || "unspecified",
+        publicOrderReview: options.publicOrderReview || "unspecified"
     };
 }
 function getPromptOutputInstructionTemplates() {
@@ -105,7 +127,11 @@ function getPromptOutputInstructionTemplates() {
         internalAggressiveExpressionReviewInstruction,
         reportedAggressiveExpressionReviewInstruction,
         internalSensitiveExpressionReviewInstruction,
-        reportedSensitiveExpressionReviewInstruction
+        reportedSensitiveExpressionReviewInstruction,
+        internalLegalComplianceReviewInstruction,
+        reportedLegalComplianceReviewInstruction,
+        internalPublicOrderReviewInstruction,
+        reportedPublicOrderReviewInstruction
     };
 }
 function trimTrailingPromptSeparators(value) {
@@ -155,6 +181,16 @@ function inferPromptOutputInstructionProfile(body) {
             ? "report"
             : normalizedBody.includes(templates.internalSensitiveExpressionReviewInstruction)
                 ? "internal"
+                : "unspecified",
+        legalComplianceReview: normalizedBody.includes(templates.reportedLegalComplianceReviewInstruction)
+            ? "report"
+            : normalizedBody.includes(templates.internalLegalComplianceReviewInstruction)
+                ? "internal"
+                : "unspecified",
+        publicOrderReview: normalizedBody.includes(templates.reportedPublicOrderReviewInstruction)
+            ? "report"
+            : normalizedBody.includes(templates.internalPublicOrderReviewInstruction)
+                ? "internal"
                 : "unspecified"
     };
 }
@@ -165,6 +201,10 @@ function stripPromptOutputInstructions(body) {
     while (changed) {
         changed = false;
         for (const template of [
+            templates.reportedPublicOrderReviewInstruction,
+            templates.internalPublicOrderReviewInstruction,
+            templates.reportedLegalComplianceReviewInstruction,
+            templates.internalLegalComplianceReviewInstruction,
             templates.reportedSensitiveExpressionReviewInstruction,
             templates.internalSensitiveExpressionReviewInstruction,
             templates.reportedAggressiveExpressionReviewInstruction,
@@ -247,6 +287,18 @@ function appendPromptOutputInstructions(body, options, hallucinationGuardMode = 
     }
     else if (options.sensitiveExpressionReview === "report") {
         segments.push(reportedSensitiveExpressionReviewInstruction);
+    }
+    if (options.legalComplianceReview === "internal") {
+        segments.push(internalLegalComplianceReviewInstruction);
+    }
+    else if (options.legalComplianceReview === "report") {
+        segments.push(reportedLegalComplianceReviewInstruction);
+    }
+    if (options.publicOrderReview === "internal") {
+        segments.push(internalPublicOrderReviewInstruction);
+    }
+    else if (options.publicOrderReview === "report") {
+        segments.push(reportedPublicOrderReviewInstruction);
     }
     return segments.join("\n\n");
 }

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -34,6 +34,8 @@ type PromptOutputOptionDefaults = {
   discomfortRiskReview: "unspecified" | "internal" | "report";
   aggressiveExpressionReview: "unspecified" | "internal" | "report";
   sensitiveExpressionReview: "unspecified" | "internal" | "report";
+  legalComplianceReview: "unspecified" | "internal" | "report";
+  publicOrderReview: "unspecified" | "internal" | "report";
 };
 
 type PromptSearchIndex = {
@@ -143,6 +145,12 @@ async function initializePromptPage() {
   const sensitiveExpressionReview =
     (document.getElementById("sensitiveExpressionReview") as HTMLSelectElement | null) ||
     (await waitForElementById<HTMLSelectElement>("sensitiveExpressionReview"));
+  const legalComplianceReview =
+    (document.getElementById("legalComplianceReview") as HTMLSelectElement | null) ||
+    (await waitForElementById<HTMLSelectElement>("legalComplianceReview"));
+  const publicOrderReview =
+    (document.getElementById("publicOrderReview") as HTMLSelectElement | null) ||
+    (await waitForElementById<HTMLSelectElement>("publicOrderReview"));
   const hallucinationGuard =
     (document.getElementById("hallucinationGuard") as HTMLSelectElement | null) ||
     (await waitForElementById<HTMLSelectElement>("hallucinationGuard"));
@@ -150,7 +158,7 @@ async function initializePromptPage() {
   const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
 
-  if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+  if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
     return;
   }
 
@@ -804,7 +812,9 @@ async function initializePromptPage() {
       considerationRiskReview: ((considerationRiskReview.value || "unspecified") as "unspecified" | "internal" | "report"),
       discomfortRiskReview: ((discomfortRiskReview.value || "unspecified") as "unspecified" | "internal" | "report"),
       aggressiveExpressionReview: ((aggressiveExpressionReview.value || "unspecified") as "unspecified" | "internal" | "report"),
-      sensitiveExpressionReview: ((sensitiveExpressionReview.value || "unspecified") as "unspecified" | "internal" | "report")
+      sensitiveExpressionReview: ((sensitiveExpressionReview.value || "unspecified") as "unspecified" | "internal" | "report"),
+      legalComplianceReview: ((legalComplianceReview.value || "unspecified") as "unspecified" | "internal" | "report"),
+      publicOrderReview: ((publicOrderReview.value || "unspecified") as "unspecified" | "internal" | "report")
     };
   }
 
@@ -819,7 +829,9 @@ async function initializePromptPage() {
         considerationRiskReview: "unspecified",
         discomfortRiskReview: "unspecified",
         aggressiveExpressionReview: "unspecified",
-        sensitiveExpressionReview: "unspecified"
+        sensitiveExpressionReview: "unspecified",
+        legalComplianceReview: "unspecified",
+        publicOrderReview: "unspecified"
       };
     }
 
@@ -842,7 +854,9 @@ async function initializePromptPage() {
         considerationRiskReview: "unspecified",
         discomfortRiskReview: "unspecified",
         aggressiveExpressionReview: "unspecified",
-        sensitiveExpressionReview: "unspecified"
+        sensitiveExpressionReview: "unspecified",
+        legalComplianceReview: "unspecified",
+        publicOrderReview: "unspecified"
       };
       promptOutputOptionDefaultsById.set(definition.id, explicitDefaults);
       return explicitDefaults;
@@ -858,7 +872,9 @@ async function initializePromptPage() {
       considerationRiskReview: "unspecified",
       discomfortRiskReview: "unspecified",
       aggressiveExpressionReview: "unspecified",
-      sensitiveExpressionReview: "unspecified"
+      sensitiveExpressionReview: "unspecified",
+      legalComplianceReview: "unspecified",
+      publicOrderReview: "unspecified"
     });
     const argsForInference: Record<string, string> = {};
     for (const argumentDefinition of getSelectedPromptArguments(definition)) {
@@ -881,7 +897,9 @@ async function initializePromptPage() {
       considerationRiskReview: instructionProfile.considerationRiskReview,
       discomfortRiskReview: instructionProfile.discomfortRiskReview,
       aggressiveExpressionReview: instructionProfile.aggressiveExpressionReview,
-      sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview
+      sensitiveExpressionReview: instructionProfile.sensitiveExpressionReview,
+      legalComplianceReview: instructionProfile.legalComplianceReview,
+      publicOrderReview: instructionProfile.publicOrderReview
     };
     promptOutputOptionDefaultsById.set(definition.id, defaults);
     return defaults;
@@ -898,6 +916,8 @@ async function initializePromptPage() {
     discomfortRiskReview.value = defaults.discomfortRiskReview;
     aggressiveExpressionReview.value = defaults.aggressiveExpressionReview;
     sensitiveExpressionReview.value = defaults.sensitiveExpressionReview;
+    legalComplianceReview.value = defaults.legalComplianceReview;
+    publicOrderReview.value = defaults.publicOrderReview;
   }
 
   function renderSelectedPromptHelp() {
@@ -1086,7 +1106,9 @@ async function initializePromptPage() {
       considerationRiskReview: "unspecified",
       discomfortRiskReview: "unspecified",
       aggressiveExpressionReview: "unspecified",
-      sensitiveExpressionReview: "unspecified"
+      sensitiveExpressionReview: "unspecified",
+      legalComplianceReview: "unspecified",
+      publicOrderReview: "unspecified"
     });
     const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
     setPromptOutputOptions(currentOptions);
@@ -1230,6 +1252,8 @@ async function initializePromptPage() {
   discomfortRiskReview.addEventListener("change", updateOutput);
   aggressiveExpressionReview.addEventListener("change", updateOutput);
   sensitiveExpressionReview.addEventListener("change", updateOutput);
+  legalComplianceReview.addEventListener("change", updateOutput);
+  publicOrderReview.addEventListener("change", updateOutput);
   hallucinationGuard.addEventListener("change", updateOutput);
   outputMarkdown.addEventListener("change", updateOutput);
   copyShareLinkButton.addEventListener("click", () => {

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions-popular.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions-popular.ts
@@ -1205,6 +1205,20 @@ ${getMarkdownFenceInstruction()}`
     buildBody: () => `与えられた内容について、センシティブな表現がないか確認してください。属性、立場、背景、文化的事情などに関わる表現で、読み手や関係者に不必要な負荷や反発を生みそうな箇所があれば整理してください。断定しすぎず、どの観点で注意が必要そうかが分かるように示してください。`
   },
   {
+    id: "popular-legal-compliance-request",
+    label: "P1001-006: 法令遵守の観点で確認する",
+    keywords: ["P1001-006", "legal compliance", "law compliance", "regulatory compliance", "legal review", "法令遵守", "法律確認", "違法性確認", "ほうれいじゅんしゅ", "いほうせいかくにん"],
+    requiresCommitId: false,
+    buildBody: () => `与えられた内容について、法令遵守の観点で問題がないか確認してください。日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば整理してください。必要に応じて、より安全で適切な方向も示してください。`
+  },
+  {
+    id: "popular-public-order-review-request",
+    label: "P1001-007: 公序良俗の観点で確認する",
+    keywords: ["P1001-007", "public order and morals", "public morals", "social acceptability", "appropriateness review", "公序良俗", "社会通念", "不適切表現", "こうじょりょうぞく", "しゃかいつうねん"],
+    requiresCommitId: false,
+    buildBody: () => `与えられた内容について、公序良俗の観点で問題がないか確認してください。日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば整理してください。必要に応じて、より穏当で適切な方向も示してください。`
+  },
+  {
     id: "popular-clarify-request-request",
     label: "P1205-003: 曖昧な依頼を明確化する",
     keywords: ["P1205-003", "clarify request", "clarify vague request", "refine request", "request clarification", "依頼明確化", "曖昧な依頼", "依頼整理", "いらいめいかくか", "あいまいないらい"],

--- a/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts
@@ -8,6 +8,8 @@ type PromptOutputOptions = {
   discomfortRiskReview: "unspecified" | "internal" | "report";
   aggressiveExpressionReview: "unspecified" | "internal" | "report";
   sensitiveExpressionReview: "unspecified" | "internal" | "report";
+  legalComplianceReview: "unspecified" | "internal" | "report";
+  publicOrderReview: "unspecified" | "internal" | "report";
 };
 
 type PromptHallucinationGuardMode = "none" | "low" | "high";
@@ -22,6 +24,8 @@ type PromptOutputInstructionProfile = {
   discomfortRiskReview: "unspecified" | "internal" | "report";
   aggressiveExpressionReview: "unspecified" | "internal" | "report";
   sensitiveExpressionReview: "unspecified" | "internal" | "report";
+  legalComplianceReview: "unspecified" | "internal" | "report";
+  publicOrderReview: "unspecified" | "internal" | "report";
 };
 
 const strictHallucinationPreventionInstruction = `○ハルシネーション防止のため、次のルールに従ってください。
@@ -91,6 +95,24 @@ const reportedSensitiveExpressionReviewInstruction = `○回答案を作成し�
 - 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
 - 最終回答の末尾に \`センシティブ表現レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
 - 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedLegalComplianceReviewInstruction = `○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。
+- 日本の法令を基準として、違法行為の助長、法的に問題となりうる指示や表現、誤解を招きやすい記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`法令遵守レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
+const internalPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 見直しの途中経過や思考過程は出力しないでください。`;
+const reportedPublicOrderReviewInstruction = `○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。
+- 日本を基準として、公序良俗に反するおそれのある内容、社会通念上不適切に受け取られうる表現、過度に扇情的または有害と受け取られうる記述があれば修正してください。
+- 必要があれば本文を修正し、改善後の内容を最終回答として出力してください。
+- 最終回答の末尾に \`公序良俗レビュー\` セクションを追加し、見直した観点と、必要に応じて修正点を簡潔に記載してください。
+- 見直しの途中経過や思考過程は出力せず、レビュー結果だけを簡潔に記載してください。`;
 
 let currentPromptOutputOptions: PromptOutputOptions = {
   hallucinationGuardLevel: "high",
@@ -101,7 +123,9 @@ let currentPromptOutputOptions: PromptOutputOptions = {
   considerationRiskReview: "unspecified",
   discomfortRiskReview: "unspecified",
   aggressiveExpressionReview: "unspecified",
-  sensitiveExpressionReview: "unspecified"
+  sensitiveExpressionReview: "unspecified",
+  legalComplianceReview: "unspecified",
+  publicOrderReview: "unspecified"
 };
 
 function setPromptOutputOptions(options: PromptOutputOptions): void {
@@ -114,7 +138,9 @@ function setPromptOutputOptions(options: PromptOutputOptions): void {
     considerationRiskReview: options.considerationRiskReview || "unspecified",
     discomfortRiskReview: options.discomfortRiskReview || "unspecified",
     aggressiveExpressionReview: options.aggressiveExpressionReview || "unspecified",
-    sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified"
+    sensitiveExpressionReview: options.sensitiveExpressionReview || "unspecified",
+    legalComplianceReview: options.legalComplianceReview || "unspecified",
+    publicOrderReview: options.publicOrderReview || "unspecified"
   };
 }
 
@@ -136,7 +162,11 @@ function getPromptOutputInstructionTemplates() {
     internalAggressiveExpressionReviewInstruction,
     reportedAggressiveExpressionReviewInstruction,
     internalSensitiveExpressionReviewInstruction,
-    reportedSensitiveExpressionReviewInstruction
+    reportedSensitiveExpressionReviewInstruction,
+    internalLegalComplianceReviewInstruction,
+    reportedLegalComplianceReviewInstruction,
+    internalPublicOrderReviewInstruction,
+    reportedPublicOrderReviewInstruction
   };
 }
 
@@ -188,6 +218,16 @@ function inferPromptOutputInstructionProfile(body: string): PromptOutputInstruct
       ? "report"
       : normalizedBody.includes(templates.internalSensitiveExpressionReviewInstruction)
         ? "internal"
+        : "unspecified",
+    legalComplianceReview: normalizedBody.includes(templates.reportedLegalComplianceReviewInstruction)
+      ? "report"
+      : normalizedBody.includes(templates.internalLegalComplianceReviewInstruction)
+        ? "internal"
+        : "unspecified",
+    publicOrderReview: normalizedBody.includes(templates.reportedPublicOrderReviewInstruction)
+      ? "report"
+      : normalizedBody.includes(templates.internalPublicOrderReviewInstruction)
+        ? "internal"
         : "unspecified"
   };
 }
@@ -200,6 +240,10 @@ function stripPromptOutputInstructions(body: string): string {
   while (changed) {
     changed = false;
     for (const template of [
+      templates.reportedPublicOrderReviewInstruction,
+      templates.internalPublicOrderReviewInstruction,
+      templates.reportedLegalComplianceReviewInstruction,
+      templates.internalLegalComplianceReviewInstruction,
       templates.reportedSensitiveExpressionReviewInstruction,
       templates.internalSensitiveExpressionReviewInstruction,
       templates.reportedAggressiveExpressionReviewInstruction,
@@ -285,6 +329,16 @@ function appendPromptOutputInstructions(
     segments.push(internalSensitiveExpressionReviewInstruction);
   } else if (options.sensitiveExpressionReview === "report") {
     segments.push(reportedSensitiveExpressionReviewInstruction);
+  }
+  if (options.legalComplianceReview === "internal") {
+    segments.push(internalLegalComplianceReviewInstruction);
+  } else if (options.legalComplianceReview === "report") {
+    segments.push(reportedLegalComplianceReviewInstruction);
+  }
+  if (options.publicOrderReview === "internal") {
+    segments.push(internalPublicOrderReviewInstruction);
+  } else if (options.publicOrderReview === "report") {
+    segments.push(reportedPublicOrderReviewInstruction);
   }
 
   return segments.join("\n\n");

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -177,6 +177,16 @@ function mountPromptDom() {
       <option value="internal">内部レビュー</option>
       <option value="report">レビュー結果出力</option>
     </select>
+    <select id="legalComplianceReview">
+      <option value="unspecified">無指定</option>
+      <option value="internal">内部レビュー</option>
+      <option value="report">レビュー結果出力</option>
+    </select>
+    <select id="publicOrderReview">
+      <option value="unspecified">無指定</option>
+      <option value="internal">内部レビュー</option>
+      <option value="report">レビュー結果出力</option>
+    </select>
     <input id="outputMarkdown" type="checkbox" />
     <button id="copyShareLinkButton" type="button"></button>
     <a id="gitPseudoSquashLink" class="md-hidden" href="../git/git-work-list.html"></a>
@@ -338,6 +348,8 @@ describe("prompt-gen main", () => {
     const discomfortRiskReview = document.getElementById("discomfortRiskReview");
     const aggressiveExpressionReview = document.getElementById("aggressiveExpressionReview");
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview");
+    const legalComplianceReview = document.getElementById("legalComplianceReview");
+    const publicOrderReview = document.getElementById("publicOrderReview");
     const outputMarkdown = document.getElementById("outputMarkdown");
     const promptOutput = document.getElementById("promptOutput");
 
@@ -349,6 +361,8 @@ describe("prompt-gen main", () => {
     expect(discomfortRiskReview.value).toBe("unspecified");
     expect(aggressiveExpressionReview.value).toBe("unspecified");
     expect(sensitiveExpressionReview.value).toBe("unspecified");
+    expect(legalComplianceReview.value).toBe("unspecified");
+    expect(publicOrderReview.value).toBe("unspecified");
     expect(outputMarkdown.checked).toBe(true);
     expect(promptOutput.textContent).toContain("○ハルシネーション防止のため");
     expect(promptOutput.textContent).toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
@@ -365,6 +379,8 @@ describe("prompt-gen main", () => {
     const discomfortRiskReview = document.getElementById("discomfortRiskReview");
     const aggressiveExpressionReview = document.getElementById("aggressiveExpressionReview");
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview");
+    const legalComplianceReview = document.getElementById("legalComplianceReview");
+    const publicOrderReview = document.getElementById("publicOrderReview");
     const outputMarkdown = document.getElementById("outputMarkdown");
     const promptOutput = document.getElementById("promptOutput");
 
@@ -384,6 +400,10 @@ describe("prompt-gen main", () => {
     aggressiveExpressionReview.dispatchEvent(new Event("change"));
     sensitiveExpressionReview.value = "internal";
     sensitiveExpressionReview.dispatchEvent(new Event("change"));
+    legalComplianceReview.value = "report";
+    legalComplianceReview.dispatchEvent(new Event("change"));
+    publicOrderReview.value = "internal";
+    publicOrderReview.dispatchEvent(new Event("change"));
     outputMarkdown.checked = false;
     outputMarkdown.dispatchEvent(new Event("change"));
 
@@ -397,6 +417,8 @@ describe("prompt-gen main", () => {
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、不快感リスクがないかを観点として見直してください。");
     expect(promptOutput.textContent).toContain("`攻撃性レビュー` セクション");
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、センシティブな表現がないかを観点として見直してください。");
+    expect(promptOutput.textContent).toContain("`法令遵守レビュー` セクション");
+    expect(promptOutput.textContent).toContain("○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。");
     expect(promptOutput.textContent.indexOf("○文体は、である調で統一してください。箇条書きは体言止めでも構いません。"))
       .toBeLessThan(promptOutput.textContent.indexOf("○回答案を作成したあと、第三者のレビューアの視点に切り替えて自己レビューしてください。"));
     expect(promptOutput.textContent.indexOf("○回答案を作成したあと、第三者のレビューアの視点に切り替えて自己レビューしてください。"))
@@ -409,6 +431,10 @@ describe("prompt-gen main", () => {
       .toBeLessThan(promptOutput.textContent.indexOf("○回答案を作成したあと、攻撃的な表現がないかを観点として見直してください。"));
     expect(promptOutput.textContent.indexOf("○回答案を作成したあと、攻撃的な表現がないかを観点として見直してください。"))
       .toBeLessThan(promptOutput.textContent.indexOf("○回答案を作成したあと、センシティブな表現がないかを観点として見直してください。"));
+    expect(promptOutput.textContent.indexOf("○回答案を作成したあと、センシティブな表現がないかを観点として見直してください。"))
+      .toBeLessThan(promptOutput.textContent.indexOf("○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。"));
+    expect(promptOutput.textContent.indexOf("○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。"))
+      .toBeLessThan(promptOutput.textContent.indexOf("○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。"));
   });
 
   it("resets output options to prompt defaults when switching prompts", async () => {
@@ -423,6 +449,8 @@ describe("prompt-gen main", () => {
     const discomfortRiskReview = document.getElementById("discomfortRiskReview");
     const aggressiveExpressionReview = document.getElementById("aggressiveExpressionReview");
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview");
+    const legalComplianceReview = document.getElementById("legalComplianceReview");
+    const publicOrderReview = document.getElementById("publicOrderReview");
     const outputMarkdown = document.getElementById("outputMarkdown");
 
     promptSearch.value = "A501";
@@ -443,6 +471,10 @@ describe("prompt-gen main", () => {
     aggressiveExpressionReview.dispatchEvent(new Event("change"));
     sensitiveExpressionReview.value = "internal";
     sensitiveExpressionReview.dispatchEvent(new Event("change"));
+    legalComplianceReview.value = "report";
+    legalComplianceReview.dispatchEvent(new Event("change"));
+    publicOrderReview.value = "internal";
+    publicOrderReview.dispatchEvent(new Event("change"));
     outputMarkdown.checked = false;
     outputMarkdown.dispatchEvent(new Event("change"));
 
@@ -459,6 +491,8 @@ describe("prompt-gen main", () => {
     expect(discomfortRiskReview.value).toBe("unspecified");
     expect(aggressiveExpressionReview.value).toBe("unspecified");
     expect(sensitiveExpressionReview.value).toBe("unspecified");
+    expect(legalComplianceReview.value).toBe("unspecified");
+    expect(publicOrderReview.value).toBe("unspecified");
     expect(outputMarkdown.checked).toBe(true);
   });
 
@@ -473,6 +507,8 @@ describe("prompt-gen main", () => {
     const discomfortRiskReview = document.getElementById("discomfortRiskReview");
     const aggressiveExpressionReview = document.getElementById("aggressiveExpressionReview");
     const sensitiveExpressionReview = document.getElementById("sensitiveExpressionReview");
+    const legalComplianceReview = document.getElementById("legalComplianceReview");
+    const publicOrderReview = document.getElementById("publicOrderReview");
     const outputMarkdown = document.getElementById("outputMarkdown");
     const promptOutput = document.getElementById("promptOutput");
 
@@ -484,6 +520,8 @@ describe("prompt-gen main", () => {
     expect(discomfortRiskReview.value).toBe("unspecified");
     expect(aggressiveExpressionReview.value).toBe("unspecified");
     expect(sensitiveExpressionReview.value).toBe("unspecified");
+    expect(legalComplianceReview.value).toBe("unspecified");
+    expect(publicOrderReview.value).toBe("unspecified");
     expect(outputMarkdown.checked).toBe(false);
     expect(promptOutput.textContent).not.toContain("○ハルシネーション防止のため");
     expect(promptOutput.textContent).not.toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
@@ -504,6 +542,10 @@ describe("prompt-gen main", () => {
     aggressiveExpressionReview.dispatchEvent(new Event("change"));
     sensitiveExpressionReview.value = "internal";
     sensitiveExpressionReview.dispatchEvent(new Event("change"));
+    legalComplianceReview.value = "internal";
+    legalComplianceReview.dispatchEvent(new Event("change"));
+    publicOrderReview.value = "internal";
+    publicOrderReview.dispatchEvent(new Event("change"));
     outputMarkdown.checked = true;
     outputMarkdown.dispatchEvent(new Event("change"));
 
@@ -517,11 +559,15 @@ describe("prompt-gen main", () => {
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、不快感リスクがないかを観点として見直してください。");
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、攻撃的な表現がないかを観点として見直してください。");
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、センシティブな表現がないかを観点として見直してください。");
+    expect(promptOutput.textContent).toContain("○回答案を作成したあと、法令遵守の観点で問題がないかを見直してください。");
+    expect(promptOutput.textContent).toContain("○回答案を作成したあと、公序良俗の観点で問題がないかを見直してください。");
     expect(promptOutput.textContent).not.toContain("`誤解表現レビュー` セクション");
     expect(promptOutput.textContent).not.toContain("`配慮不足レビュー` セクション");
     expect(promptOutput.textContent).not.toContain("`不快感レビュー` セクション");
     expect(promptOutput.textContent).not.toContain("`攻撃性レビュー` セクション");
     expect(promptOutput.textContent).not.toContain("`センシティブ表現レビュー` セクション");
+    expect(promptOutput.textContent).not.toContain("`法令遵守レビュー` セクション");
+    expect(promptOutput.textContent).not.toContain("`公序良俗レビュー` セクション");
   });
 
   it("uses docs as the default docs path for A150", async () => {


### PR DESCRIPTION
## 概要
`prompt-gen` に、`P1001` 系の確認観点として `法令遵守` と `公序良俗` を追加します。あわせて、出力オプション、関連ロジック、テスト、生成物を更新します。

## 変更内容
- `P1001` 系の人気プロンプト定義を追加
  - `P1001-006: 法令遵守の観点で確認する`
  - `P1001-007: 公序良俗の観点で確認する`
- `prompt-gen` の出力オプションを追加
  - `法令遵守`
  - `公序良俗`
- 新しい出力オプションに対応するレビュー指示文を追加
  - `内部レビュー`
  - `レビュー結果出力`
- 出力オプションの既定値推論、プロンプト再構築、UI 変更イベント処理を更新
- 関連テストを更新
- 生成済みファイルを更新
  - `docs/prompt/prompt-gen.html`
  - `docs/prompt/src/prompt-gen/js/main.js`
  - `docs/prompt/src/prompt-gen/js/prompt-definitions-popular.js`
  - `docs/prompt/src/prompt-gen/js/prompt-markdown-util.js`

## 影響箇所
- `docs/prompt/src/prompt-gen/ts/prompt-definitions-popular.ts`
- `docs/prompt/src/prompt-gen/ts/prompt-markdown-util.ts`
- `docs/prompt/src/prompt-gen/ts/main.ts`
- `docs/prompt/prompt-gen-src.html`
- `docs/prompt/tests/prompt-gen-main.test.js`

## 確認事項
- コミットメッセージは `save` であり、コミットメッセージからは意図の詳細は未確認です。
- テスト実行有無は、このコミット差分だけでは未確認です。