### PR TITLE
feat(project): mikuproject の MS Project XML round-trip 対応を拡張し、build:a…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ filelist.txt
 
 # AGENTS
 .claude
+
+# Local project data
+docs/project/local-data/

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,28 @@
 
 # DONE
 
+- [引継][mikuproject] 今回の `mikuproject` 作業の主対象は `MS Project XML` の STEP 1 拡張
+- [引継][mikuproject] 直近で round-trip 対象へ追加・整理したもの:
+- `Project`: `OutlineCodes / WBSMasks / ExtendedAttributes` と各種 metadata 項目
+- `Task`: `ExtendedAttribute / Baseline / TimephasedData` と各種実務項目
+- `Resource`: `ExtendedAttribute / Baseline / TimephasedData` と各種実務項目
+- `Assignment`: `ExtendedAttribute / Baseline / TimephasedData` と各種実務項目
+- `Calendar`: `BaseCalendarUID / WeekDays / WorkingTimes / Exceptions / WorkWeeks / IsBaselineCalendar`
+- [引継][mikuproject] プレビュー表示は `Tasks / Resources / Assignments` について、件数だけでなく `ExtendedAttributes / Baselines / TimephasedData` の件数と先頭要約を表示するところまで対応済み
+- [引継][mikuproject] 仕様メモは [docs/project/mikuproject-spec.md](/Users/igapyon/Documents/git/local-html-tools/docs/project/mikuproject-spec.md)、ギャップ整理は [docs/project/mikuproject-gap-notes.md](/Users/igapyon/Documents/git/local-html-tools/docs/project/mikuproject-gap-notes.md) に反映済み
+- [引継][mikuproject] `docs/project/local-data/` は Git 管理しない一時 XML 置き場として利用する前提
+- [引継][mikuproject] `open-msp-viewer` のサンプルを参照元として利用した旨と感謝メモは `mikuproject-spec.md` に記載済み
+- [引継][mikuproject] 最後に確認できていたコマンド:
+- `npm run build:project`
+- `npx vitest run docs/project/tests/mikuproject-main.test.js`
+- [引継][mikuproject] 上記確認時点では `docs/project/tests/mikuproject-main.test.js` は `22 tests` すべて成功
+- [引継][mikuproject] 次回再開時の最初の確認候補:
+- `git status --short`
+- `npm run build:project`
+- `npx vitest run docs/project/tests/mikuproject-main.test.js`
+- [引継][mikuproject][未完了着手] `docs/project/mikuproject-src.html` には `Calendars` プレビューカード追加を開始済み
+- [引継][mikuproject][未完了着手] 次回は [docs/project/src/mikuproject/ts/main.ts](/Users/igapyon/Documents/git/local-html-tools/docs/project/src/mikuproject/ts/main.ts) の描画処理と [docs/project/tests/mikuproject-main.test.js](/Users/igapyon/Documents/git/local-html-tools/docs/project/tests/mikuproject-main.test.js) の確認項目を追従させてから再ビルド・再テストすると復帰しやすい
+
 - [引継] `docs/prompt/prompt-gen` を段階的に整理済み
 - `docs/prompt/prompt-gen-src.html` の巨大 inline CSS / JS は外出し済み
 - 開発時ソースは `docs/prompt/src/prompt-gen/css/app.css` と `docs/prompt/src/prompt-gen/ts/*.ts`

--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-16</div>
+        <div class="md-app-meta">更新日: 2026-03-17</div>
       </div>
     </header>
 

--- a/docs/project/mikuproject-gap-notes.md
+++ b/docs/project/mikuproject-gap-notes.md
@@ -1,0 +1,241 @@
+# mikuproject gap notes
+
+`mikuproject` の次段を考えるための、実例 XML ベースの棚卸しメモ。
+
+前提:
+
+- 参照元は `docs/project/local-data/` に一時配置した実例 XML
+- Git 管理対象の testdata ではない
+- ここでは `Project / Task / Resource / Assignment / Calendar` ごとに、実例で見えた主なタグを整理する
+- 目的は「現在の内部モデルで保持しているもの」と「今後候補になるもの」の差分を把握すること
+
+## 対象実例
+
+- `3PointPlan-example.xml`
+- `01145024.xml`
+- `Project_Grouping_and_Conditional_Formatting_Example.xml`
+- `link types.xml`
+
+## 現在の STEP 1 で保持済み
+
+### Project
+
+- `Name`
+- `Title`
+- `Author`
+- `Company`
+- `CreationDate`
+- `LastSaved`
+- `SaveVersion`
+- `CurrentDate`
+- `StartDate`
+- `FinishDate`
+- `ScheduleFromStart`
+- `DefaultStartTime`
+- `DefaultFinishTime`
+- `MinutesPerDay`
+- `MinutesPerWeek`
+- `DaysPerMonth`
+- `StatusDate`
+- `WeekStartDay`
+- `WorkFormat`
+- `DurationFormat`
+- `CalendarUID`
+
+### Task
+
+- `UID`
+- `ID`
+- `Name`
+- `OutlineLevel`
+- `OutlineNumber`
+- `WBS`
+- `Type`
+- `CalendarUID`
+- `Priority`
+- `Start`
+- `Finish`
+- `Duration`
+- `ActualStart`
+- `ActualFinish`
+- `Deadline`
+- `StartVariance`
+- `FinishVariance`
+- `Work`
+- `WorkVariance`
+- `TotalSlack`
+- `FreeSlack`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `RemainingWork`
+- `ActualWork`
+- `Milestone`
+- `Summary`
+- `Critical`
+- `PercentComplete`
+- `PercentWorkComplete`
+- `Notes`
+- `ConstraintType`
+- `ConstraintDate`
+- `PredecessorLink`
+
+### Resource
+
+- `UID`
+- `ID`
+- `Name`
+- `Type`
+- `Initials`
+- `Group`
+- `WorkGroup`
+- `MaxUnits`
+- `CalendarUID`
+- `StandardRate`
+- `StandardRateFormat`
+- `OvertimeRate`
+- `OvertimeRateFormat`
+- `CostPerUse`
+- `Work`
+- `ActualWork`
+- `RemainingWork`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `PercentWorkComplete`
+
+### Assignment
+
+- `UID`
+- `TaskUID`
+- `ResourceUID`
+- `Start`
+- `Finish`
+- `StartVariance`
+- `FinishVariance`
+- `Delay`
+- `Milestone`
+- `WorkContour`
+- `Units`
+- `Work`
+- `ActualWork`
+- `RemainingWork`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `PercentWorkComplete`
+- `OvertimeWork`
+- `ActualOvertimeWork`
+
+### Calendar
+
+- `UID`
+- `Name`
+- `IsBaseCalendar`
+- `IsBaselineCalendar`
+- `BaseCalendarUID`
+- `WeekDays`
+- `Exceptions`
+- `WorkWeeks`
+
+## 実例で見えた主な未保持タグ
+
+### Project 候補
+
+優先度が高そう:
+
+- `Project CalendarUID` と calendar 実体の整合運用
+
+後回し候補:
+
+- `ExtendedAttributes` の完全対応
+- `ExtendedAttributes`
+
+### Task 候補
+
+優先度が高そう:
+
+- `Task CalendarUID` に紐づくカレンダー差分の扱い
+
+実例で頻出だが重い:
+
+- `Baseline`
+- `TimephasedData`
+
+特記事項:
+
+- `UID=0`
+- 空 `Name`
+- `OutlineLevel=0`
+
+は実例で普通に出るため、validation では placeholder 扱いを考慮済み
+
+### Resource 候補
+
+優先度が高そう:
+
+- 直近の高優先候補は消化済み
+
+実例で頻出だが重い:
+
+- `Baseline`
+- `TimephasedData`
+
+### Assignment 候補
+
+優先度が高そう:
+
+- 直近の高優先候補は消化済み
+
+実例で頻出だが重い:
+
+- `Baseline`
+- `TimephasedData`
+- `ActualCost`
+- `RemainingCost`
+- `OvertimeWork`
+- `ActualOvertimeWork`
+
+特記事項:
+
+- `ResourceUID=-65535`
+
+は実例で未割当を示す特別値として扱う前提
+
+### Calendar 候補
+
+優先度が高そう:
+
+- 直近の高優先候補は消化済み
+
+後回し候補:
+
+- 直近の軽量候補は消化済み
+
+## 次に拾う候補
+
+現時点での優先順:
+
+1. `Calendar` の実用項目
+   - 実例 XML の calendar 差分パターン整理
+2. `Resource / Assignment` の次段候補
+   - preview / validation の detail 表示強化
+3. `Task` の次段候補
+   - preview / validation の detail 表示強化
+4. `Project` の次段候補
+   - project 以外の `ExtendedAttributes`
+
+## 後回しでよいもの
+
+- `Baseline` 系
+- `TimephasedData`
+- コスト系の完全保持
+- 表示設定
+- Project Server 連携系
+- `ExtendedAttributes` の完全対応
+
+## 判断メモ
+
+- STEP 2 は、まず「実例で頻出し、意味が分かりやすく、XML 往復しやすい項目」から拾うのがよい
+- `Baseline` や `TimephasedData` は重要だが、構造が重いため別段階が自然
+- 実例 XML を読む限り、parser 自体よりも「どこまでを内部モデルで保持するか」の整理が次の主題

--- a/docs/project/mikuproject-spec.md
+++ b/docs/project/mikuproject-spec.md
@@ -58,6 +58,15 @@ STEP 1 の完了条件は次のとおり。
 - まずは `mikuproject` 自身で意味的に往復できることを優先する
 - 実際の `MS Project` 本体が出力した XML との互換確認は、将来課題として扱う
 
+検証用データの参照元メモ:
+
+- 一時的な検証用データの参照元として `https://github.com/rpbouman/open-msp-viewer/` を利用する
+- ただし、Git 管理下へそのまま格納するかどうかは別途判断する
+- `open-msp-viewer` プロジェクトのサンプルには大いに助けられた。感謝する
+- 実例 XML から見えた保持項目ギャップは `docs/project/mikuproject-gap-notes.md` に整理する
+- 仕様判断で迷った場合は、MicrosoftDocs の Project XML Data Interchange リファレンスも補助資料として参照する
+  - `https://github.com/MicrosoftDocs/office-developer-msproject-xml-docs/tree/main/project-xml-data-interchange`
+
 ## STEP 1 で扱う対象
 
 STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
@@ -74,6 +83,12 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 ### Project
 
 - `Name`
+- `Title`
+- `Author`
+- `Company`
+- `CreationDate`
+- `LastSaved`
+- `SaveVersion`
 - `CurrentDate`
 - `StartDate`
 - `FinishDate`
@@ -83,7 +98,37 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 - `MinutesPerDay`
 - `MinutesPerWeek`
 - `DaysPerMonth`
+- `StatusDate`
+- `WeekStartDay`
+- `WorkFormat`
+- `DurationFormat`
+- `CurrencyCode`
+- `CurrencyDigits`
+- `CurrencySymbol`
+- `CurrencySymbolPosition`
+- `FYStartDate`
+- `FiscalYearStart`
+- `CriticalSlackLimit`
+- `DefaultTaskType`
+- `DefaultFixedCostAccrual`
+- `DefaultStandardRate`
+- `DefaultOvertimeRate`
+- `DefaultTaskEVMethod`
+- `NewTaskStartDate`
+- `NewTasksAreManual`
+- `NewTasksEffortDriven`
+- `NewTasksEstimated`
+- `ActualsInSync`
+- `EditableActualCosts`
+- `HonorConstraints`
+- `InsertedProjectsLikeSummary`
+- `MultipleCriticalPaths`
+- `TaskUpdatesResource`
+- `UpdateManuallyScheduledTasksWhenEditingLinks`
 - `CalendarUID`
+- `OutlineCodes`
+- `WBSMasks`
+- `ExtendedAttributes`
 
 ### Tasks
 
@@ -92,17 +137,39 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 - `Name`
 - `OutlineLevel`
 - `OutlineNumber`
+- `WBS`
+- `Type`
+- `CalendarUID`
+- `Priority`
 - `Start`
 - `Finish`
 - `Duration`
 - `ActualStart`
 - `ActualFinish`
+- `Deadline`
+- `StartVariance`
+- `FinishVariance`
+- `Work`
+- `WorkVariance`
+- `TotalSlack`
+- `FreeSlack`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `RemainingWork`
+- `ActualWork`
 - `Milestone`
 - `Summary`
+- `Critical`
 - `PercentComplete`
+- `PercentWorkComplete`
 - `Notes`
 - `ConstraintType`
 - `ConstraintDate`
+- `ExtendedAttribute`
+- `Baseline`
+- `TimephasedData`
+- `TimephasedData`
 - `PredecessorLink`
 
 ### Resources
@@ -113,7 +180,24 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 - `Type`
 - `Initials`
 - `Group`
+- `WorkGroup`
 - `MaxUnits`
+- `CalendarUID`
+- `StandardRate`
+- `StandardRateFormat`
+- `OvertimeRate`
+- `OvertimeRateFormat`
+- `CostPerUse`
+- `Work`
+- `ActualWork`
+- `RemainingWork`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `PercentWorkComplete`
+- `ExtendedAttribute`
+- `Baseline`
+- `TimephasedData`
 
 ### Assignments
 
@@ -122,14 +206,33 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 - `ResourceUID`
 - `Start`
 - `Finish`
+- `StartVariance`
+- `FinishVariance`
+- `Delay`
+- `Milestone`
+- `WorkContour`
 - `Units`
 - `Work`
+- `Cost`
+- `ActualCost`
+- `RemainingCost`
+- `PercentWorkComplete`
+- `OvertimeWork`
+- `ActualOvertimeWork`
+- `ActualWork`
+- `RemainingWork`
+- `ExtendedAttribute`
+- `Baseline`
 
 ### Calendars
 
 - `UID`
 - `Name`
 - `IsBaseCalendar`
+- `BaseCalendarUID`
+- `WeekDays`
+- `Exceptions`
+- `WorkWeeks`
 
 ## STEP 1 で後回しにするもの
 
@@ -159,7 +262,37 @@ type ProjectModel = {
     minutesPerDay?: number;
     minutesPerWeek?: number;
     daysPerMonth?: number;
+    statusDate?: string;
+    weekStartDay?: number;
+    workFormat?: number;
+    durationFormat?: number;
+    currencyCode?: string;
+    currencyDigits?: number;
+    currencySymbol?: string;
+    currencySymbolPosition?: number;
+    fyStartDate?: string;
+    fiscalYearStart?: boolean;
+    criticalSlackLimit?: number;
+    defaultTaskType?: number;
+    defaultFixedCostAccrual?: number;
+    defaultStandardRate?: string;
+    defaultOvertimeRate?: string;
+    defaultTaskEVMethod?: number;
+    newTaskStartDate?: number;
+    newTasksAreManual?: boolean;
+    newTasksEffortDriven?: boolean;
+    newTasksEstimated?: boolean;
+    actualsInSync?: boolean;
+    editableActualCosts?: boolean;
+    honorConstraints?: boolean;
+    insertedProjectsLikeSummary?: boolean;
+    multipleCriticalPaths?: boolean;
+    taskUpdatesResource?: boolean;
+    updateManuallyScheduledTasksWhenEditingLinks?: boolean;
     calendarUID?: string;
+    outlineCodes: OutlineCodeModel[];
+    wbsMasks: WBSMaskModel[];
+    extendedAttributes: ProjectExtendedAttributeModel[];
   };
   calendars: CalendarModel[];
   tasks: TaskModel[];
