### PR TITLE
feat(prompt): prompt-gen に全体状態の Import/Export とカスタムプロンプト検索対応を追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-15</div>
+        <div class="md-app-meta">更新日: 2026-03-16</div>
       </div>
     </header>
 

--- a/docs/prompt/prompt-gen-src.html
+++ b/docs/prompt/prompt-gen-src.html
@@ -115,6 +115,7 @@ limitations under the License.
             </svg>
             <span>Git 作業一覧</span>
           </a>
+          <input id="customPromptImportInput" type="file" accept="application/json,.json" class="md-hidden" aria-hidden="true">
           <button id="copyShareLinkButton" type="button" class="md-secondary-button">
             <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <use href="#md-icon-link" xlink:href="#md-icon-link"></use>

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -1545,6 +1545,7 @@ md-icon-button.md-copy-button--surface {
             </svg>
             <span>Git 作業一覧</span>
           </a>
+          <input id="customPromptImportInput" type="file" accept="application/json,.json" class="md-hidden" aria-hidden="true">
           <button id="copyShareLinkButton" type="button" class="md-secondary-button">
             <svg viewBox="0 0 24 24" class="md-secondary-button__icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <use href="#md-icon-link" xlink:href="#md-icon-link"></use>
@@ -8743,6 +8744,8 @@ ${getMarkdownFenceInstruction()}`
   <script>
 async function initializePromptPage() {
     const SERIES_VISIBILITY_STORAGE_KEY = "promptGenSeriesVisibility";
+    const CUSTOM_PROMPT_STORAGE_KEY = "promptGenCustomPrompt";
+    const CUSTOM_PROMPT_EXPORT_VERSION = 1;
     const defaultSeriesVisibilitySettings = {
         showA: true,
         showX: true,
@@ -8819,9 +8822,10 @@ async function initializePromptPage() {
     const hallucinationGuard = document.getElementById("hallucinationGuard") ||
         (await waitForElementById("hallucinationGuard"));
     const outputMarkdown = document.getElementById("outputMarkdown");
+    const customPromptImportInput = document.getElementById("customPromptImportInput");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !customPromptImportInput || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -8860,6 +8864,52 @@ async function initializePromptPage() {
         }
         storage.removeItem(SERIES_VISIBILITY_STORAGE_KEY);
     }
+    function loadImportedCustomPrompt() {
+        try {
+            const storage = window.localStorage;
+            if (!storage || typeof storage.getItem !== "function") {
+                return null;
+            }
+            const raw = storage.getItem(CUSTOM_PROMPT_STORAGE_KEY);
+            if (!raw) {
+                return null;
+            }
+            const parsed = JSON.parse(raw);
+            if (typeof (parsed === null || parsed === void 0 ? void 0 : parsed.promptText) !== "string" || !parsed.promptText.trim()) {
+                return null;
+            }
+            const normalizedKeywords = Array.isArray(parsed === null || parsed === void 0 ? void 0 : parsed.keywords)
+                ? parsed.keywords.map((keyword) => String(keyword || "").trim()).filter(Boolean)
+                : [];
+            return {
+                id: typeof (parsed === null || parsed === void 0 ? void 0 : parsed.id) === "string" && parsed.id.trim() ? parsed.id.trim() : "custom-imported-prompt",
+                label: typeof (parsed === null || parsed === void 0 ? void 0 : parsed.label) === "string" && parsed.label.trim()
+                    ? parsed.label.trim()
+                    : typeof (parsed === null || parsed === void 0 ? void 0 : parsed.promptName) === "string" && parsed.promptName.trim()
+                        ? parsed.promptName.trim()
+                        : "カスタムプロンプト",
+                keywords: normalizedKeywords,
+                promptText: parsed.promptText.trim()
+            };
+        }
+        catch (_error) {
+            return null;
+        }
+    }
+    function saveImportedCustomPrompt(prompt) {
+        const storage = window.localStorage;
+        if (!storage || typeof storage.setItem !== "function") {
+            return;
+        }
+        storage.setItem(CUSTOM_PROMPT_STORAGE_KEY, JSON.stringify(prompt));
+    }
+    function clearImportedCustomPromptStorage() {
+        const storage = window.localStorage;
+        if (!storage || typeof storage.removeItem !== "function") {
+            return;
+        }
+        storage.removeItem(CUSTOM_PROMPT_STORAGE_KEY);
+    }
     let seriesVisibilitySettings = loadSeriesVisibilitySettings();
     function getLegacyPromptArguments(definition) {
         const args = [];
@@ -8892,8 +8942,21 @@ async function initializePromptPage() {
             args: Array.isArray(definition.args) ? definition.args : getLegacyPromptArguments(definition)
         };
     }
+    function createCustomPromptDefinition(prompt) {
+        if (!prompt || !prompt.promptText.trim()) {
+            return null;
+        }
+        return normalizePromptDefinition({
+            id: prompt.id,
+            label: prompt.label,
+            keywords: prompt.keywords,
+            buildBody: () => prompt.promptText
+        });
+    }
     function getVisiblePromptDefinitions() {
+        const customPromptDefinition = createCustomPromptDefinition(customPromptState);
         return [
+            ...(customPromptDefinition ? [customPromptDefinition] : []),
             ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
             ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
             ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
@@ -9040,7 +9103,9 @@ async function initializePromptPage() {
     let selectedPrompt = "";
     let lastSearchQuery = "";
     let pendingInitialPromptCode = "";
+    let pendingInitialPromptId = "";
     let suppressSearchResetOnce = false;
+    let customPromptState = loadImportedCustomPrompt();
     const promptOutputOptionDefaultsById = new Map();
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
@@ -9546,7 +9611,14 @@ async function initializePromptPage() {
             }
         }
         const { definitionMatchGrades, matchedDefinitions, prioritizedSingleDefinition } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
-        if (pendingInitialPromptCode) {
+        if (pendingInitialPromptId) {
+            const pendingDefinition = matchedDefinitions.find((definition) => definition.id === pendingInitialPromptId);
+            if (pendingDefinition) {
+                selectedPrompt = pendingDefinition.id;
+            }
+            pendingInitialPromptId = "";
+        }
+        else if (pendingInitialPromptCode) {
             const pendingDefinition = matchedDefinitions.find((definition) => getDefinitionLabelCode(definition) === pendingInitialPromptCode);
             if (pendingDefinition) {
                 selectedPrompt = pendingDefinition.id;
@@ -9642,7 +9714,11 @@ async function initializePromptPage() {
             legalComplianceReview: "unspecified",
             publicOrderReview: "unspecified"
         });
-        const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        const rawBody = customPromptState && selectedDefinition.id === customPromptState.id
+            ? customPromptState.promptText
+            : selectedDefinition
+                ? selectedDefinition.buildBody(commitId, subject)
+                : "";
         setPromptOutputOptions(currentOptions);
         const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
         const body = appendPromptOutputInstructions(stripPromptOutputInstructions(rawBody), currentOptions, instructionProfile.hallucinationGuardMode || "high");
@@ -9670,6 +9746,9 @@ async function initializePromptPage() {
         if (query) {
             url.searchParams.set("q", query);
         }
+        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.id) {
+            url.searchParams.set("promptId", selectedDefinition.id);
+        }
         if (selectedDefinitionCode) {
             url.searchParams.set("id", selectedDefinitionCode);
         }
@@ -9687,11 +9766,280 @@ async function initializePromptPage() {
         const text = buildPromptText();
         promptOutput.textContent = text;
     }
+    function createSamplePageStateExportPayload() {
+        return {
+            version: CUSTOM_PROMPT_EXPORT_VERSION,
+            exportedAt: new Date().toISOString(),
+            isSample: true,
+            note: "0件だったためサンプルを出力",
+            state: {
+                query: "",
+                selectedPromptId: "custom-sample-prompt",
+                selectedPromptCode: "",
+                argumentValues: {},
+                outputOptions: {
+                    hallucinationGuardLevel: "none",
+                    outputMarkdownEnabled: false,
+                    outputTone: "unspecified",
+                    selfReview: "unspecified",
+                    misleadingExpressionReview: "unspecified",
+                    considerationRiskReview: "unspecified",
+                    discomfortRiskReview: "unspecified",
+                    aggressiveExpressionReview: "unspecified",
+                    sensitiveExpressionReview: "unspecified",
+                    legalComplianceReview: "unspecified",
+                    publicOrderReview: "unspecified"
+                },
+                seriesVisibilitySettings: { ...defaultSeriesVisibilitySettings },
+                customPrompt: {
+                    id: "custom-sample-prompt",
+                    label: "サンプル",
+                    keywords: ["sample", "summary", "要約"],
+                    promptText: "以下の文章を、要点がひと目で分かるように3点で要約してください。専門用語はできるだけ平易な表現に言い換えてください。"
+                }
+            }
+        };
+    }
+    function setPromptOutputOptions(options) {
+        hallucinationGuard.value = options.hallucinationGuardLevel;
+        outputMarkdown.checked = options.outputMarkdownEnabled;
+        outputTone.value = options.outputTone;
+        selfReview.value = options.selfReview;
+        misleadingExpressionReview.value = options.misleadingExpressionReview;
+        considerationRiskReview.value = options.considerationRiskReview;
+        discomfortRiskReview.value = options.discomfortRiskReview;
+        aggressiveExpressionReview.value = options.aggressiveExpressionReview;
+        sensitiveExpressionReview.value = options.sensitiveExpressionReview;
+        legalComplianceReview.value = options.legalComplianceReview;
+        publicOrderReview.value = options.publicOrderReview;
+    }
+    function createPageStateExportPayload() {
+        const currentState = {
+            version: CUSTOM_PROMPT_EXPORT_VERSION,
+            exportedAt: new Date().toISOString(),
+            isSample: false,
+            state: {
+                query: (promptSearch.value || "").trim(),
+                selectedPromptId: selectedPrompt || "",
+                selectedPromptCode: getDefinitionLabelCode(getSelectedPromptDefinition()),
+                argumentValues: getPromptArgumentValues(),
+                outputOptions: getPromptOutputOptions(),
+                seriesVisibilitySettings: { ...seriesVisibilitySettings },
+                customPrompt: customPromptState ? { ...customPromptState } : null
+            }
+        };
+        const hasMeaningfulState = currentState.state.query ||
+            currentState.state.selectedPromptId ||
+            Object.values(currentState.state.argumentValues).some((value) => String(value || "").trim()) ||
+            currentState.state.customPrompt ||
+            currentState.state.outputOptions.hallucinationGuardLevel !== "none" ||
+            currentState.state.outputOptions.outputMarkdownEnabled ||
+            currentState.state.outputOptions.outputTone !== "unspecified" ||
+            currentState.state.outputOptions.selfReview !== "unspecified" ||
+            currentState.state.outputOptions.misleadingExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.considerationRiskReview !== "unspecified" ||
+            currentState.state.outputOptions.discomfortRiskReview !== "unspecified" ||
+            currentState.state.outputOptions.aggressiveExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.sensitiveExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.legalComplianceReview !== "unspecified" ||
+            currentState.state.outputOptions.publicOrderReview !== "unspecified" ||
+            JSON.stringify(currentState.state.seriesVisibilitySettings) !== JSON.stringify(defaultSeriesVisibilitySettings);
+        if (!hasMeaningfulState) {
+            return createSamplePageStateExportPayload();
+        }
+        return currentState;
+    }
+    function buildCustomPromptExportFilename() {
+        const now = new Date();
+        const yyyy = String(now.getFullYear());
+        const mm = String(now.getMonth() + 1).padStart(2, "0");
+        const dd = String(now.getDate()).padStart(2, "0");
+        const hh = String(now.getHours()).padStart(2, "0");
+        const mi = String(now.getMinutes()).padStart(2, "0");
+        const ss = String(now.getSeconds()).padStart(2, "0");
+        return `prompt-gen-export-${yyyy}${mm}${dd}-${hh}${mi}${ss}.json`;
+    }
+    function downloadTextFile(text, filename, contentType) {
+        const blob = new Blob([text], { type: contentType });
+        const objectUrl = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = objectUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.setTimeout(() => {
+            URL.revokeObjectURL(objectUrl);
+        }, 0);
+    }
+    function normalizeImportedPageStatePayload(rawPayload) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0;
+        if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+            return null;
+        }
+        const payload = rawPayload;
+        if (Number(payload.version) !== CUSTOM_PROMPT_EXPORT_VERSION) {
+            return null;
+        }
+        if (typeof payload.exportedAt !== "string" || !payload.exportedAt.trim()) {
+            return null;
+        }
+        if (!payload.state || typeof payload.state !== "object" || Array.isArray(payload.state)) {
+            return null;
+        }
+        const state = payload.state;
+        return {
+            query: typeof state.query === "string" ? state.query.trim() : "",
+            selectedPromptId: typeof state.selectedPromptId === "string" ? state.selectedPromptId.trim() : "",
+            selectedPromptCode: typeof state.selectedPromptCode === "string" ? state.selectedPromptCode.trim() : "",
+            argumentValues: state.argumentValues && typeof state.argumentValues === "object" && !Array.isArray(state.argumentValues)
+                ? Object.fromEntries(Object.entries(state.argumentValues).map(([key, value]) => [key, typeof value === "string" ? value : ""]))
+                : {},
+            outputOptions: {
+                hallucinationGuardLevel: ((_a = state.outputOptions) === null || _a === void 0 ? void 0 : _a.hallucinationGuardLevel) === "low" || ((_b = state.outputOptions) === null || _b === void 0 ? void 0 : _b.hallucinationGuardLevel) === "high"
+                    ? state.outputOptions.hallucinationGuardLevel
+                    : "none",
+                outputMarkdownEnabled: ((_c = state.outputOptions) === null || _c === void 0 ? void 0 : _c.outputMarkdownEnabled) === true,
+                outputTone: ((_d = state.outputOptions) === null || _d === void 0 ? void 0 : _d.outputTone) === "desumasu" || ((_e = state.outputOptions) === null || _e === void 0 ? void 0 : _e.outputTone) === "dearu"
+                    ? state.outputOptions.outputTone
+                    : "unspecified",
+                selfReview: ((_f = state.outputOptions) === null || _f === void 0 ? void 0 : _f.selfReview) === "internal" || ((_g = state.outputOptions) === null || _g === void 0 ? void 0 : _g.selfReview) === "report"
+                    ? state.outputOptions.selfReview
+                    : "unspecified",
+                misleadingExpressionReview: ((_h = state.outputOptions) === null || _h === void 0 ? void 0 : _h.misleadingExpressionReview) === "internal" || ((_j = state.outputOptions) === null || _j === void 0 ? void 0 : _j.misleadingExpressionReview) === "report"
+                    ? state.outputOptions.misleadingExpressionReview
+                    : "unspecified",
+                considerationRiskReview: ((_k = state.outputOptions) === null || _k === void 0 ? void 0 : _k.considerationRiskReview) === "internal" || ((_l = state.outputOptions) === null || _l === void 0 ? void 0 : _l.considerationRiskReview) === "report"
+                    ? state.outputOptions.considerationRiskReview
+                    : "unspecified",
+                discomfortRiskReview: ((_m = state.outputOptions) === null || _m === void 0 ? void 0 : _m.discomfortRiskReview) === "internal" || ((_o = state.outputOptions) === null || _o === void 0 ? void 0 : _o.discomfortRiskReview) === "report"
+                    ? state.outputOptions.discomfortRiskReview
+                    : "unspecified",
+                aggressiveExpressionReview: ((_p = state.outputOptions) === null || _p === void 0 ? void 0 : _p.aggressiveExpressionReview) === "internal" || ((_q = state.outputOptions) === null || _q === void 0 ? void 0 : _q.aggressiveExpressionReview) === "report"
+                    ? state.outputOptions.aggressiveExpressionReview
+                    : "unspecified",
+                sensitiveExpressionReview: ((_r = state.outputOptions) === null || _r === void 0 ? void 0 : _r.sensitiveExpressionReview) === "internal" || ((_s = state.outputOptions) === null || _s === void 0 ? void 0 : _s.sensitiveExpressionReview) === "report"
+                    ? state.outputOptions.sensitiveExpressionReview
+                    : "unspecified",
+                legalComplianceReview: ((_t = state.outputOptions) === null || _t === void 0 ? void 0 : _t.legalComplianceReview) === "internal" || ((_u = state.outputOptions) === null || _u === void 0 ? void 0 : _u.legalComplianceReview) === "report"
+                    ? state.outputOptions.legalComplianceReview
+                    : "unspecified",
+                publicOrderReview: ((_v = state.outputOptions) === null || _v === void 0 ? void 0 : _v.publicOrderReview) === "internal" || ((_w = state.outputOptions) === null || _w === void 0 ? void 0 : _w.publicOrderReview) === "report"
+                    ? state.outputOptions.publicOrderReview
+                    : "unspecified"
+            },
+            seriesVisibilitySettings: {
+                showA: ((_x = state.seriesVisibilitySettings) === null || _x === void 0 ? void 0 : _x.showA) !== false,
+                showX: ((_y = state.seriesVisibilitySettings) === null || _y === void 0 ? void 0 : _y.showX) !== false,
+                showS: ((_z = state.seriesVisibilitySettings) === null || _z === void 0 ? void 0 : _z.showS) !== false,
+                showP: ((_0 = state.seriesVisibilitySettings) === null || _0 === void 0 ? void 0 : _0.showP) !== false
+            },
+            customPrompt: state.customPrompt &&
+                typeof state.customPrompt === "object" &&
+                typeof state.customPrompt.promptText === "string" &&
+                state.customPrompt.promptText.trim()
+                ? {
+                    id: typeof state.customPrompt.id === "string" && state.customPrompt.id.trim()
+                        ? state.customPrompt.id.trim()
+                        : "custom-imported-prompt",
+                    label: typeof state.customPrompt.label === "string" && state.customPrompt.label.trim()
+                        ? state.customPrompt.label.trim()
+                        : typeof state.customPrompt.promptName === "string" &&
+                            String(state.customPrompt.promptName || "").trim()
+                            ? String(state.customPrompt.promptName || "").trim()
+                            : "カスタムプロンプト",
+                    keywords: Array.isArray(state.customPrompt.keywords)
+                        ? state.customPrompt.keywords.map((keyword) => String(keyword || "").trim()).filter(Boolean)
+                        : [],
+                    promptText: state.customPrompt.promptText.trim()
+                }
+                : null
+        };
+    }
+    async function importCustomPromptFile(file) {
+        if (!file) {
+            return;
+        }
+        try {
+            const rawText = await file.text();
+            const parsed = JSON.parse(rawText);
+            const normalized = normalizeImportedPageStatePayload(parsed);
+            if (!normalized) {
+                if (typeof window.showToast === "function") {
+                    window.showToast("JSON の読み込みに失敗しました");
+                }
+                return;
+            }
+            customPromptState = normalized.customPrompt;
+            if (customPromptState) {
+                saveImportedCustomPrompt(customPromptState);
+            }
+            else {
+                clearImportedCustomPromptStorage();
+            }
+            seriesVisibilitySettings = { ...normalized.seriesVisibilitySettings };
+            saveSeriesVisibilitySettings(seriesVisibilitySettings);
+            rebuildVisiblePromptIndexes();
+            pendingInitialPromptId = normalized.selectedPromptId;
+            pendingInitialPromptCode = normalized.selectedPromptCode;
+            lastSearchQuery = "";
+            promptSearch.value = normalized.query;
+            selectedPrompt = "";
+            activeArgumentDefinitions = [];
+            renderCandidates();
+            setPromptArgumentValues(normalized.argumentValues);
+            applyDefaultArgumentValues(getSelectedPromptDefinition());
+            setPromptOutputOptions(normalized.outputOptions);
+            revealOutputSection();
+            updateOutput();
+            if (typeof window.showToast === "function") {
+                window.showToast("画面状態を JSON から取り込みました");
+            }
+        }
+        catch (_error) {
+            if (typeof window.showToast === "function") {
+                window.showToast("JSON の読み込みに失敗しました");
+            }
+        }
+        finally {
+            customPromptImportInput.value = "";
+        }
+    }
+    function exportCustomPrompt() {
+        const payload = createPageStateExportPayload();
+        downloadTextFile(`${JSON.stringify(payload, null, 2)}\n`, buildCustomPromptExportFilename(), "application/json;charset=utf-8");
+        if (typeof window.showToast === "function") {
+            window.showToast(payload.isSample
+                ? "データが空のためサンプルJSONを出力しました"
+                : "画面状態を JSON でエクスポートしました");
+        }
+    }
     function createSeriesVisibilityMenu() {
         const menuPanel = document.querySelector("lht-page-menu .md-menu-panel");
         if (!menuPanel) {
             return;
         }
+        const exportButton = document.createElement("a");
+        exportButton.id = "exportCustomPromptButton";
+        exportButton.className = "md-menu-link";
+        exportButton.href = "#";
+        exportButton.textContent = "Export";
+        exportButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            exportCustomPrompt();
+        });
+        menuPanel.appendChild(exportButton);
+        const importButton = document.createElement("a");
+        importButton.id = "importCustomPromptButton";
+        importButton.className = "md-menu-link";
+        importButton.href = "#";
+        importButton.textContent = "Import";
+        importButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            customPromptImportInput.value = "";
+            customPromptImportInput.click();
+        });
+        menuPanel.appendChild(importButton);
         const separator = document.createElement("div");
         separator.className = "md-menu-separator";
         menuPanel.appendChild(separator);
@@ -9738,6 +10086,8 @@ async function initializePromptPage() {
         resetButton.className = "md-menu-settings__reset";
         resetButton.innerHTML = '<svg viewBox="0 0 24 24" class="md-menu-settings__reset-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-trash" xlink:href="#md-icon-trash"></use></svg><span>設定を初期化</span>';
         resetButton.addEventListener("click", () => {
+            clearImportedCustomPromptStorage();
+            customPromptState = null;
             clearSeriesVisibilitySettings();
             seriesVisibilitySettings = { ...defaultSeriesVisibilitySettings };
             for (const option of seriesOptions) {
@@ -9764,16 +10114,22 @@ async function initializePromptPage() {
     publicOrderReview.addEventListener("change", updateOutput);
     hallucinationGuard.addEventListener("change", updateOutput);
     outputMarkdown.addEventListener("change", updateOutput);
+    customPromptImportInput.addEventListener("change", () => {
+        var _a;
+        void importCustomPromptFile(((_a = customPromptImportInput.files) === null || _a === void 0 ? void 0 : _a[0]) || null);
+    });
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
     let initialPromptCode = "";
+    let initialPromptId = "";
     const initialArgumentValues = {};
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
         initialPromptCode = (url.searchParams.get("id") || "").trim();
+        initialPromptId = (url.searchParams.get("promptId") || "").trim();
         initialArgumentValues.subject = url.searchParams.get("subject") || "";
         initialArgumentValues.commitId = url.searchParams.get("commit") || "";
         for (const [key, value] of url.searchParams.entries()) {
@@ -9791,6 +10147,9 @@ async function initializePromptPage() {
     applyPromptOutputOptionDefaults(null);
     createSeriesVisibilityMenu();
     renderArgumentFields(null);
+    if (initialPromptId) {
+        pendingInitialPromptId = initialPromptId;
+    }
     if (initialPromptCode) {
         pendingInitialPromptCode = initialPromptCode;
     }

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -1,5 +1,7 @@
 async function initializePromptPage() {
     const SERIES_VISIBILITY_STORAGE_KEY = "promptGenSeriesVisibility";
+    const CUSTOM_PROMPT_STORAGE_KEY = "promptGenCustomPrompt";
+    const CUSTOM_PROMPT_EXPORT_VERSION = 1;
     const defaultSeriesVisibilitySettings = {
         showA: true,
         showX: true,
@@ -76,9 +78,10 @@ async function initializePromptPage() {
     const hallucinationGuard = document.getElementById("hallucinationGuard") ||
         (await waitForElementById("hallucinationGuard"));
     const outputMarkdown = document.getElementById("outputMarkdown");
+    const customPromptImportInput = document.getElementById("customPromptImportInput");
     const copyShareLinkButton = document.getElementById("copyShareLinkButton");
     const promptOutput = document.getElementById("promptOutput");
-    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+    if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !customPromptImportInput || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
         return;
     }
     function loadSeriesVisibilitySettings() {
@@ -117,6 +120,52 @@ async function initializePromptPage() {
         }
         storage.removeItem(SERIES_VISIBILITY_STORAGE_KEY);
     }
+    function loadImportedCustomPrompt() {
+        try {
+            const storage = window.localStorage;
+            if (!storage || typeof storage.getItem !== "function") {
+                return null;
+            }
+            const raw = storage.getItem(CUSTOM_PROMPT_STORAGE_KEY);
+            if (!raw) {
+                return null;
+            }
+            const parsed = JSON.parse(raw);
+            if (typeof (parsed === null || parsed === void 0 ? void 0 : parsed.promptText) !== "string" || !parsed.promptText.trim()) {
+                return null;
+            }
+            const normalizedKeywords = Array.isArray(parsed === null || parsed === void 0 ? void 0 : parsed.keywords)
+                ? parsed.keywords.map((keyword) => String(keyword || "").trim()).filter(Boolean)
+                : [];
+            return {
+                id: typeof (parsed === null || parsed === void 0 ? void 0 : parsed.id) === "string" && parsed.id.trim() ? parsed.id.trim() : "custom-imported-prompt",
+                label: typeof (parsed === null || parsed === void 0 ? void 0 : parsed.label) === "string" && parsed.label.trim()
+                    ? parsed.label.trim()
+                    : typeof (parsed === null || parsed === void 0 ? void 0 : parsed.promptName) === "string" && parsed.promptName.trim()
+                        ? parsed.promptName.trim()
+                        : "カスタムプロンプト",
+                keywords: normalizedKeywords,
+                promptText: parsed.promptText.trim()
+            };
+        }
+        catch (_error) {
+            return null;
+        }
+    }
+    function saveImportedCustomPrompt(prompt) {
+        const storage = window.localStorage;
+        if (!storage || typeof storage.setItem !== "function") {
+            return;
+        }
+        storage.setItem(CUSTOM_PROMPT_STORAGE_KEY, JSON.stringify(prompt));
+    }
+    function clearImportedCustomPromptStorage() {
+        const storage = window.localStorage;
+        if (!storage || typeof storage.removeItem !== "function") {
+            return;
+        }
+        storage.removeItem(CUSTOM_PROMPT_STORAGE_KEY);
+    }
     let seriesVisibilitySettings = loadSeriesVisibilitySettings();
     function getLegacyPromptArguments(definition) {
         const args = [];
@@ -149,8 +198,21 @@ async function initializePromptPage() {
             args: Array.isArray(definition.args) ? definition.args : getLegacyPromptArguments(definition)
         };
     }
+    function createCustomPromptDefinition(prompt) {
+        if (!prompt || !prompt.promptText.trim()) {
+            return null;
+        }
+        return normalizePromptDefinition({
+            id: prompt.id,
+            label: prompt.label,
+            keywords: prompt.keywords,
+            buildBody: () => prompt.promptText
+        });
+    }
     function getVisiblePromptDefinitions() {
+        const customPromptDefinition = createCustomPromptDefinition(customPromptState);
         return [
+            ...(customPromptDefinition ? [customPromptDefinition] : []),
             ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
             ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
             ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
@@ -297,7 +359,9 @@ async function initializePromptPage() {
     let selectedPrompt = "";
     let lastSearchQuery = "";
     let pendingInitialPromptCode = "";
+    let pendingInitialPromptId = "";
     let suppressSearchResetOnce = false;
+    let customPromptState = loadImportedCustomPrompt();
     const promptOutputOptionDefaultsById = new Map();
     const kanaToRomajiMap = new Map([
         ["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"],
@@ -803,7 +867,14 @@ async function initializePromptPage() {
             }
         }
         const { definitionMatchGrades, matchedDefinitions, prioritizedSingleDefinition } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
-        if (pendingInitialPromptCode) {
+        if (pendingInitialPromptId) {
+            const pendingDefinition = matchedDefinitions.find((definition) => definition.id === pendingInitialPromptId);
+            if (pendingDefinition) {
+                selectedPrompt = pendingDefinition.id;
+            }
+            pendingInitialPromptId = "";
+        }
+        else if (pendingInitialPromptCode) {
             const pendingDefinition = matchedDefinitions.find((definition) => getDefinitionLabelCode(definition) === pendingInitialPromptCode);
             if (pendingDefinition) {
                 selectedPrompt = pendingDefinition.id;
@@ -899,7 +970,11 @@ async function initializePromptPage() {
             legalComplianceReview: "unspecified",
             publicOrderReview: "unspecified"
         });
-        const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+        const rawBody = customPromptState && selectedDefinition.id === customPromptState.id
+            ? customPromptState.promptText
+            : selectedDefinition
+                ? selectedDefinition.buildBody(commitId, subject)
+                : "";
         setPromptOutputOptions(currentOptions);
         const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
         const body = appendPromptOutputInstructions(stripPromptOutputInstructions(rawBody), currentOptions, instructionProfile.hallucinationGuardMode || "high");
@@ -927,6 +1002,9 @@ async function initializePromptPage() {
         if (query) {
             url.searchParams.set("q", query);
         }
+        if (selectedDefinition === null || selectedDefinition === void 0 ? void 0 : selectedDefinition.id) {
+            url.searchParams.set("promptId", selectedDefinition.id);
+        }
         if (selectedDefinitionCode) {
             url.searchParams.set("id", selectedDefinitionCode);
         }
@@ -944,11 +1022,280 @@ async function initializePromptPage() {
         const text = buildPromptText();
         promptOutput.textContent = text;
     }
+    function createSamplePageStateExportPayload() {
+        return {
+            version: CUSTOM_PROMPT_EXPORT_VERSION,
+            exportedAt: new Date().toISOString(),
+            isSample: true,
+            note: "0件だったためサンプルを出力",
+            state: {
+                query: "",
+                selectedPromptId: "custom-sample-prompt",
+                selectedPromptCode: "",
+                argumentValues: {},
+                outputOptions: {
+                    hallucinationGuardLevel: "none",
+                    outputMarkdownEnabled: false,
+                    outputTone: "unspecified",
+                    selfReview: "unspecified",
+                    misleadingExpressionReview: "unspecified",
+                    considerationRiskReview: "unspecified",
+                    discomfortRiskReview: "unspecified",
+                    aggressiveExpressionReview: "unspecified",
+                    sensitiveExpressionReview: "unspecified",
+                    legalComplianceReview: "unspecified",
+                    publicOrderReview: "unspecified"
+                },
+                seriesVisibilitySettings: { ...defaultSeriesVisibilitySettings },
+                customPrompt: {
+                    id: "custom-sample-prompt",
+                    label: "サンプル",
+                    keywords: ["sample", "summary", "要約"],
+                    promptText: "以下の文章を、要点がひと目で分かるように3点で要約してください。専門用語はできるだけ平易な表現に言い換えてください。"
+                }
+            }
+        };
+    }
+    function setPromptOutputOptions(options) {
+        hallucinationGuard.value = options.hallucinationGuardLevel;
+        outputMarkdown.checked = options.outputMarkdownEnabled;
+        outputTone.value = options.outputTone;
+        selfReview.value = options.selfReview;
+        misleadingExpressionReview.value = options.misleadingExpressionReview;
+        considerationRiskReview.value = options.considerationRiskReview;
+        discomfortRiskReview.value = options.discomfortRiskReview;
+        aggressiveExpressionReview.value = options.aggressiveExpressionReview;
+        sensitiveExpressionReview.value = options.sensitiveExpressionReview;
+        legalComplianceReview.value = options.legalComplianceReview;
+        publicOrderReview.value = options.publicOrderReview;
+    }
+    function createPageStateExportPayload() {
+        const currentState = {
+            version: CUSTOM_PROMPT_EXPORT_VERSION,
+            exportedAt: new Date().toISOString(),
+            isSample: false,
+            state: {
+                query: (promptSearch.value || "").trim(),
+                selectedPromptId: selectedPrompt || "",
+                selectedPromptCode: getDefinitionLabelCode(getSelectedPromptDefinition()),
+                argumentValues: getPromptArgumentValues(),
+                outputOptions: getPromptOutputOptions(),
+                seriesVisibilitySettings: { ...seriesVisibilitySettings },
+                customPrompt: customPromptState ? { ...customPromptState } : null
+            }
+        };
+        const hasMeaningfulState = currentState.state.query ||
+            currentState.state.selectedPromptId ||
+            Object.values(currentState.state.argumentValues).some((value) => String(value || "").trim()) ||
+            currentState.state.customPrompt ||
+            currentState.state.outputOptions.hallucinationGuardLevel !== "none" ||
+            currentState.state.outputOptions.outputMarkdownEnabled ||
+            currentState.state.outputOptions.outputTone !== "unspecified" ||
+            currentState.state.outputOptions.selfReview !== "unspecified" ||
+            currentState.state.outputOptions.misleadingExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.considerationRiskReview !== "unspecified" ||
+            currentState.state.outputOptions.discomfortRiskReview !== "unspecified" ||
+            currentState.state.outputOptions.aggressiveExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.sensitiveExpressionReview !== "unspecified" ||
+            currentState.state.outputOptions.legalComplianceReview !== "unspecified" ||
+            currentState.state.outputOptions.publicOrderReview !== "unspecified" ||
+            JSON.stringify(currentState.state.seriesVisibilitySettings) !== JSON.stringify(defaultSeriesVisibilitySettings);
+        if (!hasMeaningfulState) {
+            return createSamplePageStateExportPayload();
+        }
+        return currentState;
+    }
+    function buildCustomPromptExportFilename() {
+        const now = new Date();
+        const yyyy = String(now.getFullYear());
+        const mm = String(now.getMonth() + 1).padStart(2, "0");
+        const dd = String(now.getDate()).padStart(2, "0");
+        const hh = String(now.getHours()).padStart(2, "0");
+        const mi = String(now.getMinutes()).padStart(2, "0");
+        const ss = String(now.getSeconds()).padStart(2, "0");
+        return `prompt-gen-export-${yyyy}${mm}${dd}-${hh}${mi}${ss}.json`;
+    }
+    function downloadTextFile(text, filename, contentType) {
+        const blob = new Blob([text], { type: contentType });
+        const objectUrl = URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = objectUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.setTimeout(() => {
+            URL.revokeObjectURL(objectUrl);
+        }, 0);
+    }
+    function normalizeImportedPageStatePayload(rawPayload) {
+        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0;
+        if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+            return null;
+        }
+        const payload = rawPayload;
+        if (Number(payload.version) !== CUSTOM_PROMPT_EXPORT_VERSION) {
+            return null;
+        }
+        if (typeof payload.exportedAt !== "string" || !payload.exportedAt.trim()) {
+            return null;
+        }
+        if (!payload.state || typeof payload.state !== "object" || Array.isArray(payload.state)) {
+            return null;
+        }
+        const state = payload.state;
+        return {
+            query: typeof state.query === "string" ? state.query.trim() : "",
+            selectedPromptId: typeof state.selectedPromptId === "string" ? state.selectedPromptId.trim() : "",
+            selectedPromptCode: typeof state.selectedPromptCode === "string" ? state.selectedPromptCode.trim() : "",
+            argumentValues: state.argumentValues && typeof state.argumentValues === "object" && !Array.isArray(state.argumentValues)
+                ? Object.fromEntries(Object.entries(state.argumentValues).map(([key, value]) => [key, typeof value === "string" ? value : ""]))
+                : {},
+            outputOptions: {
+                hallucinationGuardLevel: ((_a = state.outputOptions) === null || _a === void 0 ? void 0 : _a.hallucinationGuardLevel) === "low" || ((_b = state.outputOptions) === null || _b === void 0 ? void 0 : _b.hallucinationGuardLevel) === "high"
+                    ? state.outputOptions.hallucinationGuardLevel
+                    : "none",
+                outputMarkdownEnabled: ((_c = state.outputOptions) === null || _c === void 0 ? void 0 : _c.outputMarkdownEnabled) === true,
+                outputTone: ((_d = state.outputOptions) === null || _d === void 0 ? void 0 : _d.outputTone) === "desumasu" || ((_e = state.outputOptions) === null || _e === void 0 ? void 0 : _e.outputTone) === "dearu"
+                    ? state.outputOptions.outputTone
+                    : "unspecified",
+                selfReview: ((_f = state.outputOptions) === null || _f === void 0 ? void 0 : _f.selfReview) === "internal" || ((_g = state.outputOptions) === null || _g === void 0 ? void 0 : _g.selfReview) === "report"
+                    ? state.outputOptions.selfReview
+                    : "unspecified",
+                misleadingExpressionReview: ((_h = state.outputOptions) === null || _h === void 0 ? void 0 : _h.misleadingExpressionReview) === "internal" || ((_j = state.outputOptions) === null || _j === void 0 ? void 0 : _j.misleadingExpressionReview) === "report"
+                    ? state.outputOptions.misleadingExpressionReview
+                    : "unspecified",
+                considerationRiskReview: ((_k = state.outputOptions) === null || _k === void 0 ? void 0 : _k.considerationRiskReview) === "internal" || ((_l = state.outputOptions) === null || _l === void 0 ? void 0 : _l.considerationRiskReview) === "report"
+                    ? state.outputOptions.considerationRiskReview
+                    : "unspecified",
+                discomfortRiskReview: ((_m = state.outputOptions) === null || _m === void 0 ? void 0 : _m.discomfortRiskReview) === "internal" || ((_o = state.outputOptions) === null || _o === void 0 ? void 0 : _o.discomfortRiskReview) === "report"
+                    ? state.outputOptions.discomfortRiskReview
+                    : "unspecified",
+                aggressiveExpressionReview: ((_p = state.outputOptions) === null || _p === void 0 ? void 0 : _p.aggressiveExpressionReview) === "internal" || ((_q = state.outputOptions) === null || _q === void 0 ? void 0 : _q.aggressiveExpressionReview) === "report"
+                    ? state.outputOptions.aggressiveExpressionReview
+                    : "unspecified",
+                sensitiveExpressionReview: ((_r = state.outputOptions) === null || _r === void 0 ? void 0 : _r.sensitiveExpressionReview) === "internal" || ((_s = state.outputOptions) === null || _s === void 0 ? void 0 : _s.sensitiveExpressionReview) === "report"
+                    ? state.outputOptions.sensitiveExpressionReview
+                    : "unspecified",
+                legalComplianceReview: ((_t = state.outputOptions) === null || _t === void 0 ? void 0 : _t.legalComplianceReview) === "internal" || ((_u = state.outputOptions) === null || _u === void 0 ? void 0 : _u.legalComplianceReview) === "report"
+                    ? state.outputOptions.legalComplianceReview
+                    : "unspecified",
+                publicOrderReview: ((_v = state.outputOptions) === null || _v === void 0 ? void 0 : _v.publicOrderReview) === "internal" || ((_w = state.outputOptions) === null || _w === void 0 ? void 0 : _w.publicOrderReview) === "report"
+                    ? state.outputOptions.publicOrderReview
+                    : "unspecified"
+            },
+            seriesVisibilitySettings: {
+                showA: ((_x = state.seriesVisibilitySettings) === null || _x === void 0 ? void 0 : _x.showA) !== false,
+                showX: ((_y = state.seriesVisibilitySettings) === null || _y === void 0 ? void 0 : _y.showX) !== false,
+                showS: ((_z = state.seriesVisibilitySettings) === null || _z === void 0 ? void 0 : _z.showS) !== false,
+                showP: ((_0 = state.seriesVisibilitySettings) === null || _0 === void 0 ? void 0 : _0.showP) !== false
+            },
+            customPrompt: state.customPrompt &&
+                typeof state.customPrompt === "object" &&
+                typeof state.customPrompt.promptText === "string" &&
+                state.customPrompt.promptText.trim()
+                ? {
+                    id: typeof state.customPrompt.id === "string" && state.customPrompt.id.trim()
+                        ? state.customPrompt.id.trim()
+                        : "custom-imported-prompt",
+                    label: typeof state.customPrompt.label === "string" && state.customPrompt.label.trim()
+                        ? state.customPrompt.label.trim()
+                        : typeof state.customPrompt.promptName === "string" &&
+                            String(state.customPrompt.promptName || "").trim()
+                            ? String(state.customPrompt.promptName || "").trim()
+                            : "カスタムプロンプト",
+                    keywords: Array.isArray(state.customPrompt.keywords)
+                        ? state.customPrompt.keywords.map((keyword) => String(keyword || "").trim()).filter(Boolean)
+                        : [],
+                    promptText: state.customPrompt.promptText.trim()
+                }
+                : null
+        };
+    }
+    async function importCustomPromptFile(file) {
+        if (!file) {
+            return;
+        }
+        try {
+            const rawText = await file.text();
+            const parsed = JSON.parse(rawText);
+            const normalized = normalizeImportedPageStatePayload(parsed);
+            if (!normalized) {
+                if (typeof window.showToast === "function") {
+                    window.showToast("JSON の読み込みに失敗しました");
+                }
+                return;
+            }
+            customPromptState = normalized.customPrompt;
+            if (customPromptState) {
+                saveImportedCustomPrompt(customPromptState);
+            }
+            else {
+                clearImportedCustomPromptStorage();
+            }
+            seriesVisibilitySettings = { ...normalized.seriesVisibilitySettings };
+            saveSeriesVisibilitySettings(seriesVisibilitySettings);
+            rebuildVisiblePromptIndexes();
+            pendingInitialPromptId = normalized.selectedPromptId;
+            pendingInitialPromptCode = normalized.selectedPromptCode;
+            lastSearchQuery = "";
+            promptSearch.value = normalized.query;
+            selectedPrompt = "";
+            activeArgumentDefinitions = [];
+            renderCandidates();
+            setPromptArgumentValues(normalized.argumentValues);
+            applyDefaultArgumentValues(getSelectedPromptDefinition());
+            setPromptOutputOptions(normalized.outputOptions);
+            revealOutputSection();
+            updateOutput();
+            if (typeof window.showToast === "function") {
+                window.showToast("画面状態を JSON から取り込みました");
+            }
+        }
+        catch (_error) {
+            if (typeof window.showToast === "function") {
+                window.showToast("JSON の読み込みに失敗しました");
+            }
+        }
+        finally {
+            customPromptImportInput.value = "";
+        }
+    }
+    function exportCustomPrompt() {
+        const payload = createPageStateExportPayload();
+        downloadTextFile(`${JSON.stringify(payload, null, 2)}\n`, buildCustomPromptExportFilename(), "application/json;charset=utf-8");
+        if (typeof window.showToast === "function") {
+            window.showToast(payload.isSample
+                ? "データが空のためサンプルJSONを出力しました"
+                : "画面状態を JSON でエクスポートしました");
+        }
+    }
     function createSeriesVisibilityMenu() {
         const menuPanel = document.querySelector("lht-page-menu .md-menu-panel");
         if (!menuPanel) {
             return;
         }
+        const exportButton = document.createElement("a");
+        exportButton.id = "exportCustomPromptButton";
+        exportButton.className = "md-menu-link";
+        exportButton.href = "#";
+        exportButton.textContent = "Export";
+        exportButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            exportCustomPrompt();
+        });
+        menuPanel.appendChild(exportButton);
+        const importButton = document.createElement("a");
+        importButton.id = "importCustomPromptButton";
+        importButton.className = "md-menu-link";
+        importButton.href = "#";
+        importButton.textContent = "Import";
+        importButton.addEventListener("click", (event) => {
+            event.preventDefault();
+            customPromptImportInput.value = "";
+            customPromptImportInput.click();
+        });
+        menuPanel.appendChild(importButton);
         const separator = document.createElement("div");
         separator.className = "md-menu-separator";
         menuPanel.appendChild(separator);
@@ -995,6 +1342,8 @@ async function initializePromptPage() {
         resetButton.className = "md-menu-settings__reset";
         resetButton.innerHTML = '<svg viewBox="0 0 24 24" class="md-menu-settings__reset-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-trash" xlink:href="#md-icon-trash"></use></svg><span>設定を初期化</span>';
         resetButton.addEventListener("click", () => {
+            clearImportedCustomPromptStorage();
+            customPromptState = null;
             clearSeriesVisibilitySettings();
             seriesVisibilitySettings = { ...defaultSeriesVisibilitySettings };
             for (const option of seriesOptions) {
@@ -1021,16 +1370,22 @@ async function initializePromptPage() {
     publicOrderReview.addEventListener("change", updateOutput);
     hallucinationGuard.addEventListener("change", updateOutput);
     outputMarkdown.addEventListener("change", updateOutput);
+    customPromptImportInput.addEventListener("change", () => {
+        var _a;
+        void importCustomPromptFile(((_a = customPromptImportInput.files) === null || _a === void 0 ? void 0 : _a[0]) || null);
+    });
     copyShareLinkButton.addEventListener("click", () => {
         void copyText(buildShareLink());
     });
     let initialQuery = "";
     let initialPromptCode = "";
+    let initialPromptId = "";
     const initialArgumentValues = {};
     try {
         const url = new URL(window.location.href);
         initialQuery = (url.searchParams.get("q") || "").trim();
         initialPromptCode = (url.searchParams.get("id") || "").trim();
+        initialPromptId = (url.searchParams.get("promptId") || "").trim();
         initialArgumentValues.subject = url.searchParams.get("subject") || "";
         initialArgumentValues.commitId = url.searchParams.get("commit") || "";
         for (const [key, value] of url.searchParams.entries()) {
@@ -1048,6 +1403,9 @@ async function initializePromptPage() {
     applyPromptOutputOptionDefaults(null);
     createSeriesVisibilityMenu();
     renderArgumentFields(null);
+    if (initialPromptId) {
+        pendingInitialPromptId = initialPromptId;
+    }
     if (initialPromptCode) {
         pendingInitialPromptCode = initialPromptCode;
     }

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -38,6 +38,46 @@ type PromptOutputOptionDefaults = {
   publicOrderReview: "unspecified" | "internal" | "report";
 };
 
+type CustomPromptState = {
+  id: string;
+  label: string;
+  keywords: string[];
+  promptText: string;
+};
+
+type PromptPageStateExportPayload = {
+  version: number;
+  exportedAt: string;
+  isSample: boolean;
+  note?: string;
+  state: {
+    query: string;
+    selectedPromptId: string;
+    selectedPromptCode?: string;
+    argumentValues: Record<string, string>;
+    outputOptions: {
+      hallucinationGuardLevel: "none" | "low" | "high";
+      outputMarkdownEnabled: boolean;
+      outputTone: "unspecified" | "desumasu" | "dearu";
+      selfReview: "unspecified" | "internal" | "report";
+      misleadingExpressionReview: "unspecified" | "internal" | "report";
+      considerationRiskReview: "unspecified" | "internal" | "report";
+      discomfortRiskReview: "unspecified" | "internal" | "report";
+      aggressiveExpressionReview: "unspecified" | "internal" | "report";
+      sensitiveExpressionReview: "unspecified" | "internal" | "report";
+      legalComplianceReview: "unspecified" | "internal" | "report";
+      publicOrderReview: "unspecified" | "internal" | "report";
+    };
+    seriesVisibilitySettings: {
+      showA: boolean;
+      showX: boolean;
+      showS: boolean;
+      showP: boolean;
+    };
+    customPrompt: CustomPromptState | null;
+  };
+};
+
 type PromptSearchIndex = {
   definition: PromptDefinition;
   labelTokens: string[];
@@ -54,6 +94,8 @@ declare const popularPromptDefinitions: PromptDefinition[];
 
 async function initializePromptPage() {
   const SERIES_VISIBILITY_STORAGE_KEY = "promptGenSeriesVisibility";
+  const CUSTOM_PROMPT_STORAGE_KEY = "promptGenCustomPrompt";
+  const CUSTOM_PROMPT_EXPORT_VERSION = 1;
 
   type SeriesVisibilitySettings = {
     showA: boolean;
@@ -155,10 +197,11 @@ async function initializePromptPage() {
     (document.getElementById("hallucinationGuard") as HTMLSelectElement | null) ||
     (await waitForElementById<HTMLSelectElement>("hallucinationGuard"));
   const outputMarkdown = document.getElementById("outputMarkdown") as HTMLInputElement | null;
+  const customPromptImportInput = document.getElementById("customPromptImportInput") as HTMLInputElement | null;
   const copyShareLinkButton = document.getElementById("copyShareLinkButton") as HTMLButtonElement | null;
   const promptOutput = document.getElementById("promptOutput") as HTMLElement | null;
 
-  if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
+  if (!promptSearch || !outputTone || !selfReview || !misleadingExpressionReview || !considerationRiskReview || !discomfortRiskReview || !aggressiveExpressionReview || !sensitiveExpressionReview || !legalComplianceReview || !publicOrderReview || !hallucinationGuard || !outputMarkdown || !customPromptImportInput || !copyShareLinkButton || !promptOutput || !promptCandidateArea || !promptArgsSection || !promptArgsContainer || !promptOutputSection || !promptOutputTitle || !promptOutputHelp) {
     return;
   }
 
@@ -200,6 +243,54 @@ async function initializePromptPage() {
     storage.removeItem(SERIES_VISIBILITY_STORAGE_KEY);
   }
 
+  function loadImportedCustomPrompt() {
+    try {
+      const storage = window.localStorage;
+      if (!storage || typeof storage.getItem !== "function") {
+        return null;
+      }
+      const raw = storage.getItem(CUSTOM_PROMPT_STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      if (typeof parsed?.promptText !== "string" || !parsed.promptText.trim()) {
+        return null;
+      }
+      const normalizedKeywords = Array.isArray(parsed?.keywords)
+        ? parsed.keywords.map((keyword: unknown) => String(keyword || "").trim()).filter(Boolean)
+        : [];
+      return {
+        id: typeof parsed?.id === "string" && parsed.id.trim() ? parsed.id.trim() : "custom-imported-prompt",
+        label: typeof parsed?.label === "string" && parsed.label.trim()
+          ? parsed.label.trim()
+          : typeof parsed?.promptName === "string" && parsed.promptName.trim()
+            ? parsed.promptName.trim()
+            : "カスタムプロンプト",
+        keywords: normalizedKeywords,
+        promptText: parsed.promptText.trim()
+      } as CustomPromptState;
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  function saveImportedCustomPrompt(prompt: CustomPromptState) {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.setItem !== "function") {
+      return;
+    }
+    storage.setItem(CUSTOM_PROMPT_STORAGE_KEY, JSON.stringify(prompt));
+  }
+
+  function clearImportedCustomPromptStorage() {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.removeItem !== "function") {
+      return;
+    }
+    storage.removeItem(CUSTOM_PROMPT_STORAGE_KEY);
+  }
+
   let seriesVisibilitySettings = loadSeriesVisibilitySettings();
 
   function getLegacyPromptArguments(definition: PromptDefinition): PromptArgumentDefinition[] {
@@ -238,8 +329,22 @@ async function initializePromptPage() {
     };
   }
 
+  function createCustomPromptDefinition(prompt: CustomPromptState | null): PromptDefinition | null {
+    if (!prompt || !prompt.promptText.trim()) {
+      return null;
+    }
+    return normalizePromptDefinition({
+      id: prompt.id,
+      label: prompt.label,
+      keywords: prompt.keywords,
+      buildBody: () => prompt.promptText
+    });
+  }
+
   function getVisiblePromptDefinitions() {
+    const customPromptDefinition = createCustomPromptDefinition(customPromptState);
     return [
+      ...(customPromptDefinition ? [customPromptDefinition] : []),
       ...(seriesVisibilitySettings.showA ? basePromptDefinitions : []),
       ...(seriesVisibilitySettings.showX ? expansionDefinitions : []),
       ...(seriesVisibilitySettings.showS ? suggestDefinitions : []),
@@ -405,7 +510,9 @@ async function initializePromptPage() {
   let selectedPrompt = "";
   let lastSearchQuery = "";
   let pendingInitialPromptCode = "";
+  let pendingInitialPromptId = "";
   let suppressSearchResetOnce = false;
+  let customPromptState: CustomPromptState | null = loadImportedCustomPrompt();
   const promptOutputOptionDefaultsById = new Map<string, PromptOutputOptionDefaults>();
 
   const kanaToRomajiMap = new Map<string, string>([
@@ -1002,7 +1109,13 @@ async function initializePromptPage() {
       prioritizedSingleDefinition
     } = searchPromptDefinitions(query, promptSearchIndexes, promptSearchIndexById);
 
-    if (pendingInitialPromptCode) {
+    if (pendingInitialPromptId) {
+      const pendingDefinition = matchedDefinitions.find((definition) => definition.id === pendingInitialPromptId);
+      if (pendingDefinition) {
+        selectedPrompt = pendingDefinition.id;
+      }
+      pendingInitialPromptId = "";
+    } else if (pendingInitialPromptCode) {
       const pendingDefinition = matchedDefinitions.find((definition) =>
         getDefinitionLabelCode(definition) === pendingInitialPromptCode
       );
@@ -1110,7 +1223,12 @@ async function initializePromptPage() {
       legalComplianceReview: "unspecified",
       publicOrderReview: "unspecified"
     });
-    const rawBody = selectedDefinition ? selectedDefinition.buildBody(commitId, subject) : "";
+    const rawBody =
+      customPromptState && selectedDefinition.id === customPromptState.id
+        ? customPromptState.promptText
+        : selectedDefinition
+          ? selectedDefinition.buildBody(commitId, subject)
+          : "";
     setPromptOutputOptions(currentOptions);
     const instructionProfile = inferPromptOutputInstructionProfile(rawBody);
     const body = appendPromptOutputInstructions(
@@ -1149,6 +1267,9 @@ async function initializePromptPage() {
     if (query) {
       url.searchParams.set("q", query);
     }
+    if (selectedDefinition?.id) {
+      url.searchParams.set("promptId", selectedDefinition.id);
+    }
     if (selectedDefinitionCode) {
       url.searchParams.set("id", selectedDefinitionCode);
     }
@@ -1169,11 +1290,320 @@ async function initializePromptPage() {
     promptOutput.textContent = text;
   }
 
+  function createSamplePageStateExportPayload(): PromptPageStateExportPayload {
+    return {
+      version: CUSTOM_PROMPT_EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      isSample: true,
+      note: "0件だったためサンプルを出力",
+      state: {
+        query: "",
+        selectedPromptId: "custom-sample-prompt",
+        selectedPromptCode: "",
+        argumentValues: {},
+        outputOptions: {
+          hallucinationGuardLevel: "none",
+          outputMarkdownEnabled: false,
+          outputTone: "unspecified",
+          selfReview: "unspecified",
+          misleadingExpressionReview: "unspecified",
+          considerationRiskReview: "unspecified",
+          discomfortRiskReview: "unspecified",
+          aggressiveExpressionReview: "unspecified",
+          sensitiveExpressionReview: "unspecified",
+          legalComplianceReview: "unspecified",
+          publicOrderReview: "unspecified"
+        },
+        seriesVisibilitySettings: { ...defaultSeriesVisibilitySettings },
+        customPrompt: {
+          id: "custom-sample-prompt",
+          label: "サンプル",
+          keywords: ["sample", "summary", "要約"],
+          promptText: "以下の文章を、要点がひと目で分かるように3点で要約してください。専門用語はできるだけ平易な表現に言い換えてください。"
+        }
+      }
+    };
+  }
+
+  function setPromptOutputOptions(options: {
+    hallucinationGuardLevel: "none" | "low" | "high";
+    outputMarkdownEnabled: boolean;
+    outputTone: "unspecified" | "desumasu" | "dearu";
+    selfReview: "unspecified" | "internal" | "report";
+    misleadingExpressionReview: "unspecified" | "internal" | "report";
+    considerationRiskReview: "unspecified" | "internal" | "report";
+    discomfortRiskReview: "unspecified" | "internal" | "report";
+    aggressiveExpressionReview: "unspecified" | "internal" | "report";
+    sensitiveExpressionReview: "unspecified" | "internal" | "report";
+    legalComplianceReview: "unspecified" | "internal" | "report";
+    publicOrderReview: "unspecified" | "internal" | "report";
+  }) {
+    hallucinationGuard.value = options.hallucinationGuardLevel;
+    outputMarkdown.checked = options.outputMarkdownEnabled;
+    outputTone.value = options.outputTone;
+    selfReview.value = options.selfReview;
+    misleadingExpressionReview.value = options.misleadingExpressionReview;
+    considerationRiskReview.value = options.considerationRiskReview;
+    discomfortRiskReview.value = options.discomfortRiskReview;
+    aggressiveExpressionReview.value = options.aggressiveExpressionReview;
+    sensitiveExpressionReview.value = options.sensitiveExpressionReview;
+    legalComplianceReview.value = options.legalComplianceReview;
+    publicOrderReview.value = options.publicOrderReview;
+  }
+
+  function createPageStateExportPayload(): PromptPageStateExportPayload {
+    const currentState: PromptPageStateExportPayload = {
+      version: CUSTOM_PROMPT_EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      isSample: false,
+      state: {
+        query: (promptSearch.value || "").trim(),
+        selectedPromptId: selectedPrompt || "",
+        selectedPromptCode: getDefinitionLabelCode(getSelectedPromptDefinition()),
+        argumentValues: getPromptArgumentValues(),
+        outputOptions: getPromptOutputOptions(),
+        seriesVisibilitySettings: { ...seriesVisibilitySettings },
+        customPrompt: customPromptState ? { ...customPromptState } : null
+      }
+    };
+
+    const hasMeaningfulState =
+      currentState.state.query ||
+      currentState.state.selectedPromptId ||
+      Object.values(currentState.state.argumentValues).some((value) => String(value || "").trim()) ||
+      currentState.state.customPrompt ||
+      currentState.state.outputOptions.hallucinationGuardLevel !== "none" ||
+      currentState.state.outputOptions.outputMarkdownEnabled ||
+      currentState.state.outputOptions.outputTone !== "unspecified" ||
+      currentState.state.outputOptions.selfReview !== "unspecified" ||
+      currentState.state.outputOptions.misleadingExpressionReview !== "unspecified" ||
+      currentState.state.outputOptions.considerationRiskReview !== "unspecified" ||
+      currentState.state.outputOptions.discomfortRiskReview !== "unspecified" ||
+      currentState.state.outputOptions.aggressiveExpressionReview !== "unspecified" ||
+      currentState.state.outputOptions.sensitiveExpressionReview !== "unspecified" ||
+      currentState.state.outputOptions.legalComplianceReview !== "unspecified" ||
+      currentState.state.outputOptions.publicOrderReview !== "unspecified" ||
+      JSON.stringify(currentState.state.seriesVisibilitySettings) !== JSON.stringify(defaultSeriesVisibilitySettings);
+
+    if (!hasMeaningfulState) {
+      return createSamplePageStateExportPayload();
+    }
+    return currentState;
+  }
+
+  function buildCustomPromptExportFilename() {
+    const now = new Date();
+    const yyyy = String(now.getFullYear());
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    const hh = String(now.getHours()).padStart(2, "0");
+    const mi = String(now.getMinutes()).padStart(2, "0");
+    const ss = String(now.getSeconds()).padStart(2, "0");
+    return `prompt-gen-export-${yyyy}${mm}${dd}-${hh}${mi}${ss}.json`;
+  }
+
+  function downloadTextFile(text: string, filename: string, contentType: string) {
+    const blob = new Blob([text], { type: contentType });
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = objectUrl;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.setTimeout(() => {
+      URL.revokeObjectURL(objectUrl);
+    }, 0);
+  }
+
+  function normalizeImportedPageStatePayload(rawPayload: unknown) {
+    if (!rawPayload || typeof rawPayload !== "object" || Array.isArray(rawPayload)) {
+      return null;
+    }
+    const payload = rawPayload as Partial<PromptPageStateExportPayload> & {
+      version?: unknown;
+      exportedAt?: unknown;
+    };
+    if (Number(payload.version) !== CUSTOM_PROMPT_EXPORT_VERSION) {
+      return null;
+    }
+    if (typeof payload.exportedAt !== "string" || !payload.exportedAt.trim()) {
+      return null;
+    }
+    if (!payload.state || typeof payload.state !== "object" || Array.isArray(payload.state)) {
+      return null;
+    }
+
+    const state = payload.state as PromptPageStateExportPayload["state"];
+
+    return {
+      query: typeof state.query === "string" ? state.query.trim() : "",
+      selectedPromptId: typeof state.selectedPromptId === "string" ? state.selectedPromptId.trim() : "",
+      selectedPromptCode: typeof state.selectedPromptCode === "string" ? state.selectedPromptCode.trim() : "",
+      argumentValues: state.argumentValues && typeof state.argumentValues === "object" && !Array.isArray(state.argumentValues)
+        ? Object.fromEntries(
+            Object.entries(state.argumentValues).map(([key, value]) => [key, typeof value === "string" ? value : ""])
+          )
+        : {},
+      outputOptions: {
+        hallucinationGuardLevel: state.outputOptions?.hallucinationGuardLevel === "low" || state.outputOptions?.hallucinationGuardLevel === "high"
+          ? state.outputOptions.hallucinationGuardLevel
+          : "none",
+        outputMarkdownEnabled: state.outputOptions?.outputMarkdownEnabled === true,
+        outputTone: state.outputOptions?.outputTone === "desumasu" || state.outputOptions?.outputTone === "dearu"
+          ? state.outputOptions.outputTone
+          : "unspecified",
+        selfReview: state.outputOptions?.selfReview === "internal" || state.outputOptions?.selfReview === "report"
+          ? state.outputOptions.selfReview
+          : "unspecified",
+        misleadingExpressionReview: state.outputOptions?.misleadingExpressionReview === "internal" || state.outputOptions?.misleadingExpressionReview === "report"
+          ? state.outputOptions.misleadingExpressionReview
+          : "unspecified",
+        considerationRiskReview: state.outputOptions?.considerationRiskReview === "internal" || state.outputOptions?.considerationRiskReview === "report"
+          ? state.outputOptions.considerationRiskReview
+          : "unspecified",
+        discomfortRiskReview: state.outputOptions?.discomfortRiskReview === "internal" || state.outputOptions?.discomfortRiskReview === "report"
+          ? state.outputOptions.discomfortRiskReview
+          : "unspecified",
+        aggressiveExpressionReview: state.outputOptions?.aggressiveExpressionReview === "internal" || state.outputOptions?.aggressiveExpressionReview === "report"
+          ? state.outputOptions.aggressiveExpressionReview
+          : "unspecified",
+        sensitiveExpressionReview: state.outputOptions?.sensitiveExpressionReview === "internal" || state.outputOptions?.sensitiveExpressionReview === "report"
+          ? state.outputOptions.sensitiveExpressionReview
+          : "unspecified",
+        legalComplianceReview: state.outputOptions?.legalComplianceReview === "internal" || state.outputOptions?.legalComplianceReview === "report"
+          ? state.outputOptions.legalComplianceReview
+          : "unspecified",
+        publicOrderReview: state.outputOptions?.publicOrderReview === "internal" || state.outputOptions?.publicOrderReview === "report"
+          ? state.outputOptions.publicOrderReview
+          : "unspecified"
+      },
+      seriesVisibilitySettings: {
+        showA: state.seriesVisibilitySettings?.showA !== false,
+        showX: state.seriesVisibilitySettings?.showX !== false,
+        showS: state.seriesVisibilitySettings?.showS !== false,
+        showP: state.seriesVisibilitySettings?.showP !== false
+      },
+      customPrompt:
+        state.customPrompt &&
+        typeof state.customPrompt === "object" &&
+        typeof state.customPrompt.promptText === "string" &&
+        state.customPrompt.promptText.trim()
+          ? {
+              id: typeof state.customPrompt.id === "string" && state.customPrompt.id.trim()
+                ? state.customPrompt.id.trim()
+                : "custom-imported-prompt",
+              label: typeof state.customPrompt.label === "string" && state.customPrompt.label.trim()
+                ? state.customPrompt.label.trim()
+                : typeof (state.customPrompt as { promptName?: string }).promptName === "string" &&
+                    String((state.customPrompt as { promptName?: string }).promptName || "").trim()
+                  ? String((state.customPrompt as { promptName?: string }).promptName || "").trim()
+                  : "カスタムプロンプト",
+              keywords: Array.isArray(state.customPrompt.keywords)
+                ? state.customPrompt.keywords.map((keyword) => String(keyword || "").trim()).filter(Boolean)
+                : [],
+              promptText: state.customPrompt.promptText.trim()
+            }
+          : null
+    };
+  }
+
+  async function importCustomPromptFile(file: File | null) {
+    if (!file) {
+      return;
+    }
+
+    try {
+      const rawText = await file.text();
+      const parsed = JSON.parse(rawText);
+      const normalized = normalizeImportedPageStatePayload(parsed);
+      if (!normalized) {
+        if (typeof window.showToast === "function") {
+          window.showToast("JSON の読み込みに失敗しました");
+        }
+        return;
+      }
+
+      customPromptState = normalized.customPrompt;
+      if (customPromptState) {
+        saveImportedCustomPrompt(customPromptState);
+      } else {
+        clearImportedCustomPromptStorage();
+      }
+
+      seriesVisibilitySettings = { ...normalized.seriesVisibilitySettings };
+      saveSeriesVisibilitySettings(seriesVisibilitySettings);
+      rebuildVisiblePromptIndexes();
+
+      pendingInitialPromptId = normalized.selectedPromptId;
+      pendingInitialPromptCode = normalized.selectedPromptCode;
+      lastSearchQuery = "";
+      promptSearch.value = normalized.query;
+      selectedPrompt = "";
+      activeArgumentDefinitions = [];
+      renderCandidates();
+      setPromptArgumentValues(normalized.argumentValues);
+      applyDefaultArgumentValues(getSelectedPromptDefinition());
+      setPromptOutputOptions(normalized.outputOptions);
+
+      revealOutputSection();
+      updateOutput();
+      if (typeof window.showToast === "function") {
+        window.showToast("画面状態を JSON から取り込みました");
+      }
+    } catch (_error) {
+      if (typeof window.showToast === "function") {
+        window.showToast("JSON の読み込みに失敗しました");
+      }
+    } finally {
+      customPromptImportInput.value = "";
+    }
+  }
+
+  function exportCustomPrompt() {
+    const payload = createPageStateExportPayload();
+    downloadTextFile(
+      `${JSON.stringify(payload, null, 2)}\n`,
+      buildCustomPromptExportFilename(),
+      "application/json;charset=utf-8"
+    );
+    if (typeof window.showToast === "function") {
+      window.showToast(
+        payload.isSample
+          ? "データが空のためサンプルJSONを出力しました"
+          : "画面状態を JSON でエクスポートしました"
+      );
+    }
+  }
+
   function createSeriesVisibilityMenu() {
     const menuPanel = document.querySelector("lht-page-menu .md-menu-panel") as HTMLDivElement | null;
     if (!menuPanel) {
       return;
     }
+
+    const exportButton = document.createElement("a");
+    exportButton.id = "exportCustomPromptButton";
+    exportButton.className = "md-menu-link";
+    exportButton.href = "#";
+    exportButton.textContent = "Export";
+    exportButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      exportCustomPrompt();
+    });
+    menuPanel.appendChild(exportButton);
+
+    const importButton = document.createElement("a");
+    importButton.id = "importCustomPromptButton";
+    importButton.className = "md-menu-link";
+    importButton.href = "#";
+    importButton.textContent = "Import";
+    importButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      customPromptImportInput.value = "";
+      customPromptImportInput.click();
+    });
+    menuPanel.appendChild(importButton);
 
     const separator = document.createElement("div");
     separator.className = "md-menu-separator";
@@ -1228,6 +1658,8 @@ async function initializePromptPage() {
     resetButton.className = "md-menu-settings__reset";
     resetButton.innerHTML = '<svg viewBox="0 0 24 24" class="md-menu-settings__reset-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><use href="#md-icon-trash" xlink:href="#md-icon-trash"></use></svg><span>設定を初期化</span>';
     resetButton.addEventListener("click", () => {
+      clearImportedCustomPromptStorage();
+      customPromptState = null;
       clearSeriesVisibilitySettings();
       seriesVisibilitySettings = { ...defaultSeriesVisibilitySettings };
       for (const option of seriesOptions) {
@@ -1256,17 +1688,22 @@ async function initializePromptPage() {
   publicOrderReview.addEventListener("change", updateOutput);
   hallucinationGuard.addEventListener("change", updateOutput);
   outputMarkdown.addEventListener("change", updateOutput);
+  customPromptImportInput.addEventListener("change", () => {
+    void importCustomPromptFile(customPromptImportInput.files?.[0] || null);
+  });
   copyShareLinkButton.addEventListener("click", () => {
     void copyText(buildShareLink());
   });
 
   let initialQuery = "";
   let initialPromptCode = "";
+  let initialPromptId = "";
   const initialArgumentValues: Record<string, string> = {};
   try {
     const url = new URL(window.location.href);
     initialQuery = (url.searchParams.get("q") || "").trim();
     initialPromptCode = (url.searchParams.get("id") || "").trim();
+    initialPromptId = (url.searchParams.get("promptId") || "").trim();
     initialArgumentValues.subject = url.searchParams.get("subject") || "";
     initialArgumentValues.commitId = url.searchParams.get("commit") || "";
     for (const [key, value] of url.searchParams.entries()) {
@@ -1284,6 +1721,9 @@ async function initializePromptPage() {
   applyPromptOutputOptionDefaults(null);
   createSeriesVisibilityMenu();
   renderArgumentFields(null);
+  if (initialPromptId) {
+    pendingInitialPromptId = initialPromptId;
+  }
   if (initialPromptCode) {
     pendingInitialPromptCode = initialPromptCode;
   }

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -188,6 +188,7 @@ function mountPromptDom() {
       <option value="report">レビュー結果出力</option>
     </select>
     <input id="outputMarkdown" type="checkbox" />
+    <input id="customPromptImportInput" type="file" />
     <button id="copyShareLinkButton" type="button"></button>
     <a id="gitPseudoSquashLink" class="md-hidden" href="../git/git-work-list.html"></a>
     <div id="promptOutput"></div>
@@ -195,7 +196,8 @@ function mountPromptDom() {
 }
 
 function ensureLocalStorageMock() {
-  const backingStore = new Map();
+  const backingStore = globalThis.__promptGenLocalStorageStore || new Map();
+  globalThis.__promptGenLocalStorageStore = backingStore;
   Object.defineProperty(window, "localStorage", {
     configurable: true,
     value: {
@@ -215,6 +217,15 @@ function ensureLocalStorageMock() {
   });
 }
 
+function ensureUrlObjectMock() {
+  if (typeof URL.createObjectURL !== "function") {
+    URL.createObjectURL = () => "blob:mock";
+  }
+  if (typeof URL.revokeObjectURL !== "function") {
+    URL.revokeObjectURL = () => {};
+  }
+}
+
 function setRawInputValue(element, value) {
   Object.defineProperty(element, "value", {
     configurable: true,
@@ -231,7 +242,7 @@ async function bootPromptPage(urlSearch = "") {
   defineElementIfNeeded("lht-switch-help");
   defineElementIfNeeded("lht-help-tooltip");
   ensureLocalStorageMock();
-  window.localStorage.clear();
+  ensureUrlObjectMock();
   window.history.replaceState({}, "", urlSearch ? `/${urlSearch.startsWith("?") ? urlSearch : `?${urlSearch}`}` : "/");
   mountPromptDom();
   const promptOutputSection = document.getElementById("promptOutputSection");
@@ -255,7 +266,51 @@ function ensureClipboardMock() {
   return () => copiedText;
 }
 
+function ensureExportMock() {
+  let exportedText = "";
+  let exportedFilename = "";
+  const originalBlob = globalThis.Blob;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalClick = HTMLAnchorElement.prototype.click;
+
+  globalThis.Blob = class MockBlob {
+    constructor(parts) {
+      exportedText = (parts || []).map((part) => String(part)).join("");
+    }
+  };
+  URL.createObjectURL = (blob) => {
+    return "blob:mock-export";
+  };
+  URL.revokeObjectURL = () => {};
+  HTMLAnchorElement.prototype.click = function click() {
+    exportedFilename = this.download || "";
+  };
+
+  return async () => {
+    globalThis.Blob = originalBlob;
+    if (originalCreateObjectURL) {
+      URL.createObjectURL = originalCreateObjectURL;
+    } else {
+      delete URL.createObjectURL;
+    }
+    if (originalRevokeObjectURL) {
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    } else {
+      delete URL.revokeObjectURL;
+    }
+    HTMLAnchorElement.prototype.click = originalClick;
+    return { exportedText, exportedFilename };
+  };
+}
+
 describe("prompt-gen main", () => {
+  beforeEach(() => {
+    if (globalThis.__promptGenLocalStorageStore instanceof Map) {
+      globalThis.__promptGenLocalStorageStore.clear();
+    }
+  });
+
   it("applies strong class to label matches", async () => {
     await bootPromptPage();
 
@@ -311,7 +366,454 @@ describe("prompt-gen main", () => {
     copyShareLinkButton.click();
     await Promise.resolve();
 
-    expect(getCopiedText()).toBe("http://localhost:3000/?q=%E5%92%8C&id=A852&subject=a+small+fox");
+    expect(getCopiedText()).toBe("http://localhost:3000/?q=%E5%92%8C&promptId=a-washi-collage-whisper-request&id=A852&subject=a+small+fox");
+  });
+
+  it("imports a custom prompt file and shows it in the output", async () => {
+    window.localStorage.clear();
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const promptOutput = document.getElementById("promptOutput");
+    const promptOutputTitle = document.getElementById("promptOutputTitle");
+    const file = {
+      name: "weekly-prompt.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "custom",
+            selectedPromptId: "custom-weekly",
+            selectedPromptCode: "A501",
+            argumentValues: { commitId: "abc1234" },
+            outputOptions: {
+              hallucinationGuardLevel: "high",
+              outputMarkdownEnabled: true,
+              outputTone: "unspecified",
+              selfReview: "unspecified",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: true,
+              showS: true,
+              showP: true
+            },
+            customPrompt: {
+              id: "custom-weekly",
+              label: "週次カスタム",
+              keywords: ["週次", "報告", "custom"],
+              promptText: "custom prompt body"
+            }
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(promptOutput.textContent).toContain("custom prompt body");
+    expect(promptOutputTitle.textContent).toBe("週次カスタム");
+  });
+
+  it("keeps imported custom prompt after reload until settings reset", async () => {
+    window.localStorage.clear();
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const promptOutput = document.getElementById("promptOutput");
+    const file = {
+      name: "weekly-prompt.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "custom",
+            selectedPromptId: "custom-weekly",
+            selectedPromptCode: "A501",
+            argumentValues: { commitId: "abc1234" },
+            outputOptions: {
+              hallucinationGuardLevel: "high",
+              outputMarkdownEnabled: true,
+              outputTone: "unspecified",
+              selfReview: "unspecified",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: true,
+              showS: true,
+              showP: true
+            },
+            customPrompt: {
+              id: "custom-weekly",
+              label: "週次カスタム",
+              keywords: ["週次", "報告", "custom"],
+              promptText: "custom prompt body"
+            }
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(promptOutput.textContent).toContain("custom prompt body");
+
+    await bootPromptPage("?q=A501&commit=abc1234");
+    document.getElementById("promptSearch").value = "custom";
+    document.getElementById("promptSearch").dispatchEvent(new Event("input"));
+    const labels = [...document.querySelectorAll(".md-chip-button .md-chip-label")].map((node) => node.textContent);
+    expect(labels.some((label) => label.includes("週次カスタム"))).toBe(true);
+  });
+
+  it("clears imported custom prompt when settings are reset", async () => {
+    window.localStorage.clear();
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const file = {
+      name: "weekly-prompt.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "custom",
+            selectedPromptId: "custom-weekly",
+            selectedPromptCode: "A501",
+            argumentValues: { commitId: "abc1234" },
+            outputOptions: {
+              hallucinationGuardLevel: "high",
+              outputMarkdownEnabled: true,
+              outputTone: "unspecified",
+              selfReview: "unspecified",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: true,
+              showS: true,
+              showP: true
+            },
+            customPrompt: {
+              id: "custom-weekly",
+              label: "週次カスタム",
+              keywords: ["週次", "報告", "custom"],
+              promptText: "custom prompt body"
+            }
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const resetButton = document.querySelector(".md-menu-settings__reset");
+    resetButton.click();
+
+    expect(document.getElementById("promptOutput").textContent).toBe("");
+    expect(window.localStorage.getItem("promptGenCustomPrompt")).toBe(null);
+  });
+
+  it("exports the current page state as json", async () => {
+    const getExportResult = ensureExportMock();
+    window.localStorage.clear();
+    await bootPromptPage("?q=A501&commit=abc1234");
+
+    document.getElementById("outputTone").value = "dearu";
+    document.getElementById("outputTone").dispatchEvent(new Event("change"));
+
+    const exportButton = document.getElementById("exportCustomPromptButton");
+    exportButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    const { exportedText, exportedFilename } = await getExportResult();
+    const parsed = JSON.parse(exportedText);
+
+    expect(exportedFilename).toMatch(/^prompt-gen-export-\d{8}-\d{6}\.json$/);
+    expect(parsed.version).toBe(1);
+    expect(parsed.exportedAt).toBeTypeOf("string");
+    expect(parsed.isSample).toBe(false);
+    expect(parsed.state.query).toBe("A501");
+    expect(parsed.state.selectedPromptCode).toBe("A501");
+    expect(parsed.state.argumentValues.commitId).toBe("abc1234");
+    expect(parsed.state.outputOptions.outputTone).toBe("dearu");
+    expect(parsed.state.customPrompt).toBe(null);
+  });
+
+  it("exports a sample json when there is no prompt to export", async () => {
+    const getExportResult = ensureExportMock();
+    window.localStorage.clear();
+    await bootPromptPage();
+
+    const exportButton = document.getElementById("exportCustomPromptButton");
+    exportButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    const { exportedText, exportedFilename } = await getExportResult();
+    const parsed = JSON.parse(exportedText);
+
+    expect(exportedFilename).toMatch(/^prompt-gen-export-\d{8}-\d{6}\.json$/);
+    expect(parsed.version).toBe(1);
+    expect(parsed.isSample).toBe(true);
+    expect(parsed.note).toBe("0件だったためサンプルを出力");
+    expect(parsed.state.customPrompt.id).toBe("custom-sample-prompt");
+    expect(parsed.state.customPrompt.label).toBe("サンプル");
+    expect(parsed.state.customPrompt.keywords).toContain("要約");
+    expect(parsed.state.customPrompt.promptText).toContain("3点で要約");
+  });
+
+  it("imports the current page state from json", async () => {
+    window.localStorage.clear();
+    await bootPromptPage();
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const file = {
+      name: "prompt-gen-state.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "A852",
+            selectedPromptCode: "A852",
+            argumentValues: { subject: "a small fox" },
+            outputOptions: {
+              hallucinationGuardLevel: "low",
+              outputMarkdownEnabled: false,
+              outputTone: "dearu",
+              selfReview: "report",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: false,
+              showS: true,
+              showP: false
+            },
+            customPrompt: null
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.getElementById("promptSearch").value).toBe("A852");
+    expect(document.getElementById("subjectInput").value).toBe("a small fox");
+    expect(document.getElementById("outputTone").value).toBe("dearu");
+    expect(document.getElementById("selfReview").value).toBe("report");
+    expect(document.getElementById("hallucinationGuard").value).toBe("low");
+    expect(document.getElementById("outputMarkdown").checked).toBe(false);
+    expect(document.getElementById("promptOutput").textContent).toContain("a small fox");
+    expect(JSON.parse(window.localStorage.getItem("promptGenSeriesVisibility"))).toMatchObject({
+      showA: true,
+      showX: false,
+      showS: true,
+      showP: false
+    });
+  });
+
+  it("includes imported custom prompt in search results via keywords", async () => {
+    window.localStorage.clear();
+    await bootPromptPage();
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const promptSearch = document.getElementById("promptSearch");
+    const file = {
+      name: "prompt-gen-state.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "",
+            selectedPromptId: "",
+            argumentValues: {},
+            outputOptions: {
+              hallucinationGuardLevel: "none",
+              outputMarkdownEnabled: false,
+              outputTone: "unspecified",
+              selfReview: "unspecified",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: true,
+              showS: true,
+              showP: true
+            },
+            customPrompt: {
+              id: "custom-summary",
+              label: "会議要約テンプレート",
+              keywords: ["会議", "要約", "summary"],
+              promptText: "meeting summary prompt"
+            }
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    promptSearch.value = "要約";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    const labels = [...document.querySelectorAll(".md-chip-button .md-chip-label")].map((node) => node.textContent);
+    expect(labels.some((label) => label.includes("会議要約テンプレート"))).toBe(true);
+  });
+
+  it("applies output options to imported custom prompt", async () => {
+    window.localStorage.clear();
+    await bootPromptPage();
+
+    const importInput = document.getElementById("customPromptImportInput");
+    const outputTone = document.getElementById("outputTone");
+    const hallucinationGuard = document.getElementById("hallucinationGuard");
+    const outputMarkdown = document.getElementById("outputMarkdown");
+    const promptOutput = document.getElementById("promptOutput");
+    const file = {
+      name: "prompt-gen-state.json",
+      async text() {
+        return JSON.stringify({
+          version: 1,
+          exportedAt: "2026-03-16T00:00:00.000Z",
+          isSample: false,
+          state: {
+            query: "summary",
+            selectedPromptId: "custom-summary",
+            argumentValues: {},
+            outputOptions: {
+              hallucinationGuardLevel: "none",
+              outputMarkdownEnabled: false,
+              outputTone: "unspecified",
+              selfReview: "unspecified",
+              misleadingExpressionReview: "unspecified",
+              considerationRiskReview: "unspecified",
+              discomfortRiskReview: "unspecified",
+              aggressiveExpressionReview: "unspecified",
+              sensitiveExpressionReview: "unspecified",
+              legalComplianceReview: "unspecified",
+              publicOrderReview: "unspecified"
+            },
+            seriesVisibilitySettings: {
+              showA: true,
+              showX: true,
+              showS: true,
+              showP: true
+            },
+            customPrompt: {
+              id: "custom-summary",
+              label: "会議要約テンプレート",
+              keywords: ["会議", "要約", "summary"],
+              promptText: "meeting summary prompt"
+            }
+          }
+        });
+      }
+    };
+
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      get() {
+        return [file];
+      }
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    outputTone.value = "dearu";
+    outputTone.dispatchEvent(new Event("change"));
+    hallucinationGuard.value = "low";
+    hallucinationGuard.dispatchEvent(new Event("change"));
+    outputMarkdown.checked = true;
+    outputMarkdown.dispatchEvent(new Event("change"));
+
+    expect(promptOutput.textContent).toContain("meeting summary prompt");
+    expect(promptOutput.textContent).toContain("○文体は、である調で統一してください。");
+    expect(promptOutput.textContent).toContain("○事実誤認を避けるため");
+    expect(promptOutput.textContent).toContain("○最終的な回答は Markdown テキスト形式で出力し、さらに ~~~~ で囲まれた一塊として出力してください。");
   });
 
   it("applies q query parameter to the search field on load", async () => {


### PR DESCRIPTION
## 概要

`docs/prompt/prompt-gen` に対して、画面全体状態を JSON で Import / Export できる機能を追加しました。あわせて、Import したカスタムプロンプトを `id` / `label` / `keywords` / `promptText` を持つ検索対象として扱えるようにし、既存プロンプトと同様に候補検索へ統合しました。

## 変更内容

- `prompt-gen` に JSON Import 用の file input を追加
- 3本メニューに `Export` / `Import` を追加
- 画面状態の Export / Import を実装
- 0件時はサンプル JSON を出力する処理を追加
- Import したカスタムプロンプトを検索対象定義として内部化
- 共有リンクに `promptId` を含めて選択状態の復元精度を向上
- カスタムプロンプトにも文体・幻覚防止・Markdown 出力などの出力オプションを後付け適用
- 系列表示設定の初期化時にカスタムプロンプト状態もリセット
- `docs/index.html` の更新日を `2026-03-16` に更新
- `prompt-gen` のテストを大幅に追加し、Import / Export、検索反映、状態復元、出力オプション適用を検証

## 変更ファイル

- `docs/prompt/prompt-gen-src.html`
- `docs/prompt/prompt-gen.html`
- `docs/prompt/src/prompt-gen/ts/main.ts`
- `docs/prompt/src/prompt-gen/js/main.js`
- `docs/prompt/tests/prompt-gen-main.test.js`
- `docs/index.html`

## テスト

- `npx vitest run docs/prompt/tests/prompt-gen-main.test.js`

## 補足

- 0件時の Export は空データではなく、Import 形式の参考になるサンプル JSON を出力します
- カスタムプロンプトは検索候補に表示され、`keywords` による検索が可能です