@@ -173,14 +306,32 @@ type TaskModel = {
   name: string;
   outlineLevel: number;
   outlineNumber: string;
+  wbs?: string;
+  type?: number;
+  calendarUID?: string;
+  priority?: number;
   start: string;
   finish: string;
   duration: string;
   actualStart?: string;
   actualFinish?: string;
+  deadline?: string;
+  startVariance?: string;
+  finishVariance?: string;
+  work?: string;
+  workVariance?: string;
+  totalSlack?: string;
+  freeSlack?: string;
+  cost?: number;
+  actualCost?: number;
+  remainingCost?: number;
+  remainingWork?: string;
+  actualWork?: string;
   milestone: boolean;
   summary: boolean;
+  critical?: boolean;
   percentComplete: number;
+  percentWorkComplete?: number;
   notes?: string;
   constraintType?: number;
   constraintDate?: string;
@@ -200,7 +351,21 @@ type ResourceModel = {
   type?: number;
   initials?: string;
   group?: string;
+  workGroup?: number;
   maxUnits?: number;
+  calendarUID?: string;
+  standardRate?: string;
+  standardRateFormat?: number;
+  overtimeRate?: string;
+  overtimeRateFormat?: number;
+  costPerUse?: number;
+  work?: string;
+  actualWork?: string;
+  remainingWork?: string;
+  cost?: number;
+  actualCost?: number;
+  remainingCost?: number;
+  percentWorkComplete?: number;
 };
 
 type AssignmentModel = {
@@ -209,14 +374,60 @@ type AssignmentModel = {
   resourceUid: string;
   start?: string;
   finish?: string;
+  startVariance?: string;
+  finishVariance?: string;
+  delay?: string;
+  milestone?: boolean;
+  workContour?: number;
   units?: number;
   work?: string;
+  cost?: number;
+  actualCost?: number;
+  remainingCost?: number;
+  percentWorkComplete?: number;
+  overtimeWork?: string;
+  actualOvertimeWork?: string;
+  actualWork?: string;
+  remainingWork?: string;
 };
 
 type CalendarModel = {
   uid: string;
   name: string;
   isBaseCalendar: boolean;
+  isBaselineCalendar?: boolean;
+  baseCalendarUID?: string;
+  weekDays: Array<{
+    dayType: number;
+    dayWorking: boolean;
+    workingTimes: Array<{
+      fromTime: string;
+      toTime: string;
+    }>;
+  }>;
+  exceptions: Array<{
+    name?: string;
+    fromDate?: string;
+    toDate?: string;
+    dayWorking?: boolean;
+    workingTimes: Array<{
+      fromTime: string;
+      toTime: string;
+    }>;
+  }>;
+  workWeeks: Array<{
+    name?: string;
+    fromDate?: string;
+    toDate?: string;
+    weekDays: Array<{
+      dayType: number;
+      dayWorking: boolean;
+      workingTimes: Array<{
+        fromTime: string;
+        toTime: string;
+      }>;
+    }>;
+  }>;
 };
 ```
 
@@ -286,6 +497,41 @@ STEP 1 では、次は非目標とする。
 - `Project / Tasks / Resources / Assignments / Calendars` の簡易プレビュー表示
 - `project / tasks / resources / assignments / calendars` 単位の検証メッセージ表示
 - `mikuproject` 独自の最小妥当性チェック
+- `Calendar` の `BaseCalendarUID / WeekDays / WorkingTimes` の round-trip
+- `Calendar` の `IsBaselineCalendar / Exceptions / WorkWeeks / Exception WorkingTimes` の round-trip
+- `Resource` の `CalendarUID / StandardRate / CostPerUse` の round-trip
+- `Resource` の `Work / ActualWork / RemainingWork / Cost / ActualCost / RemainingCost / PercentWorkComplete` の round-trip
+- `Assignment` の `StartVariance / FinishVariance` の round-trip
+- `Resource` の `WorkGroup` の round-trip
+- `Assignment` の `Delay / Milestone / WorkContour` の round-trip
+- `Assignment` の `OvertimeWork / ActualOvertimeWork` の round-trip
+- `Task` の `Deadline / StartVariance / FinishVariance` の round-trip
+- `Task` の `WorkVariance / TotalSlack / FreeSlack / Critical` の round-trip
+- `Resource` の `StandardRateFormat / OvertimeRate / OvertimeRateFormat` の round-trip
+- `Assignment` の `PercentWorkComplete / ActualWork / RemainingWork` の round-trip
+- `Project` の `StatusDate / WeekStartDay / WorkFormat / DurationFormat` の round-trip
+- `Project` の `CurrencyCode / CurrencyDigits / CurrencySymbol / CurrencySymbolPosition` の round-trip
+- `Project` の `FYStartDate / FiscalYearStart` の round-trip
+- `Project` の `CriticalSlackLimit / DefaultTaskType` の round-trip
+- `Project` の `DefaultFixedCostAccrual / DefaultStandardRate / DefaultOvertimeRate` の round-trip
+- `Project` の `DefaultTaskEVMethod / NewTaskStartDate` の round-trip
+- `Project` の `NewTasksAreManual / NewTasksEffortDriven` の round-trip
+- `Project` の `NewTasksEstimated / ActualsInSync` の round-trip
+- `Project` の `EditableActualCosts / HonorConstraints` の round-trip
+- `Project` の `InsertedProjectsLikeSummary / MultipleCriticalPaths` の round-trip
+- `Project` の `TaskUpdatesResource / UpdateManuallyScheduledTasksWhenEditingLinks` の round-trip
+- `Project` の `OutlineCodes / WBSMasks` の最小 round-trip
+- `Project` の `ExtendedAttributes` の最小 round-trip
+- `Task` の `ExtendedAttribute` の最小 round-trip
+- `Resource` の `ExtendedAttribute` の最小 round-trip
+- `Assignment` の `ExtendedAttribute` の最小 round-trip
+- `Task` の `Baseline` の最小 round-trip
+- `Assignment` の `Baseline` の最小 round-trip
+- `Resource` の `Baseline` の最小 round-trip
+- `Task` の `TimephasedData` の最小 round-trip
+- `Resource` の `TimephasedData` の最小 round-trip
+- `Assignment` の `TimephasedData` の最小 round-trip
+- `Task / Assignment` の `Cost / ActualCost / RemainingCost` の round-trip
 - round-trip テスト
 
 ## 次に決めること

--- a/docs/project/mikuproject-src.html
+++ b/docs/project/mikuproject-src.html
@@ -80,6 +80,10 @@
           <h3 class="md-preview-card__title">Assignments</h3>
           <div id="assignmentPreview" class="md-preview-list"></div>
         </section>
+        <section class="md-preview-card">
+          <h3 class="md-preview-card__title">Calendars</h3>
+          <div id="calendarPreview" class="md-preview-list"></div>
+        </section>
       </div>
     </section>
 

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -1352,6 +1352,10 @@ lht-index-card-link {
           <h3 class="md-preview-card__title">Assignments</h3>
           <div id="assignmentPreview" class="md-preview-list"></div>
         </section>
+        <section class="md-preview-card">
+          <h3 class="md-preview-card__title">Calendars</h3>
+          <div id="calendarPreview" class="md-preview-list"></div>
+        </section>
       </div>
     </section>
 
@@ -3497,6 +3501,12 @@ if (!customElements.get("lht-page-menu")) {
     const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/project">
   <Name>Sample Project</Name>
+  <Title>Sample Project Title</Title>
+  <Company>Local HTML Tools</Company>
+  <Author>Toshiki Iga</Author>
+  <CreationDate>2026-03-16T08:30:00</CreationDate>
+  <LastSaved>2026-03-16T09:10:00</LastSaved>
+  <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
   <FinishDate>2026-03-20T18:00:00</FinishDate>
@@ -3506,12 +3516,161 @@ if (!customElements.get("lht-page-menu")) {
   <MinutesPerDay>480</MinutesPerDay>
   <MinutesPerWeek>2400</MinutesPerWeek>
   <DaysPerMonth>20</DaysPerMonth>
+  <StatusDate>2026-03-19T09:00:00</StatusDate>
+  <WeekStartDay>1</WeekStartDay>
+  <WorkFormat>2</WorkFormat>
+  <DurationFormat>7</DurationFormat>
+  <CurrencyCode>JPY</CurrencyCode>
+  <CurrencyDigits>0</CurrencyDigits>
+  <CurrencySymbol>¥</CurrencySymbol>
+  <CurrencySymbolPosition>0</CurrencySymbolPosition>
+  <FYStartDate>2026-04-01T00:00:00</FYStartDate>
+  <FiscalYearStart>1</FiscalYearStart>
+  <CriticalSlackLimit>0</CriticalSlackLimit>
+  <DefaultTaskType>1</DefaultTaskType>
+  <DefaultFixedCostAccrual>2</DefaultFixedCostAccrual>
+  <DefaultStandardRate>5000/h</DefaultStandardRate>
+  <DefaultOvertimeRate>7000/h</DefaultOvertimeRate>
+  <DefaultTaskEVMethod>0</DefaultTaskEVMethod>
+  <NewTaskStartDate>0</NewTaskStartDate>
+  <NewTasksAreManual>0</NewTasksAreManual>
+  <NewTasksEffortDriven>1</NewTasksEffortDriven>
+  <NewTasksEstimated>1</NewTasksEstimated>
+  <ActualsInSync>0</ActualsInSync>
+  <EditableActualCosts>1</EditableActualCosts>
+  <HonorConstraints>1</HonorConstraints>
+  <InsertedProjectsLikeSummary>1</InsertedProjectsLikeSummary>
+  <MultipleCriticalPaths>0</MultipleCriticalPaths>
+  <TaskUpdatesResource>1</TaskUpdatesResource>
+  <UpdateManuallyScheduledTasksWhenEditingLinks>0</UpdateManuallyScheduledTasksWhenEditingLinks>
   <CalendarUID>1</CalendarUID>
+  <OutlineCodes>
+    <OutlineCode>
+      <FieldID>188743731</FieldID>
+      <FieldName>Outline Code1</FieldName>
+      <Alias>Phase</Alias>
+      <OnlyTableValues>1</OnlyTableValues>
+      <Enterprise>0</Enterprise>
+      <ResourceSubstitutionEnabled>0</ResourceSubstitutionEnabled>
+      <LeafOnly>0</LeafOnly>
+      <AllLevelsRequired>0</AllLevelsRequired>
+      <Masks>
+        <Mask>
+          <Level>1</Level>
+          <Mask>*</Mask>
+          <Length>0</Length>
+          <Sequence>0</Sequence>
+        </Mask>
+      </Masks>
+      <Values>
+        <Value>
+          <Value>PLAN</Value>
+          <Description>Planning</Description>
+        </Value>
+        <Value>
+          <Value>BUILD</Value>
+          <Description>Implementation</Description>
+        </Value>
+      </Values>
+    </OutlineCode>
+  </OutlineCodes>
+  <WBSMasks>
+    <WBSMask>
+      <Level>1</Level>
+      <Mask>A</Mask>
+      <Length>1</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+    <WBSMask>
+      <Level>2</Level>
+      <Mask>00</Mask>
+      <Length>2</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+  </WBSMasks>
+  <ExtendedAttributes>
+    <ExtendedAttribute>
+      <FieldID>188743734</FieldID>
+      <FieldName>Text1</FieldName>
+      <Alias>Owner</Alias>
+      <CalculationType>0</CalculationType>
+      <RestrictValues>0</RestrictValues>
+      <AppendNewValues>1</AppendNewValues>
+    </ExtendedAttribute>
+  </ExtendedAttributes>
   <Calendars>
     <Calendar>
       <UID>1</UID>
       <Name>Standard</Name>
       <IsBaseCalendar>1</IsBaseCalendar>
+      <IsBaselineCalendar>1</IsBaselineCalendar>
+      <Exceptions>
+        <Exception>
+          <Name>Holiday</Name>
+          <FromDate>2026-03-20T00:00:00</FromDate>
+          <ToDate>2026-03-20T23:59:59</ToDate>
+          <DayWorking>0</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </Exception>
+      </Exceptions>
+      <WeekDays>
+        <WeekDay>
+          <DayType>2</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+            <WorkingTime>
+              <FromTime>13:00:00</FromTime>
+              <ToTime>18:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
+    </Calendar>
+    <Calendar>
+      <UID>2</UID>
+      <Name>Development</Name>
+      <IsBaseCalendar>0</IsBaseCalendar>
+      <BaseCalendarUID>1</BaseCalendarUID>
+      <WorkWeeks>
+        <WorkWeek>
+          <Name>Spring Sprint</Name>
+          <FromDate>2026-03-16T00:00:00</FromDate>
+          <ToDate>2026-03-31T23:59:59</ToDate>
+          <WeekDays>
+            <WeekDay>
+              <DayType>2</DayType>
+              <DayWorking>1</DayWorking>
+              <WorkingTimes>
+                <WorkingTime>
+                  <FromTime>10:00:00</FromTime>
+                  <ToTime>18:00:00</ToTime>
+                </WorkingTime>
+              </WorkingTimes>
+            </WeekDay>
+          </WeekDays>
+        </WorkWeek>
+      </WorkWeeks>
+      <WeekDays>
+        <WeekDay>
+          <DayType>6</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>10:00:00</FromTime>
+              <ToTime>15:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
     </Calendar>
   </Calendars>
   <Tasks>
@@ -3521,12 +3680,29 @@ if (!customElements.get("lht-page-menu")) {
       <Name>Project Summary</Name>
       <OutlineLevel>1</OutlineLevel>
       <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT40H0M0S</Duration>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT40H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <ActualWork>PT20H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>1</Summary>
+      <Critical>0</Critical>
       <PercentComplete>50</PercentComplete>
+      <PercentWorkComplete>50</PercentWorkComplete>
     </Task>
     <Task>
       <UID>2</UID>
@@ -3534,15 +3710,51 @@ if (!customElements.get("lht-page-menu")) {
       <Name>Design</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.1</OutlineNumber>
+      <WBS>1.1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
       <Duration>PT16H0M0S</Duration>
       <ActualStart>2026-03-16T09:00:00</ActualStart>
       <ActualFinish>2026-03-17T18:00:00</ActualFinish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT16H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>80000</Cost>
+      <ActualCost>80000</ActualCost>
+      <RemainingCost>0</RemainingCost>
+      <RemainingWork>PT0H0M0S</RemainingWork>
+      <ActualWork>PT16H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>0</Critical>
       <PercentComplete>100</PercentComplete>
+      <PercentWorkComplete>100</PercentWorkComplete>
       <Notes>Design completed</Notes>
+      <ExtendedAttribute>
+        <FieldID>188743734</FieldID>
+        <Value>Miku</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>2</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Task>
     <Task>
       <UID>3</UID>
@@ -3550,14 +3762,32 @@ if (!customElements.get("lht-page-menu")) {
       <Name>Implementation</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.2</OutlineNumber>
+      <WBS>1.2</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>700</Priority>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT24H0M0S</Duration>
+      <Deadline>2026-03-21T18:00:00</Deadline>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT24H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT4H0M0S</TotalSlack>
+      <FreeSlack>PT2H0M0S</FreeSlack>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <RemainingWork>PT24H0M0S</RemainingWork>
+      <ActualWork>PT0H0M0S</ActualWork>
       <ConstraintType>4</ConstraintType>
       <ConstraintDate>2026-03-18T09:00:00</ConstraintDate>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>1</Critical>
       <PercentComplete>0</PercentComplete>
+      <PercentWorkComplete>0</PercentWorkComplete>
       <Notes>Implementation starts after design</Notes>
       <PredecessorLink>
         <PredecessorUID>2</PredecessorUID>
@@ -3574,7 +3804,40 @@ if (!customElements.get("lht-page-menu")) {
       <Type>1</Type>
       <Initials>MK</Initials>
       <Group>Engineering</Group>
+      <WorkGroup>0</WorkGroup>
       <MaxUnits>1</MaxUnits>
+      <CalendarUID>2</CalendarUID>
+      <StandardRate>5000/h</StandardRate>
+      <StandardRateFormat>2</StandardRateFormat>
+      <OvertimeRate>7000/h</OvertimeRate>
+      <OvertimeRateFormat>2</OvertimeRateFormat>
+      <CostPerUse>1000</CostPerUse>
+      <Work>PT40H0M0S</Work>
+      <ActualWork>PT20H0M0S</ActualWork>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <ExtendedAttribute>
+        <FieldID>188743737</FieldID>
+        <Value>Platform Team</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-20T18:00:00</Finish>
+        <Work>PT40H0M0S</Work>
+        <Cost>200000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Resource>
   </Resources>
   <Assignments>
@@ -3584,8 +3847,40 @@ if (!customElements.get("lht-page-menu")) {
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT16H0M0S</Work>
+      <Cost>80000</Cost>
+      <ActualCost>40000</ActualCost>
+      <RemainingCost>40000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <OvertimeWork>PT2H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT1H0M0S</ActualOvertimeWork>
+      <ActualWork>PT8H0M0S</ActualWork>
+      <RemainingWork>PT8H0M0S</RemainingWork>
+      <ExtendedAttribute>
+        <FieldID>255852547</FieldID>
+        <Value>Design Slot</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Assignment>
     <Assignment>
       <UID>2</UID>
@@ -3593,8 +3888,21 @@ if (!customElements.get("lht-page-menu")) {
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT24H0M0S</Work>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <PercentWorkComplete>0</PercentWorkComplete>
+      <OvertimeWork>PT0H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT0H0M0S</ActualOvertimeWork>
+      <ActualWork>PT0H0M0S</ActualWork>
+      <RemainingWork>PT24H0M0S</RemainingWork>
     </Assignment>
   </Assignments>
 </Project>`;
@@ -3616,6 +3924,95 @@ if (!customElements.get("lht-page-menu")) {
         const timestamp = Date.parse(value);
         return Number.isFinite(timestamp) ? timestamp : null;
     }
+    function parseWeekDays(parent) {
+        var _a;
+        return Array.from(((_a = parent.getElementsByTagName("WeekDays")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WeekDay")) || []).map((weekDay) => {
+            var _a;
+            return ({
+                dayType: parseNumber(textContent(weekDay, "DayType"), 0),
+                dayWorking: parseBoolean(textContent(weekDay, "DayWorking")),
+                workingTimes: Array.from(((_a = weekDay.getElementsByTagName("WorkingTimes")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WorkingTime")) || []).map((workingTime) => ({
+                    fromTime: textContent(workingTime, "FromTime"),
+                    toTime: textContent(workingTime, "ToTime")
+                }))
+            });
+        });
+    }
+    function appendWeekDays(doc, parent, weekDays) {
+        if (weekDays.length === 0) {
+            return;
+        }
+        const weekDaysElement = doc.createElement("WeekDays");
+        for (const weekDay of weekDays) {
+            const weekDayElement = doc.createElement("WeekDay");
+            appendTextElement(doc, weekDayElement, "DayType", weekDay.dayType);
+            appendTextElement(doc, weekDayElement, "DayWorking", weekDay.dayWorking);
+            if (weekDay.workingTimes.length > 0) {
+                const workingTimesElement = doc.createElement("WorkingTimes");
+                for (const workingTime of weekDay.workingTimes) {
+                    const workingTimeElement = doc.createElement("WorkingTime");
+                    appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+                    appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+                    workingTimesElement.appendChild(workingTimeElement);
+                }
+                weekDayElement.appendChild(workingTimesElement);
+            }
+            weekDaysElement.appendChild(weekDayElement);
+        }
+        parent.appendChild(weekDaysElement);
+    }
+    function parseWorkingTimes(parent) {
+        var _a;
+        return Array.from(((_a = parent.getElementsByTagName("WorkingTimes")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WorkingTime")) || []).map((workingTime) => ({
+            fromTime: textContent(workingTime, "FromTime"),
+            toTime: textContent(workingTime, "ToTime")
+        }));
+    }
+    function appendWorkingTimes(doc, parent, workingTimes) {
+        if (workingTimes.length === 0) {
+            return;
+        }
+        const workingTimesElement = doc.createElement("WorkingTimes");
+        for (const workingTime of workingTimes) {
+            const workingTimeElement = doc.createElement("WorkingTime");
+            appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+            appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+            workingTimesElement.appendChild(workingTimeElement);
+        }
+        parent.appendChild(workingTimesElement);
+    }
+    function parseOutlineCodeMasks(parent) {
+        const masksElement = parent.getElementsByTagName("Masks")[0];
+        if (!masksElement) {
+            return [];
+        }
+        return Array.from(masksElement.children)
+            .filter((child) => child.tagName === "Mask")
+            .map((mask) => ({
+            level: parseNumber(textContent(mask, "Level"), 0),
+            mask: textContent(mask, "Mask") || undefined,
+            length: textContent(mask, "Length") ? parseNumber(textContent(mask, "Length"), 0) : undefined,
+            sequence: textContent(mask, "Sequence") ? parseNumber(textContent(mask, "Sequence"), 0) : undefined
+        }));
+    }
+    function parseOutlineCodeValues(parent) {
+        const valuesElement = parent.getElementsByTagName("Values")[0];
+        if (!valuesElement) {
+            return [];
+        }
+        return Array.from(valuesElement.children)
+            .filter((child) => child.tagName === "Value")
+            .map((value) => ({
+            value: textContent(value, "Value"),
+            description: textContent(value, "Description") || undefined
+        }));
+    }
+    function isPlaceholderUid(value) {
+        return String(value || "").trim() === "0";
+    }
+    function isUnassignedResourceUid(value) {
+        return String(value || "").trim() === "-65535";
+    }
     function parseXmlDocument(xmlText) {
         const parser = new DOMParser();
         const xml = parser.parseFromString(xmlText, "application/xml");
@@ -3626,7 +4023,7 @@ if (!customElements.get("lht-page-menu")) {
         return xml;
     }
     function importMsProjectXml(xmlText) {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e, _f, _g;
         const xml = parseXmlDocument(xmlText);
         const projectElement = xml.documentElement;
         const calendars = Array.from(((_a = projectElement.getElementsByTagName("Calendars")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("Calendar")) || []);
@@ -3636,6 +4033,12 @@ if (!customElements.get("lht-page-menu")) {
         return {
             project: {
                 name: textContent(projectElement, "Name"),
+                title: textContent(projectElement, "Title") || undefined,
+                author: textContent(projectElement, "Author") || undefined,
+                company: textContent(projectElement, "Company") || undefined,
+                creationDate: textContent(projectElement, "CreationDate") || undefined,
+                lastSaved: textContent(projectElement, "LastSaved") || undefined,
+                saveVersion: textContent(projectElement, "SaveVersion") ? parseNumber(textContent(projectElement, "SaveVersion"), 0) : undefined,
                 currentDate: textContent(projectElement, "CurrentDate") || undefined,
                 startDate: textContent(projectElement, "StartDate"),
                 finishDate: textContent(projectElement, "FinishDate"),
@@ -3645,30 +4048,139 @@ if (!customElements.get("lht-page-menu")) {
                 minutesPerDay: textContent(projectElement, "MinutesPerDay") ? parseNumber(textContent(projectElement, "MinutesPerDay"), 0) : undefined,
                 minutesPerWeek: textContent(projectElement, "MinutesPerWeek") ? parseNumber(textContent(projectElement, "MinutesPerWeek"), 0) : undefined,
                 daysPerMonth: textContent(projectElement, "DaysPerMonth") ? parseNumber(textContent(projectElement, "DaysPerMonth"), 0) : undefined,
-                calendarUID: textContent(projectElement, "CalendarUID") || undefined
+                statusDate: textContent(projectElement, "StatusDate") || undefined,
+                weekStartDay: textContent(projectElement, "WeekStartDay") ? parseNumber(textContent(projectElement, "WeekStartDay"), 0) : undefined,
+                workFormat: textContent(projectElement, "WorkFormat") ? parseNumber(textContent(projectElement, "WorkFormat"), 0) : undefined,
+                durationFormat: textContent(projectElement, "DurationFormat") ? parseNumber(textContent(projectElement, "DurationFormat"), 0) : undefined,
+                currencyCode: textContent(projectElement, "CurrencyCode") || undefined,
+                currencyDigits: textContent(projectElement, "CurrencyDigits") ? parseNumber(textContent(projectElement, "CurrencyDigits"), 0) : undefined,
+                currencySymbol: textContent(projectElement, "CurrencySymbol") || undefined,
+                currencySymbolPosition: textContent(projectElement, "CurrencySymbolPosition") ? parseNumber(textContent(projectElement, "CurrencySymbolPosition"), 0) : undefined,
+                fyStartDate: textContent(projectElement, "FYStartDate") || undefined,
+                fiscalYearStart: textContent(projectElement, "FiscalYearStart") ? parseBoolean(textContent(projectElement, "FiscalYearStart")) : undefined,
+                criticalSlackLimit: textContent(projectElement, "CriticalSlackLimit") ? parseNumber(textContent(projectElement, "CriticalSlackLimit"), 0) : undefined,
+                defaultTaskType: textContent(projectElement, "DefaultTaskType") ? parseNumber(textContent(projectElement, "DefaultTaskType"), 0) : undefined,
+                defaultFixedCostAccrual: textContent(projectElement, "DefaultFixedCostAccrual") ? parseNumber(textContent(projectElement, "DefaultFixedCostAccrual"), 0) : undefined,
+                defaultStandardRate: textContent(projectElement, "DefaultStandardRate") || undefined,
+                defaultOvertimeRate: textContent(projectElement, "DefaultOvertimeRate") || undefined,
+                defaultTaskEVMethod: textContent(projectElement, "DefaultTaskEVMethod") ? parseNumber(textContent(projectElement, "DefaultTaskEVMethod"), 0) : undefined,
+                newTaskStartDate: textContent(projectElement, "NewTaskStartDate") ? parseNumber(textContent(projectElement, "NewTaskStartDate"), 0) : undefined,
+                newTasksAreManual: textContent(projectElement, "NewTasksAreManual") ? parseBoolean(textContent(projectElement, "NewTasksAreManual")) : undefined,
+                newTasksEffortDriven: textContent(projectElement, "NewTasksEffortDriven") ? parseBoolean(textContent(projectElement, "NewTasksEffortDriven")) : undefined,
+                newTasksEstimated: textContent(projectElement, "NewTasksEstimated") ? parseBoolean(textContent(projectElement, "NewTasksEstimated")) : undefined,
+                actualsInSync: textContent(projectElement, "ActualsInSync") ? parseBoolean(textContent(projectElement, "ActualsInSync")) : undefined,
+                editableActualCosts: textContent(projectElement, "EditableActualCosts") ? parseBoolean(textContent(projectElement, "EditableActualCosts")) : undefined,
+                honorConstraints: textContent(projectElement, "HonorConstraints") ? parseBoolean(textContent(projectElement, "HonorConstraints")) : undefined,
+                insertedProjectsLikeSummary: textContent(projectElement, "InsertedProjectsLikeSummary") ? parseBoolean(textContent(projectElement, "InsertedProjectsLikeSummary")) : undefined,
+                multipleCriticalPaths: textContent(projectElement, "MultipleCriticalPaths") ? parseBoolean(textContent(projectElement, "MultipleCriticalPaths")) : undefined,
+                taskUpdatesResource: textContent(projectElement, "TaskUpdatesResource") ? parseBoolean(textContent(projectElement, "TaskUpdatesResource")) : undefined,
+                updateManuallyScheduledTasksWhenEditingLinks: textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks") ? parseBoolean(textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks")) : undefined,
+                calendarUID: textContent(projectElement, "CalendarUID") || undefined,
+                outlineCodes: Array.from(((_e = projectElement.getElementsByTagName("OutlineCodes")[0]) === null || _e === void 0 ? void 0 : _e.getElementsByTagName("OutlineCode")) || []).map((outlineCode) => ({
+                    fieldID: textContent(outlineCode, "FieldID") || undefined,
+                    fieldName: textContent(outlineCode, "FieldName") || undefined,
+                    alias: textContent(outlineCode, "Alias") || undefined,
+                    onlyTableValues: textContent(outlineCode, "OnlyTableValues") ? parseBoolean(textContent(outlineCode, "OnlyTableValues")) : undefined,
+                    enterprise: textContent(outlineCode, "Enterprise") ? parseBoolean(textContent(outlineCode, "Enterprise")) : undefined,
+                    resourceSubstitutionEnabled: textContent(outlineCode, "ResourceSubstitutionEnabled") ? parseBoolean(textContent(outlineCode, "ResourceSubstitutionEnabled")) : undefined,
+                    leafOnly: textContent(outlineCode, "LeafOnly") ? parseBoolean(textContent(outlineCode, "LeafOnly")) : undefined,
+                    allLevelsRequired: textContent(outlineCode, "AllLevelsRequired") ? parseBoolean(textContent(outlineCode, "AllLevelsRequired")) : undefined,
+                    masks: parseOutlineCodeMasks(outlineCode),
+                    values: parseOutlineCodeValues(outlineCode)
+                })),
+                wbsMasks: Array.from(((_f = projectElement.getElementsByTagName("WBSMasks")[0]) === null || _f === void 0 ? void 0 : _f.getElementsByTagName("WBSMask")) || []).map((wbsMask) => ({
+                    level: parseNumber(textContent(wbsMask, "Level"), 0),
+                    mask: textContent(wbsMask, "Mask") || undefined,
+                    length: textContent(wbsMask, "Length") ? parseNumber(textContent(wbsMask, "Length"), 0) : undefined,
+                    sequence: textContent(wbsMask, "Sequence") ? parseNumber(textContent(wbsMask, "Sequence"), 0) : undefined
+                })),
+                extendedAttributes: Array.from(((_g = projectElement.getElementsByTagName("ExtendedAttributes")[0]) === null || _g === void 0 ? void 0 : _g.getElementsByTagName("ExtendedAttribute")) || []).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    fieldName: textContent(attribute, "FieldName") || undefined,
+                    alias: textContent(attribute, "Alias") || undefined,
+                    calculationType: textContent(attribute, "CalculationType") ? parseNumber(textContent(attribute, "CalculationType"), 0) : undefined,
+                    restrictValues: textContent(attribute, "RestrictValues") ? parseBoolean(textContent(attribute, "RestrictValues")) : undefined,
+                    appendNewValues: textContent(attribute, "AppendNewValues") ? parseBoolean(textContent(attribute, "AppendNewValues")) : undefined
+                }))
             },
-            calendars: calendars.map((calendar) => ({
-                uid: textContent(calendar, "UID"),
-                name: textContent(calendar, "Name"),
-                isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar"))
-            })),
+            calendars: calendars.map((calendar) => {
+                var _a, _b;
+                return ({
+                    uid: textContent(calendar, "UID"),
+                    name: textContent(calendar, "Name"),
+                    isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar")),
+                    isBaselineCalendar: textContent(calendar, "IsBaselineCalendar") ? parseBoolean(textContent(calendar, "IsBaselineCalendar")) : undefined,
+                    baseCalendarUID: textContent(calendar, "BaseCalendarUID") || undefined,
+                    weekDays: parseWeekDays(calendar),
+                    exceptions: Array.from(((_a = calendar.getElementsByTagName("Exceptions")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("Exception")) || []).map((exception) => ({
+                        name: textContent(exception, "Name") || undefined,
+                        fromDate: textContent(exception, "FromDate") || undefined,
+                        toDate: textContent(exception, "ToDate") || undefined,
+                        dayWorking: textContent(exception, "DayWorking") ? parseBoolean(textContent(exception, "DayWorking")) : undefined,
+                        workingTimes: parseWorkingTimes(exception)
+                    })),
+                    workWeeks: Array.from(((_b = calendar.getElementsByTagName("WorkWeeks")[0]) === null || _b === void 0 ? void 0 : _b.getElementsByTagName("WorkWeek")) || []).map((workWeek) => ({
+                        name: textContent(workWeek, "Name") || undefined,
+                        fromDate: textContent(workWeek, "FromDate") || undefined,
+                        toDate: textContent(workWeek, "ToDate") || undefined,
+                        weekDays: parseWeekDays(workWeek)
+                    }))
+                });
+            }),
             tasks: tasks.map((task) => ({
                 uid: textContent(task, "UID"),
                 id: textContent(task, "ID"),
                 name: textContent(task, "Name"),
                 outlineLevel: parseNumber(textContent(task, "OutlineLevel"), 1),
                 outlineNumber: textContent(task, "OutlineNumber"),
+                wbs: textContent(task, "WBS") || undefined,
+                type: textContent(task, "Type") ? parseNumber(textContent(task, "Type"), 0) : undefined,
+                calendarUID: textContent(task, "CalendarUID") || undefined,
+                priority: textContent(task, "Priority") ? parseNumber(textContent(task, "Priority"), 0) : undefined,
                 start: textContent(task, "Start"),
                 finish: textContent(task, "Finish"),
                 duration: textContent(task, "Duration"),
                 actualStart: textContent(task, "ActualStart") || undefined,
                 actualFinish: textContent(task, "ActualFinish") || undefined,
+                deadline: textContent(task, "Deadline") || undefined,
+                startVariance: textContent(task, "StartVariance") || undefined,
+                finishVariance: textContent(task, "FinishVariance") || undefined,
+                work: textContent(task, "Work") || undefined,
+                workVariance: textContent(task, "WorkVariance") || undefined,
+                totalSlack: textContent(task, "TotalSlack") || undefined,
+                freeSlack: textContent(task, "FreeSlack") || undefined,
+                cost: textContent(task, "Cost") ? parseNumber(textContent(task, "Cost"), 0) : undefined,
+                actualCost: textContent(task, "ActualCost") ? parseNumber(textContent(task, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(task, "RemainingCost") ? parseNumber(textContent(task, "RemainingCost"), 0) : undefined,
+                remainingWork: textContent(task, "RemainingWork") || undefined,
+                actualWork: textContent(task, "ActualWork") || undefined,
                 milestone: parseBoolean(textContent(task, "Milestone")),
                 summary: parseBoolean(textContent(task, "Summary")),
+                critical: textContent(task, "Critical") ? parseBoolean(textContent(task, "Critical")) : undefined,
                 percentComplete: parseNumber(textContent(task, "PercentComplete"), 0),
+                percentWorkComplete: textContent(task, "PercentWorkComplete") ? parseNumber(textContent(task, "PercentWorkComplete"), 0) : undefined,
                 notes: textContent(task, "Notes") || undefined,
                 constraintType: textContent(task, "ConstraintType") ? parseNumber(textContent(task, "ConstraintType"), 0) : undefined,
                 constraintDate: textContent(task, "ConstraintDate") || undefined,
+                extendedAttributes: Array.from(task.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(task.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(task.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                })),
                 predecessors: Array.from(task.getElementsByTagName("PredecessorLink")).map((link) => ({
                     predecessorUid: textContent(link, "PredecessorUID"),
                     type: parseNumber(textContent(link, "Type"), 0),
@@ -3682,7 +4194,40 @@ if (!customElements.get("lht-page-menu")) {
                 type: parseNumber(textContent(resource, "Type"), 0),
                 initials: textContent(resource, "Initials") || undefined,
                 group: textContent(resource, "Group") || undefined,
-                maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined
+                workGroup: textContent(resource, "WorkGroup") ? parseNumber(textContent(resource, "WorkGroup"), 0) : undefined,
+                maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined,
+                calendarUID: textContent(resource, "CalendarUID") || undefined,
+                standardRate: textContent(resource, "StandardRate") || undefined,
+                standardRateFormat: textContent(resource, "StandardRateFormat") ? parseNumber(textContent(resource, "StandardRateFormat"), 0) : undefined,
+                overtimeRate: textContent(resource, "OvertimeRate") || undefined,
+                overtimeRateFormat: textContent(resource, "OvertimeRateFormat") ? parseNumber(textContent(resource, "OvertimeRateFormat"), 0) : undefined,
+                costPerUse: textContent(resource, "CostPerUse") ? parseNumber(textContent(resource, "CostPerUse"), 0) : undefined,
+                work: textContent(resource, "Work") || undefined,
+                actualWork: textContent(resource, "ActualWork") || undefined,
+                remainingWork: textContent(resource, "RemainingWork") || undefined,
+                cost: textContent(resource, "Cost") ? parseNumber(textContent(resource, "Cost"), 0) : undefined,
+                actualCost: textContent(resource, "ActualCost") ? parseNumber(textContent(resource, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(resource, "RemainingCost") ? parseNumber(textContent(resource, "RemainingCost"), 0) : undefined,
+                percentWorkComplete: textContent(resource, "PercentWorkComplete") ? parseNumber(textContent(resource, "PercentWorkComplete"), 0) : undefined,
+                extendedAttributes: Array.from(resource.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(resource.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(resource.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                }))
             })),
             assignments: assignments.map((assignment) => ({
                 uid: textContent(assignment, "UID"),
@@ -3690,8 +4235,40 @@ if (!customElements.get("lht-page-menu")) {
                 resourceUid: textContent(assignment, "ResourceUID"),
                 start: textContent(assignment, "Start") || undefined,
                 finish: textContent(assignment, "Finish") || undefined,
+                startVariance: textContent(assignment, "StartVariance") || undefined,
+                finishVariance: textContent(assignment, "FinishVariance") || undefined,
+                delay: textContent(assignment, "Delay") || undefined,
+                milestone: textContent(assignment, "Milestone") ? parseBoolean(textContent(assignment, "Milestone")) : undefined,
+                workContour: textContent(assignment, "WorkContour") ? parseNumber(textContent(assignment, "WorkContour"), 0) : undefined,
                 units: parseNumber(textContent(assignment, "Units"), 0),
-                work: textContent(assignment, "Work") || undefined
+                work: textContent(assignment, "Work") || undefined,
+                cost: textContent(assignment, "Cost") ? parseNumber(textContent(assignment, "Cost"), 0) : undefined,
+                actualCost: textContent(assignment, "ActualCost") ? parseNumber(textContent(assignment, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(assignment, "RemainingCost") ? parseNumber(textContent(assignment, "RemainingCost"), 0) : undefined,
+                percentWorkComplete: textContent(assignment, "PercentWorkComplete") ? parseNumber(textContent(assignment, "PercentWorkComplete"), 0) : undefined,
+                overtimeWork: textContent(assignment, "OvertimeWork") || undefined,
+                actualOvertimeWork: textContent(assignment, "ActualOvertimeWork") || undefined,
+                actualWork: textContent(assignment, "ActualWork") || undefined,
+                remainingWork: textContent(assignment, "RemainingWork") || undefined,
+                extendedAttributes: Array.from(assignment.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(assignment.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(assignment.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                }))
             }))
         };
     }
@@ -3733,6 +4310,12 @@ if (!customElements.get("lht-page-menu")) {
         const project = doc.documentElement;
         project.setAttribute("xmlns", "http://schemas.microsoft.com/project");
         appendTextElement(doc, project, "Name", model.project.name);
+        appendTextElement(doc, project, "Title", model.project.title);
+        appendTextElement(doc, project, "Company", model.project.company);
+        appendTextElement(doc, project, "Author", model.project.author);
+        appendTextElement(doc, project, "CreationDate", model.project.creationDate);
+        appendTextElement(doc, project, "LastSaved", model.project.lastSaved);
+        appendTextElement(doc, project, "SaveVersion", model.project.saveVersion);
         appendTextElement(doc, project, "CurrentDate", model.project.currentDate);
         appendTextElement(doc, project, "StartDate", model.project.startDate);
         appendTextElement(doc, project, "FinishDate", model.project.finishDate);
@@ -3742,13 +4325,132 @@ if (!customElements.get("lht-page-menu")) {
         appendTextElement(doc, project, "MinutesPerDay", model.project.minutesPerDay);
         appendTextElement(doc, project, "MinutesPerWeek", model.project.minutesPerWeek);
         appendTextElement(doc, project, "DaysPerMonth", model.project.daysPerMonth);
+        appendTextElement(doc, project, "StatusDate", model.project.statusDate);
+        appendTextElement(doc, project, "WeekStartDay", model.project.weekStartDay);
+        appendTextElement(doc, project, "WorkFormat", model.project.workFormat);
+        appendTextElement(doc, project, "DurationFormat", model.project.durationFormat);
+        appendTextElement(doc, project, "CurrencyCode", model.project.currencyCode);
+        appendTextElement(doc, project, "CurrencyDigits", model.project.currencyDigits);
+        appendTextElement(doc, project, "CurrencySymbol", model.project.currencySymbol);
+        appendTextElement(doc, project, "CurrencySymbolPosition", model.project.currencySymbolPosition);
+        appendTextElement(doc, project, "FYStartDate", model.project.fyStartDate);
+        appendTextElement(doc, project, "FiscalYearStart", model.project.fiscalYearStart);
+        appendTextElement(doc, project, "CriticalSlackLimit", model.project.criticalSlackLimit);
+        appendTextElement(doc, project, "DefaultTaskType", model.project.defaultTaskType);
+        appendTextElement(doc, project, "DefaultFixedCostAccrual", model.project.defaultFixedCostAccrual);
+        appendTextElement(doc, project, "DefaultStandardRate", model.project.defaultStandardRate);
+        appendTextElement(doc, project, "DefaultOvertimeRate", model.project.defaultOvertimeRate);
+        appendTextElement(doc, project, "DefaultTaskEVMethod", model.project.defaultTaskEVMethod);
+        appendTextElement(doc, project, "NewTaskStartDate", model.project.newTaskStartDate);
+        appendTextElement(doc, project, "NewTasksAreManual", model.project.newTasksAreManual);
+        appendTextElement(doc, project, "NewTasksEffortDriven", model.project.newTasksEffortDriven);
+        appendTextElement(doc, project, "NewTasksEstimated", model.project.newTasksEstimated);
+        appendTextElement(doc, project, "ActualsInSync", model.project.actualsInSync);
+        appendTextElement(doc, project, "EditableActualCosts", model.project.editableActualCosts);
+        appendTextElement(doc, project, "HonorConstraints", model.project.honorConstraints);
+        appendTextElement(doc, project, "InsertedProjectsLikeSummary", model.project.insertedProjectsLikeSummary);
+        appendTextElement(doc, project, "MultipleCriticalPaths", model.project.multipleCriticalPaths);
+        appendTextElement(doc, project, "TaskUpdatesResource", model.project.taskUpdatesResource);
+        appendTextElement(doc, project, "UpdateManuallyScheduledTasksWhenEditingLinks", model.project.updateManuallyScheduledTasksWhenEditingLinks);
         appendTextElement(doc, project, "CalendarUID", model.project.calendarUID);
+        if (model.project.outlineCodes.length > 0) {
+            const outlineCodesElement = doc.createElement("OutlineCodes");
+            for (const outlineCode of model.project.outlineCodes) {
+                const outlineCodeElement = doc.createElement("OutlineCode");
+                appendTextElement(doc, outlineCodeElement, "FieldID", outlineCode.fieldID);
+                appendTextElement(doc, outlineCodeElement, "FieldName", outlineCode.fieldName);
+                appendTextElement(doc, outlineCodeElement, "Alias", outlineCode.alias);
+                appendTextElement(doc, outlineCodeElement, "OnlyTableValues", outlineCode.onlyTableValues);
+                appendTextElement(doc, outlineCodeElement, "Enterprise", outlineCode.enterprise);
+                appendTextElement(doc, outlineCodeElement, "ResourceSubstitutionEnabled", outlineCode.resourceSubstitutionEnabled);
+                appendTextElement(doc, outlineCodeElement, "LeafOnly", outlineCode.leafOnly);
+                appendTextElement(doc, outlineCodeElement, "AllLevelsRequired", outlineCode.allLevelsRequired);
+                if (outlineCode.masks.length > 0) {
+                    const masksElement = doc.createElement("Masks");
+                    for (const mask of outlineCode.masks) {
+                        const maskElement = doc.createElement("Mask");
+                        appendTextElement(doc, maskElement, "Level", mask.level);
+                        appendTextElement(doc, maskElement, "Mask", mask.mask);
+                        appendTextElement(doc, maskElement, "Length", mask.length);
+                        appendTextElement(doc, maskElement, "Sequence", mask.sequence);
+                        masksElement.appendChild(maskElement);
+                    }
+                    outlineCodeElement.appendChild(masksElement);
+                }
+                if (outlineCode.values.length > 0) {
+                    const valuesElement = doc.createElement("Values");
+                    for (const value of outlineCode.values) {
+                        const valueElement = doc.createElement("Value");
+                        appendTextElement(doc, valueElement, "Value", value.value);
+                        appendTextElement(doc, valueElement, "Description", value.description);
+                        valuesElement.appendChild(valueElement);
+                    }
+                    outlineCodeElement.appendChild(valuesElement);
+                }
+                outlineCodesElement.appendChild(outlineCodeElement);
+            }
+            project.appendChild(outlineCodesElement);
+        }
+        if (model.project.wbsMasks.length > 0) {
+            const wbsMasksElement = doc.createElement("WBSMasks");
+            for (const wbsMask of model.project.wbsMasks) {
+                const wbsMaskElement = doc.createElement("WBSMask");
+                appendTextElement(doc, wbsMaskElement, "Level", wbsMask.level);
+                appendTextElement(doc, wbsMaskElement, "Mask", wbsMask.mask);
+                appendTextElement(doc, wbsMaskElement, "Length", wbsMask.length);
+                appendTextElement(doc, wbsMaskElement, "Sequence", wbsMask.sequence);
+                wbsMasksElement.appendChild(wbsMaskElement);
+            }
+            project.appendChild(wbsMasksElement);
+        }
+        if (model.project.extendedAttributes.length > 0) {
+            const extendedAttributesElement = doc.createElement("ExtendedAttributes");
+            for (const attribute of model.project.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "FieldName", attribute.fieldName);
+                appendTextElement(doc, extendedAttributeElement, "Alias", attribute.alias);
+                appendTextElement(doc, extendedAttributeElement, "CalculationType", attribute.calculationType);
+                appendTextElement(doc, extendedAttributeElement, "RestrictValues", attribute.restrictValues);
+                appendTextElement(doc, extendedAttributeElement, "AppendNewValues", attribute.appendNewValues);
+                extendedAttributesElement.appendChild(extendedAttributeElement);
+            }
+            project.appendChild(extendedAttributesElement);
+        }
         const calendarsElement = doc.createElement("Calendars");
         for (const calendar of model.calendars) {
             const calendarElement = doc.createElement("Calendar");
             appendTextElement(doc, calendarElement, "UID", calendar.uid);
             appendTextElement(doc, calendarElement, "Name", calendar.name);
             appendTextElement(doc, calendarElement, "IsBaseCalendar", calendar.isBaseCalendar);
+            appendTextElement(doc, calendarElement, "IsBaselineCalendar", calendar.isBaselineCalendar);
+            appendTextElement(doc, calendarElement, "BaseCalendarUID", calendar.baseCalendarUID);
+            if (calendar.exceptions.length > 0) {
+                const exceptionsElement = doc.createElement("Exceptions");
+                for (const exception of calendar.exceptions) {
+                    const exceptionElement = doc.createElement("Exception");
+                    appendTextElement(doc, exceptionElement, "Name", exception.name);
+                    appendTextElement(doc, exceptionElement, "FromDate", exception.fromDate);
+                    appendTextElement(doc, exceptionElement, "ToDate", exception.toDate);
+                    appendTextElement(doc, exceptionElement, "DayWorking", exception.dayWorking);
+                    appendWorkingTimes(doc, exceptionElement, exception.workingTimes);
+                    exceptionsElement.appendChild(exceptionElement);
+                }
+                calendarElement.appendChild(exceptionsElement);
+            }
+            if (calendar.workWeeks.length > 0) {
+                const workWeeksElement = doc.createElement("WorkWeeks");
+                for (const workWeek of calendar.workWeeks) {
+                    const workWeekElement = doc.createElement("WorkWeek");
+                    appendTextElement(doc, workWeekElement, "Name", workWeek.name);
+                    appendTextElement(doc, workWeekElement, "FromDate", workWeek.fromDate);
+                    appendTextElement(doc, workWeekElement, "ToDate", workWeek.toDate);
+                    appendWeekDays(doc, workWeekElement, workWeek.weekDays);
+                    workWeeksElement.appendChild(workWeekElement);
+                }
+                calendarElement.appendChild(workWeeksElement);
+            }
+            appendWeekDays(doc, calendarElement, calendar.weekDays);
             calendarsElement.appendChild(calendarElement);
         }
         project.appendChild(calendarsElement);
@@ -3760,17 +4462,60 @@ if (!customElements.get("lht-page-menu")) {
             appendTextElement(doc, taskElement, "Name", task.name);
             appendTextElement(doc, taskElement, "OutlineLevel", task.outlineLevel);
             appendTextElement(doc, taskElement, "OutlineNumber", task.outlineNumber);
+            appendTextElement(doc, taskElement, "WBS", task.wbs);
+            appendTextElement(doc, taskElement, "Type", task.type);
+            appendTextElement(doc, taskElement, "CalendarUID", task.calendarUID);
+            appendTextElement(doc, taskElement, "Priority", task.priority);
             appendTextElement(doc, taskElement, "Start", task.start);
             appendTextElement(doc, taskElement, "Finish", task.finish);
             appendTextElement(doc, taskElement, "Duration", task.duration);
             appendTextElement(doc, taskElement, "ActualStart", task.actualStart);
             appendTextElement(doc, taskElement, "ActualFinish", task.actualFinish);
+            appendTextElement(doc, taskElement, "Deadline", task.deadline);
+            appendTextElement(doc, taskElement, "StartVariance", task.startVariance);
+            appendTextElement(doc, taskElement, "FinishVariance", task.finishVariance);
+            appendTextElement(doc, taskElement, "Work", task.work);
+            appendTextElement(doc, taskElement, "WorkVariance", task.workVariance);
+            appendTextElement(doc, taskElement, "TotalSlack", task.totalSlack);
+            appendTextElement(doc, taskElement, "FreeSlack", task.freeSlack);
+            appendTextElement(doc, taskElement, "Cost", task.cost);
+            appendTextElement(doc, taskElement, "ActualCost", task.actualCost);
+            appendTextElement(doc, taskElement, "RemainingCost", task.remainingCost);
+            appendTextElement(doc, taskElement, "RemainingWork", task.remainingWork);
+            appendTextElement(doc, taskElement, "ActualWork", task.actualWork);
             appendTextElement(doc, taskElement, "ConstraintType", task.constraintType);
             appendTextElement(doc, taskElement, "ConstraintDate", task.constraintDate);
             appendTextElement(doc, taskElement, "Milestone", task.milestone);
             appendTextElement(doc, taskElement, "Summary", task.summary);
+            appendTextElement(doc, taskElement, "Critical", task.critical);
             appendTextElement(doc, taskElement, "PercentComplete", task.percentComplete);
+            appendTextElement(doc, taskElement, "PercentWorkComplete", task.percentWorkComplete);
             appendTextElement(doc, taskElement, "Notes", task.notes);
+            for (const attribute of task.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                taskElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of task.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                taskElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of task.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                taskElement.appendChild(timephasedDataElement);
+            }
             for (const predecessor of task.predecessors) {
                 const predecessorElement = doc.createElement("PredecessorLink");
                 appendTextElement(doc, predecessorElement, "PredecessorUID", predecessor.predecessorUid);
@@ -3790,7 +4535,46 @@ if (!customElements.get("lht-page-menu")) {
             appendTextElement(doc, resourceElement, "Type", resource.type);
             appendTextElement(doc, resourceElement, "Initials", resource.initials);
             appendTextElement(doc, resourceElement, "Group", resource.group);
+            appendTextElement(doc, resourceElement, "WorkGroup", resource.workGroup);
             appendTextElement(doc, resourceElement, "MaxUnits", resource.maxUnits);
+            appendTextElement(doc, resourceElement, "CalendarUID", resource.calendarUID);
+            appendTextElement(doc, resourceElement, "StandardRate", resource.standardRate);
+            appendTextElement(doc, resourceElement, "StandardRateFormat", resource.standardRateFormat);
+            appendTextElement(doc, resourceElement, "OvertimeRate", resource.overtimeRate);
+            appendTextElement(doc, resourceElement, "OvertimeRateFormat", resource.overtimeRateFormat);
+            appendTextElement(doc, resourceElement, "CostPerUse", resource.costPerUse);
+            appendTextElement(doc, resourceElement, "Work", resource.work);
+            appendTextElement(doc, resourceElement, "ActualWork", resource.actualWork);
+            appendTextElement(doc, resourceElement, "RemainingWork", resource.remainingWork);
+            appendTextElement(doc, resourceElement, "Cost", resource.cost);
+            appendTextElement(doc, resourceElement, "ActualCost", resource.actualCost);
+            appendTextElement(doc, resourceElement, "RemainingCost", resource.remainingCost);
+            appendTextElement(doc, resourceElement, "PercentWorkComplete", resource.percentWorkComplete);
+            for (const attribute of resource.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                resourceElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of resource.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                resourceElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of resource.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                resourceElement.appendChild(timephasedDataElement);
+            }
             resourcesElement.appendChild(resourceElement);
         }
         project.appendChild(resourcesElement);
@@ -3802,8 +4586,46 @@ if (!customElements.get("lht-page-menu")) {
             appendTextElement(doc, assignmentElement, "ResourceUID", assignment.resourceUid);
             appendTextElement(doc, assignmentElement, "Start", assignment.start);
             appendTextElement(doc, assignmentElement, "Finish", assignment.finish);
+            appendTextElement(doc, assignmentElement, "StartVariance", assignment.startVariance);
+            appendTextElement(doc, assignmentElement, "FinishVariance", assignment.finishVariance);
+            appendTextElement(doc, assignmentElement, "Delay", assignment.delay);
+            appendTextElement(doc, assignmentElement, "Milestone", assignment.milestone);
+            appendTextElement(doc, assignmentElement, "WorkContour", assignment.workContour);
             appendTextElement(doc, assignmentElement, "Units", assignment.units);
             appendTextElement(doc, assignmentElement, "Work", assignment.work);
+            appendTextElement(doc, assignmentElement, "Cost", assignment.cost);
+            appendTextElement(doc, assignmentElement, "ActualCost", assignment.actualCost);
+            appendTextElement(doc, assignmentElement, "RemainingCost", assignment.remainingCost);
+            appendTextElement(doc, assignmentElement, "PercentWorkComplete", assignment.percentWorkComplete);
+            appendTextElement(doc, assignmentElement, "OvertimeWork", assignment.overtimeWork);
+            appendTextElement(doc, assignmentElement, "ActualOvertimeWork", assignment.actualOvertimeWork);
+            appendTextElement(doc, assignmentElement, "ActualWork", assignment.actualWork);
+            appendTextElement(doc, assignmentElement, "RemainingWork", assignment.remainingWork);
+            for (const attribute of assignment.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                assignmentElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of assignment.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                assignmentElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of assignment.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                assignmentElement.appendChild(timephasedDataElement);
+            }
             assignmentsElement.appendChild(assignmentElement);
         }
         project.appendChild(assignmentsElement);
@@ -3823,6 +4645,9 @@ if (!customElements.get("lht-page-menu")) {
         if (!model.project.name) {
             issues.push({ level: "warning", scope: "project", message: "Project Name が空です" });
         }
+        if (model.project.saveVersion !== undefined && model.project.saveVersion < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project SaveVersion は 0 以上が望ましいです" });
+        }
         if (!model.project.startDate) {
             issues.push({ level: "warning", scope: "project", message: "Project StartDate が空です" });
         }
@@ -3838,14 +4663,135 @@ if (!customElements.get("lht-page-menu")) {
         if (model.project.daysPerMonth !== undefined && model.project.daysPerMonth <= 0) {
             issues.push({ level: "warning", scope: "project", message: "Project DaysPerMonth は正の値が望ましいです" });
         }
+        if (model.project.weekStartDay !== undefined && (model.project.weekStartDay < 1 || model.project.weekStartDay > 7)) {
+            issues.push({ level: "warning", scope: "project", message: "Project WeekStartDay は 1..7 が望ましいです" });
+        }
+        if (model.project.workFormat !== undefined && model.project.workFormat < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project WorkFormat は 0 以上が望ましいです" });
+        }
+        if (model.project.durationFormat !== undefined && model.project.durationFormat < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DurationFormat は 0 以上が望ましいです" });
+        }
+        if (model.project.currencyDigits !== undefined && model.project.currencyDigits < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CurrencyDigits は 0 以上が望ましいです" });
+        }
+        if (model.project.currencySymbolPosition !== undefined && model.project.currencySymbolPosition < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CurrencySymbolPosition は 0 以上が望ましいです" });
+        }
+        if (model.project.fyStartDate !== undefined && !parseDateValue(model.project.fyStartDate)) {
+            issues.push({ level: "warning", scope: "project", message: "Project FYStartDate の日付形式が解釈できません" });
+        }
+        if (model.project.criticalSlackLimit !== undefined && model.project.criticalSlackLimit < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CriticalSlackLimit は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultTaskType !== undefined && model.project.defaultTaskType < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskType は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultFixedCostAccrual !== undefined && model.project.defaultFixedCostAccrual < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultFixedCostAccrual は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultTaskEVMethod !== undefined && model.project.defaultTaskEVMethod < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskEVMethod は 0 以上が望ましいです" });
+        }
+        if (model.project.newTaskStartDate !== undefined && model.project.newTaskStartDate < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project NewTaskStartDate は 0 以上が望ましいです" });
+        }
+        for (const outlineCode of model.project.outlineCodes) {
+            if (!outlineCode.fieldID && !outlineCode.fieldName) {
+                issues.push({ level: "warning", scope: "project", message: "Project OutlineCode は FieldID または FieldName を持つことが望ましいです" });
+            }
+            for (const mask of outlineCode.masks) {
+                if (mask.level < 1) {
+                    issues.push({ level: "warning", scope: "project", message: "Project OutlineCode Mask Level は 1 以上が望ましいです" });
+                }
+            }
+        }
+        for (const wbsMask of model.project.wbsMasks) {
+            if (wbsMask.level < 1) {
+                issues.push({ level: "warning", scope: "project", message: "Project WBSMask Level は 1 以上が望ましいです" });
+            }
+        }
+        for (const attribute of model.project.extendedAttributes) {
+            if (!attribute.fieldID && !attribute.fieldName) {
+                issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute は FieldID または FieldName を持つことが望ましいです" });
+            }
+            if (attribute.calculationType !== undefined && attribute.calculationType < 0) {
+                issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute CalculationType は 0 以上が望ましいです" });
+            }
+        }
         for (const calendar of model.calendars) {
             if (!calendar.uid) {
                 issues.push({ level: "error", scope: "calendars", message: "Calendar UID が空です" });
+            }
+            if (calendar.isBaselineCalendar !== undefined && !calendar.isBaseCalendar && calendar.isBaselineCalendar) {
+                issues.push({
+                    level: "warning",
+                    scope: "calendars",
+                    message: `Calendar IsBaselineCalendar は通常 BaseCalendar と整合していることが望ましいです: UID=${calendar.uid}`
+                });
             }
             if (calendarUidSet.has(calendar.uid)) {
                 issues.push({ level: "error", scope: "calendars", message: `Calendar UID が重複しています: ${calendar.uid}` });
             }
             calendarUidSet.add(calendar.uid);
+            for (const weekDay of calendar.weekDays) {
+                if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar WeekDay DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+                    });
+                }
+                for (const workingTime of weekDay.workingTimes) {
+                    if (!workingTime.fromTime || !workingTime.toTime) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
+            for (const exception of calendar.exceptions) {
+                const exceptionFrom = parseDateValue(exception.fromDate);
+                const exceptionTo = parseDateValue(exception.toDate);
+                if (exceptionFrom !== null && exceptionTo !== null && exceptionFrom > exceptionTo) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar Exception FromDate が ToDate より後です: UID=${calendar.uid}`
+                    });
+                }
+                for (const workingTime of exception.workingTimes) {
+                    if (!workingTime.fromTime || !workingTime.toTime) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar Exception WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
+            for (const workWeek of calendar.workWeeks) {
+                const workWeekFrom = parseDateValue(workWeek.fromDate);
+                const workWeekTo = parseDateValue(workWeek.toDate);
+                if (workWeekFrom !== null && workWeekTo !== null && workWeekFrom > workWeekTo) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar WorkWeek FromDate が ToDate より後です: UID=${calendar.uid}`
+                    });
+                }
+                for (const weekDay of workWeek.weekDays) {
+                    if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar WorkWeek DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
         }
         if (model.project.calendarUID && !calendarUidSet.has(model.project.calendarUID)) {
             issues.push({
@@ -3853,6 +4799,15 @@ if (!customElements.get("lht-page-menu")) {
                 scope: "project",
                 message: `Project CalendarUID が既存 Calendar を指していません: ${model.project.calendarUID}`
             });
+        }
+        for (const calendar of model.calendars) {
+            if (calendar.baseCalendarUID && !calendarUidSet.has(calendar.baseCalendarUID)) {
+                issues.push({
+                    level: "warning",
+                    scope: "calendars",
+                    message: `Calendar BaseCalendarUID が既存 Calendar を指していません: UID=${calendar.uid}`
+                });
+            }
         }
         for (const task of model.tasks) {
             if (!task.uid) {
@@ -3862,7 +4817,9 @@ if (!customElements.get("lht-page-menu")) {
                 issues.push({ level: "error", scope: "tasks", message: `Task ID が空です: ${task.name || "(無名)"}` });
             }
             if (!task.name) {
-                issues.push({ level: "error", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+                if (!isPlaceholderUid(task.uid)) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+                }
             }
             if (taskIdSet.has(task.id)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task ID が重複しています: ${task.id}` });
@@ -3874,10 +4831,10 @@ if (!customElements.get("lht-page-menu")) {
             if (!task.finish) {
                 issues.push({ level: "warning", scope: "tasks", message: `Task Finish が空です: UID=${task.uid}` });
             }
-            if (task.outlineLevel < 1) {
+            if (task.outlineLevel < 1 && !isPlaceholderUid(task.uid)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task OutlineLevel が不正です: UID=${task.uid}` });
             }
-            if (task.outlineNumber) {
+            if (task.outlineNumber && !isPlaceholderUid(task.uid)) {
                 const outlineParts = task.outlineNumber.split(".").filter(Boolean);
                 if (outlineParts.length !== task.outlineLevel) {
                     issues.push({
@@ -3894,15 +4851,31 @@ if (!customElements.get("lht-page-menu")) {
                     message: `Task PercentComplete が 0..100 の範囲外です: UID=${task.uid}`
                 });
             }
+            if (task.percentWorkComplete !== undefined &&
+                (task.percentWorkComplete < 0 || task.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task PercentWorkComplete が 0..100 の範囲外です: UID=${task.uid}`
+                });
+            }
             const taskStart = parseDateValue(task.start);
             const taskFinish = parseDateValue(task.finish);
             const taskActualStart = parseDateValue(task.actualStart);
             const taskActualFinish = parseDateValue(task.actualFinish);
+            const taskDeadline = parseDateValue(task.deadline);
             if (taskStart !== null && taskFinish !== null && taskStart > taskFinish) {
                 issues.push({
                     level: "warning",
                     scope: "tasks",
                     message: `Task Start が Finish より後です: UID=${task.uid}`
+                });
+            }
+            if (taskFinish !== null && taskDeadline !== null && taskFinish > taskDeadline) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task Finish が Deadline より後です: UID=${task.uid}`
                 });
             }
             if (taskActualStart !== null && taskActualFinish !== null && taskActualStart > taskActualFinish) {
@@ -3915,19 +4888,141 @@ if (!customElements.get("lht-page-menu")) {
             if (taskUidSet.has(task.uid)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task UID が重複しています: ${task.uid}` });
             }
+            for (const attribute of task.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task ExtendedAttribute に FieldID がありません: UID=${task.uid}` });
+                }
+            }
+            for (const baseline of task.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Number は 0 以上が望ましいです: UID=${task.uid}` });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Start が Finish より後です: UID=${task.uid}` });
+                }
+            }
+            for (const timephasedData of task.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Type は 0 以上が望ましいです: UID=${task.uid}` });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Start が Finish より後です: UID=${task.uid}` });
+                }
+            }
             taskUidSet.add(task.uid);
+            if (task.priority !== undefined && (task.priority < 0 || task.priority > 1000)) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task Priority が 0..1000 の範囲外です: UID=${task.uid}`
+                });
+            }
+            if (task.cost !== undefined && task.cost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task Cost が負値です: UID=${task.uid}` });
+            }
+            if (task.actualCost !== undefined && task.actualCost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task ActualCost が負値です: UID=${task.uid}` });
+            }
+            if (task.remainingCost !== undefined && task.remainingCost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task RemainingCost が負値です: UID=${task.uid}` });
+            }
         }
         for (const resource of model.resources) {
             if (!resource.uid) {
                 issues.push({ level: "error", scope: "resources", message: "Resource UID が空です" });
             }
             if (!resource.name) {
-                issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+                if (!isPlaceholderUid(resource.uid)) {
+                    issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+                }
             }
             if (resourceUidSet.has(resource.uid)) {
                 issues.push({ level: "error", scope: "resources", message: `Resource UID が重複しています: ${resource.uid}` });
             }
             resourceUidSet.add(resource.uid);
+            if (resource.calendarUID && !calendarUidSet.has(resource.calendarUID)) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource CalendarUID が既存 Calendar を指していません: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.workGroup !== undefined && resource.workGroup < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource WorkGroup は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.overtimeRateFormat !== undefined && resource.overtimeRateFormat < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource OvertimeRateFormat は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.cost !== undefined && resource.cost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource Cost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.actualCost !== undefined && resource.actualCost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource ActualCost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.remainingCost !== undefined && resource.remainingCost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource RemainingCost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.percentWorkComplete !== undefined &&
+                (resource.percentWorkComplete < 0 || resource.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource PercentWorkComplete が 0..100 の範囲外です: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            for (const attribute of resource.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({ level: "warning", scope: "resources", message: `Resource ExtendedAttribute に FieldID がありません: UID=${resource.uid || "(なし)"}` });
+                }
+            }
+            for (const baseline of resource.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource Baseline Number は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource Baseline Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const timephasedData of resource.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource TimephasedData Type は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource TimephasedData Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+            }
         }
         for (const task of model.tasks) {
             for (const predecessor of task.predecessors) {
@@ -3951,7 +5046,7 @@ if (!customElements.get("lht-page-menu")) {
                     message: `Assignment TaskUID が既存 Task を指していません: ${assignment.taskUid}`
                 });
             }
-            if (!resourceUidSet.has(assignment.resourceUid)) {
+            if (!resourceUidSet.has(assignment.resourceUid) && !isUnassignedResourceUid(assignment.resourceUid)) {
                 issues.push({
                     level: "error",
                     scope: "assignments",
@@ -3978,6 +5073,115 @@ if (!customElements.get("lht-page-menu")) {
                     level: "warning",
                     scope: "assignments",
                     message: `Assignment Units が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.cost !== undefined && assignment.cost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment Cost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.actualCost !== undefined && assignment.actualCost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment ActualCost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.remainingCost !== undefined && assignment.remainingCost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment RemainingCost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.percentWorkComplete !== undefined &&
+                (assignment.percentWorkComplete < 0 || assignment.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment PercentWorkComplete が 0..100 の範囲外です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.overtimeWork !== undefined && !assignment.overtimeWork) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment OvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.actualOvertimeWork !== undefined && !assignment.actualOvertimeWork) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment ActualOvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.workContour !== undefined && assignment.workContour < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment WorkContour は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.startVariance !== undefined && !assignment.startVariance) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment StartVariance が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            for (const attribute of assignment.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment ExtendedAttribute に FieldID がありません: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const baseline of assignment.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment Baseline Number は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment Baseline Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const timephasedData of assignment.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment TimephasedData Type は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment TimephasedData Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            if (assignment.finishVariance !== undefined && !assignment.finishVariance) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment FinishVariance が空です: UID=${assignment.uid || "(なし)"}`
                 });
             }
         }
@@ -4028,6 +5232,22 @@ if (!customElements.get("lht-page-menu")) {
         }
         container.innerHTML = items.join("");
     }
+    function formatFirstBaselineSummary(item) {
+        var _a, _b;
+        const baseline = item.baselines[0];
+        if (!baseline) {
+            return "-";
+        }
+        return `#${(_a = baseline.number) !== null && _a !== void 0 ? _a : "-"} ${baseline.start || "-"} -> ${baseline.finish || "-"} / Work=${baseline.work || "-"} / Cost=${(_b = baseline.cost) !== null && _b !== void 0 ? _b : "-"}`;
+    }
+    function formatFirstTimephasedSummary(item) {
+        var _a, _b;
+        const timephasedData = item.timephasedData[0];
+        if (!timephasedData) {
+            return "-";
+        }
+        return `Type=${(_a = timephasedData.type) !== null && _a !== void 0 ? _a : "-"} ${timephasedData.start || "-"} -> ${timephasedData.finish || "-"} / Unit=${(_b = timephasedData.unit) !== null && _b !== void 0 ? _b : "-"} / Value=${timephasedData.value || "-"}`;
+    }
     function renderValidationIssues(issues) {
         const container = getElement("validationIssues");
         if (issues.length === 0) {
@@ -4077,7 +5297,10 @@ if (!customElements.get("lht-page-menu")) {
         <div class="md-preview-item__meta">UID=${task.uid} / ID=${task.id} / Outline=${task.outlineNumber || task.outlineLevel}
 Start=${task.start || "-"}
 Finish=${task.finish || "-"}
-Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}</div>
+Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}
+Ext=${task.extendedAttributes.length} / Baselines=${task.baselines.length} / Timephased=${task.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(task)}
+Timephased1=${formatFirstTimephasedSummary(task)}</div>
       </div>
     `) : []);
         renderPreviewList("resourcePreview", model ? model.resources.map((resource) => `
@@ -4085,7 +5308,10 @@ Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") |
         <div class="md-preview-item__title">${resource.name || "(no name)"}</div>
         <div class="md-preview-item__meta">UID=${resource.uid} / ID=${resource.id}
 Initials=${resource.initials || "-"}
-Group=${resource.group || "-"}</div>
+Group=${resource.group || "-"}
+Ext=${resource.extendedAttributes.length} / Baselines=${resource.baselines.length} / Timephased=${resource.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(resource)}
+Timephased1=${formatFirstTimephasedSummary(resource)}</div>
       </div>
     `) : []);
         renderPreviewList("assignmentPreview", model ? model.assignments.map((assignment) => `
@@ -4094,7 +5320,10 @@ Group=${resource.group || "-"}</div>
         <div class="md-preview-item__meta">TaskUID=${assignment.taskUid}
 ResourceUID=${assignment.resourceUid}
 Start=${assignment.start || "-"}
-Finish=${assignment.finish || "-"}</div>
+Finish=${assignment.finish || "-"}
+Ext=${assignment.extendedAttributes.length} / Baselines=${assignment.baselines.length} / Timephased=${assignment.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(assignment)}
+Timephased1=${formatFirstTimephasedSummary(assignment)}</div>
       </div>
     `) : []);
     }

--- a/docs/project/src/mikuproject/js/main.js
+++ b/docs/project/src/mikuproject/js/main.js
@@ -31,6 +31,22 @@
         }
         container.innerHTML = items.join("");
     }
+    function formatFirstBaselineSummary(item) {
+        var _a, _b;
+        const baseline = item.baselines[0];
+        if (!baseline) {
+            return "-";
+        }
+        return `#${(_a = baseline.number) !== null && _a !== void 0 ? _a : "-"} ${baseline.start || "-"} -> ${baseline.finish || "-"} / Work=${baseline.work || "-"} / Cost=${(_b = baseline.cost) !== null && _b !== void 0 ? _b : "-"}`;
+    }
+    function formatFirstTimephasedSummary(item) {
+        var _a, _b;
+        const timephasedData = item.timephasedData[0];
+        if (!timephasedData) {
+            return "-";
+        }
+        return `Type=${(_a = timephasedData.type) !== null && _a !== void 0 ? _a : "-"} ${timephasedData.start || "-"} -> ${timephasedData.finish || "-"} / Unit=${(_b = timephasedData.unit) !== null && _b !== void 0 ? _b : "-"} / Value=${timephasedData.value || "-"}`;
+    }
     function renderValidationIssues(issues) {
         const container = getElement("validationIssues");
         if (issues.length === 0) {
@@ -80,7 +96,10 @@
         <div class="md-preview-item__meta">UID=${task.uid} / ID=${task.id} / Outline=${task.outlineNumber || task.outlineLevel}
 Start=${task.start || "-"}
 Finish=${task.finish || "-"}
-Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}</div>
+Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}
+Ext=${task.extendedAttributes.length} / Baselines=${task.baselines.length} / Timephased=${task.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(task)}
+Timephased1=${formatFirstTimephasedSummary(task)}</div>
       </div>
     `) : []);
         renderPreviewList("resourcePreview", model ? model.resources.map((resource) => `
@@ -88,7 +107,10 @@ Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") |
         <div class="md-preview-item__title">${resource.name || "(no name)"}</div>
         <div class="md-preview-item__meta">UID=${resource.uid} / ID=${resource.id}
 Initials=${resource.initials || "-"}
-Group=${resource.group || "-"}</div>
+Group=${resource.group || "-"}
+Ext=${resource.extendedAttributes.length} / Baselines=${resource.baselines.length} / Timephased=${resource.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(resource)}
+Timephased1=${formatFirstTimephasedSummary(resource)}</div>
       </div>
     `) : []);
         renderPreviewList("assignmentPreview", model ? model.assignments.map((assignment) => `
@@ -97,7 +119,10 @@ Group=${resource.group || "-"}</div>
         <div class="md-preview-item__meta">TaskUID=${assignment.taskUid}
 ResourceUID=${assignment.resourceUid}
 Start=${assignment.start || "-"}
-Finish=${assignment.finish || "-"}</div>
+Finish=${assignment.finish || "-"}
+Ext=${assignment.extendedAttributes.length} / Baselines=${assignment.baselines.length} / Timephased=${assignment.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(assignment)}
+Timephased1=${formatFirstTimephasedSummary(assignment)}</div>
       </div>
     `) : []);
     }

--- a/docs/project/src/mikuproject/js/msproject-xml.js
+++ b/docs/project/src/mikuproject/js/msproject-xml.js
@@ -2,6 +2,12 @@
     const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/project">
   <Name>Sample Project</Name>
+  <Title>Sample Project Title</Title>
+  <Company>Local HTML Tools</Company>
+  <Author>Toshiki Iga</Author>
+  <CreationDate>2026-03-16T08:30:00</CreationDate>
+  <LastSaved>2026-03-16T09:10:00</LastSaved>
+  <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
   <FinishDate>2026-03-20T18:00:00</FinishDate>
@@ -11,12 +17,161 @@
   <MinutesPerDay>480</MinutesPerDay>
   <MinutesPerWeek>2400</MinutesPerWeek>
   <DaysPerMonth>20</DaysPerMonth>
+  <StatusDate>2026-03-19T09:00:00</StatusDate>
+  <WeekStartDay>1</WeekStartDay>
+  <WorkFormat>2</WorkFormat>
+  <DurationFormat>7</DurationFormat>
+  <CurrencyCode>JPY</CurrencyCode>
+  <CurrencyDigits>0</CurrencyDigits>
+  <CurrencySymbol>¥</CurrencySymbol>
+  <CurrencySymbolPosition>0</CurrencySymbolPosition>
+  <FYStartDate>2026-04-01T00:00:00</FYStartDate>
+  <FiscalYearStart>1</FiscalYearStart>
+  <CriticalSlackLimit>0</CriticalSlackLimit>
+  <DefaultTaskType>1</DefaultTaskType>
+  <DefaultFixedCostAccrual>2</DefaultFixedCostAccrual>
+  <DefaultStandardRate>5000/h</DefaultStandardRate>
+  <DefaultOvertimeRate>7000/h</DefaultOvertimeRate>
+  <DefaultTaskEVMethod>0</DefaultTaskEVMethod>
+  <NewTaskStartDate>0</NewTaskStartDate>
+  <NewTasksAreManual>0</NewTasksAreManual>
+  <NewTasksEffortDriven>1</NewTasksEffortDriven>
+  <NewTasksEstimated>1</NewTasksEstimated>
+  <ActualsInSync>0</ActualsInSync>
+  <EditableActualCosts>1</EditableActualCosts>
+  <HonorConstraints>1</HonorConstraints>
+  <InsertedProjectsLikeSummary>1</InsertedProjectsLikeSummary>
+  <MultipleCriticalPaths>0</MultipleCriticalPaths>
+  <TaskUpdatesResource>1</TaskUpdatesResource>
+  <UpdateManuallyScheduledTasksWhenEditingLinks>0</UpdateManuallyScheduledTasksWhenEditingLinks>
   <CalendarUID>1</CalendarUID>
+  <OutlineCodes>
+    <OutlineCode>
+      <FieldID>188743731</FieldID>
+      <FieldName>Outline Code1</FieldName>
+      <Alias>Phase</Alias>
+      <OnlyTableValues>1</OnlyTableValues>
+      <Enterprise>0</Enterprise>
+      <ResourceSubstitutionEnabled>0</ResourceSubstitutionEnabled>
+      <LeafOnly>0</LeafOnly>
+      <AllLevelsRequired>0</AllLevelsRequired>
+      <Masks>
+        <Mask>
+          <Level>1</Level>
+          <Mask>*</Mask>
+          <Length>0</Length>
+          <Sequence>0</Sequence>
+        </Mask>
+      </Masks>
+      <Values>
+        <Value>
+          <Value>PLAN</Value>
+          <Description>Planning</Description>
+        </Value>
+        <Value>
+          <Value>BUILD</Value>
+          <Description>Implementation</Description>
+        </Value>
+      </Values>
+    </OutlineCode>
+  </OutlineCodes>
+  <WBSMasks>
+    <WBSMask>
+      <Level>1</Level>
+      <Mask>A</Mask>
+      <Length>1</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+    <WBSMask>
+      <Level>2</Level>
+      <Mask>00</Mask>
+      <Length>2</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+  </WBSMasks>
+  <ExtendedAttributes>
+    <ExtendedAttribute>
+      <FieldID>188743734</FieldID>
+      <FieldName>Text1</FieldName>
+      <Alias>Owner</Alias>
+      <CalculationType>0</CalculationType>
+      <RestrictValues>0</RestrictValues>
+      <AppendNewValues>1</AppendNewValues>
+    </ExtendedAttribute>
+  </ExtendedAttributes>
   <Calendars>
     <Calendar>
       <UID>1</UID>
       <Name>Standard</Name>
       <IsBaseCalendar>1</IsBaseCalendar>
+      <IsBaselineCalendar>1</IsBaselineCalendar>
+      <Exceptions>
+        <Exception>
+          <Name>Holiday</Name>
+          <FromDate>2026-03-20T00:00:00</FromDate>
+          <ToDate>2026-03-20T23:59:59</ToDate>
+          <DayWorking>0</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </Exception>
+      </Exceptions>
+      <WeekDays>
+        <WeekDay>
+          <DayType>2</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+            <WorkingTime>
+              <FromTime>13:00:00</FromTime>
+              <ToTime>18:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
+    </Calendar>
+    <Calendar>
+      <UID>2</UID>
+      <Name>Development</Name>
+      <IsBaseCalendar>0</IsBaseCalendar>
+      <BaseCalendarUID>1</BaseCalendarUID>
+      <WorkWeeks>
+        <WorkWeek>
+          <Name>Spring Sprint</Name>
+          <FromDate>2026-03-16T00:00:00</FromDate>
+          <ToDate>2026-03-31T23:59:59</ToDate>
+          <WeekDays>
+            <WeekDay>
+              <DayType>2</DayType>
+              <DayWorking>1</DayWorking>
+              <WorkingTimes>
+                <WorkingTime>
+                  <FromTime>10:00:00</FromTime>
+                  <ToTime>18:00:00</ToTime>
+                </WorkingTime>
+              </WorkingTimes>
+            </WeekDay>
+          </WeekDays>
+        </WorkWeek>
+      </WorkWeeks>
+      <WeekDays>
+        <WeekDay>
+          <DayType>6</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>10:00:00</FromTime>
+              <ToTime>15:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
     </Calendar>
   </Calendars>
   <Tasks>
@@ -26,12 +181,29 @@
       <Name>Project Summary</Name>
       <OutlineLevel>1</OutlineLevel>
       <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT40H0M0S</Duration>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT40H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <ActualWork>PT20H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>1</Summary>
+      <Critical>0</Critical>
       <PercentComplete>50</PercentComplete>
+      <PercentWorkComplete>50</PercentWorkComplete>
     </Task>
     <Task>
       <UID>2</UID>
@@ -39,15 +211,51 @@
       <Name>Design</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.1</OutlineNumber>
+      <WBS>1.1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
       <Duration>PT16H0M0S</Duration>
       <ActualStart>2026-03-16T09:00:00</ActualStart>
       <ActualFinish>2026-03-17T18:00:00</ActualFinish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT16H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>80000</Cost>
+      <ActualCost>80000</ActualCost>
+      <RemainingCost>0</RemainingCost>
+      <RemainingWork>PT0H0M0S</RemainingWork>
+      <ActualWork>PT16H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>0</Critical>
       <PercentComplete>100</PercentComplete>
+      <PercentWorkComplete>100</PercentWorkComplete>
       <Notes>Design completed</Notes>
+      <ExtendedAttribute>
+        <FieldID>188743734</FieldID>
+        <Value>Miku</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>2</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Task>
     <Task>
       <UID>3</UID>
@@ -55,14 +263,32 @@
       <Name>Implementation</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.2</OutlineNumber>
+      <WBS>1.2</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>700</Priority>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT24H0M0S</Duration>
+      <Deadline>2026-03-21T18:00:00</Deadline>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT24H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT4H0M0S</TotalSlack>
+      <FreeSlack>PT2H0M0S</FreeSlack>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <RemainingWork>PT24H0M0S</RemainingWork>
+      <ActualWork>PT0H0M0S</ActualWork>
       <ConstraintType>4</ConstraintType>
       <ConstraintDate>2026-03-18T09:00:00</ConstraintDate>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>1</Critical>
       <PercentComplete>0</PercentComplete>
+      <PercentWorkComplete>0</PercentWorkComplete>
       <Notes>Implementation starts after design</Notes>
       <PredecessorLink>
         <PredecessorUID>2</PredecessorUID>
@@ -79,7 +305,40 @@
       <Type>1</Type>
       <Initials>MK</Initials>
       <Group>Engineering</Group>
+      <WorkGroup>0</WorkGroup>
       <MaxUnits>1</MaxUnits>
+      <CalendarUID>2</CalendarUID>
+      <StandardRate>5000/h</StandardRate>
+      <StandardRateFormat>2</StandardRateFormat>
+      <OvertimeRate>7000/h</OvertimeRate>
+      <OvertimeRateFormat>2</OvertimeRateFormat>
+      <CostPerUse>1000</CostPerUse>
+      <Work>PT40H0M0S</Work>
+      <ActualWork>PT20H0M0S</ActualWork>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <ExtendedAttribute>
+        <FieldID>188743737</FieldID>
+        <Value>Platform Team</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-20T18:00:00</Finish>
+        <Work>PT40H0M0S</Work>
+        <Cost>200000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Resource>
   </Resources>
   <Assignments>
@@ -89,8 +348,40 @@
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT16H0M0S</Work>
+      <Cost>80000</Cost>
+      <ActualCost>40000</ActualCost>
+      <RemainingCost>40000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <OvertimeWork>PT2H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT1H0M0S</ActualOvertimeWork>
+      <ActualWork>PT8H0M0S</ActualWork>
+      <RemainingWork>PT8H0M0S</RemainingWork>
+      <ExtendedAttribute>
+        <FieldID>255852547</FieldID>
+        <Value>Design Slot</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Assignment>
     <Assignment>
       <UID>2</UID>
@@ -98,8 +389,21 @@
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT24H0M0S</Work>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <PercentWorkComplete>0</PercentWorkComplete>
+      <OvertimeWork>PT0H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT0H0M0S</ActualOvertimeWork>
+      <ActualWork>PT0H0M0S</ActualWork>
+      <RemainingWork>PT24H0M0S</RemainingWork>
     </Assignment>
   </Assignments>
 </Project>`;
@@ -121,6 +425,95 @@
         const timestamp = Date.parse(value);
         return Number.isFinite(timestamp) ? timestamp : null;
     }
+    function parseWeekDays(parent) {
+        var _a;
+        return Array.from(((_a = parent.getElementsByTagName("WeekDays")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WeekDay")) || []).map((weekDay) => {
+            var _a;
+            return ({
+                dayType: parseNumber(textContent(weekDay, "DayType"), 0),
+                dayWorking: parseBoolean(textContent(weekDay, "DayWorking")),
+                workingTimes: Array.from(((_a = weekDay.getElementsByTagName("WorkingTimes")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WorkingTime")) || []).map((workingTime) => ({
+                    fromTime: textContent(workingTime, "FromTime"),
+                    toTime: textContent(workingTime, "ToTime")
+                }))
+            });
+        });
+    }
+    function appendWeekDays(doc, parent, weekDays) {
+        if (weekDays.length === 0) {
+            return;
+        }
+        const weekDaysElement = doc.createElement("WeekDays");
+        for (const weekDay of weekDays) {
+            const weekDayElement = doc.createElement("WeekDay");
+            appendTextElement(doc, weekDayElement, "DayType", weekDay.dayType);
+            appendTextElement(doc, weekDayElement, "DayWorking", weekDay.dayWorking);
+            if (weekDay.workingTimes.length > 0) {
+                const workingTimesElement = doc.createElement("WorkingTimes");
+                for (const workingTime of weekDay.workingTimes) {
+                    const workingTimeElement = doc.createElement("WorkingTime");
+                    appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+                    appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+                    workingTimesElement.appendChild(workingTimeElement);
+                }
+                weekDayElement.appendChild(workingTimesElement);
+            }
+            weekDaysElement.appendChild(weekDayElement);
+        }
+        parent.appendChild(weekDaysElement);
+    }
+    function parseWorkingTimes(parent) {
+        var _a;
+        return Array.from(((_a = parent.getElementsByTagName("WorkingTimes")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("WorkingTime")) || []).map((workingTime) => ({
+            fromTime: textContent(workingTime, "FromTime"),
+            toTime: textContent(workingTime, "ToTime")
+        }));
+    }
+    function appendWorkingTimes(doc, parent, workingTimes) {
+        if (workingTimes.length === 0) {
+            return;
+        }
+        const workingTimesElement = doc.createElement("WorkingTimes");
+        for (const workingTime of workingTimes) {
+            const workingTimeElement = doc.createElement("WorkingTime");
+            appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+            appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+            workingTimesElement.appendChild(workingTimeElement);
+        }
+        parent.appendChild(workingTimesElement);
+    }
+    function parseOutlineCodeMasks(parent) {
+        const masksElement = parent.getElementsByTagName("Masks")[0];
+        if (!masksElement) {
+            return [];
+        }
+        return Array.from(masksElement.children)
+            .filter((child) => child.tagName === "Mask")
+            .map((mask) => ({
+            level: parseNumber(textContent(mask, "Level"), 0),
+            mask: textContent(mask, "Mask") || undefined,
+            length: textContent(mask, "Length") ? parseNumber(textContent(mask, "Length"), 0) : undefined,
+            sequence: textContent(mask, "Sequence") ? parseNumber(textContent(mask, "Sequence"), 0) : undefined
+        }));
+    }
+    function parseOutlineCodeValues(parent) {
+        const valuesElement = parent.getElementsByTagName("Values")[0];
+        if (!valuesElement) {
+            return [];
+        }
+        return Array.from(valuesElement.children)
+            .filter((child) => child.tagName === "Value")
+            .map((value) => ({
+            value: textContent(value, "Value"),
+            description: textContent(value, "Description") || undefined
+        }));
+    }
+    function isPlaceholderUid(value) {
+        return String(value || "").trim() === "0";
+    }
+    function isUnassignedResourceUid(value) {
+        return String(value || "").trim() === "-65535";
+    }
     function parseXmlDocument(xmlText) {
         const parser = new DOMParser();
         const xml = parser.parseFromString(xmlText, "application/xml");
@@ -131,7 +524,7 @@
         return xml;
     }
     function importMsProjectXml(xmlText) {
-        var _a, _b, _c, _d;
+        var _a, _b, _c, _d, _e, _f, _g;
         const xml = parseXmlDocument(xmlText);
         const projectElement = xml.documentElement;
         const calendars = Array.from(((_a = projectElement.getElementsByTagName("Calendars")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("Calendar")) || []);
@@ -141,6 +534,12 @@
         return {
             project: {
                 name: textContent(projectElement, "Name"),
+                title: textContent(projectElement, "Title") || undefined,
+                author: textContent(projectElement, "Author") || undefined,
+                company: textContent(projectElement, "Company") || undefined,
+                creationDate: textContent(projectElement, "CreationDate") || undefined,
+                lastSaved: textContent(projectElement, "LastSaved") || undefined,
+                saveVersion: textContent(projectElement, "SaveVersion") ? parseNumber(textContent(projectElement, "SaveVersion"), 0) : undefined,
                 currentDate: textContent(projectElement, "CurrentDate") || undefined,
                 startDate: textContent(projectElement, "StartDate"),
                 finishDate: textContent(projectElement, "FinishDate"),
@@ -150,30 +549,139 @@
                 minutesPerDay: textContent(projectElement, "MinutesPerDay") ? parseNumber(textContent(projectElement, "MinutesPerDay"), 0) : undefined,
                 minutesPerWeek: textContent(projectElement, "MinutesPerWeek") ? parseNumber(textContent(projectElement, "MinutesPerWeek"), 0) : undefined,
                 daysPerMonth: textContent(projectElement, "DaysPerMonth") ? parseNumber(textContent(projectElement, "DaysPerMonth"), 0) : undefined,
-                calendarUID: textContent(projectElement, "CalendarUID") || undefined
+                statusDate: textContent(projectElement, "StatusDate") || undefined,
+                weekStartDay: textContent(projectElement, "WeekStartDay") ? parseNumber(textContent(projectElement, "WeekStartDay"), 0) : undefined,
+                workFormat: textContent(projectElement, "WorkFormat") ? parseNumber(textContent(projectElement, "WorkFormat"), 0) : undefined,
+                durationFormat: textContent(projectElement, "DurationFormat") ? parseNumber(textContent(projectElement, "DurationFormat"), 0) : undefined,
+                currencyCode: textContent(projectElement, "CurrencyCode") || undefined,
+                currencyDigits: textContent(projectElement, "CurrencyDigits") ? parseNumber(textContent(projectElement, "CurrencyDigits"), 0) : undefined,
+                currencySymbol: textContent(projectElement, "CurrencySymbol") || undefined,
+                currencySymbolPosition: textContent(projectElement, "CurrencySymbolPosition") ? parseNumber(textContent(projectElement, "CurrencySymbolPosition"), 0) : undefined,
+                fyStartDate: textContent(projectElement, "FYStartDate") || undefined,
+                fiscalYearStart: textContent(projectElement, "FiscalYearStart") ? parseBoolean(textContent(projectElement, "FiscalYearStart")) : undefined,
+                criticalSlackLimit: textContent(projectElement, "CriticalSlackLimit") ? parseNumber(textContent(projectElement, "CriticalSlackLimit"), 0) : undefined,
+                defaultTaskType: textContent(projectElement, "DefaultTaskType") ? parseNumber(textContent(projectElement, "DefaultTaskType"), 0) : undefined,
+                defaultFixedCostAccrual: textContent(projectElement, "DefaultFixedCostAccrual") ? parseNumber(textContent(projectElement, "DefaultFixedCostAccrual"), 0) : undefined,
+                defaultStandardRate: textContent(projectElement, "DefaultStandardRate") || undefined,
+                defaultOvertimeRate: textContent(projectElement, "DefaultOvertimeRate") || undefined,
+                defaultTaskEVMethod: textContent(projectElement, "DefaultTaskEVMethod") ? parseNumber(textContent(projectElement, "DefaultTaskEVMethod"), 0) : undefined,
+                newTaskStartDate: textContent(projectElement, "NewTaskStartDate") ? parseNumber(textContent(projectElement, "NewTaskStartDate"), 0) : undefined,
+                newTasksAreManual: textContent(projectElement, "NewTasksAreManual") ? parseBoolean(textContent(projectElement, "NewTasksAreManual")) : undefined,
+                newTasksEffortDriven: textContent(projectElement, "NewTasksEffortDriven") ? parseBoolean(textContent(projectElement, "NewTasksEffortDriven")) : undefined,
+                newTasksEstimated: textContent(projectElement, "NewTasksEstimated") ? parseBoolean(textContent(projectElement, "NewTasksEstimated")) : undefined,
+                actualsInSync: textContent(projectElement, "ActualsInSync") ? parseBoolean(textContent(projectElement, "ActualsInSync")) : undefined,
+                editableActualCosts: textContent(projectElement, "EditableActualCosts") ? parseBoolean(textContent(projectElement, "EditableActualCosts")) : undefined,
+                honorConstraints: textContent(projectElement, "HonorConstraints") ? parseBoolean(textContent(projectElement, "HonorConstraints")) : undefined,
+                insertedProjectsLikeSummary: textContent(projectElement, "InsertedProjectsLikeSummary") ? parseBoolean(textContent(projectElement, "InsertedProjectsLikeSummary")) : undefined,
+                multipleCriticalPaths: textContent(projectElement, "MultipleCriticalPaths") ? parseBoolean(textContent(projectElement, "MultipleCriticalPaths")) : undefined,
+                taskUpdatesResource: textContent(projectElement, "TaskUpdatesResource") ? parseBoolean(textContent(projectElement, "TaskUpdatesResource")) : undefined,
+                updateManuallyScheduledTasksWhenEditingLinks: textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks") ? parseBoolean(textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks")) : undefined,
+                calendarUID: textContent(projectElement, "CalendarUID") || undefined,
+                outlineCodes: Array.from(((_e = projectElement.getElementsByTagName("OutlineCodes")[0]) === null || _e === void 0 ? void 0 : _e.getElementsByTagName("OutlineCode")) || []).map((outlineCode) => ({
+                    fieldID: textContent(outlineCode, "FieldID") || undefined,
+                    fieldName: textContent(outlineCode, "FieldName") || undefined,
+                    alias: textContent(outlineCode, "Alias") || undefined,
+                    onlyTableValues: textContent(outlineCode, "OnlyTableValues") ? parseBoolean(textContent(outlineCode, "OnlyTableValues")) : undefined,
+                    enterprise: textContent(outlineCode, "Enterprise") ? parseBoolean(textContent(outlineCode, "Enterprise")) : undefined,
+                    resourceSubstitutionEnabled: textContent(outlineCode, "ResourceSubstitutionEnabled") ? parseBoolean(textContent(outlineCode, "ResourceSubstitutionEnabled")) : undefined,
+                    leafOnly: textContent(outlineCode, "LeafOnly") ? parseBoolean(textContent(outlineCode, "LeafOnly")) : undefined,
+                    allLevelsRequired: textContent(outlineCode, "AllLevelsRequired") ? parseBoolean(textContent(outlineCode, "AllLevelsRequired")) : undefined,
+                    masks: parseOutlineCodeMasks(outlineCode),
+                    values: parseOutlineCodeValues(outlineCode)
+                })),
+                wbsMasks: Array.from(((_f = projectElement.getElementsByTagName("WBSMasks")[0]) === null || _f === void 0 ? void 0 : _f.getElementsByTagName("WBSMask")) || []).map((wbsMask) => ({
+                    level: parseNumber(textContent(wbsMask, "Level"), 0),
+                    mask: textContent(wbsMask, "Mask") || undefined,
+                    length: textContent(wbsMask, "Length") ? parseNumber(textContent(wbsMask, "Length"), 0) : undefined,
+                    sequence: textContent(wbsMask, "Sequence") ? parseNumber(textContent(wbsMask, "Sequence"), 0) : undefined
+                })),
+                extendedAttributes: Array.from(((_g = projectElement.getElementsByTagName("ExtendedAttributes")[0]) === null || _g === void 0 ? void 0 : _g.getElementsByTagName("ExtendedAttribute")) || []).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    fieldName: textContent(attribute, "FieldName") || undefined,
+                    alias: textContent(attribute, "Alias") || undefined,
+                    calculationType: textContent(attribute, "CalculationType") ? parseNumber(textContent(attribute, "CalculationType"), 0) : undefined,
+                    restrictValues: textContent(attribute, "RestrictValues") ? parseBoolean(textContent(attribute, "RestrictValues")) : undefined,
+                    appendNewValues: textContent(attribute, "AppendNewValues") ? parseBoolean(textContent(attribute, "AppendNewValues")) : undefined
+                }))
             },
-            calendars: calendars.map((calendar) => ({
-                uid: textContent(calendar, "UID"),
-                name: textContent(calendar, "Name"),
-                isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar"))
-            })),
+            calendars: calendars.map((calendar) => {
+                var _a, _b;
+                return ({
+                    uid: textContent(calendar, "UID"),
+                    name: textContent(calendar, "Name"),
+                    isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar")),
+                    isBaselineCalendar: textContent(calendar, "IsBaselineCalendar") ? parseBoolean(textContent(calendar, "IsBaselineCalendar")) : undefined,
+                    baseCalendarUID: textContent(calendar, "BaseCalendarUID") || undefined,
+                    weekDays: parseWeekDays(calendar),
+                    exceptions: Array.from(((_a = calendar.getElementsByTagName("Exceptions")[0]) === null || _a === void 0 ? void 0 : _a.getElementsByTagName("Exception")) || []).map((exception) => ({
+                        name: textContent(exception, "Name") || undefined,
+                        fromDate: textContent(exception, "FromDate") || undefined,
+                        toDate: textContent(exception, "ToDate") || undefined,
+                        dayWorking: textContent(exception, "DayWorking") ? parseBoolean(textContent(exception, "DayWorking")) : undefined,
+                        workingTimes: parseWorkingTimes(exception)
+                    })),
+                    workWeeks: Array.from(((_b = calendar.getElementsByTagName("WorkWeeks")[0]) === null || _b === void 0 ? void 0 : _b.getElementsByTagName("WorkWeek")) || []).map((workWeek) => ({
+                        name: textContent(workWeek, "Name") || undefined,
+                        fromDate: textContent(workWeek, "FromDate") || undefined,
+                        toDate: textContent(workWeek, "ToDate") || undefined,
+                        weekDays: parseWeekDays(workWeek)
+                    }))
+                });
+            }),
             tasks: tasks.map((task) => ({
                 uid: textContent(task, "UID"),
                 id: textContent(task, "ID"),
                 name: textContent(task, "Name"),
                 outlineLevel: parseNumber(textContent(task, "OutlineLevel"), 1),
                 outlineNumber: textContent(task, "OutlineNumber"),
+                wbs: textContent(task, "WBS") || undefined,
+                type: textContent(task, "Type") ? parseNumber(textContent(task, "Type"), 0) : undefined,
+                calendarUID: textContent(task, "CalendarUID") || undefined,
+                priority: textContent(task, "Priority") ? parseNumber(textContent(task, "Priority"), 0) : undefined,
                 start: textContent(task, "Start"),
                 finish: textContent(task, "Finish"),
                 duration: textContent(task, "Duration"),
                 actualStart: textContent(task, "ActualStart") || undefined,
                 actualFinish: textContent(task, "ActualFinish") || undefined,
+                deadline: textContent(task, "Deadline") || undefined,
+                startVariance: textContent(task, "StartVariance") || undefined,
+                finishVariance: textContent(task, "FinishVariance") || undefined,
+                work: textContent(task, "Work") || undefined,
+                workVariance: textContent(task, "WorkVariance") || undefined,
+                totalSlack: textContent(task, "TotalSlack") || undefined,
+                freeSlack: textContent(task, "FreeSlack") || undefined,
+                cost: textContent(task, "Cost") ? parseNumber(textContent(task, "Cost"), 0) : undefined,
+                actualCost: textContent(task, "ActualCost") ? parseNumber(textContent(task, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(task, "RemainingCost") ? parseNumber(textContent(task, "RemainingCost"), 0) : undefined,
+                remainingWork: textContent(task, "RemainingWork") || undefined,
+                actualWork: textContent(task, "ActualWork") || undefined,
                 milestone: parseBoolean(textContent(task, "Milestone")),
                 summary: parseBoolean(textContent(task, "Summary")),
+                critical: textContent(task, "Critical") ? parseBoolean(textContent(task, "Critical")) : undefined,
                 percentComplete: parseNumber(textContent(task, "PercentComplete"), 0),
+                percentWorkComplete: textContent(task, "PercentWorkComplete") ? parseNumber(textContent(task, "PercentWorkComplete"), 0) : undefined,
                 notes: textContent(task, "Notes") || undefined,
                 constraintType: textContent(task, "ConstraintType") ? parseNumber(textContent(task, "ConstraintType"), 0) : undefined,
                 constraintDate: textContent(task, "ConstraintDate") || undefined,
+                extendedAttributes: Array.from(task.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(task.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(task.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                })),
                 predecessors: Array.from(task.getElementsByTagName("PredecessorLink")).map((link) => ({
                     predecessorUid: textContent(link, "PredecessorUID"),
                     type: parseNumber(textContent(link, "Type"), 0),
@@ -187,7 +695,40 @@
                 type: parseNumber(textContent(resource, "Type"), 0),
                 initials: textContent(resource, "Initials") || undefined,
                 group: textContent(resource, "Group") || undefined,
-                maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined
+                workGroup: textContent(resource, "WorkGroup") ? parseNumber(textContent(resource, "WorkGroup"), 0) : undefined,
+                maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined,
+                calendarUID: textContent(resource, "CalendarUID") || undefined,
+                standardRate: textContent(resource, "StandardRate") || undefined,
+                standardRateFormat: textContent(resource, "StandardRateFormat") ? parseNumber(textContent(resource, "StandardRateFormat"), 0) : undefined,
+                overtimeRate: textContent(resource, "OvertimeRate") || undefined,
+                overtimeRateFormat: textContent(resource, "OvertimeRateFormat") ? parseNumber(textContent(resource, "OvertimeRateFormat"), 0) : undefined,
+                costPerUse: textContent(resource, "CostPerUse") ? parseNumber(textContent(resource, "CostPerUse"), 0) : undefined,
+                work: textContent(resource, "Work") || undefined,
+                actualWork: textContent(resource, "ActualWork") || undefined,
+                remainingWork: textContent(resource, "RemainingWork") || undefined,
+                cost: textContent(resource, "Cost") ? parseNumber(textContent(resource, "Cost"), 0) : undefined,
+                actualCost: textContent(resource, "ActualCost") ? parseNumber(textContent(resource, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(resource, "RemainingCost") ? parseNumber(textContent(resource, "RemainingCost"), 0) : undefined,
+                percentWorkComplete: textContent(resource, "PercentWorkComplete") ? parseNumber(textContent(resource, "PercentWorkComplete"), 0) : undefined,
+                extendedAttributes: Array.from(resource.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(resource.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(resource.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                }))
             })),
             assignments: assignments.map((assignment) => ({
                 uid: textContent(assignment, "UID"),
@@ -195,8 +736,40 @@
                 resourceUid: textContent(assignment, "ResourceUID"),
                 start: textContent(assignment, "Start") || undefined,
                 finish: textContent(assignment, "Finish") || undefined,
+                startVariance: textContent(assignment, "StartVariance") || undefined,
+                finishVariance: textContent(assignment, "FinishVariance") || undefined,
+                delay: textContent(assignment, "Delay") || undefined,
+                milestone: textContent(assignment, "Milestone") ? parseBoolean(textContent(assignment, "Milestone")) : undefined,
+                workContour: textContent(assignment, "WorkContour") ? parseNumber(textContent(assignment, "WorkContour"), 0) : undefined,
                 units: parseNumber(textContent(assignment, "Units"), 0),
-                work: textContent(assignment, "Work") || undefined
+                work: textContent(assignment, "Work") || undefined,
+                cost: textContent(assignment, "Cost") ? parseNumber(textContent(assignment, "Cost"), 0) : undefined,
+                actualCost: textContent(assignment, "ActualCost") ? parseNumber(textContent(assignment, "ActualCost"), 0) : undefined,
+                remainingCost: textContent(assignment, "RemainingCost") ? parseNumber(textContent(assignment, "RemainingCost"), 0) : undefined,
+                percentWorkComplete: textContent(assignment, "PercentWorkComplete") ? parseNumber(textContent(assignment, "PercentWorkComplete"), 0) : undefined,
+                overtimeWork: textContent(assignment, "OvertimeWork") || undefined,
+                actualOvertimeWork: textContent(assignment, "ActualOvertimeWork") || undefined,
+                actualWork: textContent(assignment, "ActualWork") || undefined,
+                remainingWork: textContent(assignment, "RemainingWork") || undefined,
+                extendedAttributes: Array.from(assignment.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+                    fieldID: textContent(attribute, "FieldID") || undefined,
+                    value: textContent(attribute, "Value") || undefined
+                })),
+                baselines: Array.from(assignment.getElementsByTagName("Baseline")).map((baseline) => ({
+                    number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+                    start: textContent(baseline, "Start") || undefined,
+                    finish: textContent(baseline, "Finish") || undefined,
+                    work: textContent(baseline, "Work") || undefined,
+                    cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+                })),
+                timephasedData: Array.from(assignment.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+                    type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+                    uid: textContent(timephasedData, "UID") || undefined,
+                    start: textContent(timephasedData, "Start") || undefined,
+                    finish: textContent(timephasedData, "Finish") || undefined,
+                    unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+                    value: textContent(timephasedData, "Value") || undefined
+                }))
             }))
         };
     }
@@ -238,6 +811,12 @@
         const project = doc.documentElement;
         project.setAttribute("xmlns", "http://schemas.microsoft.com/project");
         appendTextElement(doc, project, "Name", model.project.name);
+        appendTextElement(doc, project, "Title", model.project.title);
+        appendTextElement(doc, project, "Company", model.project.company);
+        appendTextElement(doc, project, "Author", model.project.author);
+        appendTextElement(doc, project, "CreationDate", model.project.creationDate);
+        appendTextElement(doc, project, "LastSaved", model.project.lastSaved);
+        appendTextElement(doc, project, "SaveVersion", model.project.saveVersion);
         appendTextElement(doc, project, "CurrentDate", model.project.currentDate);
         appendTextElement(doc, project, "StartDate", model.project.startDate);
         appendTextElement(doc, project, "FinishDate", model.project.finishDate);
@@ -247,13 +826,132 @@
         appendTextElement(doc, project, "MinutesPerDay", model.project.minutesPerDay);
         appendTextElement(doc, project, "MinutesPerWeek", model.project.minutesPerWeek);
         appendTextElement(doc, project, "DaysPerMonth", model.project.daysPerMonth);
+        appendTextElement(doc, project, "StatusDate", model.project.statusDate);
+        appendTextElement(doc, project, "WeekStartDay", model.project.weekStartDay);
+        appendTextElement(doc, project, "WorkFormat", model.project.workFormat);
+        appendTextElement(doc, project, "DurationFormat", model.project.durationFormat);
+        appendTextElement(doc, project, "CurrencyCode", model.project.currencyCode);
+        appendTextElement(doc, project, "CurrencyDigits", model.project.currencyDigits);
+        appendTextElement(doc, project, "CurrencySymbol", model.project.currencySymbol);
+        appendTextElement(doc, project, "CurrencySymbolPosition", model.project.currencySymbolPosition);
+        appendTextElement(doc, project, "FYStartDate", model.project.fyStartDate);
+        appendTextElement(doc, project, "FiscalYearStart", model.project.fiscalYearStart);
+        appendTextElement(doc, project, "CriticalSlackLimit", model.project.criticalSlackLimit);
+        appendTextElement(doc, project, "DefaultTaskType", model.project.defaultTaskType);
+        appendTextElement(doc, project, "DefaultFixedCostAccrual", model.project.defaultFixedCostAccrual);
+        appendTextElement(doc, project, "DefaultStandardRate", model.project.defaultStandardRate);
+        appendTextElement(doc, project, "DefaultOvertimeRate", model.project.defaultOvertimeRate);
+        appendTextElement(doc, project, "DefaultTaskEVMethod", model.project.defaultTaskEVMethod);
+        appendTextElement(doc, project, "NewTaskStartDate", model.project.newTaskStartDate);
+        appendTextElement(doc, project, "NewTasksAreManual", model.project.newTasksAreManual);
+        appendTextElement(doc, project, "NewTasksEffortDriven", model.project.newTasksEffortDriven);
+        appendTextElement(doc, project, "NewTasksEstimated", model.project.newTasksEstimated);
+        appendTextElement(doc, project, "ActualsInSync", model.project.actualsInSync);
+        appendTextElement(doc, project, "EditableActualCosts", model.project.editableActualCosts);
+        appendTextElement(doc, project, "HonorConstraints", model.project.honorConstraints);
+        appendTextElement(doc, project, "InsertedProjectsLikeSummary", model.project.insertedProjectsLikeSummary);
+        appendTextElement(doc, project, "MultipleCriticalPaths", model.project.multipleCriticalPaths);
+        appendTextElement(doc, project, "TaskUpdatesResource", model.project.taskUpdatesResource);
+        appendTextElement(doc, project, "UpdateManuallyScheduledTasksWhenEditingLinks", model.project.updateManuallyScheduledTasksWhenEditingLinks);
         appendTextElement(doc, project, "CalendarUID", model.project.calendarUID);
+        if (model.project.outlineCodes.length > 0) {
+            const outlineCodesElement = doc.createElement("OutlineCodes");
+            for (const outlineCode of model.project.outlineCodes) {
+                const outlineCodeElement = doc.createElement("OutlineCode");
+                appendTextElement(doc, outlineCodeElement, "FieldID", outlineCode.fieldID);
+                appendTextElement(doc, outlineCodeElement, "FieldName", outlineCode.fieldName);
+                appendTextElement(doc, outlineCodeElement, "Alias", outlineCode.alias);
+                appendTextElement(doc, outlineCodeElement, "OnlyTableValues", outlineCode.onlyTableValues);
+                appendTextElement(doc, outlineCodeElement, "Enterprise", outlineCode.enterprise);
+                appendTextElement(doc, outlineCodeElement, "ResourceSubstitutionEnabled", outlineCode.resourceSubstitutionEnabled);
+                appendTextElement(doc, outlineCodeElement, "LeafOnly", outlineCode.leafOnly);
+                appendTextElement(doc, outlineCodeElement, "AllLevelsRequired", outlineCode.allLevelsRequired);
+                if (outlineCode.masks.length > 0) {
+                    const masksElement = doc.createElement("Masks");
+                    for (const mask of outlineCode.masks) {
+                        const maskElement = doc.createElement("Mask");
+                        appendTextElement(doc, maskElement, "Level", mask.level);
+                        appendTextElement(doc, maskElement, "Mask", mask.mask);
+                        appendTextElement(doc, maskElement, "Length", mask.length);
+                        appendTextElement(doc, maskElement, "Sequence", mask.sequence);
+                        masksElement.appendChild(maskElement);
+                    }
+                    outlineCodeElement.appendChild(masksElement);
+                }
+                if (outlineCode.values.length > 0) {
+                    const valuesElement = doc.createElement("Values");
+                    for (const value of outlineCode.values) {
+                        const valueElement = doc.createElement("Value");
+                        appendTextElement(doc, valueElement, "Value", value.value);
+                        appendTextElement(doc, valueElement, "Description", value.description);
+                        valuesElement.appendChild(valueElement);
+                    }
+                    outlineCodeElement.appendChild(valuesElement);
+                }
+                outlineCodesElement.appendChild(outlineCodeElement);
+            }
+            project.appendChild(outlineCodesElement);
+        }
+        if (model.project.wbsMasks.length > 0) {
+            const wbsMasksElement = doc.createElement("WBSMasks");
+            for (const wbsMask of model.project.wbsMasks) {
+                const wbsMaskElement = doc.createElement("WBSMask");
+                appendTextElement(doc, wbsMaskElement, "Level", wbsMask.level);
+                appendTextElement(doc, wbsMaskElement, "Mask", wbsMask.mask);
+                appendTextElement(doc, wbsMaskElement, "Length", wbsMask.length);
+                appendTextElement(doc, wbsMaskElement, "Sequence", wbsMask.sequence);
+                wbsMasksElement.appendChild(wbsMaskElement);
+            }
+            project.appendChild(wbsMasksElement);
+        }
+        if (model.project.extendedAttributes.length > 0) {
+            const extendedAttributesElement = doc.createElement("ExtendedAttributes");
+            for (const attribute of model.project.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "FieldName", attribute.fieldName);
+                appendTextElement(doc, extendedAttributeElement, "Alias", attribute.alias);
+                appendTextElement(doc, extendedAttributeElement, "CalculationType", attribute.calculationType);
+                appendTextElement(doc, extendedAttributeElement, "RestrictValues", attribute.restrictValues);
+                appendTextElement(doc, extendedAttributeElement, "AppendNewValues", attribute.appendNewValues);
+                extendedAttributesElement.appendChild(extendedAttributeElement);
+            }
+            project.appendChild(extendedAttributesElement);
+        }
         const calendarsElement = doc.createElement("Calendars");
         for (const calendar of model.calendars) {
             const calendarElement = doc.createElement("Calendar");
             appendTextElement(doc, calendarElement, "UID", calendar.uid);
             appendTextElement(doc, calendarElement, "Name", calendar.name);
             appendTextElement(doc, calendarElement, "IsBaseCalendar", calendar.isBaseCalendar);
+            appendTextElement(doc, calendarElement, "IsBaselineCalendar", calendar.isBaselineCalendar);
+            appendTextElement(doc, calendarElement, "BaseCalendarUID", calendar.baseCalendarUID);
+            if (calendar.exceptions.length > 0) {
+                const exceptionsElement = doc.createElement("Exceptions");
+                for (const exception of calendar.exceptions) {
+                    const exceptionElement = doc.createElement("Exception");
+                    appendTextElement(doc, exceptionElement, "Name", exception.name);
+                    appendTextElement(doc, exceptionElement, "FromDate", exception.fromDate);
+                    appendTextElement(doc, exceptionElement, "ToDate", exception.toDate);
+                    appendTextElement(doc, exceptionElement, "DayWorking", exception.dayWorking);
+                    appendWorkingTimes(doc, exceptionElement, exception.workingTimes);
+                    exceptionsElement.appendChild(exceptionElement);
+                }
+                calendarElement.appendChild(exceptionsElement);
+            }
+            if (calendar.workWeeks.length > 0) {
+                const workWeeksElement = doc.createElement("WorkWeeks");
+                for (const workWeek of calendar.workWeeks) {
+                    const workWeekElement = doc.createElement("WorkWeek");
+                    appendTextElement(doc, workWeekElement, "Name", workWeek.name);
+                    appendTextElement(doc, workWeekElement, "FromDate", workWeek.fromDate);
+                    appendTextElement(doc, workWeekElement, "ToDate", workWeek.toDate);
+                    appendWeekDays(doc, workWeekElement, workWeek.weekDays);
+                    workWeeksElement.appendChild(workWeekElement);
+                }
+                calendarElement.appendChild(workWeeksElement);
+            }
+            appendWeekDays(doc, calendarElement, calendar.weekDays);
             calendarsElement.appendChild(calendarElement);
         }
         project.appendChild(calendarsElement);
@@ -265,17 +963,60 @@
             appendTextElement(doc, taskElement, "Name", task.name);
             appendTextElement(doc, taskElement, "OutlineLevel", task.outlineLevel);
             appendTextElement(doc, taskElement, "OutlineNumber", task.outlineNumber);
+            appendTextElement(doc, taskElement, "WBS", task.wbs);
+            appendTextElement(doc, taskElement, "Type", task.type);
+            appendTextElement(doc, taskElement, "CalendarUID", task.calendarUID);
+            appendTextElement(doc, taskElement, "Priority", task.priority);
             appendTextElement(doc, taskElement, "Start", task.start);
             appendTextElement(doc, taskElement, "Finish", task.finish);
             appendTextElement(doc, taskElement, "Duration", task.duration);
             appendTextElement(doc, taskElement, "ActualStart", task.actualStart);
             appendTextElement(doc, taskElement, "ActualFinish", task.actualFinish);
+            appendTextElement(doc, taskElement, "Deadline", task.deadline);
+            appendTextElement(doc, taskElement, "StartVariance", task.startVariance);
+            appendTextElement(doc, taskElement, "FinishVariance", task.finishVariance);
+            appendTextElement(doc, taskElement, "Work", task.work);
+            appendTextElement(doc, taskElement, "WorkVariance", task.workVariance);
+            appendTextElement(doc, taskElement, "TotalSlack", task.totalSlack);
+            appendTextElement(doc, taskElement, "FreeSlack", task.freeSlack);
+            appendTextElement(doc, taskElement, "Cost", task.cost);
+            appendTextElement(doc, taskElement, "ActualCost", task.actualCost);
+            appendTextElement(doc, taskElement, "RemainingCost", task.remainingCost);
+            appendTextElement(doc, taskElement, "RemainingWork", task.remainingWork);
+            appendTextElement(doc, taskElement, "ActualWork", task.actualWork);
             appendTextElement(doc, taskElement, "ConstraintType", task.constraintType);
             appendTextElement(doc, taskElement, "ConstraintDate", task.constraintDate);
             appendTextElement(doc, taskElement, "Milestone", task.milestone);
             appendTextElement(doc, taskElement, "Summary", task.summary);
+            appendTextElement(doc, taskElement, "Critical", task.critical);
             appendTextElement(doc, taskElement, "PercentComplete", task.percentComplete);
+            appendTextElement(doc, taskElement, "PercentWorkComplete", task.percentWorkComplete);
             appendTextElement(doc, taskElement, "Notes", task.notes);
+            for (const attribute of task.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                taskElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of task.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                taskElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of task.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                taskElement.appendChild(timephasedDataElement);
+            }
             for (const predecessor of task.predecessors) {
                 const predecessorElement = doc.createElement("PredecessorLink");
                 appendTextElement(doc, predecessorElement, "PredecessorUID", predecessor.predecessorUid);
@@ -295,7 +1036,46 @@
             appendTextElement(doc, resourceElement, "Type", resource.type);
             appendTextElement(doc, resourceElement, "Initials", resource.initials);
             appendTextElement(doc, resourceElement, "Group", resource.group);
+            appendTextElement(doc, resourceElement, "WorkGroup", resource.workGroup);
             appendTextElement(doc, resourceElement, "MaxUnits", resource.maxUnits);
+            appendTextElement(doc, resourceElement, "CalendarUID", resource.calendarUID);
+            appendTextElement(doc, resourceElement, "StandardRate", resource.standardRate);
+            appendTextElement(doc, resourceElement, "StandardRateFormat", resource.standardRateFormat);
+            appendTextElement(doc, resourceElement, "OvertimeRate", resource.overtimeRate);
+            appendTextElement(doc, resourceElement, "OvertimeRateFormat", resource.overtimeRateFormat);
+            appendTextElement(doc, resourceElement, "CostPerUse", resource.costPerUse);
+            appendTextElement(doc, resourceElement, "Work", resource.work);
+            appendTextElement(doc, resourceElement, "ActualWork", resource.actualWork);
+            appendTextElement(doc, resourceElement, "RemainingWork", resource.remainingWork);
+            appendTextElement(doc, resourceElement, "Cost", resource.cost);
+            appendTextElement(doc, resourceElement, "ActualCost", resource.actualCost);
+            appendTextElement(doc, resourceElement, "RemainingCost", resource.remainingCost);
+            appendTextElement(doc, resourceElement, "PercentWorkComplete", resource.percentWorkComplete);
+            for (const attribute of resource.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                resourceElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of resource.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                resourceElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of resource.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                resourceElement.appendChild(timephasedDataElement);
+            }
             resourcesElement.appendChild(resourceElement);
         }
         project.appendChild(resourcesElement);
@@ -307,8 +1087,46 @@
             appendTextElement(doc, assignmentElement, "ResourceUID", assignment.resourceUid);
             appendTextElement(doc, assignmentElement, "Start", assignment.start);
             appendTextElement(doc, assignmentElement, "Finish", assignment.finish);
+            appendTextElement(doc, assignmentElement, "StartVariance", assignment.startVariance);
+            appendTextElement(doc, assignmentElement, "FinishVariance", assignment.finishVariance);
+            appendTextElement(doc, assignmentElement, "Delay", assignment.delay);
+            appendTextElement(doc, assignmentElement, "Milestone", assignment.milestone);
+            appendTextElement(doc, assignmentElement, "WorkContour", assignment.workContour);
             appendTextElement(doc, assignmentElement, "Units", assignment.units);
             appendTextElement(doc, assignmentElement, "Work", assignment.work);
+            appendTextElement(doc, assignmentElement, "Cost", assignment.cost);
+            appendTextElement(doc, assignmentElement, "ActualCost", assignment.actualCost);
+            appendTextElement(doc, assignmentElement, "RemainingCost", assignment.remainingCost);
+            appendTextElement(doc, assignmentElement, "PercentWorkComplete", assignment.percentWorkComplete);
+            appendTextElement(doc, assignmentElement, "OvertimeWork", assignment.overtimeWork);
+            appendTextElement(doc, assignmentElement, "ActualOvertimeWork", assignment.actualOvertimeWork);
+            appendTextElement(doc, assignmentElement, "ActualWork", assignment.actualWork);
+            appendTextElement(doc, assignmentElement, "RemainingWork", assignment.remainingWork);
+            for (const attribute of assignment.extendedAttributes) {
+                const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+                appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+                appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+                assignmentElement.appendChild(extendedAttributeElement);
+            }
+            for (const baseline of assignment.baselines) {
+                const baselineElement = doc.createElement("Baseline");
+                appendTextElement(doc, baselineElement, "Number", baseline.number);
+                appendTextElement(doc, baselineElement, "Start", baseline.start);
+                appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+                appendTextElement(doc, baselineElement, "Work", baseline.work);
+                appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+                assignmentElement.appendChild(baselineElement);
+            }
+            for (const timephasedData of assignment.timephasedData) {
+                const timephasedDataElement = doc.createElement("TimephasedData");
+                appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+                appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+                appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+                appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+                appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+                appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+                assignmentElement.appendChild(timephasedDataElement);
+            }
             assignmentsElement.appendChild(assignmentElement);
         }
         project.appendChild(assignmentsElement);
@@ -328,6 +1146,9 @@
         if (!model.project.name) {
             issues.push({ level: "warning", scope: "project", message: "Project Name が空です" });
         }
+        if (model.project.saveVersion !== undefined && model.project.saveVersion < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project SaveVersion は 0 以上が望ましいです" });
+        }
         if (!model.project.startDate) {
             issues.push({ level: "warning", scope: "project", message: "Project StartDate が空です" });
         }
@@ -343,14 +1164,135 @@
         if (model.project.daysPerMonth !== undefined && model.project.daysPerMonth <= 0) {
             issues.push({ level: "warning", scope: "project", message: "Project DaysPerMonth は正の値が望ましいです" });
         }
+        if (model.project.weekStartDay !== undefined && (model.project.weekStartDay < 1 || model.project.weekStartDay > 7)) {
+            issues.push({ level: "warning", scope: "project", message: "Project WeekStartDay は 1..7 が望ましいです" });
+        }
+        if (model.project.workFormat !== undefined && model.project.workFormat < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project WorkFormat は 0 以上が望ましいです" });
+        }
+        if (model.project.durationFormat !== undefined && model.project.durationFormat < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DurationFormat は 0 以上が望ましいです" });
+        }
+        if (model.project.currencyDigits !== undefined && model.project.currencyDigits < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CurrencyDigits は 0 以上が望ましいです" });
+        }
+        if (model.project.currencySymbolPosition !== undefined && model.project.currencySymbolPosition < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CurrencySymbolPosition は 0 以上が望ましいです" });
+        }
+        if (model.project.fyStartDate !== undefined && !parseDateValue(model.project.fyStartDate)) {
+            issues.push({ level: "warning", scope: "project", message: "Project FYStartDate の日付形式が解釈できません" });
+        }
+        if (model.project.criticalSlackLimit !== undefined && model.project.criticalSlackLimit < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project CriticalSlackLimit は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultTaskType !== undefined && model.project.defaultTaskType < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskType は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultFixedCostAccrual !== undefined && model.project.defaultFixedCostAccrual < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultFixedCostAccrual は 0 以上が望ましいです" });
+        }
+        if (model.project.defaultTaskEVMethod !== undefined && model.project.defaultTaskEVMethod < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskEVMethod は 0 以上が望ましいです" });
+        }
+        if (model.project.newTaskStartDate !== undefined && model.project.newTaskStartDate < 0) {
+            issues.push({ level: "warning", scope: "project", message: "Project NewTaskStartDate は 0 以上が望ましいです" });
+        }
+        for (const outlineCode of model.project.outlineCodes) {
+            if (!outlineCode.fieldID && !outlineCode.fieldName) {
+                issues.push({ level: "warning", scope: "project", message: "Project OutlineCode は FieldID または FieldName を持つことが望ましいです" });
+            }
+            for (const mask of outlineCode.masks) {
+                if (mask.level < 1) {
+                    issues.push({ level: "warning", scope: "project", message: "Project OutlineCode Mask Level は 1 以上が望ましいです" });
+                }
+            }
+        }
+        for (const wbsMask of model.project.wbsMasks) {
+            if (wbsMask.level < 1) {
+                issues.push({ level: "warning", scope: "project", message: "Project WBSMask Level は 1 以上が望ましいです" });
+            }
+        }
+        for (const attribute of model.project.extendedAttributes) {
+            if (!attribute.fieldID && !attribute.fieldName) {
+                issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute は FieldID または FieldName を持つことが望ましいです" });
+            }
+            if (attribute.calculationType !== undefined && attribute.calculationType < 0) {
+                issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute CalculationType は 0 以上が望ましいです" });
+            }
+        }
         for (const calendar of model.calendars) {
             if (!calendar.uid) {
                 issues.push({ level: "error", scope: "calendars", message: "Calendar UID が空です" });
+            }
+            if (calendar.isBaselineCalendar !== undefined && !calendar.isBaseCalendar && calendar.isBaselineCalendar) {
+                issues.push({
+                    level: "warning",
+                    scope: "calendars",
+                    message: `Calendar IsBaselineCalendar は通常 BaseCalendar と整合していることが望ましいです: UID=${calendar.uid}`
+                });
             }
             if (calendarUidSet.has(calendar.uid)) {
                 issues.push({ level: "error", scope: "calendars", message: `Calendar UID が重複しています: ${calendar.uid}` });
             }
             calendarUidSet.add(calendar.uid);
+            for (const weekDay of calendar.weekDays) {
+                if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar WeekDay DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+                    });
+                }
+                for (const workingTime of weekDay.workingTimes) {
+                    if (!workingTime.fromTime || !workingTime.toTime) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
+            for (const exception of calendar.exceptions) {
+                const exceptionFrom = parseDateValue(exception.fromDate);
+                const exceptionTo = parseDateValue(exception.toDate);
+                if (exceptionFrom !== null && exceptionTo !== null && exceptionFrom > exceptionTo) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar Exception FromDate が ToDate より後です: UID=${calendar.uid}`
+                    });
+                }
+                for (const workingTime of exception.workingTimes) {
+                    if (!workingTime.fromTime || !workingTime.toTime) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar Exception WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
+            for (const workWeek of calendar.workWeeks) {
+                const workWeekFrom = parseDateValue(workWeek.fromDate);
+                const workWeekTo = parseDateValue(workWeek.toDate);
+                if (workWeekFrom !== null && workWeekTo !== null && workWeekFrom > workWeekTo) {
+                    issues.push({
+                        level: "warning",
+                        scope: "calendars",
+                        message: `Calendar WorkWeek FromDate が ToDate より後です: UID=${calendar.uid}`
+                    });
+                }
+                for (const weekDay of workWeek.weekDays) {
+                    if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+                        issues.push({
+                            level: "warning",
+                            scope: "calendars",
+                            message: `Calendar WorkWeek DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+                        });
+                    }
+                }
+            }
         }
         if (model.project.calendarUID && !calendarUidSet.has(model.project.calendarUID)) {
             issues.push({
@@ -358,6 +1300,15 @@
                 scope: "project",
                 message: `Project CalendarUID が既存 Calendar を指していません: ${model.project.calendarUID}`
             });
+        }
+        for (const calendar of model.calendars) {
+            if (calendar.baseCalendarUID && !calendarUidSet.has(calendar.baseCalendarUID)) {
+                issues.push({
+                    level: "warning",
+                    scope: "calendars",
+                    message: `Calendar BaseCalendarUID が既存 Calendar を指していません: UID=${calendar.uid}`
+                });
+            }
         }
         for (const task of model.tasks) {
             if (!task.uid) {
@@ -367,7 +1318,9 @@
                 issues.push({ level: "error", scope: "tasks", message: `Task ID が空です: ${task.name || "(無名)"}` });
             }
             if (!task.name) {
-                issues.push({ level: "error", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+                if (!isPlaceholderUid(task.uid)) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+                }
             }
             if (taskIdSet.has(task.id)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task ID が重複しています: ${task.id}` });
@@ -379,10 +1332,10 @@
             if (!task.finish) {
                 issues.push({ level: "warning", scope: "tasks", message: `Task Finish が空です: UID=${task.uid}` });
             }
-            if (task.outlineLevel < 1) {
+            if (task.outlineLevel < 1 && !isPlaceholderUid(task.uid)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task OutlineLevel が不正です: UID=${task.uid}` });
             }
-            if (task.outlineNumber) {
+            if (task.outlineNumber && !isPlaceholderUid(task.uid)) {
                 const outlineParts = task.outlineNumber.split(".").filter(Boolean);
                 if (outlineParts.length !== task.outlineLevel) {
                     issues.push({
@@ -399,15 +1352,31 @@
                     message: `Task PercentComplete が 0..100 の範囲外です: UID=${task.uid}`
                 });
             }
+            if (task.percentWorkComplete !== undefined &&
+                (task.percentWorkComplete < 0 || task.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task PercentWorkComplete が 0..100 の範囲外です: UID=${task.uid}`
+                });
+            }
             const taskStart = parseDateValue(task.start);
             const taskFinish = parseDateValue(task.finish);
             const taskActualStart = parseDateValue(task.actualStart);
             const taskActualFinish = parseDateValue(task.actualFinish);
+            const taskDeadline = parseDateValue(task.deadline);
             if (taskStart !== null && taskFinish !== null && taskStart > taskFinish) {
                 issues.push({
                     level: "warning",
                     scope: "tasks",
                     message: `Task Start が Finish より後です: UID=${task.uid}`
+                });
+            }
+            if (taskFinish !== null && taskDeadline !== null && taskFinish > taskDeadline) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task Finish が Deadline より後です: UID=${task.uid}`
                 });
             }
             if (taskActualStart !== null && taskActualFinish !== null && taskActualStart > taskActualFinish) {
@@ -420,19 +1389,141 @@
             if (taskUidSet.has(task.uid)) {
                 issues.push({ level: "error", scope: "tasks", message: `Task UID が重複しています: ${task.uid}` });
             }
+            for (const attribute of task.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task ExtendedAttribute に FieldID がありません: UID=${task.uid}` });
+                }
+            }
+            for (const baseline of task.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Number は 0 以上が望ましいです: UID=${task.uid}` });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Start が Finish より後です: UID=${task.uid}` });
+                }
+            }
+            for (const timephasedData of task.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Type は 0 以上が望ましいです: UID=${task.uid}` });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Start が Finish より後です: UID=${task.uid}` });
+                }
+            }
             taskUidSet.add(task.uid);
+            if (task.priority !== undefined && (task.priority < 0 || task.priority > 1000)) {
+                issues.push({
+                    level: "warning",
+                    scope: "tasks",
+                    message: `Task Priority が 0..1000 の範囲外です: UID=${task.uid}`
+                });
+            }
+            if (task.cost !== undefined && task.cost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task Cost が負値です: UID=${task.uid}` });
+            }
+            if (task.actualCost !== undefined && task.actualCost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task ActualCost が負値です: UID=${task.uid}` });
+            }
+            if (task.remainingCost !== undefined && task.remainingCost < 0) {
+                issues.push({ level: "warning", scope: "tasks", message: `Task RemainingCost が負値です: UID=${task.uid}` });
+            }
         }
         for (const resource of model.resources) {
             if (!resource.uid) {
                 issues.push({ level: "error", scope: "resources", message: "Resource UID が空です" });
             }
             if (!resource.name) {
-                issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+                if (!isPlaceholderUid(resource.uid)) {
+                    issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+                }
             }
             if (resourceUidSet.has(resource.uid)) {
                 issues.push({ level: "error", scope: "resources", message: `Resource UID が重複しています: ${resource.uid}` });
             }
             resourceUidSet.add(resource.uid);
+            if (resource.calendarUID && !calendarUidSet.has(resource.calendarUID)) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource CalendarUID が既存 Calendar を指していません: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.workGroup !== undefined && resource.workGroup < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource WorkGroup は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.overtimeRateFormat !== undefined && resource.overtimeRateFormat < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource OvertimeRateFormat は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            if (resource.cost !== undefined && resource.cost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource Cost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.actualCost !== undefined && resource.actualCost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource ActualCost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.remainingCost !== undefined && resource.remainingCost < 0) {
+                issues.push({ level: "warning", scope: "resources", message: `Resource RemainingCost が負値です: UID=${resource.uid || "(なし)"}` });
+            }
+            if (resource.percentWorkComplete !== undefined &&
+                (resource.percentWorkComplete < 0 || resource.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "resources",
+                    message: `Resource PercentWorkComplete が 0..100 の範囲外です: UID=${resource.uid || "(なし)"}`
+                });
+            }
+            for (const attribute of resource.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({ level: "warning", scope: "resources", message: `Resource ExtendedAttribute に FieldID がありません: UID=${resource.uid || "(なし)"}` });
+                }
+            }
+            for (const baseline of resource.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource Baseline Number は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource Baseline Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const timephasedData of resource.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource TimephasedData Type は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "resources",
+                        message: `Resource TimephasedData Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+                    });
+                }
+            }
         }
         for (const task of model.tasks) {
             for (const predecessor of task.predecessors) {
@@ -456,7 +1547,7 @@
                     message: `Assignment TaskUID が既存 Task を指していません: ${assignment.taskUid}`
                 });
             }
-            if (!resourceUidSet.has(assignment.resourceUid)) {
+            if (!resourceUidSet.has(assignment.resourceUid) && !isUnassignedResourceUid(assignment.resourceUid)) {
                 issues.push({
                     level: "error",
                     scope: "assignments",
@@ -483,6 +1574,115 @@
                     level: "warning",
                     scope: "assignments",
                     message: `Assignment Units が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.cost !== undefined && assignment.cost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment Cost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.actualCost !== undefined && assignment.actualCost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment ActualCost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.remainingCost !== undefined && assignment.remainingCost < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment RemainingCost が負値です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.percentWorkComplete !== undefined &&
+                (assignment.percentWorkComplete < 0 || assignment.percentWorkComplete > 100)) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment PercentWorkComplete が 0..100 の範囲外です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.overtimeWork !== undefined && !assignment.overtimeWork) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment OvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.actualOvertimeWork !== undefined && !assignment.actualOvertimeWork) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment ActualOvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.workContour !== undefined && assignment.workContour < 0) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment WorkContour は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            if (assignment.startVariance !== undefined && !assignment.startVariance) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment StartVariance が空です: UID=${assignment.uid || "(なし)"}`
+                });
+            }
+            for (const attribute of assignment.extendedAttributes) {
+                if (!attribute.fieldID) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment ExtendedAttribute に FieldID がありません: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const baseline of assignment.baselines) {
+                if (baseline.number !== undefined && baseline.number < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment Baseline Number は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+                const baselineStart = parseDateValue(baseline.start);
+                const baselineFinish = parseDateValue(baseline.finish);
+                if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment Baseline Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            for (const timephasedData of assignment.timephasedData) {
+                if (timephasedData.type !== undefined && timephasedData.type < 0) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment TimephasedData Type は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+                const timephasedStart = parseDateValue(timephasedData.start);
+                const timephasedFinish = parseDateValue(timephasedData.finish);
+                if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+                    issues.push({
+                        level: "warning",
+                        scope: "assignments",
+                        message: `Assignment TimephasedData Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+                    });
+                }
+            }
+            if (assignment.finishVariance !== undefined && !assignment.finishVariance) {
+                issues.push({
+                    level: "warning",
+                    scope: "assignments",
+                    message: `Assignment FinishVariance が空です: UID=${assignment.uid || "(なし)"}`
                 });
             }
         }

--- a/docs/project/src/mikuproject/ts/main.ts
+++ b/docs/project/src/mikuproject/ts/main.ts
@@ -47,6 +47,22 @@
     container.innerHTML = items.join("");
   }
 
+  function formatFirstBaselineSummary<T extends { baselines: Array<{ number?: number; start?: string; finish?: string; work?: string; cost?: number }> }>(item: T): string {
+    const baseline = item.baselines[0];
+    if (!baseline) {
+      return "-";
+    }
+    return `#${baseline.number ?? "-"} ${baseline.start || "-"} -> ${baseline.finish || "-"} / Work=${baseline.work || "-"} / Cost=${baseline.cost ?? "-"}`;
+  }
+
+  function formatFirstTimephasedSummary<T extends { timephasedData: Array<{ type?: number; start?: string; finish?: string; unit?: number; value?: string }> }>(item: T): string {
+    const timephasedData = item.timephasedData[0];
+    if (!timephasedData) {
+      return "-";
+    }
+    return `Type=${timephasedData.type ?? "-"} ${timephasedData.start || "-"} -> ${timephasedData.finish || "-"} / Unit=${timephasedData.unit ?? "-"} / Value=${timephasedData.value || "-"}`;
+  }
+
   function renderValidationIssues(issues: ValidationIssue[]): void {
     const container = getElement<HTMLElement>("validationIssues");
     if (issues.length === 0) {
@@ -97,7 +113,10 @@
         <div class="md-preview-item__meta">UID=${task.uid} / ID=${task.id} / Outline=${task.outlineNumber || task.outlineLevel}
 Start=${task.start || "-"}
 Finish=${task.finish || "-"}
-Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}</div>
+Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") || "-"}
+Ext=${task.extendedAttributes.length} / Baselines=${task.baselines.length} / Timephased=${task.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(task)}
+Timephased1=${formatFirstTimephasedSummary(task)}</div>
       </div>
     `) : []);
     renderPreviewList("resourcePreview", model ? model.resources.map((resource) => `
@@ -105,7 +124,10 @@ Predecessors=${task.predecessors.map((item) => item.predecessorUid).join(", ") |
         <div class="md-preview-item__title">${resource.name || "(no name)"}</div>
         <div class="md-preview-item__meta">UID=${resource.uid} / ID=${resource.id}
 Initials=${resource.initials || "-"}
-Group=${resource.group || "-"}</div>
+Group=${resource.group || "-"}
+Ext=${resource.extendedAttributes.length} / Baselines=${resource.baselines.length} / Timephased=${resource.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(resource)}
+Timephased1=${formatFirstTimephasedSummary(resource)}</div>
       </div>
     `) : []);
     renderPreviewList("assignmentPreview", model ? model.assignments.map((assignment) => `
@@ -114,7 +136,10 @@ Group=${resource.group || "-"}</div>
         <div class="md-preview-item__meta">TaskUID=${assignment.taskUid}
 ResourceUID=${assignment.resourceUid}
 Start=${assignment.start || "-"}
-Finish=${assignment.finish || "-"}</div>
+Finish=${assignment.finish || "-"}
+Ext=${assignment.extendedAttributes.length} / Baselines=${assignment.baselines.length} / Timephased=${assignment.timephasedData.length}
+Baseline1=${formatFirstBaselineSummary(assignment)}
+Timephased1=${formatFirstTimephasedSummary(assignment)}</div>
       </div>
     `) : []);
   }

--- a/docs/project/src/mikuproject/ts/msproject-xml.ts
+++ b/docs/project/src/mikuproject/ts/msproject-xml.ts
@@ -2,6 +2,12 @@
   const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/project">
   <Name>Sample Project</Name>
+  <Title>Sample Project Title</Title>
+  <Company>Local HTML Tools</Company>
+  <Author>Toshiki Iga</Author>
+  <CreationDate>2026-03-16T08:30:00</CreationDate>
+  <LastSaved>2026-03-16T09:10:00</LastSaved>
+  <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
   <FinishDate>2026-03-20T18:00:00</FinishDate>
@@ -11,12 +17,161 @@
   <MinutesPerDay>480</MinutesPerDay>
   <MinutesPerWeek>2400</MinutesPerWeek>
   <DaysPerMonth>20</DaysPerMonth>
+  <StatusDate>2026-03-19T09:00:00</StatusDate>
+  <WeekStartDay>1</WeekStartDay>
+  <WorkFormat>2</WorkFormat>
+  <DurationFormat>7</DurationFormat>
+  <CurrencyCode>JPY</CurrencyCode>
+  <CurrencyDigits>0</CurrencyDigits>
+  <CurrencySymbol>¥</CurrencySymbol>
+  <CurrencySymbolPosition>0</CurrencySymbolPosition>
+  <FYStartDate>2026-04-01T00:00:00</FYStartDate>
+  <FiscalYearStart>1</FiscalYearStart>
+  <CriticalSlackLimit>0</CriticalSlackLimit>
+  <DefaultTaskType>1</DefaultTaskType>
+  <DefaultFixedCostAccrual>2</DefaultFixedCostAccrual>
+  <DefaultStandardRate>5000/h</DefaultStandardRate>
+  <DefaultOvertimeRate>7000/h</DefaultOvertimeRate>
+  <DefaultTaskEVMethod>0</DefaultTaskEVMethod>
+  <NewTaskStartDate>0</NewTaskStartDate>
+  <NewTasksAreManual>0</NewTasksAreManual>
+  <NewTasksEffortDriven>1</NewTasksEffortDriven>
+  <NewTasksEstimated>1</NewTasksEstimated>
+  <ActualsInSync>0</ActualsInSync>
+  <EditableActualCosts>1</EditableActualCosts>
+  <HonorConstraints>1</HonorConstraints>
+  <InsertedProjectsLikeSummary>1</InsertedProjectsLikeSummary>
+  <MultipleCriticalPaths>0</MultipleCriticalPaths>
+  <TaskUpdatesResource>1</TaskUpdatesResource>
+  <UpdateManuallyScheduledTasksWhenEditingLinks>0</UpdateManuallyScheduledTasksWhenEditingLinks>
   <CalendarUID>1</CalendarUID>
+  <OutlineCodes>
+    <OutlineCode>
+      <FieldID>188743731</FieldID>
+      <FieldName>Outline Code1</FieldName>
+      <Alias>Phase</Alias>
+      <OnlyTableValues>1</OnlyTableValues>
+      <Enterprise>0</Enterprise>
+      <ResourceSubstitutionEnabled>0</ResourceSubstitutionEnabled>
+      <LeafOnly>0</LeafOnly>
+      <AllLevelsRequired>0</AllLevelsRequired>
+      <Masks>
+        <Mask>
+          <Level>1</Level>
+          <Mask>*</Mask>
+          <Length>0</Length>
+          <Sequence>0</Sequence>
+        </Mask>
+      </Masks>
+      <Values>
+        <Value>
+          <Value>PLAN</Value>
+          <Description>Planning</Description>
+        </Value>
+        <Value>
+          <Value>BUILD</Value>
+          <Description>Implementation</Description>
+        </Value>
+      </Values>
+    </OutlineCode>
+  </OutlineCodes>
+  <WBSMasks>
+    <WBSMask>
+      <Level>1</Level>
+      <Mask>A</Mask>
+      <Length>1</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+    <WBSMask>
+      <Level>2</Level>
+      <Mask>00</Mask>
+      <Length>2</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+  </WBSMasks>
+  <ExtendedAttributes>
+    <ExtendedAttribute>
+      <FieldID>188743734</FieldID>
+      <FieldName>Text1</FieldName>
+      <Alias>Owner</Alias>
+      <CalculationType>0</CalculationType>
+      <RestrictValues>0</RestrictValues>
+      <AppendNewValues>1</AppendNewValues>
+    </ExtendedAttribute>
+  </ExtendedAttributes>
   <Calendars>
     <Calendar>
       <UID>1</UID>
       <Name>Standard</Name>
       <IsBaseCalendar>1</IsBaseCalendar>
+      <IsBaselineCalendar>1</IsBaselineCalendar>
+      <Exceptions>
+        <Exception>
+          <Name>Holiday</Name>
+          <FromDate>2026-03-20T00:00:00</FromDate>
+          <ToDate>2026-03-20T23:59:59</ToDate>
+          <DayWorking>0</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </Exception>
+      </Exceptions>
+      <WeekDays>
+        <WeekDay>
+          <DayType>2</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+            <WorkingTime>
+              <FromTime>13:00:00</FromTime>
+              <ToTime>18:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
+    </Calendar>
+    <Calendar>
+      <UID>2</UID>
+      <Name>Development</Name>
+      <IsBaseCalendar>0</IsBaseCalendar>
+      <BaseCalendarUID>1</BaseCalendarUID>
+      <WorkWeeks>
+        <WorkWeek>
+          <Name>Spring Sprint</Name>
+          <FromDate>2026-03-16T00:00:00</FromDate>
+          <ToDate>2026-03-31T23:59:59</ToDate>
+          <WeekDays>
+            <WeekDay>
+              <DayType>2</DayType>
+              <DayWorking>1</DayWorking>
+              <WorkingTimes>
+                <WorkingTime>
+                  <FromTime>10:00:00</FromTime>
+                  <ToTime>18:00:00</ToTime>
+                </WorkingTime>
+              </WorkingTimes>
+            </WeekDay>
+          </WeekDays>
+        </WorkWeek>
+      </WorkWeeks>
+      <WeekDays>
+        <WeekDay>
+          <DayType>6</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>10:00:00</FromTime>
+              <ToTime>15:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
     </Calendar>
   </Calendars>
   <Tasks>
@@ -26,12 +181,29 @@
       <Name>Project Summary</Name>
       <OutlineLevel>1</OutlineLevel>
       <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT40H0M0S</Duration>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT40H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <ActualWork>PT20H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>1</Summary>
+      <Critical>0</Critical>
       <PercentComplete>50</PercentComplete>
+      <PercentWorkComplete>50</PercentWorkComplete>
     </Task>
     <Task>
       <UID>2</UID>
@@ -39,15 +211,51 @@
       <Name>Design</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.1</OutlineNumber>
+      <WBS>1.1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>500</Priority>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
       <Duration>PT16H0M0S</Duration>
       <ActualStart>2026-03-16T09:00:00</ActualStart>
       <ActualFinish>2026-03-17T18:00:00</ActualFinish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT16H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT0H0M0S</TotalSlack>
+      <FreeSlack>PT0H0M0S</FreeSlack>
+      <Cost>80000</Cost>
+      <ActualCost>80000</ActualCost>
+      <RemainingCost>0</RemainingCost>
+      <RemainingWork>PT0H0M0S</RemainingWork>
+      <ActualWork>PT16H0M0S</ActualWork>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>0</Critical>
       <PercentComplete>100</PercentComplete>
+      <PercentWorkComplete>100</PercentWorkComplete>
       <Notes>Design completed</Notes>
+      <ExtendedAttribute>
+        <FieldID>188743734</FieldID>
+        <Value>Miku</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>2</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Task>
     <Task>
       <UID>3</UID>
@@ -55,14 +263,32 @@
       <Name>Implementation</Name>
       <OutlineLevel>2</OutlineLevel>
       <OutlineNumber>1.2</OutlineNumber>
+      <WBS>1.2</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>700</Priority>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
       <Duration>PT24H0M0S</Duration>
+      <Deadline>2026-03-21T18:00:00</Deadline>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Work>PT24H0M0S</Work>
+      <WorkVariance>PT0H0M0S</WorkVariance>
+      <TotalSlack>PT4H0M0S</TotalSlack>
+      <FreeSlack>PT2H0M0S</FreeSlack>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <RemainingWork>PT24H0M0S</RemainingWork>
+      <ActualWork>PT0H0M0S</ActualWork>
       <ConstraintType>4</ConstraintType>
       <ConstraintDate>2026-03-18T09:00:00</ConstraintDate>
       <Milestone>0</Milestone>
       <Summary>0</Summary>
+      <Critical>1</Critical>
       <PercentComplete>0</PercentComplete>
+      <PercentWorkComplete>0</PercentWorkComplete>
       <Notes>Implementation starts after design</Notes>
       <PredecessorLink>
         <PredecessorUID>2</PredecessorUID>
@@ -79,7 +305,40 @@
       <Type>1</Type>
       <Initials>MK</Initials>
       <Group>Engineering</Group>
+      <WorkGroup>0</WorkGroup>
       <MaxUnits>1</MaxUnits>
+      <CalendarUID>2</CalendarUID>
+      <StandardRate>5000/h</StandardRate>
+      <StandardRateFormat>2</StandardRateFormat>
+      <OvertimeRate>7000/h</OvertimeRate>
+      <OvertimeRateFormat>2</OvertimeRateFormat>
+      <CostPerUse>1000</CostPerUse>
+      <Work>PT40H0M0S</Work>
+      <ActualWork>PT20H0M0S</ActualWork>
+      <RemainingWork>PT20H0M0S</RemainingWork>
+      <Cost>200000</Cost>
+      <ActualCost>100000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <ExtendedAttribute>
+        <FieldID>188743737</FieldID>
+        <Value>Platform Team</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-20T18:00:00</Finish>
+        <Work>PT40H0M0S</Work>
+        <Cost>200000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Resource>
   </Resources>
   <Assignments>
@@ -89,8 +348,40 @@
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-16T09:00:00</Start>
       <Finish>2026-03-17T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT16H0M0S</Work>
+      <Cost>80000</Cost>
+      <ActualCost>40000</ActualCost>
+      <RemainingCost>40000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <OvertimeWork>PT2H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT1H0M0S</ActualOvertimeWork>
+      <ActualWork>PT8H0M0S</ActualWork>
+      <RemainingWork>PT8H0M0S</RemainingWork>
+      <ExtendedAttribute>
+        <FieldID>255852547</FieldID>
+        <Value>Design Slot</Value>
+      </ExtendedAttribute>
+      <Baseline>
+        <Number>0</Number>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-17T18:00:00</Finish>
+        <Work>PT16H0M0S</Work>
+        <Cost>80000</Cost>
+      </Baseline>
+      <TimephasedData>
+        <Type>1</Type>
+        <UID>1</UID>
+        <Start>2026-03-16T09:00:00</Start>
+        <Finish>2026-03-16T18:00:00</Finish>
+        <Unit>2</Unit>
+        <Value>PT8H0M0S</Value>
+      </TimephasedData>
     </Assignment>
     <Assignment>
       <UID>2</UID>
@@ -98,8 +389,21 @@
       <ResourceUID>1</ResourceUID>
       <Start>2026-03-18T09:00:00</Start>
       <Finish>2026-03-20T18:00:00</Finish>
+      <StartVariance>PT0H0M0S</StartVariance>
+      <FinishVariance>PT0H0M0S</FinishVariance>
+      <Delay>PT0H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>0</WorkContour>
       <Units>1</Units>
       <Work>PT24H0M0S</Work>
+      <Cost>120000</Cost>
+      <ActualCost>0</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <PercentWorkComplete>0</PercentWorkComplete>
+      <OvertimeWork>PT0H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT0H0M0S</ActualOvertimeWork>
+      <ActualWork>PT0H0M0S</ActualWork>
+      <RemainingWork>PT24H0M0S</RemainingWork>
     </Assignment>
   </Assignments>
 </Project>`;
@@ -126,6 +430,98 @@
     return Number.isFinite(timestamp) ? timestamp : null;
   }
 
+  function parseWeekDays(parent: Element): WeekDayModel[] {
+    return Array.from(parent.getElementsByTagName("WeekDays")[0]?.getElementsByTagName("WeekDay") || []).map((weekDay) => ({
+      dayType: parseNumber(textContent(weekDay, "DayType"), 0),
+      dayWorking: parseBoolean(textContent(weekDay, "DayWorking")),
+      workingTimes: Array.from(weekDay.getElementsByTagName("WorkingTimes")[0]?.getElementsByTagName("WorkingTime") || []).map((workingTime) => ({
+        fromTime: textContent(workingTime, "FromTime"),
+        toTime: textContent(workingTime, "ToTime")
+      }))
+    }));
+  }
+
+  function appendWeekDays(doc: XMLDocument, parent: Element, weekDays: WeekDayModel[]): void {
+    if (weekDays.length === 0) {
+      return;
+    }
+    const weekDaysElement = doc.createElement("WeekDays");
+    for (const weekDay of weekDays) {
+      const weekDayElement = doc.createElement("WeekDay");
+      appendTextElement(doc, weekDayElement, "DayType", weekDay.dayType);
+      appendTextElement(doc, weekDayElement, "DayWorking", weekDay.dayWorking);
+      if (weekDay.workingTimes.length > 0) {
+        const workingTimesElement = doc.createElement("WorkingTimes");
+        for (const workingTime of weekDay.workingTimes) {
+          const workingTimeElement = doc.createElement("WorkingTime");
+          appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+          appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+          workingTimesElement.appendChild(workingTimeElement);
+        }
+        weekDayElement.appendChild(workingTimesElement);
+      }
+      weekDaysElement.appendChild(weekDayElement);
+    }
+    parent.appendChild(weekDaysElement);
+  }
+
+  function parseWorkingTimes(parent: Element): WorkingTimeModel[] {
+    return Array.from(parent.getElementsByTagName("WorkingTimes")[0]?.getElementsByTagName("WorkingTime") || []).map((workingTime) => ({
+      fromTime: textContent(workingTime, "FromTime"),
+      toTime: textContent(workingTime, "ToTime")
+    }));
+  }
+
+  function appendWorkingTimes(doc: XMLDocument, parent: Element, workingTimes: WorkingTimeModel[]): void {
+    if (workingTimes.length === 0) {
+      return;
+    }
+    const workingTimesElement = doc.createElement("WorkingTimes");
+    for (const workingTime of workingTimes) {
+      const workingTimeElement = doc.createElement("WorkingTime");
+      appendTextElement(doc, workingTimeElement, "FromTime", workingTime.fromTime);
+      appendTextElement(doc, workingTimeElement, "ToTime", workingTime.toTime);
+      workingTimesElement.appendChild(workingTimeElement);
+    }
+    parent.appendChild(workingTimesElement);
+  }
+
+  function parseOutlineCodeMasks(parent: Element): OutlineCodeMaskModel[] {
+    const masksElement = parent.getElementsByTagName("Masks")[0];
+    if (!masksElement) {
+      return [];
+    }
+    return Array.from(masksElement.children)
+      .filter((child) => child.tagName === "Mask")
+      .map((mask) => ({
+        level: parseNumber(textContent(mask, "Level"), 0),
+        mask: textContent(mask, "Mask") || undefined,
+        length: textContent(mask, "Length") ? parseNumber(textContent(mask, "Length"), 0) : undefined,
+        sequence: textContent(mask, "Sequence") ? parseNumber(textContent(mask, "Sequence"), 0) : undefined
+      }));
+  }
+
+  function parseOutlineCodeValues(parent: Element): OutlineCodeValueModel[] {
+    const valuesElement = parent.getElementsByTagName("Values")[0];
+    if (!valuesElement) {
+      return [];
+    }
+    return Array.from(valuesElement.children)
+      .filter((child) => child.tagName === "Value")
+      .map((value) => ({
+        value: textContent(value, "Value"),
+        description: textContent(value, "Description") || undefined
+      }));
+  }
+
+  function isPlaceholderUid(value: string | undefined): boolean {
+    return String(value || "").trim() === "0";
+  }
+
+  function isUnassignedResourceUid(value: string | undefined): boolean {
+    return String(value || "").trim() === "-65535";
+  }
+
   function parseXmlDocument(xmlText: string): XMLDocument {
     const parser = new DOMParser();
     const xml = parser.parseFromString(xmlText, "application/xml");
@@ -147,6 +543,12 @@
     return {
       project: {
         name: textContent(projectElement, "Name"),
+        title: textContent(projectElement, "Title") || undefined,
+        author: textContent(projectElement, "Author") || undefined,
+        company: textContent(projectElement, "Company") || undefined,
+        creationDate: textContent(projectElement, "CreationDate") || undefined,
+        lastSaved: textContent(projectElement, "LastSaved") || undefined,
+        saveVersion: textContent(projectElement, "SaveVersion") ? parseNumber(textContent(projectElement, "SaveVersion"), 0) : undefined,
         currentDate: textContent(projectElement, "CurrentDate") || undefined,
         startDate: textContent(projectElement, "StartDate"),
         finishDate: textContent(projectElement, "FinishDate"),
@@ -156,12 +558,81 @@
         minutesPerDay: textContent(projectElement, "MinutesPerDay") ? parseNumber(textContent(projectElement, "MinutesPerDay"), 0) : undefined,
         minutesPerWeek: textContent(projectElement, "MinutesPerWeek") ? parseNumber(textContent(projectElement, "MinutesPerWeek"), 0) : undefined,
         daysPerMonth: textContent(projectElement, "DaysPerMonth") ? parseNumber(textContent(projectElement, "DaysPerMonth"), 0) : undefined,
-        calendarUID: textContent(projectElement, "CalendarUID") || undefined
+        statusDate: textContent(projectElement, "StatusDate") || undefined,
+        weekStartDay: textContent(projectElement, "WeekStartDay") ? parseNumber(textContent(projectElement, "WeekStartDay"), 0) : undefined,
+        workFormat: textContent(projectElement, "WorkFormat") ? parseNumber(textContent(projectElement, "WorkFormat"), 0) : undefined,
+        durationFormat: textContent(projectElement, "DurationFormat") ? parseNumber(textContent(projectElement, "DurationFormat"), 0) : undefined,
+        currencyCode: textContent(projectElement, "CurrencyCode") || undefined,
+        currencyDigits: textContent(projectElement, "CurrencyDigits") ? parseNumber(textContent(projectElement, "CurrencyDigits"), 0) : undefined,
+        currencySymbol: textContent(projectElement, "CurrencySymbol") || undefined,
+        currencySymbolPosition: textContent(projectElement, "CurrencySymbolPosition") ? parseNumber(textContent(projectElement, "CurrencySymbolPosition"), 0) : undefined,
+        fyStartDate: textContent(projectElement, "FYStartDate") || undefined,
+        fiscalYearStart: textContent(projectElement, "FiscalYearStart") ? parseBoolean(textContent(projectElement, "FiscalYearStart")) : undefined,
+        criticalSlackLimit: textContent(projectElement, "CriticalSlackLimit") ? parseNumber(textContent(projectElement, "CriticalSlackLimit"), 0) : undefined,
+        defaultTaskType: textContent(projectElement, "DefaultTaskType") ? parseNumber(textContent(projectElement, "DefaultTaskType"), 0) : undefined,
+        defaultFixedCostAccrual: textContent(projectElement, "DefaultFixedCostAccrual") ? parseNumber(textContent(projectElement, "DefaultFixedCostAccrual"), 0) : undefined,
+        defaultStandardRate: textContent(projectElement, "DefaultStandardRate") || undefined,
+        defaultOvertimeRate: textContent(projectElement, "DefaultOvertimeRate") || undefined,
+        defaultTaskEVMethod: textContent(projectElement, "DefaultTaskEVMethod") ? parseNumber(textContent(projectElement, "DefaultTaskEVMethod"), 0) : undefined,
+        newTaskStartDate: textContent(projectElement, "NewTaskStartDate") ? parseNumber(textContent(projectElement, "NewTaskStartDate"), 0) : undefined,
+        newTasksAreManual: textContent(projectElement, "NewTasksAreManual") ? parseBoolean(textContent(projectElement, "NewTasksAreManual")) : undefined,
+        newTasksEffortDriven: textContent(projectElement, "NewTasksEffortDriven") ? parseBoolean(textContent(projectElement, "NewTasksEffortDriven")) : undefined,
+        newTasksEstimated: textContent(projectElement, "NewTasksEstimated") ? parseBoolean(textContent(projectElement, "NewTasksEstimated")) : undefined,
+        actualsInSync: textContent(projectElement, "ActualsInSync") ? parseBoolean(textContent(projectElement, "ActualsInSync")) : undefined,
+        editableActualCosts: textContent(projectElement, "EditableActualCosts") ? parseBoolean(textContent(projectElement, "EditableActualCosts")) : undefined,
+        honorConstraints: textContent(projectElement, "HonorConstraints") ? parseBoolean(textContent(projectElement, "HonorConstraints")) : undefined,
+        insertedProjectsLikeSummary: textContent(projectElement, "InsertedProjectsLikeSummary") ? parseBoolean(textContent(projectElement, "InsertedProjectsLikeSummary")) : undefined,
+        multipleCriticalPaths: textContent(projectElement, "MultipleCriticalPaths") ? parseBoolean(textContent(projectElement, "MultipleCriticalPaths")) : undefined,
+        taskUpdatesResource: textContent(projectElement, "TaskUpdatesResource") ? parseBoolean(textContent(projectElement, "TaskUpdatesResource")) : undefined,
+        updateManuallyScheduledTasksWhenEditingLinks: textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks") ? parseBoolean(textContent(projectElement, "UpdateManuallyScheduledTasksWhenEditingLinks")) : undefined,
+        calendarUID: textContent(projectElement, "CalendarUID") || undefined,
+        outlineCodes: Array.from(projectElement.getElementsByTagName("OutlineCodes")[0]?.getElementsByTagName("OutlineCode") || []).map((outlineCode) => ({
+          fieldID: textContent(outlineCode, "FieldID") || undefined,
+          fieldName: textContent(outlineCode, "FieldName") || undefined,
+          alias: textContent(outlineCode, "Alias") || undefined,
+          onlyTableValues: textContent(outlineCode, "OnlyTableValues") ? parseBoolean(textContent(outlineCode, "OnlyTableValues")) : undefined,
+          enterprise: textContent(outlineCode, "Enterprise") ? parseBoolean(textContent(outlineCode, "Enterprise")) : undefined,
+          resourceSubstitutionEnabled: textContent(outlineCode, "ResourceSubstitutionEnabled") ? parseBoolean(textContent(outlineCode, "ResourceSubstitutionEnabled")) : undefined,
+          leafOnly: textContent(outlineCode, "LeafOnly") ? parseBoolean(textContent(outlineCode, "LeafOnly")) : undefined,
+          allLevelsRequired: textContent(outlineCode, "AllLevelsRequired") ? parseBoolean(textContent(outlineCode, "AllLevelsRequired")) : undefined,
+          masks: parseOutlineCodeMasks(outlineCode),
+          values: parseOutlineCodeValues(outlineCode)
+        })),
+        wbsMasks: Array.from(projectElement.getElementsByTagName("WBSMasks")[0]?.getElementsByTagName("WBSMask") || []).map((wbsMask) => ({
+          level: parseNumber(textContent(wbsMask, "Level"), 0),
+          mask: textContent(wbsMask, "Mask") || undefined,
+          length: textContent(wbsMask, "Length") ? parseNumber(textContent(wbsMask, "Length"), 0) : undefined,
+          sequence: textContent(wbsMask, "Sequence") ? parseNumber(textContent(wbsMask, "Sequence"), 0) : undefined
+        })),
+        extendedAttributes: Array.from(projectElement.getElementsByTagName("ExtendedAttributes")[0]?.getElementsByTagName("ExtendedAttribute") || []).map((attribute) => ({
+          fieldID: textContent(attribute, "FieldID") || undefined,
+          fieldName: textContent(attribute, "FieldName") || undefined,
+          alias: textContent(attribute, "Alias") || undefined,
+          calculationType: textContent(attribute, "CalculationType") ? parseNumber(textContent(attribute, "CalculationType"), 0) : undefined,
+          restrictValues: textContent(attribute, "RestrictValues") ? parseBoolean(textContent(attribute, "RestrictValues")) : undefined,
+          appendNewValues: textContent(attribute, "AppendNewValues") ? parseBoolean(textContent(attribute, "AppendNewValues")) : undefined
+        }))
       },
       calendars: calendars.map((calendar) => ({
         uid: textContent(calendar, "UID"),
         name: textContent(calendar, "Name"),
-        isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar"))
+        isBaseCalendar: parseBoolean(textContent(calendar, "IsBaseCalendar")),
+        isBaselineCalendar: textContent(calendar, "IsBaselineCalendar") ? parseBoolean(textContent(calendar, "IsBaselineCalendar")) : undefined,
+        baseCalendarUID: textContent(calendar, "BaseCalendarUID") || undefined,
+        weekDays: parseWeekDays(calendar),
+        exceptions: Array.from(calendar.getElementsByTagName("Exceptions")[0]?.getElementsByTagName("Exception") || []).map((exception) => ({
+          name: textContent(exception, "Name") || undefined,
+          fromDate: textContent(exception, "FromDate") || undefined,
+          toDate: textContent(exception, "ToDate") || undefined,
+          dayWorking: textContent(exception, "DayWorking") ? parseBoolean(textContent(exception, "DayWorking")) : undefined,
+          workingTimes: parseWorkingTimes(exception)
+        })),
+        workWeeks: Array.from(calendar.getElementsByTagName("WorkWeeks")[0]?.getElementsByTagName("WorkWeek") || []).map((workWeek) => ({
+          name: textContent(workWeek, "Name") || undefined,
+          fromDate: textContent(workWeek, "FromDate") || undefined,
+          toDate: textContent(workWeek, "ToDate") || undefined,
+          weekDays: parseWeekDays(workWeek)
+        }))
       })),
       tasks: tasks.map((task) => ({
         uid: textContent(task, "UID"),
@@ -169,17 +640,54 @@
         name: textContent(task, "Name"),
         outlineLevel: parseNumber(textContent(task, "OutlineLevel"), 1),
         outlineNumber: textContent(task, "OutlineNumber"),
+        wbs: textContent(task, "WBS") || undefined,
+        type: textContent(task, "Type") ? parseNumber(textContent(task, "Type"), 0) : undefined,
+        calendarUID: textContent(task, "CalendarUID") || undefined,
+        priority: textContent(task, "Priority") ? parseNumber(textContent(task, "Priority"), 0) : undefined,
         start: textContent(task, "Start"),
         finish: textContent(task, "Finish"),
         duration: textContent(task, "Duration"),
         actualStart: textContent(task, "ActualStart") || undefined,
         actualFinish: textContent(task, "ActualFinish") || undefined,
+        deadline: textContent(task, "Deadline") || undefined,
+        startVariance: textContent(task, "StartVariance") || undefined,
+        finishVariance: textContent(task, "FinishVariance") || undefined,
+        work: textContent(task, "Work") || undefined,
+        workVariance: textContent(task, "WorkVariance") || undefined,
+        totalSlack: textContent(task, "TotalSlack") || undefined,
+        freeSlack: textContent(task, "FreeSlack") || undefined,
+        cost: textContent(task, "Cost") ? parseNumber(textContent(task, "Cost"), 0) : undefined,
+        actualCost: textContent(task, "ActualCost") ? parseNumber(textContent(task, "ActualCost"), 0) : undefined,
+        remainingCost: textContent(task, "RemainingCost") ? parseNumber(textContent(task, "RemainingCost"), 0) : undefined,
+        remainingWork: textContent(task, "RemainingWork") || undefined,
+        actualWork: textContent(task, "ActualWork") || undefined,
         milestone: parseBoolean(textContent(task, "Milestone")),
         summary: parseBoolean(textContent(task, "Summary")),
+        critical: textContent(task, "Critical") ? parseBoolean(textContent(task, "Critical")) : undefined,
         percentComplete: parseNumber(textContent(task, "PercentComplete"), 0),
+        percentWorkComplete: textContent(task, "PercentWorkComplete") ? parseNumber(textContent(task, "PercentWorkComplete"), 0) : undefined,
         notes: textContent(task, "Notes") || undefined,
         constraintType: textContent(task, "ConstraintType") ? parseNumber(textContent(task, "ConstraintType"), 0) : undefined,
         constraintDate: textContent(task, "ConstraintDate") || undefined,
+        extendedAttributes: Array.from(task.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+          fieldID: textContent(attribute, "FieldID") || undefined,
+          value: textContent(attribute, "Value") || undefined
+        })),
+        baselines: Array.from(task.getElementsByTagName("Baseline")).map((baseline) => ({
+          number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+          start: textContent(baseline, "Start") || undefined,
+          finish: textContent(baseline, "Finish") || undefined,
+          work: textContent(baseline, "Work") || undefined,
+          cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+        })),
+        timephasedData: Array.from(task.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+          type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+          uid: textContent(timephasedData, "UID") || undefined,
+          start: textContent(timephasedData, "Start") || undefined,
+          finish: textContent(timephasedData, "Finish") || undefined,
+          unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+          value: textContent(timephasedData, "Value") || undefined
+        })),
         predecessors: Array.from(task.getElementsByTagName("PredecessorLink")).map((link) => ({
           predecessorUid: textContent(link, "PredecessorUID"),
           type: parseNumber(textContent(link, "Type"), 0),
@@ -193,7 +701,40 @@
         type: parseNumber(textContent(resource, "Type"), 0),
         initials: textContent(resource, "Initials") || undefined,
         group: textContent(resource, "Group") || undefined,
-        maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined
+        workGroup: textContent(resource, "WorkGroup") ? parseNumber(textContent(resource, "WorkGroup"), 0) : undefined,
+        maxUnits: textContent(resource, "MaxUnits") ? parseNumber(textContent(resource, "MaxUnits"), 0) : undefined,
+        calendarUID: textContent(resource, "CalendarUID") || undefined,
+        standardRate: textContent(resource, "StandardRate") || undefined,
+        standardRateFormat: textContent(resource, "StandardRateFormat") ? parseNumber(textContent(resource, "StandardRateFormat"), 0) : undefined,
+        overtimeRate: textContent(resource, "OvertimeRate") || undefined,
+        overtimeRateFormat: textContent(resource, "OvertimeRateFormat") ? parseNumber(textContent(resource, "OvertimeRateFormat"), 0) : undefined,
+        costPerUse: textContent(resource, "CostPerUse") ? parseNumber(textContent(resource, "CostPerUse"), 0) : undefined,
+        work: textContent(resource, "Work") || undefined,
+        actualWork: textContent(resource, "ActualWork") || undefined,
+        remainingWork: textContent(resource, "RemainingWork") || undefined,
+        cost: textContent(resource, "Cost") ? parseNumber(textContent(resource, "Cost"), 0) : undefined,
+        actualCost: textContent(resource, "ActualCost") ? parseNumber(textContent(resource, "ActualCost"), 0) : undefined,
+        remainingCost: textContent(resource, "RemainingCost") ? parseNumber(textContent(resource, "RemainingCost"), 0) : undefined,
+        percentWorkComplete: textContent(resource, "PercentWorkComplete") ? parseNumber(textContent(resource, "PercentWorkComplete"), 0) : undefined,
+        extendedAttributes: Array.from(resource.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+          fieldID: textContent(attribute, "FieldID") || undefined,
+          value: textContent(attribute, "Value") || undefined
+        })),
+        baselines: Array.from(resource.getElementsByTagName("Baseline")).map((baseline) => ({
+          number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+          start: textContent(baseline, "Start") || undefined,
+          finish: textContent(baseline, "Finish") || undefined,
+          work: textContent(baseline, "Work") || undefined,
+          cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+        })),
+        timephasedData: Array.from(resource.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+          type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+          uid: textContent(timephasedData, "UID") || undefined,
+          start: textContent(timephasedData, "Start") || undefined,
+          finish: textContent(timephasedData, "Finish") || undefined,
+          unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+          value: textContent(timephasedData, "Value") || undefined
+        }))
       })),
       assignments: assignments.map((assignment) => ({
         uid: textContent(assignment, "UID"),
@@ -201,8 +742,40 @@
         resourceUid: textContent(assignment, "ResourceUID"),
         start: textContent(assignment, "Start") || undefined,
         finish: textContent(assignment, "Finish") || undefined,
+        startVariance: textContent(assignment, "StartVariance") || undefined,
+        finishVariance: textContent(assignment, "FinishVariance") || undefined,
+        delay: textContent(assignment, "Delay") || undefined,
+        milestone: textContent(assignment, "Milestone") ? parseBoolean(textContent(assignment, "Milestone")) : undefined,
+        workContour: textContent(assignment, "WorkContour") ? parseNumber(textContent(assignment, "WorkContour"), 0) : undefined,
         units: parseNumber(textContent(assignment, "Units"), 0),
-        work: textContent(assignment, "Work") || undefined
+        work: textContent(assignment, "Work") || undefined,
+        cost: textContent(assignment, "Cost") ? parseNumber(textContent(assignment, "Cost"), 0) : undefined,
+        actualCost: textContent(assignment, "ActualCost") ? parseNumber(textContent(assignment, "ActualCost"), 0) : undefined,
+        remainingCost: textContent(assignment, "RemainingCost") ? parseNumber(textContent(assignment, "RemainingCost"), 0) : undefined,
+        percentWorkComplete: textContent(assignment, "PercentWorkComplete") ? parseNumber(textContent(assignment, "PercentWorkComplete"), 0) : undefined,
+        overtimeWork: textContent(assignment, "OvertimeWork") || undefined,
+        actualOvertimeWork: textContent(assignment, "ActualOvertimeWork") || undefined,
+        actualWork: textContent(assignment, "ActualWork") || undefined,
+        remainingWork: textContent(assignment, "RemainingWork") || undefined,
+        extendedAttributes: Array.from(assignment.getElementsByTagName("ExtendedAttribute")).map((attribute) => ({
+          fieldID: textContent(attribute, "FieldID") || undefined,
+          value: textContent(attribute, "Value") || undefined
+        })),
+        baselines: Array.from(assignment.getElementsByTagName("Baseline")).map((baseline) => ({
+          number: textContent(baseline, "Number") ? parseNumber(textContent(baseline, "Number"), 0) : undefined,
+          start: textContent(baseline, "Start") || undefined,
+          finish: textContent(baseline, "Finish") || undefined,
+          work: textContent(baseline, "Work") || undefined,
+          cost: textContent(baseline, "Cost") ? parseNumber(textContent(baseline, "Cost"), 0) : undefined
+        })),
+        timephasedData: Array.from(assignment.getElementsByTagName("TimephasedData")).map((timephasedData) => ({
+          type: textContent(timephasedData, "Type") ? parseNumber(textContent(timephasedData, "Type"), 0) : undefined,
+          uid: textContent(timephasedData, "UID") || undefined,
+          start: textContent(timephasedData, "Start") || undefined,
+          finish: textContent(timephasedData, "Finish") || undefined,
+          unit: textContent(timephasedData, "Unit") ? parseNumber(textContent(timephasedData, "Unit"), 0) : undefined,
+          value: textContent(timephasedData, "Value") || undefined
+        }))
       }))
     };
   }
@@ -252,6 +825,12 @@
     project.setAttribute("xmlns", "http://schemas.microsoft.com/project");
 
     appendTextElement(doc, project, "Name", model.project.name);
+    appendTextElement(doc, project, "Title", model.project.title);
+    appendTextElement(doc, project, "Company", model.project.company);
+    appendTextElement(doc, project, "Author", model.project.author);
+    appendTextElement(doc, project, "CreationDate", model.project.creationDate);
+    appendTextElement(doc, project, "LastSaved", model.project.lastSaved);
+    appendTextElement(doc, project, "SaveVersion", model.project.saveVersion);
     appendTextElement(doc, project, "CurrentDate", model.project.currentDate);
     appendTextElement(doc, project, "StartDate", model.project.startDate);
     appendTextElement(doc, project, "FinishDate", model.project.finishDate);
@@ -261,7 +840,98 @@
     appendTextElement(doc, project, "MinutesPerDay", model.project.minutesPerDay);
     appendTextElement(doc, project, "MinutesPerWeek", model.project.minutesPerWeek);
     appendTextElement(doc, project, "DaysPerMonth", model.project.daysPerMonth);
+    appendTextElement(doc, project, "StatusDate", model.project.statusDate);
+    appendTextElement(doc, project, "WeekStartDay", model.project.weekStartDay);
+    appendTextElement(doc, project, "WorkFormat", model.project.workFormat);
+    appendTextElement(doc, project, "DurationFormat", model.project.durationFormat);
+    appendTextElement(doc, project, "CurrencyCode", model.project.currencyCode);
+    appendTextElement(doc, project, "CurrencyDigits", model.project.currencyDigits);
+    appendTextElement(doc, project, "CurrencySymbol", model.project.currencySymbol);
+    appendTextElement(doc, project, "CurrencySymbolPosition", model.project.currencySymbolPosition);
+    appendTextElement(doc, project, "FYStartDate", model.project.fyStartDate);
+    appendTextElement(doc, project, "FiscalYearStart", model.project.fiscalYearStart);
+    appendTextElement(doc, project, "CriticalSlackLimit", model.project.criticalSlackLimit);
+    appendTextElement(doc, project, "DefaultTaskType", model.project.defaultTaskType);
+    appendTextElement(doc, project, "DefaultFixedCostAccrual", model.project.defaultFixedCostAccrual);
+    appendTextElement(doc, project, "DefaultStandardRate", model.project.defaultStandardRate);
+    appendTextElement(doc, project, "DefaultOvertimeRate", model.project.defaultOvertimeRate);
+    appendTextElement(doc, project, "DefaultTaskEVMethod", model.project.defaultTaskEVMethod);
+    appendTextElement(doc, project, "NewTaskStartDate", model.project.newTaskStartDate);
+    appendTextElement(doc, project, "NewTasksAreManual", model.project.newTasksAreManual);
+    appendTextElement(doc, project, "NewTasksEffortDriven", model.project.newTasksEffortDriven);
+    appendTextElement(doc, project, "NewTasksEstimated", model.project.newTasksEstimated);
+    appendTextElement(doc, project, "ActualsInSync", model.project.actualsInSync);
+    appendTextElement(doc, project, "EditableActualCosts", model.project.editableActualCosts);
+    appendTextElement(doc, project, "HonorConstraints", model.project.honorConstraints);
+    appendTextElement(doc, project, "InsertedProjectsLikeSummary", model.project.insertedProjectsLikeSummary);
+    appendTextElement(doc, project, "MultipleCriticalPaths", model.project.multipleCriticalPaths);
+    appendTextElement(doc, project, "TaskUpdatesResource", model.project.taskUpdatesResource);
+    appendTextElement(doc, project, "UpdateManuallyScheduledTasksWhenEditingLinks", model.project.updateManuallyScheduledTasksWhenEditingLinks);
     appendTextElement(doc, project, "CalendarUID", model.project.calendarUID);
+    if (model.project.outlineCodes.length > 0) {
+      const outlineCodesElement = doc.createElement("OutlineCodes");
+      for (const outlineCode of model.project.outlineCodes) {
+        const outlineCodeElement = doc.createElement("OutlineCode");
+        appendTextElement(doc, outlineCodeElement, "FieldID", outlineCode.fieldID);
+        appendTextElement(doc, outlineCodeElement, "FieldName", outlineCode.fieldName);
+        appendTextElement(doc, outlineCodeElement, "Alias", outlineCode.alias);
+        appendTextElement(doc, outlineCodeElement, "OnlyTableValues", outlineCode.onlyTableValues);
+        appendTextElement(doc, outlineCodeElement, "Enterprise", outlineCode.enterprise);
+        appendTextElement(doc, outlineCodeElement, "ResourceSubstitutionEnabled", outlineCode.resourceSubstitutionEnabled);
+        appendTextElement(doc, outlineCodeElement, "LeafOnly", outlineCode.leafOnly);
+        appendTextElement(doc, outlineCodeElement, "AllLevelsRequired", outlineCode.allLevelsRequired);
+        if (outlineCode.masks.length > 0) {
+          const masksElement = doc.createElement("Masks");
+          for (const mask of outlineCode.masks) {
+            const maskElement = doc.createElement("Mask");
+            appendTextElement(doc, maskElement, "Level", mask.level);
+            appendTextElement(doc, maskElement, "Mask", mask.mask);
+            appendTextElement(doc, maskElement, "Length", mask.length);
+            appendTextElement(doc, maskElement, "Sequence", mask.sequence);
+            masksElement.appendChild(maskElement);
+          }
+          outlineCodeElement.appendChild(masksElement);
+        }
+        if (outlineCode.values.length > 0) {
+          const valuesElement = doc.createElement("Values");
+          for (const value of outlineCode.values) {
+            const valueElement = doc.createElement("Value");
+            appendTextElement(doc, valueElement, "Value", value.value);
+            appendTextElement(doc, valueElement, "Description", value.description);
+            valuesElement.appendChild(valueElement);
+          }
+          outlineCodeElement.appendChild(valuesElement);
+        }
+        outlineCodesElement.appendChild(outlineCodeElement);
+      }
+      project.appendChild(outlineCodesElement);
+    }
+    if (model.project.wbsMasks.length > 0) {
+      const wbsMasksElement = doc.createElement("WBSMasks");
+      for (const wbsMask of model.project.wbsMasks) {
+        const wbsMaskElement = doc.createElement("WBSMask");
+        appendTextElement(doc, wbsMaskElement, "Level", wbsMask.level);
+        appendTextElement(doc, wbsMaskElement, "Mask", wbsMask.mask);
+        appendTextElement(doc, wbsMaskElement, "Length", wbsMask.length);
+        appendTextElement(doc, wbsMaskElement, "Sequence", wbsMask.sequence);
+        wbsMasksElement.appendChild(wbsMaskElement);
+      }
+      project.appendChild(wbsMasksElement);
+    }
+    if (model.project.extendedAttributes.length > 0) {
+      const extendedAttributesElement = doc.createElement("ExtendedAttributes");
+      for (const attribute of model.project.extendedAttributes) {
+        const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+        appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+        appendTextElement(doc, extendedAttributeElement, "FieldName", attribute.fieldName);
+        appendTextElement(doc, extendedAttributeElement, "Alias", attribute.alias);
+        appendTextElement(doc, extendedAttributeElement, "CalculationType", attribute.calculationType);
+        appendTextElement(doc, extendedAttributeElement, "RestrictValues", attribute.restrictValues);
+        appendTextElement(doc, extendedAttributeElement, "AppendNewValues", attribute.appendNewValues);
+        extendedAttributesElement.appendChild(extendedAttributeElement);
+      }
+      project.appendChild(extendedAttributesElement);
+    }
 
     const calendarsElement = doc.createElement("Calendars");
     for (const calendar of model.calendars) {
@@ -269,6 +939,34 @@
       appendTextElement(doc, calendarElement, "UID", calendar.uid);
       appendTextElement(doc, calendarElement, "Name", calendar.name);
       appendTextElement(doc, calendarElement, "IsBaseCalendar", calendar.isBaseCalendar);
+      appendTextElement(doc, calendarElement, "IsBaselineCalendar", calendar.isBaselineCalendar);
+      appendTextElement(doc, calendarElement, "BaseCalendarUID", calendar.baseCalendarUID);
+      if (calendar.exceptions.length > 0) {
+        const exceptionsElement = doc.createElement("Exceptions");
+        for (const exception of calendar.exceptions) {
+          const exceptionElement = doc.createElement("Exception");
+          appendTextElement(doc, exceptionElement, "Name", exception.name);
+          appendTextElement(doc, exceptionElement, "FromDate", exception.fromDate);
+          appendTextElement(doc, exceptionElement, "ToDate", exception.toDate);
+          appendTextElement(doc, exceptionElement, "DayWorking", exception.dayWorking);
+          appendWorkingTimes(doc, exceptionElement, exception.workingTimes);
+          exceptionsElement.appendChild(exceptionElement);
+        }
+        calendarElement.appendChild(exceptionsElement);
+      }
+      if (calendar.workWeeks.length > 0) {
+        const workWeeksElement = doc.createElement("WorkWeeks");
+        for (const workWeek of calendar.workWeeks) {
+          const workWeekElement = doc.createElement("WorkWeek");
+          appendTextElement(doc, workWeekElement, "Name", workWeek.name);
+          appendTextElement(doc, workWeekElement, "FromDate", workWeek.fromDate);
+          appendTextElement(doc, workWeekElement, "ToDate", workWeek.toDate);
+          appendWeekDays(doc, workWeekElement, workWeek.weekDays);
+          workWeeksElement.appendChild(workWeekElement);
+        }
+        calendarElement.appendChild(workWeeksElement);
+      }
+      appendWeekDays(doc, calendarElement, calendar.weekDays);
       calendarsElement.appendChild(calendarElement);
     }
     project.appendChild(calendarsElement);
@@ -281,17 +979,60 @@
       appendTextElement(doc, taskElement, "Name", task.name);
       appendTextElement(doc, taskElement, "OutlineLevel", task.outlineLevel);
       appendTextElement(doc, taskElement, "OutlineNumber", task.outlineNumber);
+      appendTextElement(doc, taskElement, "WBS", task.wbs);
+      appendTextElement(doc, taskElement, "Type", task.type);
+      appendTextElement(doc, taskElement, "CalendarUID", task.calendarUID);
+      appendTextElement(doc, taskElement, "Priority", task.priority);
       appendTextElement(doc, taskElement, "Start", task.start);
       appendTextElement(doc, taskElement, "Finish", task.finish);
       appendTextElement(doc, taskElement, "Duration", task.duration);
       appendTextElement(doc, taskElement, "ActualStart", task.actualStart);
       appendTextElement(doc, taskElement, "ActualFinish", task.actualFinish);
+      appendTextElement(doc, taskElement, "Deadline", task.deadline);
+      appendTextElement(doc, taskElement, "StartVariance", task.startVariance);
+      appendTextElement(doc, taskElement, "FinishVariance", task.finishVariance);
+      appendTextElement(doc, taskElement, "Work", task.work);
+      appendTextElement(doc, taskElement, "WorkVariance", task.workVariance);
+      appendTextElement(doc, taskElement, "TotalSlack", task.totalSlack);
+      appendTextElement(doc, taskElement, "FreeSlack", task.freeSlack);
+      appendTextElement(doc, taskElement, "Cost", task.cost);
+      appendTextElement(doc, taskElement, "ActualCost", task.actualCost);
+      appendTextElement(doc, taskElement, "RemainingCost", task.remainingCost);
+      appendTextElement(doc, taskElement, "RemainingWork", task.remainingWork);
+      appendTextElement(doc, taskElement, "ActualWork", task.actualWork);
       appendTextElement(doc, taskElement, "ConstraintType", task.constraintType);
       appendTextElement(doc, taskElement, "ConstraintDate", task.constraintDate);
       appendTextElement(doc, taskElement, "Milestone", task.milestone);
       appendTextElement(doc, taskElement, "Summary", task.summary);
+      appendTextElement(doc, taskElement, "Critical", task.critical);
       appendTextElement(doc, taskElement, "PercentComplete", task.percentComplete);
+      appendTextElement(doc, taskElement, "PercentWorkComplete", task.percentWorkComplete);
       appendTextElement(doc, taskElement, "Notes", task.notes);
+      for (const attribute of task.extendedAttributes) {
+        const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+        appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+        appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+        taskElement.appendChild(extendedAttributeElement);
+      }
+      for (const baseline of task.baselines) {
+        const baselineElement = doc.createElement("Baseline");
+        appendTextElement(doc, baselineElement, "Number", baseline.number);
+        appendTextElement(doc, baselineElement, "Start", baseline.start);
+        appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+        appendTextElement(doc, baselineElement, "Work", baseline.work);
+        appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+        taskElement.appendChild(baselineElement);
+      }
+      for (const timephasedData of task.timephasedData) {
+        const timephasedDataElement = doc.createElement("TimephasedData");
+        appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+        appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+        appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+        appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+        appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+        appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+        taskElement.appendChild(timephasedDataElement);
+      }
       for (const predecessor of task.predecessors) {
         const predecessorElement = doc.createElement("PredecessorLink");
         appendTextElement(doc, predecessorElement, "PredecessorUID", predecessor.predecessorUid);
@@ -312,7 +1053,46 @@
       appendTextElement(doc, resourceElement, "Type", resource.type);
       appendTextElement(doc, resourceElement, "Initials", resource.initials);
       appendTextElement(doc, resourceElement, "Group", resource.group);
+      appendTextElement(doc, resourceElement, "WorkGroup", resource.workGroup);
       appendTextElement(doc, resourceElement, "MaxUnits", resource.maxUnits);
+      appendTextElement(doc, resourceElement, "CalendarUID", resource.calendarUID);
+      appendTextElement(doc, resourceElement, "StandardRate", resource.standardRate);
+      appendTextElement(doc, resourceElement, "StandardRateFormat", resource.standardRateFormat);
+      appendTextElement(doc, resourceElement, "OvertimeRate", resource.overtimeRate);
+      appendTextElement(doc, resourceElement, "OvertimeRateFormat", resource.overtimeRateFormat);
+      appendTextElement(doc, resourceElement, "CostPerUse", resource.costPerUse);
+      appendTextElement(doc, resourceElement, "Work", resource.work);
+      appendTextElement(doc, resourceElement, "ActualWork", resource.actualWork);
+      appendTextElement(doc, resourceElement, "RemainingWork", resource.remainingWork);
+      appendTextElement(doc, resourceElement, "Cost", resource.cost);
+      appendTextElement(doc, resourceElement, "ActualCost", resource.actualCost);
+      appendTextElement(doc, resourceElement, "RemainingCost", resource.remainingCost);
+      appendTextElement(doc, resourceElement, "PercentWorkComplete", resource.percentWorkComplete);
+      for (const attribute of resource.extendedAttributes) {
+        const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+        appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+        appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+        resourceElement.appendChild(extendedAttributeElement);
+      }
+      for (const baseline of resource.baselines) {
+        const baselineElement = doc.createElement("Baseline");
+        appendTextElement(doc, baselineElement, "Number", baseline.number);
+        appendTextElement(doc, baselineElement, "Start", baseline.start);
+        appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+        appendTextElement(doc, baselineElement, "Work", baseline.work);
+        appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+        resourceElement.appendChild(baselineElement);
+      }
+      for (const timephasedData of resource.timephasedData) {
+        const timephasedDataElement = doc.createElement("TimephasedData");
+        appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+        appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+        appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+        appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+        appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+        appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+        resourceElement.appendChild(timephasedDataElement);
+      }
       resourcesElement.appendChild(resourceElement);
     }
     project.appendChild(resourcesElement);
@@ -325,8 +1105,46 @@
       appendTextElement(doc, assignmentElement, "ResourceUID", assignment.resourceUid);
       appendTextElement(doc, assignmentElement, "Start", assignment.start);
       appendTextElement(doc, assignmentElement, "Finish", assignment.finish);
+      appendTextElement(doc, assignmentElement, "StartVariance", assignment.startVariance);
+      appendTextElement(doc, assignmentElement, "FinishVariance", assignment.finishVariance);
+      appendTextElement(doc, assignmentElement, "Delay", assignment.delay);
+      appendTextElement(doc, assignmentElement, "Milestone", assignment.milestone);
+      appendTextElement(doc, assignmentElement, "WorkContour", assignment.workContour);
       appendTextElement(doc, assignmentElement, "Units", assignment.units);
       appendTextElement(doc, assignmentElement, "Work", assignment.work);
+      appendTextElement(doc, assignmentElement, "Cost", assignment.cost);
+      appendTextElement(doc, assignmentElement, "ActualCost", assignment.actualCost);
+      appendTextElement(doc, assignmentElement, "RemainingCost", assignment.remainingCost);
+      appendTextElement(doc, assignmentElement, "PercentWorkComplete", assignment.percentWorkComplete);
+      appendTextElement(doc, assignmentElement, "OvertimeWork", assignment.overtimeWork);
+      appendTextElement(doc, assignmentElement, "ActualOvertimeWork", assignment.actualOvertimeWork);
+      appendTextElement(doc, assignmentElement, "ActualWork", assignment.actualWork);
+      appendTextElement(doc, assignmentElement, "RemainingWork", assignment.remainingWork);
+      for (const attribute of assignment.extendedAttributes) {
+        const extendedAttributeElement = doc.createElement("ExtendedAttribute");
+        appendTextElement(doc, extendedAttributeElement, "FieldID", attribute.fieldID);
+        appendTextElement(doc, extendedAttributeElement, "Value", attribute.value);
+        assignmentElement.appendChild(extendedAttributeElement);
+      }
+      for (const baseline of assignment.baselines) {
+        const baselineElement = doc.createElement("Baseline");
+        appendTextElement(doc, baselineElement, "Number", baseline.number);
+        appendTextElement(doc, baselineElement, "Start", baseline.start);
+        appendTextElement(doc, baselineElement, "Finish", baseline.finish);
+        appendTextElement(doc, baselineElement, "Work", baseline.work);
+        appendTextElement(doc, baselineElement, "Cost", baseline.cost);
+        assignmentElement.appendChild(baselineElement);
+      }
+      for (const timephasedData of assignment.timephasedData) {
+        const timephasedDataElement = doc.createElement("TimephasedData");
+        appendTextElement(doc, timephasedDataElement, "Type", timephasedData.type);
+        appendTextElement(doc, timephasedDataElement, "UID", timephasedData.uid);
+        appendTextElement(doc, timephasedDataElement, "Start", timephasedData.start);
+        appendTextElement(doc, timephasedDataElement, "Finish", timephasedData.finish);
+        appendTextElement(doc, timephasedDataElement, "Unit", timephasedData.unit);
+        appendTextElement(doc, timephasedDataElement, "Value", timephasedData.value);
+        assignmentElement.appendChild(timephasedDataElement);
+      }
       assignmentsElement.appendChild(assignmentElement);
     }
     project.appendChild(assignmentsElement);
@@ -350,6 +1168,9 @@
     if (!model.project.name) {
       issues.push({ level: "warning", scope: "project", message: "Project Name が空です" });
     }
+    if (model.project.saveVersion !== undefined && model.project.saveVersion < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project SaveVersion は 0 以上が望ましいです" });
+    }
     if (!model.project.startDate) {
       issues.push({ level: "warning", scope: "project", message: "Project StartDate が空です" });
     }
@@ -365,15 +1186,136 @@
     if (model.project.daysPerMonth !== undefined && model.project.daysPerMonth <= 0) {
       issues.push({ level: "warning", scope: "project", message: "Project DaysPerMonth は正の値が望ましいです" });
     }
+    if (model.project.weekStartDay !== undefined && (model.project.weekStartDay < 1 || model.project.weekStartDay > 7)) {
+      issues.push({ level: "warning", scope: "project", message: "Project WeekStartDay は 1..7 が望ましいです" });
+    }
+    if (model.project.workFormat !== undefined && model.project.workFormat < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project WorkFormat は 0 以上が望ましいです" });
+    }
+    if (model.project.durationFormat !== undefined && model.project.durationFormat < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project DurationFormat は 0 以上が望ましいです" });
+    }
+    if (model.project.currencyDigits !== undefined && model.project.currencyDigits < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project CurrencyDigits は 0 以上が望ましいです" });
+    }
+    if (model.project.currencySymbolPosition !== undefined && model.project.currencySymbolPosition < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project CurrencySymbolPosition は 0 以上が望ましいです" });
+    }
+    if (model.project.fyStartDate !== undefined && !parseDateValue(model.project.fyStartDate)) {
+      issues.push({ level: "warning", scope: "project", message: "Project FYStartDate の日付形式が解釈できません" });
+    }
+    if (model.project.criticalSlackLimit !== undefined && model.project.criticalSlackLimit < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project CriticalSlackLimit は 0 以上が望ましいです" });
+    }
+    if (model.project.defaultTaskType !== undefined && model.project.defaultTaskType < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskType は 0 以上が望ましいです" });
+    }
+    if (model.project.defaultFixedCostAccrual !== undefined && model.project.defaultFixedCostAccrual < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project DefaultFixedCostAccrual は 0 以上が望ましいです" });
+    }
+    if (model.project.defaultTaskEVMethod !== undefined && model.project.defaultTaskEVMethod < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project DefaultTaskEVMethod は 0 以上が望ましいです" });
+    }
+    if (model.project.newTaskStartDate !== undefined && model.project.newTaskStartDate < 0) {
+      issues.push({ level: "warning", scope: "project", message: "Project NewTaskStartDate は 0 以上が望ましいです" });
+    }
+    for (const outlineCode of model.project.outlineCodes) {
+      if (!outlineCode.fieldID && !outlineCode.fieldName) {
+        issues.push({ level: "warning", scope: "project", message: "Project OutlineCode は FieldID または FieldName を持つことが望ましいです" });
+      }
+      for (const mask of outlineCode.masks) {
+        if (mask.level < 1) {
+          issues.push({ level: "warning", scope: "project", message: "Project OutlineCode Mask Level は 1 以上が望ましいです" });
+        }
+      }
+    }
+    for (const wbsMask of model.project.wbsMasks) {
+      if (wbsMask.level < 1) {
+        issues.push({ level: "warning", scope: "project", message: "Project WBSMask Level は 1 以上が望ましいです" });
+      }
+    }
+    for (const attribute of model.project.extendedAttributes) {
+      if (!attribute.fieldID && !attribute.fieldName) {
+        issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute は FieldID または FieldName を持つことが望ましいです" });
+      }
+      if (attribute.calculationType !== undefined && attribute.calculationType < 0) {
+        issues.push({ level: "warning", scope: "project", message: "Project ExtendedAttribute CalculationType は 0 以上が望ましいです" });
+      }
+    }
 
     for (const calendar of model.calendars) {
       if (!calendar.uid) {
         issues.push({ level: "error", scope: "calendars", message: "Calendar UID が空です" });
       }
+      if (calendar.isBaselineCalendar !== undefined && !calendar.isBaseCalendar && calendar.isBaselineCalendar) {
+        issues.push({
+          level: "warning",
+          scope: "calendars",
+          message: `Calendar IsBaselineCalendar は通常 BaseCalendar と整合していることが望ましいです: UID=${calendar.uid}`
+        });
+      }
       if (calendarUidSet.has(calendar.uid)) {
         issues.push({ level: "error", scope: "calendars", message: `Calendar UID が重複しています: ${calendar.uid}` });
       }
       calendarUidSet.add(calendar.uid);
+      for (const weekDay of calendar.weekDays) {
+        if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+          issues.push({
+            level: "warning",
+            scope: "calendars",
+            message: `Calendar WeekDay DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+          });
+        }
+        for (const workingTime of weekDay.workingTimes) {
+          if (!workingTime.fromTime || !workingTime.toTime) {
+            issues.push({
+              level: "warning",
+              scope: "calendars",
+              message: `Calendar WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+            });
+          }
+        }
+      }
+      for (const exception of calendar.exceptions) {
+        const exceptionFrom = parseDateValue(exception.fromDate);
+        const exceptionTo = parseDateValue(exception.toDate);
+        if (exceptionFrom !== null && exceptionTo !== null && exceptionFrom > exceptionTo) {
+          issues.push({
+            level: "warning",
+            scope: "calendars",
+            message: `Calendar Exception FromDate が ToDate より後です: UID=${calendar.uid}`
+          });
+        }
+        for (const workingTime of exception.workingTimes) {
+          if (!workingTime.fromTime || !workingTime.toTime) {
+            issues.push({
+              level: "warning",
+              scope: "calendars",
+              message: `Calendar Exception WorkingTime の時刻が不足しています: UID=${calendar.uid}`
+            });
+          }
+        }
+      }
+      for (const workWeek of calendar.workWeeks) {
+        const workWeekFrom = parseDateValue(workWeek.fromDate);
+        const workWeekTo = parseDateValue(workWeek.toDate);
+        if (workWeekFrom !== null && workWeekTo !== null && workWeekFrom > workWeekTo) {
+          issues.push({
+            level: "warning",
+            scope: "calendars",
+            message: `Calendar WorkWeek FromDate が ToDate より後です: UID=${calendar.uid}`
+          });
+        }
+        for (const weekDay of workWeek.weekDays) {
+          if (weekDay.dayType < 1 || weekDay.dayType > 7) {
+            issues.push({
+              level: "warning",
+              scope: "calendars",
+              message: `Calendar WorkWeek DayType が 1..7 の範囲外です: UID=${calendar.uid}`
+            });
+          }
+        }
+      }
     }
 
     if (model.project.calendarUID && !calendarUidSet.has(model.project.calendarUID)) {
@@ -384,6 +1326,16 @@
       });
     }
 
+    for (const calendar of model.calendars) {
+      if (calendar.baseCalendarUID && !calendarUidSet.has(calendar.baseCalendarUID)) {
+        issues.push({
+          level: "warning",
+          scope: "calendars",
+          message: `Calendar BaseCalendarUID が既存 Calendar を指していません: UID=${calendar.uid}`
+        });
+      }
+    }
+
     for (const task of model.tasks) {
       if (!task.uid) {
         issues.push({ level: "error", scope: "tasks", message: "Task UID が空です" });
@@ -392,7 +1344,9 @@
         issues.push({ level: "error", scope: "tasks", message: `Task ID が空です: ${task.name || "(無名)"}` });
       }
       if (!task.name) {
-        issues.push({ level: "error", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+        if (!isPlaceholderUid(task.uid)) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task Name が空です: UID=${task.uid || "(なし)"}` });
+        }
       }
       if (taskIdSet.has(task.id)) {
         issues.push({ level: "error", scope: "tasks", message: `Task ID が重複しています: ${task.id}` });
@@ -404,10 +1358,10 @@
       if (!task.finish) {
         issues.push({ level: "warning", scope: "tasks", message: `Task Finish が空です: UID=${task.uid}` });
       }
-      if (task.outlineLevel < 1) {
+      if (task.outlineLevel < 1 && !isPlaceholderUid(task.uid)) {
         issues.push({ level: "error", scope: "tasks", message: `Task OutlineLevel が不正です: UID=${task.uid}` });
       }
-      if (task.outlineNumber) {
+      if (task.outlineNumber && !isPlaceholderUid(task.uid)) {
         const outlineParts = task.outlineNumber.split(".").filter(Boolean);
         if (outlineParts.length !== task.outlineLevel) {
           issues.push({
@@ -424,15 +1378,33 @@
           message: `Task PercentComplete が 0..100 の範囲外です: UID=${task.uid}`
         });
       }
+      if (
+        task.percentWorkComplete !== undefined &&
+        (task.percentWorkComplete < 0 || task.percentWorkComplete > 100)
+      ) {
+        issues.push({
+          level: "warning",
+          scope: "tasks",
+          message: `Task PercentWorkComplete が 0..100 の範囲外です: UID=${task.uid}`
+        });
+      }
       const taskStart = parseDateValue(task.start);
       const taskFinish = parseDateValue(task.finish);
       const taskActualStart = parseDateValue(task.actualStart);
       const taskActualFinish = parseDateValue(task.actualFinish);
+      const taskDeadline = parseDateValue(task.deadline);
       if (taskStart !== null && taskFinish !== null && taskStart > taskFinish) {
         issues.push({
           level: "warning",
           scope: "tasks",
           message: `Task Start が Finish より後です: UID=${task.uid}`
+        });
+      }
+      if (taskFinish !== null && taskDeadline !== null && taskFinish > taskDeadline) {
+        issues.push({
+          level: "warning",
+          scope: "tasks",
+          message: `Task Finish が Deadline より後です: UID=${task.uid}`
         });
       }
       if (taskActualStart !== null && taskActualFinish !== null && taskActualStart > taskActualFinish) {
@@ -445,7 +1417,48 @@
       if (taskUidSet.has(task.uid)) {
         issues.push({ level: "error", scope: "tasks", message: `Task UID が重複しています: ${task.uid}` });
       }
+      for (const attribute of task.extendedAttributes) {
+        if (!attribute.fieldID) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task ExtendedAttribute に FieldID がありません: UID=${task.uid}` });
+        }
+      }
+      for (const baseline of task.baselines) {
+        if (baseline.number !== undefined && baseline.number < 0) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Number は 0 以上が望ましいです: UID=${task.uid}` });
+        }
+        const baselineStart = parseDateValue(baseline.start);
+        const baselineFinish = parseDateValue(baseline.finish);
+        if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task Baseline Start が Finish より後です: UID=${task.uid}` });
+        }
+      }
+      for (const timephasedData of task.timephasedData) {
+        if (timephasedData.type !== undefined && timephasedData.type < 0) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Type は 0 以上が望ましいです: UID=${task.uid}` });
+        }
+        const timephasedStart = parseDateValue(timephasedData.start);
+        const timephasedFinish = parseDateValue(timephasedData.finish);
+        if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+          issues.push({ level: "warning", scope: "tasks", message: `Task TimephasedData Start が Finish より後です: UID=${task.uid}` });
+        }
+      }
       taskUidSet.add(task.uid);
+      if (task.priority !== undefined && (task.priority < 0 || task.priority > 1000)) {
+        issues.push({
+          level: "warning",
+          scope: "tasks",
+          message: `Task Priority が 0..1000 の範囲外です: UID=${task.uid}`
+        });
+      }
+      if (task.cost !== undefined && task.cost < 0) {
+        issues.push({ level: "warning", scope: "tasks", message: `Task Cost が負値です: UID=${task.uid}` });
+      }
+      if (task.actualCost !== undefined && task.actualCost < 0) {
+        issues.push({ level: "warning", scope: "tasks", message: `Task ActualCost が負値です: UID=${task.uid}` });
+      }
+      if (task.remainingCost !== undefined && task.remainingCost < 0) {
+        issues.push({ level: "warning", scope: "tasks", message: `Task RemainingCost が負値です: UID=${task.uid}` });
+      }
     }
 
     for (const resource of model.resources) {
@@ -453,12 +1466,95 @@
         issues.push({ level: "error", scope: "resources", message: "Resource UID が空です" });
       }
       if (!resource.name) {
-        issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+        if (!isPlaceholderUid(resource.uid)) {
+          issues.push({ level: "warning", scope: "resources", message: `Resource Name が空です: UID=${resource.uid || "(なし)"}` });
+        }
       }
       if (resourceUidSet.has(resource.uid)) {
         issues.push({ level: "error", scope: "resources", message: `Resource UID が重複しています: ${resource.uid}` });
       }
       resourceUidSet.add(resource.uid);
+      if (resource.calendarUID && !calendarUidSet.has(resource.calendarUID)) {
+        issues.push({
+          level: "warning",
+          scope: "resources",
+          message: `Resource CalendarUID が既存 Calendar を指していません: UID=${resource.uid || "(なし)"}`
+        });
+      }
+      if (resource.workGroup !== undefined && resource.workGroup < 0) {
+        issues.push({
+          level: "warning",
+          scope: "resources",
+          message: `Resource WorkGroup は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+        });
+      }
+      if (resource.overtimeRateFormat !== undefined && resource.overtimeRateFormat < 0) {
+        issues.push({
+          level: "warning",
+          scope: "resources",
+          message: `Resource OvertimeRateFormat は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+        });
+      }
+      if (resource.cost !== undefined && resource.cost < 0) {
+        issues.push({ level: "warning", scope: "resources", message: `Resource Cost が負値です: UID=${resource.uid || "(なし)"}` });
+      }
+      if (resource.actualCost !== undefined && resource.actualCost < 0) {
+        issues.push({ level: "warning", scope: "resources", message: `Resource ActualCost が負値です: UID=${resource.uid || "(なし)"}` });
+      }
+      if (resource.remainingCost !== undefined && resource.remainingCost < 0) {
+        issues.push({ level: "warning", scope: "resources", message: `Resource RemainingCost が負値です: UID=${resource.uid || "(なし)"}` });
+      }
+      if (
+        resource.percentWorkComplete !== undefined &&
+        (resource.percentWorkComplete < 0 || resource.percentWorkComplete > 100)
+      ) {
+        issues.push({
+          level: "warning",
+          scope: "resources",
+          message: `Resource PercentWorkComplete が 0..100 の範囲外です: UID=${resource.uid || "(なし)"}`
+        });
+      }
+      for (const attribute of resource.extendedAttributes) {
+        if (!attribute.fieldID) {
+          issues.push({ level: "warning", scope: "resources", message: `Resource ExtendedAttribute に FieldID がありません: UID=${resource.uid || "(なし)"}` });
+        }
+      }
+      for (const baseline of resource.baselines) {
+        if (baseline.number !== undefined && baseline.number < 0) {
+          issues.push({
+            level: "warning",
+            scope: "resources",
+            message: `Resource Baseline Number は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+          });
+        }
+        const baselineStart = parseDateValue(baseline.start);
+        const baselineFinish = parseDateValue(baseline.finish);
+        if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+          issues.push({
+            level: "warning",
+            scope: "resources",
+            message: `Resource Baseline Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+          });
+        }
+      }
+      for (const timephasedData of resource.timephasedData) {
+        if (timephasedData.type !== undefined && timephasedData.type < 0) {
+          issues.push({
+            level: "warning",
+            scope: "resources",
+            message: `Resource TimephasedData Type は 0 以上が望ましいです: UID=${resource.uid || "(なし)"}`
+          });
+        }
+        const timephasedStart = parseDateValue(timephasedData.start);
+        const timephasedFinish = parseDateValue(timephasedData.finish);
+        if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+          issues.push({
+            level: "warning",
+            scope: "resources",
+            message: `Resource TimephasedData Start が Finish より後です: UID=${resource.uid || "(なし)"}`
+          });
+        }
+      }
     }
 
     for (const task of model.tasks) {
@@ -484,7 +1580,7 @@
           message: `Assignment TaskUID が既存 Task を指していません: ${assignment.taskUid}`
         });
       }
-      if (!resourceUidSet.has(assignment.resourceUid)) {
+      if (!resourceUidSet.has(assignment.resourceUid) && !isUnassignedResourceUid(assignment.resourceUid)) {
         issues.push({
           level: "error",
           scope: "assignments",
@@ -511,6 +1607,117 @@
           level: "warning",
           scope: "assignments",
           message: `Assignment Units が負値です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.cost !== undefined && assignment.cost < 0) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment Cost が負値です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.actualCost !== undefined && assignment.actualCost < 0) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment ActualCost が負値です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.remainingCost !== undefined && assignment.remainingCost < 0) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment RemainingCost が負値です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (
+        assignment.percentWorkComplete !== undefined &&
+        (assignment.percentWorkComplete < 0 || assignment.percentWorkComplete > 100)
+      ) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment PercentWorkComplete が 0..100 の範囲外です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.overtimeWork !== undefined && !assignment.overtimeWork) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment OvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.actualOvertimeWork !== undefined && !assignment.actualOvertimeWork) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment ActualOvertimeWork が空です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.workContour !== undefined && assignment.workContour < 0) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment WorkContour は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      if (assignment.startVariance !== undefined && !assignment.startVariance) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment StartVariance が空です: UID=${assignment.uid || "(なし)"}`
+        });
+      }
+      for (const attribute of assignment.extendedAttributes) {
+        if (!attribute.fieldID) {
+          issues.push({
+            level: "warning",
+            scope: "assignments",
+            message: `Assignment ExtendedAttribute に FieldID がありません: UID=${assignment.uid || "(なし)"}`
+          });
+        }
+      }
+      for (const baseline of assignment.baselines) {
+        if (baseline.number !== undefined && baseline.number < 0) {
+          issues.push({
+            level: "warning",
+            scope: "assignments",
+            message: `Assignment Baseline Number は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+          });
+        }
+        const baselineStart = parseDateValue(baseline.start);
+        const baselineFinish = parseDateValue(baseline.finish);
+        if (baselineStart !== null && baselineFinish !== null && baselineStart > baselineFinish) {
+          issues.push({
+            level: "warning",
+            scope: "assignments",
+            message: `Assignment Baseline Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+          });
+        }
+      }
+      for (const timephasedData of assignment.timephasedData) {
+        if (timephasedData.type !== undefined && timephasedData.type < 0) {
+          issues.push({
+            level: "warning",
+            scope: "assignments",
+            message: `Assignment TimephasedData Type は 0 以上が望ましいです: UID=${assignment.uid || "(なし)"}`
+          });
+        }
+        const timephasedStart = parseDateValue(timephasedData.start);
+        const timephasedFinish = parseDateValue(timephasedData.finish);
+        if (timephasedStart !== null && timephasedFinish !== null && timephasedStart > timephasedFinish) {
+          issues.push({
+            level: "warning",
+            scope: "assignments",
+            message: `Assignment TimephasedData Start が Finish より後です: UID=${assignment.uid || "(なし)"}`
+          });
+        }
+      }
+      if (assignment.finishVariance !== undefined && !assignment.finishVariance) {
+        issues.push({
+          level: "warning",
+          scope: "assignments",
+          message: `Assignment FinishVariance が空です: UID=${assignment.uid || "(なし)"}`
         });
       }
     }

--- a/docs/project/src/mikuproject/ts/types.ts
+++ b/docs/project/src/mikuproject/ts/types.ts
@@ -1,6 +1,12 @@
 (() => {
   type ProjectInfo = {
     name: string;
+    title?: string;
+    author?: string;
+    company?: string;
+    creationDate?: string;
+    lastSaved?: string;
+    saveVersion?: number;
     startDate: string;
     finishDate: string;
     scheduleFromStart: boolean;
@@ -10,7 +16,78 @@
     minutesPerDay?: number;
     minutesPerWeek?: number;
     daysPerMonth?: number;
+    statusDate?: string;
+    weekStartDay?: number;
+    workFormat?: number;
+    durationFormat?: number;
+    currencyCode?: string;
+    currencyDigits?: number;
+    currencySymbol?: string;
+    currencySymbolPosition?: number;
+    fyStartDate?: string;
+    fiscalYearStart?: boolean;
+    criticalSlackLimit?: number;
+    defaultTaskType?: number;
+    defaultFixedCostAccrual?: number;
+    defaultStandardRate?: string;
+    defaultOvertimeRate?: string;
+    defaultTaskEVMethod?: number;
+    newTaskStartDate?: number;
+    newTasksAreManual?: boolean;
+    newTasksEffortDriven?: boolean;
+    newTasksEstimated?: boolean;
+    actualsInSync?: boolean;
+    editableActualCosts?: boolean;
+    honorConstraints?: boolean;
+    insertedProjectsLikeSummary?: boolean;
+    multipleCriticalPaths?: boolean;
+    taskUpdatesResource?: boolean;
+    updateManuallyScheduledTasksWhenEditingLinks?: boolean;
     calendarUID?: string;
+    outlineCodes: OutlineCodeModel[];
+    wbsMasks: WBSMaskModel[];
+    extendedAttributes: ProjectExtendedAttributeModel[];
+  };
+
+  type OutlineCodeValueModel = {
+    value: string;
+    description?: string;
+  };
+
+  type OutlineCodeMaskModel = {
+    level: number;
+    mask?: string;
+    length?: number;
+    sequence?: number;
+  };
+
+  type OutlineCodeModel = {
+    fieldID?: string;
+    fieldName?: string;
+    alias?: string;
+    onlyTableValues?: boolean;
+    enterprise?: boolean;
+    resourceSubstitutionEnabled?: boolean;
+    leafOnly?: boolean;
+    allLevelsRequired?: boolean;
+    masks: OutlineCodeMaskModel[];
+    values: OutlineCodeValueModel[];
+  };
+
+  type WBSMaskModel = {
+    level: number;
+    mask?: string;
+    length?: number;
+    sequence?: number;
+  };
+
+  type ProjectExtendedAttributeModel = {
+    fieldID?: string;
+    fieldName?: string;
+    alias?: string;
+    calculationType?: number;
+    restrictValues?: boolean;
+    appendNewValues?: boolean;
   };
 
   type PredecessorModel = {
@@ -19,23 +96,110 @@
     linkLag?: string;
   };
 
+  type TaskExtendedAttributeModel = {
+    fieldID?: string;
+    value?: string;
+  };
+
+  type TaskBaselineModel = {
+    number?: number;
+    start?: string;
+    finish?: string;
+    work?: string;
+    cost?: number;
+  };
+
+  type TaskTimephasedDataModel = {
+    type?: number;
+    uid?: string;
+    start?: string;
+    finish?: string;
+    unit?: number;
+    value?: string;
+  };
+
+  type ResourceExtendedAttributeModel = {
+    fieldID?: string;
+    value?: string;
+  };
+
+  type ResourceBaselineModel = {
+    number?: number;
+    start?: string;
+    finish?: string;
+    work?: string;
+    cost?: number;
+  };
+
+  type ResourceTimephasedDataModel = {
+    type?: number;
+    uid?: string;
+    start?: string;
+    finish?: string;
+    unit?: number;
+    value?: string;
+  };
+
+  type AssignmentExtendedAttributeModel = {
+    fieldID?: string;
+    value?: string;
+  };
+
+  type AssignmentBaselineModel = {
+    number?: number;
+    start?: string;
+    finish?: string;
+    work?: string;
+    cost?: number;
+  };
+
+  type AssignmentTimephasedDataModel = {
+    type?: number;
+    uid?: string;
+    start?: string;
+    finish?: string;
+    unit?: number;
+    value?: string;
+  };
+
   type TaskModel = {
     uid: string;
     id: string;
     name: string;
     outlineLevel: number;
     outlineNumber: string;
+    wbs?: string;
+    type?: number;
+    calendarUID?: string;
+    priority?: number;
     start: string;
     finish: string;
     duration: string;
     actualStart?: string;
     actualFinish?: string;
+    deadline?: string;
+    startVariance?: string;
+    finishVariance?: string;
+    work?: string;
+    workVariance?: string;
+    totalSlack?: string;
+    freeSlack?: string;
+    cost?: number;
+    actualCost?: number;
+    remainingCost?: number;
+    remainingWork?: string;
+    actualWork?: string;
     milestone: boolean;
     summary: boolean;
+    critical?: boolean;
     percentComplete: number;
+    percentWorkComplete?: number;
     notes?: string;
     constraintType?: number;
     constraintDate?: string;
+    extendedAttributes: TaskExtendedAttributeModel[];
+    baselines: TaskBaselineModel[];
+    timephasedData: TaskTimephasedDataModel[];
     predecessors: PredecessorModel[];
   };
 
@@ -46,7 +210,24 @@
     type?: number;
     initials?: string;
     group?: string;
+    workGroup?: number;
     maxUnits?: number;
+    calendarUID?: string;
+    standardRate?: string;
+    standardRateFormat?: number;
+    overtimeRate?: string;
+    overtimeRateFormat?: number;
+    costPerUse?: number;
+    work?: string;
+    actualWork?: string;
+    remainingWork?: string;
+    cost?: number;
+    actualCost?: number;
+    remainingCost?: number;
+    percentWorkComplete?: number;
+    extendedAttributes: ResourceExtendedAttributeModel[];
+    baselines: ResourceBaselineModel[];
+    timephasedData: ResourceTimephasedDataModel[];
   };
 
   type AssignmentModel = {
@@ -55,14 +236,61 @@
     resourceUid: string;
     start?: string;
     finish?: string;
+    startVariance?: string;
+    finishVariance?: string;
+    delay?: string;
+    milestone?: boolean;
+    workContour?: number;
     units?: number;
     work?: string;
+    cost?: number;
+    actualCost?: number;
+    remainingCost?: number;
+    percentWorkComplete?: number;
+    overtimeWork?: string;
+    actualOvertimeWork?: string;
+    actualWork?: string;
+    remainingWork?: string;
+    extendedAttributes: AssignmentExtendedAttributeModel[];
+    baselines: AssignmentBaselineModel[];
+    timephasedData: AssignmentTimephasedDataModel[];
+  };
+
+  type WorkingTimeModel = {
+    fromTime: string;
+    toTime: string;
+  };
+
+  type WeekDayModel = {
+    dayType: number;
+    dayWorking: boolean;
+    workingTimes: WorkingTimeModel[];
+  };
+
+  type CalendarExceptionModel = {
+    name?: string;
+    fromDate?: string;
+    toDate?: string;
+    dayWorking?: boolean;
+    workingTimes: WorkingTimeModel[];
+  };
+
+  type WorkWeekModel = {
+    name?: string;
+    fromDate?: string;
+    toDate?: string;
+    weekDays: WeekDayModel[];
   };
 
   type CalendarModel = {
     uid: string;
     name: string;
     isBaseCalendar: boolean;
+    isBaselineCalendar?: boolean;
+    baseCalendarUID?: string;
+    weekDays: WeekDayModel[];
+    exceptions: CalendarExceptionModel[];
+    workWeeks: WorkWeekModel[];
   };
 
   type ProjectModel = {

--- a/docs/project/tests/mikuproject-main.test.js
+++ b/docs/project/tests/mikuproject-main.test.js
@@ -104,23 +104,134 @@ describe("mikuproject main", () => {
     expect(document.getElementById("summaryTaskCount").textContent).toBe("3");
     expect(document.getElementById("summaryResourceCount").textContent).toBe("1");
     expect(document.getElementById("summaryAssignmentCount").textContent).toBe("2");
-    expect(document.getElementById("summaryCalendarCount").textContent).toBe("1");
+    expect(document.getElementById("summaryCalendarCount").textContent).toBe("2");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Sample Project\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"title\": \"Sample Project Title\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"author\": \"Toshiki Iga\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"company\": \"Local HTML Tools\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"creationDate\": \"2026-03-16T08:30:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"lastSaved\": \"2026-03-16T09:10:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"saveVersion\": 14");
     expect(document.getElementById("modelOutput").value).toContain("\"currentDate\": \"2026-03-16T09:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"defaultStartTime\": \"09:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"minutesPerDay\": 480");
+    expect(document.getElementById("modelOutput").value).toContain("\"statusDate\": \"2026-03-19T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"weekStartDay\": 1");
+    expect(document.getElementById("modelOutput").value).toContain("\"workFormat\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"durationFormat\": 7");
+    expect(document.getElementById("modelOutput").value).toContain("\"currencyCode\": \"JPY\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"currencyDigits\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"currencySymbol\": \"¥\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"currencySymbolPosition\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"fyStartDate\": \"2026-04-01T00:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"fiscalYearStart\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"criticalSlackLimit\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"defaultTaskType\": 1");
+    expect(document.getElementById("modelOutput").value).toContain("\"defaultFixedCostAccrual\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"defaultStandardRate\": \"5000/h\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"defaultOvertimeRate\": \"7000/h\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"defaultTaskEVMethod\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"newTaskStartDate\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"newTasksAreManual\": false");
+    expect(document.getElementById("modelOutput").value).toContain("\"newTasksEffortDriven\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"newTasksEstimated\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualsInSync\": false");
+    expect(document.getElementById("modelOutput").value).toContain("\"editableActualCosts\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"honorConstraints\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"insertedProjectsLikeSummary\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"multipleCriticalPaths\": false");
+    expect(document.getElementById("modelOutput").value).toContain("\"taskUpdatesResource\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"updateManuallyScheduledTasksWhenEditingLinks\": false");
     expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"1\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"fieldID\": \"188743731\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"fieldName\": \"Outline Code1\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"alias\": \"Phase\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"onlyTableValues\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"value\": \"PLAN\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"description\": \"Planning\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"level\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"mask\": \"00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"fieldName\": \"Text1\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"alias\": \"Owner\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"appendNewValues\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"isBaselineCalendar\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"1\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"dayType\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"fromTime\": \"10:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Holiday\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"workingTimes\": [");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Spring Sprint\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"wbs\": \"1.2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"priority\": 700");
+    expect(document.getElementById("modelOutput").value).toContain("\"type\": 1");
+    expect(document.getElementById("modelOutput").value).toContain("\"work\": \"PT24H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"workVariance\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"totalSlack\": \"PT4H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"freeSlack\": \"PT2H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"cost\": 120000");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualCost\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"remainingCost\": 120000");
+    expect(document.getElementById("modelOutput").value).toContain("\"remainingWork\": \"PT24H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualWork\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"critical\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 0");
     expect(document.getElementById("modelOutput").value).toContain("\"predecessorUid\": \"2\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard\"");
     expect(document.getElementById("modelOutput").value).toContain("\"actualStart\": \"2026-03-16T09:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"constraintType\": 4");
     expect(document.getElementById("modelOutput").value).toContain("\"notes\": \"Implementation starts after design\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"deadline\": \"2026-03-21T18:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"startVariance\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finishVariance\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"value\": \"Miku\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"number\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"unit\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"value\": \"PT8H0M0S\"");
     expect(document.getElementById("modelOutput").value).toContain("\"initials\": \"MK\"");
     expect(document.getElementById("modelOutput").value).toContain("\"group\": \"Engineering\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"workGroup\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"standardRate\": \"5000/h\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"standardRateFormat\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"overtimeRate\": \"7000/h\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"overtimeRateFormat\": 2");
+    expect(document.getElementById("modelOutput").value).toContain("\"costPerUse\": 1000");
+    expect(document.getElementById("modelOutput").value).toContain("\"work\": \"PT40H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualWork\": \"PT20H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"remainingWork\": \"PT20H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"cost\": 200000");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualCost\": 100000");
+    expect(document.getElementById("modelOutput").value).toContain("\"remainingCost\": 100000");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 50");
+    expect(document.getElementById("modelOutput").value).toContain("\"value\": \"Platform Team\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"work\": \"PT40H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"unit\": 2");
     expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-16T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"startVariance\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finishVariance\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"delay\": \"PT0H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"milestone\": false");
+    expect(document.getElementById("modelOutput").value).toContain("\"workContour\": 0");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 50");
+    expect(document.getElementById("modelOutput").value).toContain("\"overtimeWork\": \"PT2H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualOvertimeWork\": \"PT1H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"actualWork\": \"PT8H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"remainingWork\": \"PT8H0M0S\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"value\": \"Design Slot\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"cost\": 80000");
+    expect(document.getElementById("modelOutput").value).toContain("\"unit\": 2");
     expect(document.getElementById("taskPreview").textContent).toContain("Implementation");
+    expect(document.getElementById("taskPreview").textContent).toContain("Ext=1 / Baselines=1 / Timephased=1");
+    expect(document.getElementById("taskPreview").textContent).toContain("Baseline1=#0 2026-03-16T09:00:00 -> 2026-03-17T18:00:00");
+    expect(document.getElementById("taskPreview").textContent).toContain("Timephased1=Type=1 2026-03-16T09:00:00 -> 2026-03-16T18:00:00");
     expect(document.getElementById("resourcePreview").textContent).toContain("Engineering");
+    expect(document.getElementById("resourcePreview").textContent).toContain("Ext=1 / Baselines=1 / Timephased=1");
+    expect(document.getElementById("resourcePreview").textContent).toContain("Baseline1=#0 2026-03-16T09:00:00 -> 2026-03-20T18:00:00");
+    expect(document.getElementById("resourcePreview").textContent).toContain("Timephased1=Type=1 2026-03-16T09:00:00 -> 2026-03-16T18:00:00");
     expect(document.getElementById("assignmentPreview").textContent).toContain("TaskUID=2");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Ext=1 / Baselines=1 / Timephased=1");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Baseline1=#0 2026-03-16T09:00:00 -> 2026-03-17T18:00:00");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Timephased1=Type=1 2026-03-16T09:00:00 -> 2026-03-16T18:00:00");
   });
 
   it("exports xml from the current model", () => {
@@ -132,21 +243,143 @@ describe("mikuproject main", () => {
     const xmlText = document.getElementById("xmlInput").value;
     expect(xmlText).toContain("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
     expect(xmlText).toContain("\n<Project xmlns=\"http://schemas.microsoft.com/project\">\n");
+    expect(xmlText).toContain("<Title>Sample Project Title</Title>");
+    expect(xmlText).toContain("<Company>Local HTML Tools</Company>");
+    expect(xmlText).toContain("<Author>Toshiki Iga</Author>");
+    expect(xmlText).toContain("<CreationDate>2026-03-16T08:30:00</CreationDate>");
+    expect(xmlText).toContain("<LastSaved>2026-03-16T09:10:00</LastSaved>");
+    expect(xmlText).toContain("<SaveVersion>14</SaveVersion>");
     expect(xmlText).toContain("<CurrentDate>2026-03-16T09:00:00</CurrentDate>");
+    expect(xmlText).toContain("<StatusDate>2026-03-19T09:00:00</StatusDate>");
+    expect(xmlText).toContain("<WeekStartDay>1</WeekStartDay>");
+    expect(xmlText).toContain("<WorkFormat>2</WorkFormat>");
+    expect(xmlText).toContain("<DurationFormat>7</DurationFormat>");
+    expect(xmlText).toContain("<CurrencyCode>JPY</CurrencyCode>");
+    expect(xmlText).toContain("<CurrencyDigits>0</CurrencyDigits>");
+    expect(xmlText).toContain("<CurrencySymbol>¥</CurrencySymbol>");
+    expect(xmlText).toContain("<CurrencySymbolPosition>0</CurrencySymbolPosition>");
+    expect(xmlText).toContain("<FYStartDate>2026-04-01T00:00:00</FYStartDate>");
+    expect(xmlText).toContain("<FiscalYearStart>1</FiscalYearStart>");
+    expect(xmlText).toContain("<CriticalSlackLimit>0</CriticalSlackLimit>");
+    expect(xmlText).toContain("<DefaultTaskType>1</DefaultTaskType>");
+    expect(xmlText).toContain("<DefaultFixedCostAccrual>2</DefaultFixedCostAccrual>");
+    expect(xmlText).toContain("<DefaultStandardRate>5000/h</DefaultStandardRate>");
+    expect(xmlText).toContain("<DefaultOvertimeRate>7000/h</DefaultOvertimeRate>");
+    expect(xmlText).toContain("<DefaultTaskEVMethod>0</DefaultTaskEVMethod>");
+    expect(xmlText).toContain("<NewTaskStartDate>0</NewTaskStartDate>");
+    expect(xmlText).toContain("<NewTasksAreManual>0</NewTasksAreManual>");
+    expect(xmlText).toContain("<NewTasksEffortDriven>1</NewTasksEffortDriven>");
+    expect(xmlText).toContain("<NewTasksEstimated>1</NewTasksEstimated>");
+    expect(xmlText).toContain("<ActualsInSync>0</ActualsInSync>");
+    expect(xmlText).toContain("<EditableActualCosts>1</EditableActualCosts>");
+    expect(xmlText).toContain("<HonorConstraints>1</HonorConstraints>");
+    expect(xmlText).toContain("<InsertedProjectsLikeSummary>1</InsertedProjectsLikeSummary>");
+    expect(xmlText).toContain("<MultipleCriticalPaths>0</MultipleCriticalPaths>");
+    expect(xmlText).toContain("<TaskUpdatesResource>1</TaskUpdatesResource>");
+    expect(xmlText).toContain("<UpdateManuallyScheduledTasksWhenEditingLinks>0</UpdateManuallyScheduledTasksWhenEditingLinks>");
+    expect(xmlText).toContain("<OutlineCodes>");
+    expect(xmlText).toContain("<FieldID>188743731</FieldID>");
+    expect(xmlText).toContain("<FieldName>Outline Code1</FieldName>");
+    expect(xmlText).toContain("<Alias>Phase</Alias>");
+    expect(xmlText).toContain("<OnlyTableValues>1</OnlyTableValues>");
+    expect(xmlText).toContain("<Values>");
+    expect(xmlText).toContain("<Value>PLAN</Value>");
+    expect(xmlText).toContain("<Description>Planning</Description>");
+    expect(xmlText).toContain("<WBSMasks>");
+    expect(xmlText).toContain("<WBSMask>");
+    expect(xmlText).toContain("<Level>2</Level>");
+    expect(xmlText).toContain("<Mask>00</Mask>");
+    expect(xmlText).toContain("<ExtendedAttributes>");
+    expect(xmlText).toContain("<ExtendedAttribute>");
+    expect(xmlText).toContain("<FieldName>Text1</FieldName>");
+    expect(xmlText).toContain("<Alias>Owner</Alias>");
+    expect(xmlText).toContain("<AppendNewValues>1</AppendNewValues>");
+    expect(xmlText).toContain("<WBS>1.2</WBS>");
+    expect(xmlText).toContain("<Priority>700</Priority>");
+    expect(xmlText).toContain("<CalendarUID>1</CalendarUID>");
+    expect(xmlText).toContain("<Work>PT24H0M0S</Work>");
+    expect(xmlText).toContain("<WorkVariance>PT0H0M0S</WorkVariance>");
+    expect(xmlText).toContain("<TotalSlack>PT4H0M0S</TotalSlack>");
+    expect(xmlText).toContain("<FreeSlack>PT2H0M0S</FreeSlack>");
+    expect(xmlText).toContain("<Cost>120000</Cost>");
+    expect(xmlText).toContain("<ActualCost>0</ActualCost>");
+    expect(xmlText).toContain("<RemainingCost>120000</RemainingCost>");
+    expect(xmlText).toContain("<RemainingWork>PT24H0M0S</RemainingWork>");
+    expect(xmlText).toContain("<ActualWork>PT0H0M0S</ActualWork>");
+    expect(xmlText).toContain("<PercentWorkComplete>0</PercentWorkComplete>");
     expect(xmlText).toContain("<DefaultStartTime>09:00:00</DefaultStartTime>");
     expect(xmlText).toContain("<MinutesPerDay>480</MinutesPerDay>");
     expect(xmlText).toContain("<CalendarUID>1</CalendarUID>");
     expect(xmlText).toContain("<Calendars>");
     expect(xmlText).toContain("\n  <Calendars>\n");
+    expect(xmlText).toContain("<IsBaselineCalendar>1</IsBaselineCalendar>");
+    expect(xmlText).toContain("<BaseCalendarUID>1</BaseCalendarUID>");
+    expect(xmlText).toContain("<Exceptions>");
+    expect(xmlText).toContain("<WorkWeeks>");
+    expect(xmlText).toContain("<Name>Holiday</Name>");
+    expect(xmlText).toContain("<WorkingTimes>");
+    expect(xmlText).toContain("<Name>Spring Sprint</Name>");
+    expect(xmlText).toContain("<WeekDays>");
+    expect(xmlText).toContain("<DayType>2</DayType>");
+    expect(xmlText).toContain("<FromTime>10:00:00</FromTime>");
     expect(xmlText).toContain("<Tasks>");
     expect(xmlText).toContain("<Assignments>");
     expect(xmlText).toContain("<LinkLag>PT0H0M0S</LinkLag>");
     expect(xmlText).toContain("<ActualStart>2026-03-16T09:00:00</ActualStart>");
+    expect(xmlText).toContain("<Deadline>2026-03-21T18:00:00</Deadline>");
+    expect(xmlText).toContain("<StartVariance>PT0H0M0S</StartVariance>");
+    expect(xmlText).toContain("<FinishVariance>PT0H0M0S</FinishVariance>");
     expect(xmlText).toContain("<ConstraintType>4</ConstraintType>");
     expect(xmlText).toContain("<Notes>Implementation starts after design</Notes>");
+    expect(xmlText).toContain("<ExtendedAttribute>");
+    expect(xmlText).toContain("<FieldID>188743734</FieldID>");
+    expect(xmlText).toContain("<Value>Miku</Value>");
+    expect(xmlText).toContain("<Baseline>");
+    expect(xmlText).toContain("<Number>0</Number>");
+    expect(xmlText).toContain("<Work>PT16H0M0S</Work>");
+    expect(xmlText).toContain("<TimephasedData>");
+    expect(xmlText).toContain("<Unit>2</Unit>");
+    expect(xmlText).toContain("<Value>PT8H0M0S</Value>");
+    expect(xmlText).toContain("<Critical>1</Critical>");
     expect(xmlText).toContain("<Initials>MK</Initials>");
     expect(xmlText).toContain("<Group>Engineering</Group>");
+    expect(xmlText).toContain("<WorkGroup>0</WorkGroup>");
+    expect(xmlText).toContain("<StandardRate>5000/h</StandardRate>");
+    expect(xmlText).toContain("<StandardRateFormat>2</StandardRateFormat>");
+    expect(xmlText).toContain("<OvertimeRate>7000/h</OvertimeRate>");
+    expect(xmlText).toContain("<OvertimeRateFormat>2</OvertimeRateFormat>");
+    expect(xmlText).toContain("<CostPerUse>1000</CostPerUse>");
+    expect(xmlText).toContain("<Work>PT40H0M0S</Work>");
+    expect(xmlText).toContain("<ActualWork>PT20H0M0S</ActualWork>");
+    expect(xmlText).toContain("<RemainingWork>PT20H0M0S</RemainingWork>");
+    expect(xmlText).toContain("<Cost>200000</Cost>");
+    expect(xmlText).toContain("<ActualCost>100000</ActualCost>");
+    expect(xmlText).toContain("<RemainingCost>100000</RemainingCost>");
+    expect(xmlText).toContain("<PercentWorkComplete>50</PercentWorkComplete>");
+    expect(xmlText).toContain("<ExtendedAttribute>");
+    expect(xmlText).toContain("<FieldID>188743737</FieldID>");
+    expect(xmlText).toContain("<Value>Platform Team</Value>");
+    expect(xmlText).toContain("<Baseline>");
+    expect(xmlText).toContain("<Work>PT40H0M0S</Work>");
+    expect(xmlText).toContain("<TimephasedData>");
+    expect(xmlText).toContain("<Unit>2</Unit>");
     expect(xmlText).toContain("<Start>2026-03-16T09:00:00</Start>");
+    expect(xmlText).toContain("<StartVariance>PT0H0M0S</StartVariance>");
+    expect(xmlText).toContain("<FinishVariance>PT0H0M0S</FinishVariance>");
+    expect(xmlText).toContain("<Delay>PT0H0M0S</Delay>");
+    expect(xmlText).toContain("<Milestone>0</Milestone>");
+    expect(xmlText).toContain("<WorkContour>0</WorkContour>");
+    expect(xmlText).toContain("<PercentWorkComplete>50</PercentWorkComplete>");
+    expect(xmlText).toContain("<OvertimeWork>PT2H0M0S</OvertimeWork>");
+    expect(xmlText).toContain("<ActualOvertimeWork>PT1H0M0S</ActualOvertimeWork>");
+    expect(xmlText).toContain("<ActualWork>PT8H0M0S</ActualWork>");
+    expect(xmlText).toContain("<RemainingWork>PT8H0M0S</RemainingWork>");
+    expect(xmlText).toContain("<FieldID>255852547</FieldID>");
+    expect(xmlText).toContain("<Value>Design Slot</Value>");
+    expect(xmlText).toContain("<Baseline>");
+    expect(xmlText).toContain("<Number>0</Number>");
+    expect(xmlText).toContain("<TimephasedData>");
+    expect(xmlText).toContain("<Unit>2</Unit>");
   });
 
   it("passes round-trip check", () => {
@@ -156,6 +389,7 @@ describe("mikuproject main", () => {
     document.getElementById("roundTripBtn").click();
 
     expect(document.getElementById("statusMessage").textContent).toContain("再読込テストに成功");
+    expect(document.getElementById("modelOutput").value).toContain("\"extendedAttributes\": [");
   });
 
   it("imports xml from a file into the textarea", async () => {
@@ -258,6 +492,541 @@ describe("mikuproject main", () => {
     expect(xmlTools.validateProjectModel(reparsedModel)).toHaveLength(0);
   });
 
+  it("round-trips project metadata fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Metadata Project</Name>
+  <Title>Metadata Title</Title>
+  <Company>Example Company</Company>
+  <Author>Example Author</Author>
+  <CreationDate>2026-03-16T07:00:00</CreationDate>
+  <LastSaved>2026-03-16T10:15:00</LastSaved>
+  <SaveVersion>14</SaveVersion>
+  <CurrencyCode>JPY</CurrencyCode>
+  <CurrencyDigits>0</CurrencyDigits>
+  <CurrencySymbol>¥</CurrencySymbol>
+  <CurrencySymbolPosition>0</CurrencySymbolPosition>
+  <FYStartDate>2026-04-01T00:00:00</FYStartDate>
+  <FiscalYearStart>1</FiscalYearStart>
+  <CriticalSlackLimit>0</CriticalSlackLimit>
+  <DefaultTaskType>1</DefaultTaskType>
+  <DefaultFixedCostAccrual>2</DefaultFixedCostAccrual>
+  <DefaultStandardRate>5000/h</DefaultStandardRate>
+  <DefaultOvertimeRate>7000/h</DefaultOvertimeRate>
+  <DefaultTaskEVMethod>0</DefaultTaskEVMethod>
+  <NewTaskStartDate>0</NewTaskStartDate>
+  <NewTasksAreManual>0</NewTasksAreManual>
+  <NewTasksEffortDriven>1</NewTasksEffortDriven>
+  <NewTasksEstimated>1</NewTasksEstimated>
+  <ActualsInSync>0</ActualsInSync>
+  <EditableActualCosts>1</EditableActualCosts>
+  <HonorConstraints>1</HonorConstraints>
+  <InsertedProjectsLikeSummary>1</InsertedProjectsLikeSummary>
+  <MultipleCriticalPaths>0</MultipleCriticalPaths>
+  <TaskUpdatesResource>1</TaskUpdatesResource>
+  <UpdateManuallyScheduledTasksWhenEditingLinks>0</UpdateManuallyScheduledTasksWhenEditingLinks>
+  <OutlineCodes>
+    <OutlineCode>
+      <FieldID>188743731</FieldID>
+      <FieldName>Outline Code1</FieldName>
+      <Alias>Phase</Alias>
+      <OnlyTableValues>1</OnlyTableValues>
+      <Masks>
+        <Mask>
+          <Level>1</Level>
+          <Mask>*</Mask>
+          <Length>0</Length>
+          <Sequence>0</Sequence>
+        </Mask>
+      </Masks>
+      <Values>
+        <Value>
+          <Value>PLAN</Value>
+          <Description>Planning</Description>
+        </Value>
+      </Values>
+    </OutlineCode>
+  </OutlineCodes>
+  <WBSMasks>
+    <WBSMask>
+      <Level>1</Level>
+      <Mask>A</Mask>
+      <Length>1</Length>
+      <Sequence>1</Sequence>
+    </WBSMask>
+  </WBSMasks>
+  <ExtendedAttributes>
+    <ExtendedAttribute>
+      <FieldID>188743734</FieldID>
+      <FieldName>Text1</FieldName>
+      <Alias>Owner</Alias>
+      <CalculationType>0</CalculationType>
+      <RestrictValues>0</RestrictValues>
+      <AppendNewValues>1</AppendNewValues>
+    </ExtendedAttribute>
+  </ExtendedAttributes>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-16T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks />
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.project.title).toBe("Metadata Title");
+    expect(reparsedModel.project.company).toBe("Example Company");
+    expect(reparsedModel.project.author).toBe("Example Author");
+    expect(reparsedModel.project.creationDate).toBe("2026-03-16T07:00:00");
+    expect(reparsedModel.project.lastSaved).toBe("2026-03-16T10:15:00");
+    expect(reparsedModel.project.saveVersion).toBe(14);
+    expect(reparsedModel.project.currencyCode).toBe("JPY");
+    expect(reparsedModel.project.currencyDigits).toBe(0);
+    expect(reparsedModel.project.currencySymbol).toBe("¥");
+    expect(reparsedModel.project.currencySymbolPosition).toBe(0);
+    expect(reparsedModel.project.fyStartDate).toBe("2026-04-01T00:00:00");
+    expect(reparsedModel.project.fiscalYearStart).toBe(true);
+    expect(reparsedModel.project.criticalSlackLimit).toBe(0);
+    expect(reparsedModel.project.defaultTaskType).toBe(1);
+    expect(reparsedModel.project.defaultFixedCostAccrual).toBe(2);
+    expect(reparsedModel.project.defaultStandardRate).toBe("5000/h");
+    expect(reparsedModel.project.defaultOvertimeRate).toBe("7000/h");
+    expect(reparsedModel.project.defaultTaskEVMethod).toBe(0);
+    expect(reparsedModel.project.newTaskStartDate).toBe(0);
+    expect(reparsedModel.project.newTasksAreManual).toBe(false);
+    expect(reparsedModel.project.newTasksEffortDriven).toBe(true);
+    expect(reparsedModel.project.newTasksEstimated).toBe(true);
+    expect(reparsedModel.project.actualsInSync).toBe(false);
+    expect(reparsedModel.project.editableActualCosts).toBe(true);
+    expect(reparsedModel.project.honorConstraints).toBe(true);
+    expect(reparsedModel.project.insertedProjectsLikeSummary).toBe(true);
+    expect(reparsedModel.project.multipleCriticalPaths).toBe(false);
+    expect(reparsedModel.project.taskUpdatesResource).toBe(true);
+    expect(reparsedModel.project.updateManuallyScheduledTasksWhenEditingLinks).toBe(false);
+    expect(reparsedModel.project.outlineCodes).toHaveLength(1);
+    expect(reparsedModel.project.outlineCodes[0].fieldID).toBe("188743731");
+    expect(reparsedModel.project.outlineCodes[0].alias).toBe("Phase");
+    expect(reparsedModel.project.outlineCodes[0].values[0].value).toBe("PLAN");
+    expect(reparsedModel.project.wbsMasks).toHaveLength(1);
+    expect(reparsedModel.project.wbsMasks[0].mask).toBe("A");
+    expect(reparsedModel.project.extendedAttributes).toHaveLength(1);
+    expect(reparsedModel.project.extendedAttributes[0].fieldName).toBe("Text1");
+    expect(reparsedModel.project.extendedAttributes[0].alias).toBe("Owner");
+    expect(reparsedModel.project.extendedAttributes[0].appendNewValues).toBe(true);
+  });
+
+  it("round-trips project scheduling metadata fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Schedule Metadata Project</Name>
+  <StatusDate>2026-03-17T09:00:00</StatusDate>
+  <WeekStartDay>2</WeekStartDay>
+  <WorkFormat>2</WorkFormat>
+  <DurationFormat>7</DurationFormat>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-18T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks />
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.project.statusDate).toBe("2026-03-17T09:00:00");
+    expect(reparsedModel.project.weekStartDay).toBe(2);
+    expect(reparsedModel.project.workFormat).toBe(2);
+    expect(reparsedModel.project.durationFormat).toBe(7);
+  });
+
+  it("round-trips calendar base and weekday fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Calendar Detail Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-16T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Calendars>
+    <Calendar>
+      <UID>1</UID>
+      <Name>Standard</Name>
+      <IsBaseCalendar>1</IsBaseCalendar>
+      <IsBaselineCalendar>1</IsBaselineCalendar>
+    </Calendar>
+    <Calendar>
+      <UID>2</UID>
+      <Name>Night Shift</Name>
+      <IsBaseCalendar>0</IsBaseCalendar>
+      <BaseCalendarUID>1</BaseCalendarUID>
+      <WeekDays>
+        <WeekDay>
+          <DayType>7</DayType>
+          <DayWorking>1</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>18:00:00</FromTime>
+              <ToTime>22:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </WeekDay>
+      </WeekDays>
+    </Calendar>
+  </Calendars>
+  <Tasks />
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.calendars).toHaveLength(2);
+    expect(reparsedModel.calendars[0].isBaselineCalendar).toBe(true);
+    expect(reparsedModel.calendars[1].baseCalendarUID).toBe("1");
+    expect(reparsedModel.calendars[1].weekDays[0].dayType).toBe(7);
+    expect(reparsedModel.calendars[1].weekDays[0].dayWorking).toBe(true);
+    expect(reparsedModel.calendars[1].weekDays[0].workingTimes[0].fromTime).toBe("18:00:00");
+    expect(reparsedModel.calendars[1].weekDays[0].workingTimes[0].toTime).toBe("22:00:00");
+  });
+
+  it("round-trips calendar exceptions and workweeks", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Calendar Exception Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-16T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Calendars>
+    <Calendar>
+      <UID>1</UID>
+      <Name>Standard</Name>
+      <IsBaseCalendar>1</IsBaseCalendar>
+      <Exceptions>
+        <Exception>
+          <Name>Holiday</Name>
+          <FromDate>2026-03-20T00:00:00</FromDate>
+          <ToDate>2026-03-20T23:59:59</ToDate>
+          <DayWorking>0</DayWorking>
+          <WorkingTimes>
+            <WorkingTime>
+              <FromTime>09:00:00</FromTime>
+              <ToTime>12:00:00</ToTime>
+            </WorkingTime>
+          </WorkingTimes>
+        </Exception>
+      </Exceptions>
+      <WorkWeeks>
+        <WorkWeek>
+          <Name>Sprint 1</Name>
+          <FromDate>2026-03-16T00:00:00</FromDate>
+          <ToDate>2026-03-31T23:59:59</ToDate>
+          <WeekDays>
+            <WeekDay>
+              <DayType>2</DayType>
+              <DayWorking>1</DayWorking>
+              <WorkingTimes>
+                <WorkingTime>
+                  <FromTime>09:00:00</FromTime>
+                  <ToTime>17:00:00</ToTime>
+                </WorkingTime>
+              </WorkingTimes>
+            </WeekDay>
+          </WeekDays>
+        </WorkWeek>
+      </WorkWeeks>
+    </Calendar>
+  </Calendars>
+  <Tasks />
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.calendars[0].exceptions[0].name).toBe("Holiday");
+    expect(reparsedModel.calendars[0].exceptions[0].dayWorking).toBe(false);
+    expect(reparsedModel.calendars[0].exceptions[0].workingTimes[0].fromTime).toBe("09:00:00");
+    expect(reparsedModel.calendars[0].exceptions[0].workingTimes[0].toTime).toBe("12:00:00");
+    expect(reparsedModel.calendars[0].workWeeks[0].name).toBe("Sprint 1");
+    expect(reparsedModel.calendars[0].workWeeks[0].weekDays[0].dayType).toBe(2);
+    expect(reparsedModel.calendars[0].workWeeks[0].weekDays[0].workingTimes[0].toTime).toBe("17:00:00");
+  });
+
+  it("round-trips resource and assignment practical fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Resource Assignment Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-17T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Calendars>
+    <Calendar>
+      <UID>1</UID>
+      <Name>Standard</Name>
+      <IsBaseCalendar>1</IsBaseCalendar>
+    </Calendar>
+  </Calendars>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <ID>1</ID>
+      <Name>Assigned Task</Name>
+      <OutlineLevel>1</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-17T18:00:00</Finish>
+      <Duration>PT16H0M0S</Duration>
+      <Milestone>0</Milestone>
+      <Summary>0</Summary>
+      <PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+  <Resources>
+    <Resource>
+      <UID>1</UID>
+      <ID>1</ID>
+      <Name>Worker</Name>
+      <Type>1</Type>
+      <WorkGroup>0</WorkGroup>
+      <CalendarUID>1</CalendarUID>
+      <StandardRate>8000/h</StandardRate>
+      <StandardRateFormat>2</StandardRateFormat>
+      <OvertimeRate>12000/h</OvertimeRate>
+      <OvertimeRateFormat>2</OvertimeRateFormat>
+      <CostPerUse>1500</CostPerUse>
+      <Work>PT24H0M0S</Work>
+      <ActualWork>PT8H0M0S</ActualWork>
+      <RemainingWork>PT16H0M0S</RemainingWork>
+      <Cost>180000</Cost>
+      <ActualCost>60000</ActualCost>
+      <RemainingCost>120000</RemainingCost>
+      <PercentWorkComplete>33</PercentWorkComplete>
+    </Resource>
+  </Resources>
+  <Assignments>
+    <Assignment>
+      <UID>1</UID>
+      <TaskUID>1</TaskUID>
+      <ResourceUID>1</ResourceUID>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-17T18:00:00</Finish>
+      <StartVariance>PT1H0M0S</StartVariance>
+      <FinishVariance>PT2H0M0S</FinishVariance>
+      <Delay>PT3H0M0S</Delay>
+      <Milestone>0</Milestone>
+      <WorkContour>1</WorkContour>
+      <Units>1</Units>
+      <Work>PT16H0M0S</Work>
+      <Cost>100000</Cost>
+      <ActualCost>30000</ActualCost>
+      <RemainingCost>70000</RemainingCost>
+      <PercentWorkComplete>50</PercentWorkComplete>
+      <OvertimeWork>PT2H0M0S</OvertimeWork>
+      <ActualOvertimeWork>PT1H0M0S</ActualOvertimeWork>
+      <ActualWork>PT6H0M0S</ActualWork>
+      <RemainingWork>PT10H0M0S</RemainingWork>
+    </Assignment>
+  </Assignments>
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.resources[0].calendarUID).toBe("1");
+    expect(reparsedModel.resources[0].workGroup).toBe(0);
+    expect(reparsedModel.resources[0].standardRate).toBe("8000/h");
+    expect(reparsedModel.resources[0].standardRateFormat).toBe(2);
+    expect(reparsedModel.resources[0].overtimeRate).toBe("12000/h");
+    expect(reparsedModel.resources[0].overtimeRateFormat).toBe(2);
+    expect(reparsedModel.resources[0].costPerUse).toBe(1500);
+    expect(reparsedModel.resources[0].work).toBe("PT24H0M0S");
+    expect(reparsedModel.resources[0].actualWork).toBe("PT8H0M0S");
+    expect(reparsedModel.resources[0].remainingWork).toBe("PT16H0M0S");
+    expect(reparsedModel.resources[0].cost).toBe(180000);
+    expect(reparsedModel.resources[0].actualCost).toBe(60000);
+    expect(reparsedModel.resources[0].remainingCost).toBe(120000);
+    expect(reparsedModel.resources[0].percentWorkComplete).toBe(33);
+    expect(reparsedModel.assignments[0].startVariance).toBe("PT1H0M0S");
+    expect(reparsedModel.assignments[0].finishVariance).toBe("PT2H0M0S");
+    expect(reparsedModel.assignments[0].delay).toBe("PT3H0M0S");
+    expect(reparsedModel.assignments[0].milestone).toBe(false);
+    expect(reparsedModel.assignments[0].workContour).toBe(1);
+    expect(reparsedModel.assignments[0].cost).toBe(100000);
+    expect(reparsedModel.assignments[0].actualCost).toBe(30000);
+    expect(reparsedModel.assignments[0].remainingCost).toBe(70000);
+    expect(reparsedModel.assignments[0].percentWorkComplete).toBe(50);
+    expect(reparsedModel.assignments[0].overtimeWork).toBe("PT2H0M0S");
+    expect(reparsedModel.assignments[0].actualOvertimeWork).toBe("PT1H0M0S");
+    expect(reparsedModel.assignments[0].actualWork).toBe("PT6H0M0S");
+    expect(reparsedModel.assignments[0].remainingWork).toBe("PT10H0M0S");
+  });
+
+  it("round-trips task and assignment cost fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Cost Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-18T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <ID>1</ID>
+      <Name>Cost Task</Name>
+      <OutlineLevel>1</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-18T18:00:00</Finish>
+      <Duration>PT24H0M0S</Duration>
+      <Work>PT24H0M0S</Work>
+      <Cost>150000</Cost>
+      <ActualCost>50000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+      <Milestone>0</Milestone>
+      <Summary>0</Summary>
+      <PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+  <Resources />
+  <Assignments>
+    <Assignment>
+      <UID>1</UID>
+      <TaskUID>1</TaskUID>
+      <ResourceUID>-65535</ResourceUID>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-18T18:00:00</Finish>
+      <Units>1</Units>
+      <Work>PT24H0M0S</Work>
+      <Cost>150000</Cost>
+      <ActualCost>50000</ActualCost>
+      <RemainingCost>100000</RemainingCost>
+    </Assignment>
+  </Assignments>
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.tasks[0].cost).toBe(150000);
+    expect(reparsedModel.tasks[0].actualCost).toBe(50000);
+    expect(reparsedModel.tasks[0].remainingCost).toBe(100000);
+    expect(reparsedModel.assignments[0].cost).toBe(150000);
+    expect(reparsedModel.assignments[0].actualCost).toBe(50000);
+    expect(reparsedModel.assignments[0].remainingCost).toBe(100000);
+  });
+
+  it("round-trips task deadline and variance fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Task Variance Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-18T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <ID>1</ID>
+      <Name>Variance Task</Name>
+      <OutlineLevel>1</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-18T18:00:00</Finish>
+      <Deadline>2026-03-19T18:00:00</Deadline>
+      <Duration>PT24H0M0S</Duration>
+      <StartVariance>PT1H0M0S</StartVariance>
+      <FinishVariance>PT2H0M0S</FinishVariance>
+      <Milestone>0</Milestone>
+      <Summary>0</Summary>
+      <PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.tasks[0].deadline).toBe("2026-03-19T18:00:00");
+    expect(reparsedModel.tasks[0].startVariance).toBe("PT1H0M0S");
+    expect(reparsedModel.tasks[0].finishVariance).toBe("PT2H0M0S");
+  });
+
+  it("round-trips extended task work fields", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Task Detail Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-17T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <ID>1</ID>
+      <Name>Detailed Task</Name>
+      <OutlineLevel>1</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Type>1</Type>
+      <CalendarUID>1</CalendarUID>
+      <Priority>700</Priority>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-17T18:00:00</Finish>
+      <Duration>PT16H0M0S</Duration>
+      <Work>PT16H0M0S</Work>
+      <WorkVariance>PT1H0M0S</WorkVariance>
+      <TotalSlack>PT4H0M0S</TotalSlack>
+      <FreeSlack>PT2H0M0S</FreeSlack>
+      <RemainingWork>PT8H0M0S</RemainingWork>
+      <ActualWork>PT8H0M0S</ActualWork>
+      <Milestone>0</Milestone>
+      <Summary>0</Summary>
+      <Critical>1</Critical>
+      <PercentComplete>50</PercentComplete>
+      <PercentWorkComplete>50</PercentWorkComplete>
+    </Task>
+  </Tasks>
+  <Resources />
+  <Assignments />
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.tasks[0].wbs).toBe("1");
+    expect(reparsedModel.tasks[0].type).toBe(1);
+    expect(reparsedModel.tasks[0].calendarUID).toBe("1");
+    expect(reparsedModel.tasks[0].priority).toBe(700);
+    expect(reparsedModel.tasks[0].work).toBe("PT16H0M0S");
+    expect(reparsedModel.tasks[0].workVariance).toBe("PT1H0M0S");
+    expect(reparsedModel.tasks[0].totalSlack).toBe("PT4H0M0S");
+    expect(reparsedModel.tasks[0].freeSlack).toBe("PT2H0M0S");
+    expect(reparsedModel.tasks[0].remainingWork).toBe("PT8H0M0S");
+    expect(reparsedModel.tasks[0].actualWork).toBe("PT8H0M0S");
+    expect(reparsedModel.tasks[0].critical).toBe(true);
+    expect(reparsedModel.tasks[0].percentWorkComplete).toBe(50);
+  });
+
   it("round-trips the hierarchy xml sample", () => {
     const xmlTools = bootXmlModule();
 
@@ -285,5 +1054,57 @@ describe("mikuproject main", () => {
     expect(reparsedModel.assignments).toHaveLength(1);
     expect(reparsedModel.assignments[0].taskUid).toBe("2");
     expect(xmlTools.validateProjectModel(reparsedModel)).toHaveLength(0);
+  });
+
+  it("allows placeholder UID=0 and unassigned ResourceUID=-65535", () => {
+    const xmlTools = bootXmlModule();
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Placeholder Project</Name>
+  <StartDate>2026-03-16T09:00:00</StartDate>
+  <FinishDate>2026-03-16T18:00:00</FinishDate>
+  <ScheduleFromStart>1</ScheduleFromStart>
+  <Tasks>
+    <Task>
+      <UID>0</UID>
+      <ID>0</ID>
+      <Name></Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber></OutlineNumber>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-16T18:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Milestone>0</Milestone>
+      <Summary>0</Summary>
+      <PercentComplete>0</PercentComplete>
+    </Task>
+  </Tasks>
+  <Resources>
+    <Resource>
+      <UID>0</UID>
+      <ID>0</ID>
+      <Name></Name>
+      <Type>1</Type>
+    </Resource>
+  </Resources>
+  <Assignments>
+    <Assignment>
+      <UID>1</UID>
+      <TaskUID>0</TaskUID>
+      <ResourceUID>-65535</ResourceUID>
+      <Start>2026-03-16T09:00:00</Start>
+      <Finish>2026-03-16T18:00:00</Finish>
+      <Units>1</Units>
+      <Work>PT8H0M0S</Work>
+    </Assignment>
+  </Assignments>
+</Project>`;
+
+    const model = xmlTools.importMsProjectXml(xml);
+    const issues = xmlTools.validateProjectModel(model);
+
+    expect(issues.some((issue) => issue.message.includes("OutlineLevel"))).toBe(false);
+    expect(issues.some((issue) => issue.message.includes("ResourceUID が既存 Resource"))).toBe(false);
+    expect(issues.some((issue) => issue.message.includes("Resource Name が空"))).toBe(false);
   });
 });

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -9916,6 +9916,10 @@ async function initializePromptPage() {
     }
     function getDefinitionSearchGroup(definition) {
         const labelCode = getDefinitionLabelCode(definition);
+        const pSeriesMatch = labelCode.match(/^P\d+-\d+$/);
+        if (pSeriesMatch) {
+            return labelCode;
+        }
         const match = labelCode.match(/^([A-Z]\d+)/);
         return match ? match[1] : "";
     }

--- a/docs/prompt/src/prompt-gen/js/main.js
+++ b/docs/prompt/src/prompt-gen/js/main.js
@@ -1030,6 +1030,10 @@ async function initializePromptPage() {
     }
     function getDefinitionSearchGroup(definition) {
         const labelCode = getDefinitionLabelCode(definition);
+        const pSeriesMatch = labelCode.match(/^P\d+-\d+$/);
+        if (pSeriesMatch) {
+            return labelCode;
+        }
         const match = labelCode.match(/^([A-Z]\d+)/);
         return match ? match[1] : "";
     }

--- a/docs/prompt/src/prompt-gen/ts/main.ts
+++ b/docs/prompt/src/prompt-gen/ts/main.ts
@@ -1297,6 +1297,10 @@ async function initializePromptPage() {
 
   function getDefinitionSearchGroup(definition: PromptDefinition | null) {
     const labelCode = getDefinitionLabelCode(definition);
+    const pSeriesMatch = labelCode.match(/^P\d+-\d+$/);
+    if (pSeriesMatch) {
+      return labelCode;
+    }
     const match = labelCode.match(/^([A-Z]\d+)/);
     return match ? match[1] : "";
   }

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -835,7 +835,6 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "P1001-500";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(hallucinationGuard.value).toBe("none");
     expect(promptOutput.textContent).toContain("○事実誤認を避けるため、次のルールを意識してください。");
@@ -843,7 +842,6 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "P1001-501";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(hallucinationGuard.value).toBe("none");
     expect(promptOutput.textContent).toContain("○ハルシネーション防止のため、次のルールに従ってください。");
@@ -857,7 +855,6 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "P1001-502";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、あなた自身の判断として内容を見直してください。");
     expect(promptOutput.textContent).toContain("`自己判断メモ` セクション");
@@ -871,7 +868,6 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "P1001-503";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(promptOutput.textContent).toContain("`最小差分で割り切った点`");
     expect(promptOutput.textContent).toContain("`あなたが本来志向していた理想形`");
@@ -886,14 +882,12 @@ describe("prompt-gen main", () => {
 
     promptSearch.value = "P1001-001";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、誤解を招く表現がないかを観点として見直してください。");
     expect(promptOutput.textContent).toContain("`誤解表現レビュー` セクション");
 
     promptSearch.value = "P1001-011";
     promptSearch.dispatchEvent(new Event("input"));
-    document.querySelector(".md-chip-button").click();
 
     expect(promptOutput.textContent).toContain("○回答案を作成したあと、誤解を招く表現がないかを観点として見直してください。");
     expect(promptOutput.textContent).not.toContain("`誤解表現レビュー` セクション");
@@ -1212,7 +1206,7 @@ describe("prompt-gen main", () => {
     expect(promptOutput.textContent).toContain("A simplified cute illustration of `ぶどう`");
   });
 
-  it("fills the empty search field with the parent numeric code when a candidate is clicked", async () => {
+  it("fills the search field with the parent code on the first candidate click", async () => {
     await bootPromptPage();
 
     const promptSearch = document.getElementById("promptSearch");
@@ -1249,6 +1243,48 @@ describe("prompt-gen main", () => {
     );
     a501Button.click();
     expect(promptSearch.value).toBe("A5");
+  });
+
+  it("auto-selects a single matching candidate", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const promptOutputTitle = document.getElementById("promptOutputTitle");
+    const promptOutput = document.getElementById("promptOutput");
+
+    promptSearch.value = "P1005-007";
+    promptSearch.dispatchEvent(new Event("input"));
+
+    expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
+    expect(document.querySelector(".md-chip-button").classList.contains("is-active")).toBe(true);
+    expect(promptOutputTitle.textContent).toContain("P1005-007:");
+    expect(promptOutput.textContent).toContain("攻撃面を洗い出してください。");
+  });
+
+  it("uses the full P-series code when a selected P prompt is clicked again", async () => {
+    await bootPromptPage();
+
+    const promptSearch = document.getElementById("promptSearch");
+    const promptOutputTitle = document.getElementById("promptOutputTitle");
+    const promptOutput = document.getElementById("promptOutput");
+
+    promptSearch.value = "P1005";
+    promptSearch.dispatchEvent(new Event("input"));
+    const p1005Button = [...document.querySelectorAll(".md-chip-button")].find((button) =>
+      button.querySelector(".md-chip-label").textContent.includes("P1005-007:")
+    );
+    p1005Button.click();
+
+    expect(promptSearch.value).toBe("P1005");
+
+    p1005Button.click();
+
+    expect(promptSearch.value).toBe("P1005-007");
+    expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
+    expect(document.querySelector(".md-chip-button .md-chip-label").textContent).toContain("P1005-007:");
+    expect(document.querySelector(".md-chip-button").classList.contains("is-active")).toBe(true);
+    expect(promptOutputTitle.textContent).toContain("P1005-007:");
+    expect(promptOutput.textContent).toContain("攻撃面を洗い出してください。");
   });
 
   it("applies commit query parameter and generates output on load", async () => {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:knowledge-timeline": "node scripts/build-knowledge-timeline.mjs",
     "typecheck:music": "tsc -p tsconfig.music.json --noEmit",
     "test": "vitest run",
+    "test:unit": "vitest run",
     "test:watch": "vitest",
     "build:grep": "npm run build:git:material && node scripts/build-grep.mjs",
     "build:password": "npm run build:git:material && node scripts/build-password.mjs",
@@ -21,7 +22,7 @@
     "build:text": "node scripts/build-text.mjs",
     "build:img": "node scripts/build-img.mjs",
     "build:docs": "node scripts/build-docs-index.mjs",
-    "build:all": "npm run build:music && npm run build:git && npm run build:knowledge-timeline && npm run build:grep && npm run build:password && npm run build:diagram && npm run build:ffmpeg && npm run build:life && npm run build:link && npm run build:project && npm run build:prompt && npm run build:text && npm run build:img && npm run build:docs"
+    "build:all": "npm run build:music && npm run build:git && npm run build:knowledge-timeline && npm run build:grep && npm run build:password && npm run build:diagram && npm run build:ffmpeg && npm run build:life && npm run build:link && npm run build:project && npm run build:prompt && npm run build:text && npm run build:img && npm run build:docs && npm test"
   },
   "devDependencies": {
     "@material/web": "^2.4.1",


### PR DESCRIPTION
…ll にテストを組み込む

## 概要

`mikuproject` の `MS Project XML` 対応を大きく拡張し、仕様メモ・gap notes・テストを整備しました。あわせて、`prompt-gen` の `P` 系候補の再クリック時検索挙動を調整し、`build:all` の最後にテストを実行するようにしました。

## 変更内容

### mikuproject

- `docs/project/mikuproject-spec.md` を大幅更新
- `docs/project/mikuproject-gap-notes.md` を新規追加
- `docs/project/src/mikuproject/ts/types.ts` を新規追加
- `docs/project/src/mikuproject/ts/msproject-xml.ts` を大幅拡張
- `docs/project/src/mikuproject/ts/main.ts` を更新
- 生成物の `docs/project/mikuproject.html` と `docs/project/src/mikuproject/js/*.js` を更新
- `docs/project/tests/mikuproject-main.test.js` を大幅更新

今回の `mikuproject` 側では、少なくとも次の系統が round-trip 対象として整理されています。

- `Project` metadata
- `Task / Resource / Assignment / Calendar` の主要項目
- `OutlineCodes / WBSMasks`
- `ExtendedAttributes`
- `Baseline`
- `TimephasedData`

また、`Tasks / Resources / Assignments` のプレビュー表示も強化されています。

### prompt-gen

- `docs/prompt/src/prompt-gen/ts/main.ts` を更新
- `docs/prompt/tests/prompt-gen-main.test.js` を更新
- 生成物の `docs/prompt/prompt-gen.html` と `docs/prompt/src/prompt-gen/js/main.js` を更新

変更点として確認できるのは、`P1005-007` のような `Pxxxx-xxx` 形式の候補について、再クリック時の検索語を親コードではなく完全コードとして扱うようにしたことです。あわせて、単一候補の自動選択や再クリック時の挙動を確認するテストが追加・整理されています。

### build / 運用メモ

- `package.json`
  - `test:unit` を追加
  - `build:all` の最後に `npm test` を追加
- `.gitignore`
  - `docs/project/local-data/` を追加
- `TODO.md`
  - `mikuproject` の引き継ぎメモを追記
- `docs/index.html`
  - 更新日表示を更新

## 主なファイル

- `.gitignore`
- `TODO.md`
- `docs/index.html`
- `docs/project/mikuproject-spec.md`
- `docs/project/mikuproject-gap-notes.md`
- `docs/project/mikuproject-src.html`
- `docs/project/mikuproject.html`
- `docs/project/src/mikuproject/ts/types.ts`
- `docs/project/src/mikuproject/ts/msproject-xml.ts`
- `docs/project/src/mikuproject/ts/main.ts`
- `docs/project/tests/mikuproject-main.test.js`
- `docs/prompt/src/prompt-gen/ts/main.ts`
- `docs/prompt/tests/prompt-gen-main.test.js`
- `package.json`

## テスト

差分と今回の会話から確認できる範囲では、次が実行対象として整理されています。

- `npm run build:project`
- `npx vitest run docs/project/tests/mikuproject-main.test.js`
- `build:all` の最後に `npm test`

補足:
- `mikuproject` 側のテスト本数の詳細は、この会話中では `22 tests` 成功として扱われています。
- `build:all` にテストを含める変更は、このコミット差分から確認できます。

## 補足

- `docs/project/local-data/` は Git 管理しない一時 XML 置き場として扱う前提です。
- `mikuproject` の仕様メモには、`open-msp-viewer` のサンプル参照に関する記述と感謝メモが含まれています。