### PR TITLE
`xlsx2md` の UI 簡素化と数式 AST evaluator の対応範囲拡張

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -236,11 +236,31 @@
     - 判定: `ISBLANK / ISNUMBER / ISTEXT / ISERROR / ISNA / NA`
 - [xlsx2md][formula] 次段タスク
   - `scripts/observe-xlsx2md-formulas.mjs` による観測を継続し、AST evaluator 側へ寄せる関数群を整理する
-  - 既存の文字列ベース evaluator と AST evaluator の使い分け方針を決める
+  - 優先順は `cached value -> AST evaluator -> 既存 resolver -> fallback_formula` で固定
+  - 既存の文字列ベース evaluator は互換 fallback として維持しつつ、AST evaluator 側へ段階移行する
+  - 既存 resolver は現時点では安全装置として必要であり、短期的には削除しない
+  - 中長期的には、実データ観測を踏まえて担当範囲を縮小し、後方互換 fallback へ寄せる
   - 次候補:
-    - `ROW / COLUMN` の引数なし形を AST 側でどう扱うか整理
-    - 近似一致付き `VLOOKUP / HLOOKUP` をどうするか整理
+    - `XLOOKUP` の binary search `search_mode=2/-2` の境界条件を必要に応じて詰める
     - 実データ頻出関数を AST evaluator 側へさらに寄せる
+- [xlsx2md][未対応整理] 数式未対応
+  - `space intersection`
+  - 配列定数の完全対応
+  - dynamic array / spill の完全対応
+  - `LAMBDA / LET / MAP / REDUCE / SCAN`
+  - 完全な `R1C1` 文法
+  - Excel の future function 全般
+  - `NOW` など volatile 関数の完全再計算
+- [xlsx2md][未対応整理] レイアウト未対応
+  - `セクション分割ブロック` の導入
+  - `カレンダー / ボード / ダッシュボード系` シートの専用扱い
+  - レイアウト中心シートの完全再現は対象外であり、`セクション / 表 / リスト / 画像` 分解で扱う
+- [xlsx2md][未対応整理] 方針未確定
+  - `XLOOKUP` 近似一致や binary search を未ソート範囲でどう扱うか
+  - `ROW / COLUMN` の文脈なし引数なし形をどう扱うか
+  - 配列定数をどの段階で AST 側へ入れるか
+  - `TODAY / NOW` を cached value 専用に留めるか
+  - `existing resolver` から AST evaluator へ、どこまで段階移行したら縮小判断するか
 - [引継][xlsx2md] `local-data` の実データ差分レビューを開始
   - 重点対象は `docs/xlsx2md/local-data-review.md` を参照
   - 優先順:
@@ -261,7 +281,7 @@
   - `edge/edge-empty-sample01.xlsx`
   - `edge/edge-weird-sheetname-sample01.xlsx`
   - 現在の `docs/xlsx2md/tests/xlsx2md-main.test.js` は `23 tests` 成功
-  - 現在の `docs/xlsx2md/tests/xlsx2md-formula-parser.test.js` は `39 tests` 成功
+  - 現在の `docs/xlsx2md/tests/xlsx2md-formula-parser.test.js` は `45 tests` 成功
   - 最後に反映済みの実装:
   - 数式セルの `cached value` と再解決値にも表示形式を再適用
   - 出力ファイル名サニタイズを強化

--- a/docs/xlsx2md/src/xlsx2md/js/formula/evaluator.js
+++ b/docs/xlsx2md/src/xlsx2md/js/formula/evaluator.js
@@ -396,51 +396,142 @@
         return (_d = source[columnNumber - 1]) !== null && _d !== void 0 ? _d : null;
     }
     function evaluateVLookup(args, context) {
-        var _a;
+        var _a, _b, _c;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
         const columnNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
+        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
         if (approximate) {
-            throw new Error("Approximate VLOOKUP is not supported");
+            let matchedRow = null;
+            for (const row of table) {
+                if (looselyEquals(row[0], lookupValue)) {
+                    return (_a = row[columnNumber - 1]) !== null && _a !== void 0 ? _a : "#N/A";
+                }
+                if (compareValues(row[0], lookupValue) <= 0) {
+                    matchedRow = row;
+                }
+            }
+            return matchedRow ? (_b = matchedRow[columnNumber - 1]) !== null && _b !== void 0 ? _b : "#N/A" : "#N/A";
         }
         for (const row of table) {
             if (looselyEquals(row[0], lookupValue)) {
-                return (_a = row[columnNumber - 1]) !== null && _a !== void 0 ? _a : "#N/A";
+                return (_c = row[columnNumber - 1]) !== null && _c !== void 0 ? _c : "#N/A";
             }
         }
         return "#N/A";
     }
     function evaluateHLookup(args, context) {
-        var _a, _b, _c;
+        var _a, _b, _c, _d, _e;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
         const rowNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
-        if (approximate) {
-            throw new Error("Approximate HLOOKUP is not supported");
-        }
+        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
         const headerRow = (_a = table[0]) !== null && _a !== void 0 ? _a : [];
         const targetRow = (_b = table[rowNumber - 1]) !== null && _b !== void 0 ? _b : [];
+        if (approximate) {
+            let matchedIndex = -1;
+            for (let index = 0; index < headerRow.length; index += 1) {
+                if (looselyEquals(headerRow[index], lookupValue)) {
+                    return (_c = targetRow[index]) !== null && _c !== void 0 ? _c : "#N/A";
+                }
+                if (compareValues(headerRow[index], lookupValue) <= 0) {
+                    matchedIndex = index;
+                }
+            }
+            return matchedIndex >= 0 ? (_d = targetRow[matchedIndex]) !== null && _d !== void 0 ? _d : "#N/A" : "#N/A";
+        }
         for (let index = 0; index < headerRow.length; index += 1) {
             if (looselyEquals(headerRow[index], lookupValue)) {
-                return (_c = targetRow[index]) !== null && _c !== void 0 ? _c : "#N/A";
+                return (_e = targetRow[index]) !== null && _e !== void 0 ? _e : "#N/A";
             }
         }
         return "#N/A";
     }
     function evaluateXLookup(args, context) {
-        var _a;
+        var _a, _b, _c, _d, _e;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const lookupArray = flattenValues(evaluateFormulaAst(args[1], context));
         const returnArray = flattenValues(evaluateFormulaAst(args[2], context));
         const notFoundValue = args[3] ? evaluateFormulaAst(args[3], context) : "#N/A";
-        for (let index = 0; index < lookupArray.length; index += 1) {
+        const matchMode = args[4] ? Math.trunc(toNumber(evaluateFormulaAst(args[4], context))) : 0;
+        const searchMode = args[5] ? Math.trunc(toNumber(evaluateFormulaAst(args[5], context))) : 1;
+        if (searchMode === 2 || searchMode === -2) {
+            const matchedIndex = findXLookupBinaryIndex(lookupArray, lookupValue, matchMode, searchMode);
+            return matchedIndex >= 0 ? (_a = returnArray[matchedIndex]) !== null && _a !== void 0 ? _a : notFoundValue : notFoundValue;
+        }
+        const indices = searchMode === -1
+            ? Array.from({ length: lookupArray.length }, (_, index) => lookupArray.length - 1 - index)
+            : Array.from({ length: lookupArray.length }, (_, index) => index);
+        for (const index of indices) {
             if (looselyEquals(lookupArray[index], lookupValue)) {
-                return (_a = returnArray[index]) !== null && _a !== void 0 ? _a : notFoundValue;
+                return (_b = returnArray[index]) !== null && _b !== void 0 ? _b : notFoundValue;
             }
         }
+        if (matchMode === 2) {
+            const matcher = createExcelWildcardMatcher(lookupValue);
+            if (!matcher) {
+                return notFoundValue;
+            }
+            for (const index of indices) {
+                if (matcher(toText(lookupArray[index]))) {
+                    return (_c = returnArray[index]) !== null && _c !== void 0 ? _c : notFoundValue;
+                }
+            }
+            return notFoundValue;
+        }
+        if (matchMode === -1) {
+            let matchedIndex = -1;
+            for (const index of indices) {
+                if (compareValues(lookupArray[index], lookupValue) <= 0) {
+                    matchedIndex = index;
+                    if (searchMode === -1) {
+                        break;
+                    }
+                }
+            }
+            return matchedIndex >= 0 ? (_d = returnArray[matchedIndex]) !== null && _d !== void 0 ? _d : notFoundValue : notFoundValue;
+        }
+        if (matchMode === 1) {
+            let matchedIndex = -1;
+            for (const index of indices) {
+                if (compareValues(lookupArray[index], lookupValue) >= 0) {
+                    matchedIndex = index;
+                    break;
+                }
+            }
+            return matchedIndex >= 0 ? (_e = returnArray[matchedIndex]) !== null && _e !== void 0 ? _e : notFoundValue : notFoundValue;
+        }
         return notFoundValue;
+    }
+    function findXLookupBinaryIndex(lookupArray, lookupValue, matchMode, searchMode) {
+        const descending = searchMode === -2;
+        let low = 0;
+        let high = lookupArray.length - 1;
+        let fallbackIndex = -1;
+        while (low <= high) {
+            const mid = Math.floor((low + high) / 2);
+            const compare = compareValues(lookupArray[mid], lookupValue);
+            if (looselyEquals(lookupArray[mid], lookupValue)) {
+                return mid;
+            }
+            if (matchMode === -1) {
+                if (compare <= 0 && (fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) > 0)) {
+                    fallbackIndex = mid;
+                }
+            }
+            else if (matchMode === 1) {
+                if (compare >= 0 && (fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) < 0)) {
+                    fallbackIndex = mid;
+                }
+            }
+            if ((!descending && compare < 0) || (descending && compare > 0)) {
+                low = mid + 1;
+            }
+            else {
+                high = mid - 1;
+            }
+        }
+        return fallbackIndex;
     }
     function evaluateText(args, context) {
         const value = evaluateFormulaAst(args[0], context);
@@ -467,6 +558,36 @@
             return `${parts.year}${separator}${parts.month}${separator}${parts.day}`;
         }
         return toText(value);
+    }
+    function createExcelWildcardMatcher(patternValue) {
+        const pattern = toText(patternValue);
+        if (!pattern) {
+            return null;
+        }
+        let regexText = "^";
+        for (let index = 0; index < pattern.length; index += 1) {
+            const char = pattern[index];
+            if (char === "~" && index + 1 < pattern.length) {
+                regexText += escapeRegExp(pattern[index + 1]);
+                index += 1;
+                continue;
+            }
+            if (char === "*") {
+                regexText += ".*";
+                continue;
+            }
+            if (char === "?") {
+                regexText += ".";
+                continue;
+            }
+            regexText += escapeRegExp(char);
+        }
+        regexText += "$";
+        const regex = new RegExp(regexText, "i");
+        return (value) => regex.test(String(value !== null && value !== void 0 ? value : ""));
+    }
+    function escapeRegExp(value) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }
     function evaluateToday(context) {
         var _a;

--- a/docs/xlsx2md/src/xlsx2md/js/main.js
+++ b/docs/xlsx2md/src/xlsx2md/js/main.js
@@ -214,6 +214,9 @@
         }
         getElement("markdownOutput").textContent = markdown;
     }
+    function createMarkdownChunkLabel(fileName) {
+        return String(fileName || "").replace(/\.md$/i, "");
+    }
     function clearError() {
         const errorAlert = getElement("errorAlert");
         if (typeof errorAlert.clear === "function") {
@@ -265,7 +268,9 @@
             updatePreviewModeBanner(getSelectedOutputMode());
             return;
         }
-        const combinedMarkdown = currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n");
+        const combinedMarkdown = currentFiles
+            .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+            .join("\n\n");
         const outputMode = ((_a = currentFiles[0]) === null || _a === void 0 ? void 0 : _a.summary.outputMode) || "display";
         updatePreviewModeBanner(outputMode);
         setSummaryHtml(renderAnalysisSummary(currentFiles, (currentWorkbook === null || currentWorkbook === void 0 ? void 0 : currentWorkbook.name) || "workbook.xlsx"));
@@ -283,7 +288,9 @@
         const suffix = outputMode === "display" ? "" : `_${outputMode}`;
         return {
             fileName: `${((currentWorkbook === null || currentWorkbook === void 0 ? void 0 : currentWorkbook.name) || "workbook").replace(/\.xlsx$/i, "")}_all${suffix}.md`,
-            content: currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n")
+            content: currentFiles
+                .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+                .join("\n\n")
         };
     }
     function downloadCurrentMarkdown() {
@@ -323,6 +330,23 @@
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
         showToast("ZIP を保存しました");
     }
+    function convertCurrentWorkbook(showSuccessToast = true) {
+        clearError();
+        if (!currentWorkbook) {
+            showError("先に xlsx ファイルを読み込んでください");
+            return;
+        }
+        try {
+            currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
+            renderCurrentSelection();
+            if (showSuccessToast) {
+                showToast("Markdown を生成しました");
+            }
+        }
+        catch (error) {
+            showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
+        }
+    }
     async function loadWorkbookFromFile(file) {
         clearError();
         setLoading(true, "xlsx を読み込んでいます");
@@ -330,13 +354,8 @@
             const arrayBuffer = await file.arrayBuffer();
             currentWorkbook = await xlsx2md.parseWorkbook(arrayBuffer, file.name);
             currentFiles = [];
-            setSummaryText(`${file.name} を読み込みました。変換ボタンを押してください。`);
-            setScoreSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-            setFormulaSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-            setPreviewMarkdown("");
-            getElement("downloadBtn").disabled = true;
-            getElement("exportZipBtn").disabled = true;
-            showToast("xlsx を読み込みました");
+            convertCurrentWorkbook(false);
+            showToast("xlsx を読み込み、Markdown を生成しました");
         }
         catch (error) {
             currentWorkbook = null;
@@ -365,19 +384,7 @@
     }
     function bindActions() {
         getElement("convertBtn").addEventListener("click", () => {
-            clearError();
-            if (!currentWorkbook) {
-                showError("先に xlsx ファイルを読み込んでください");
-                return;
-            }
-            try {
-                currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
-                renderCurrentSelection();
-                showToast("Markdown を生成しました");
-            }
-            catch (error) {
-                showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
-            }
+            convertCurrentWorkbook(true);
         });
         getElement("downloadBtn").addEventListener("click", () => {
             downloadCurrentMarkdown();

--- a/docs/xlsx2md/src/xlsx2md/ts/formula/evaluator.ts
+++ b/docs/xlsx2md/src/xlsx2md/ts/formula/evaluator.ts
@@ -450,9 +450,18 @@
     const lookupValue = evaluateFormulaAst(args[0], context);
     const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
     const columnNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-    const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
+    const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
     if (approximate) {
-      throw new Error("Approximate VLOOKUP is not supported");
+      let matchedRow: unknown[] | null = null;
+      for (const row of table) {
+        if (looselyEquals(row[0], lookupValue)) {
+          return row[columnNumber - 1] ?? "#N/A";
+        }
+        if (compareValues(row[0], lookupValue) <= 0) {
+          matchedRow = row;
+        }
+      }
+      return matchedRow ? matchedRow[columnNumber - 1] ?? "#N/A" : "#N/A";
     }
     for (const row of table) {
       if (looselyEquals(row[0], lookupValue)) {
@@ -466,12 +475,21 @@
     const lookupValue = evaluateFormulaAst(args[0], context);
     const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
     const rowNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-    const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
-    if (approximate) {
-      throw new Error("Approximate HLOOKUP is not supported");
-    }
+    const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
     const headerRow = table[0] ?? [];
     const targetRow = table[rowNumber - 1] ?? [];
+    if (approximate) {
+      let matchedIndex = -1;
+      for (let index = 0; index < headerRow.length; index += 1) {
+        if (looselyEquals(headerRow[index], lookupValue)) {
+          return targetRow[index] ?? "#N/A";
+        }
+        if (compareValues(headerRow[index], lookupValue) <= 0) {
+          matchedIndex = index;
+        }
+      }
+      return matchedIndex >= 0 ? targetRow[matchedIndex] ?? "#N/A" : "#N/A";
+    }
     for (let index = 0; index < headerRow.length; index += 1) {
       if (looselyEquals(headerRow[index], lookupValue)) {
         return targetRow[index] ?? "#N/A";
@@ -485,12 +503,98 @@
     const lookupArray = flattenValues(evaluateFormulaAst(args[1], context));
     const returnArray = flattenValues(evaluateFormulaAst(args[2], context));
     const notFoundValue = args[3] ? evaluateFormulaAst(args[3], context) : "#N/A";
-    for (let index = 0; index < lookupArray.length; index += 1) {
+    const matchMode = args[4] ? Math.trunc(toNumber(evaluateFormulaAst(args[4], context))) : 0;
+    const searchMode = args[5] ? Math.trunc(toNumber(evaluateFormulaAst(args[5], context))) : 1;
+    if (searchMode === 2 || searchMode === -2) {
+      const matchedIndex = findXLookupBinaryIndex(lookupArray, lookupValue, matchMode, searchMode);
+      return matchedIndex >= 0 ? returnArray[matchedIndex] ?? notFoundValue : notFoundValue;
+    }
+    const indices = searchMode === -1
+      ? Array.from({ length: lookupArray.length }, (_, index) => lookupArray.length - 1 - index)
+      : Array.from({ length: lookupArray.length }, (_, index) => index);
+
+    for (const index of indices) {
       if (looselyEquals(lookupArray[index], lookupValue)) {
         return returnArray[index] ?? notFoundValue;
       }
     }
+
+    if (matchMode === 2) {
+      const matcher = createExcelWildcardMatcher(lookupValue);
+      if (!matcher) {
+        return notFoundValue;
+      }
+      for (const index of indices) {
+        if (matcher(toText(lookupArray[index]))) {
+          return returnArray[index] ?? notFoundValue;
+        }
+      }
+      return notFoundValue;
+    }
+
+    if (matchMode === -1) {
+      let matchedIndex = -1;
+      for (const index of indices) {
+        if (compareValues(lookupArray[index], lookupValue) <= 0) {
+          matchedIndex = index;
+          if (searchMode === -1) {
+            break;
+          }
+        }
+      }
+      return matchedIndex >= 0 ? returnArray[matchedIndex] ?? notFoundValue : notFoundValue;
+    }
+
+    if (matchMode === 1) {
+      let matchedIndex = -1;
+      for (const index of indices) {
+        if (compareValues(lookupArray[index], lookupValue) >= 0) {
+          matchedIndex = index;
+          break;
+        }
+      }
+      return matchedIndex >= 0 ? returnArray[matchedIndex] ?? notFoundValue : notFoundValue;
+    }
+
     return notFoundValue;
+  }
+
+  function findXLookupBinaryIndex(
+    lookupArray: unknown[],
+    lookupValue: unknown,
+    matchMode: number,
+    searchMode: number
+  ): number {
+    const descending = searchMode === -2;
+    let low = 0;
+    let high = lookupArray.length - 1;
+    let fallbackIndex = -1;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const compare = compareValues(lookupArray[mid], lookupValue);
+      if (looselyEquals(lookupArray[mid], lookupValue)) {
+        return mid;
+      }
+      if (matchMode === -1) {
+        if (compare <= 0 && (
+          fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) > 0
+        )) {
+          fallbackIndex = mid;
+        }
+      } else if (matchMode === 1) {
+        if (compare >= 0 && (
+          fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) < 0
+        )) {
+          fallbackIndex = mid;
+        }
+      }
+      if ((!descending && compare < 0) || (descending && compare > 0)) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return fallbackIndex;
   }
 
   function evaluateText(args: FormulaAstNode[], context: EvaluateFormulaAstContext) {
@@ -523,6 +627,38 @@
     }
 
     return toText(value);
+  }
+
+  function createExcelWildcardMatcher(patternValue: unknown): ((value: string) => boolean) | null {
+    const pattern = toText(patternValue);
+    if (!pattern) {
+      return null;
+    }
+    let regexText = "^";
+    for (let index = 0; index < pattern.length; index += 1) {
+      const char = pattern[index];
+      if (char === "~" && index + 1 < pattern.length) {
+        regexText += escapeRegExp(pattern[index + 1]);
+        index += 1;
+        continue;
+      }
+      if (char === "*") {
+        regexText += ".*";
+        continue;
+      }
+      if (char === "?") {
+        regexText += ".";
+        continue;
+      }
+      regexText += escapeRegExp(char);
+    }
+    regexText += "$";
+    const regex = new RegExp(regexText, "i");
+    return (value: string) => regex.test(String(value ?? ""));
+  }
+
+  function escapeRegExp(value: string): string {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }
 
   function evaluateToday(context: EvaluateFormulaAstContext) {

--- a/docs/xlsx2md/src/xlsx2md/ts/main.ts
+++ b/docs/xlsx2md/src/xlsx2md/ts/main.ts
@@ -288,6 +288,10 @@
     getElement<HTMLElement>("markdownOutput").textContent = markdown;
   }
 
+  function createMarkdownChunkLabel(fileName: string): string {
+    return String(fileName || "").replace(/\.md$/i, "");
+  }
+
   function clearError(): void {
     const errorAlert = getElement<HTMLElement>("errorAlert") as HTMLElement & { clear?: () => void };
     if (typeof errorAlert.clear === "function") {
@@ -337,7 +341,9 @@
       updatePreviewModeBanner(getSelectedOutputMode());
       return;
     }
-    const combinedMarkdown = currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n");
+    const combinedMarkdown = currentFiles
+      .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+      .join("\n\n");
     const outputMode = currentFiles[0]?.summary.outputMode || "display";
     updatePreviewModeBanner(outputMode);
     setSummaryHtml(renderAnalysisSummary(currentFiles, currentWorkbook?.name || "workbook.xlsx"));
@@ -354,7 +360,9 @@
     const suffix = outputMode === "display" ? "" : `_${outputMode}`;
     return {
       fileName: `${(currentWorkbook?.name || "workbook").replace(/\.xlsx$/i, "")}_all${suffix}.md`,
-      content: currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n")
+      content: currentFiles
+        .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+        .join("\n\n")
     };
   }
 
@@ -396,6 +404,23 @@
     showToast("ZIP を保存しました");
   }
 
+  function convertCurrentWorkbook(showSuccessToast = true): void {
+    clearError();
+    if (!currentWorkbook) {
+      showError("先に xlsx ファイルを読み込んでください");
+      return;
+    }
+    try {
+      currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
+      renderCurrentSelection();
+      if (showSuccessToast) {
+        showToast("Markdown を生成しました");
+      }
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
+    }
+  }
+
   async function loadWorkbookFromFile(file: File): Promise<void> {
     clearError();
     setLoading(true, "xlsx を読み込んでいます");
@@ -403,13 +428,8 @@
       const arrayBuffer = await file.arrayBuffer();
       currentWorkbook = await xlsx2md.parseWorkbook(arrayBuffer, file.name);
       currentFiles = [];
-      setSummaryText(`${file.name} を読み込みました。変換ボタンを押してください。`);
-      setScoreSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-      setFormulaSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-      setPreviewMarkdown("");
-      getElement<HTMLButtonElement>("downloadBtn").disabled = true;
-      getElement<HTMLButtonElement>("exportZipBtn").disabled = true;
-      showToast("xlsx を読み込みました");
+      convertCurrentWorkbook(false);
+      showToast("xlsx を読み込み、Markdown を生成しました");
     } catch (error) {
       currentWorkbook = null;
       currentFiles = [];
@@ -436,18 +456,7 @@
 
   function bindActions(): void {
     getElement<HTMLButtonElement>("convertBtn").addEventListener("click", () => {
-      clearError();
-      if (!currentWorkbook) {
-        showError("先に xlsx ファイルを読み込んでください");
-        return;
-      }
-      try {
-        currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
-        renderCurrentSelection();
-        showToast("Markdown を生成しました");
-      } catch (error) {
-        showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
-      }
+      convertCurrentWorkbook(true);
     });
     getElement<HTMLButtonElement>("downloadBtn").addEventListener("click", () => {
       downloadCurrentMarkdown();

--- a/docs/xlsx2md/tests/xlsx2md-formula-parser.test.js
+++ b/docs/xlsx2md/tests/xlsx2md-formula-parser.test.js
@@ -420,6 +420,218 @@ describe("xlsx2md formula parser", () => {
     expect(xlookupValue).toBe(20);
   });
 
+  it("evaluates XLOOKUP match_mode and search_mode via AST", () => {
+    const api = bootFormulaParser();
+    const nextSmaller = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(25,A1:A3,B1:B3,"NF",-1)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[10], [20], [30]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const nextLarger = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(25,A1:A3,B1:B3,"NF",1)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[10], [20], [30]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const reverseSearch = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP("K2",A1:A4,B1:B4,"NF",0,-1)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A4") {
+          return [["K1"], ["K2"], ["K2"], ["K3"]];
+        }
+        if (startRef === "B1" && endRef === "B4") {
+          return [[10], [20], [200], [30]];
+        }
+        return [];
+      }
+    });
+
+    expect(nextSmaller).toBe("B");
+    expect(nextLarger).toBe("C");
+    expect(reverseSearch).toBe(200);
+  });
+
+  it("evaluates XLOOKUP wildcard match_mode via AST", () => {
+    const api = bootFormulaParser();
+    const wildcardValue = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP("K*",A1:A3,B1:B3,"NF",2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [["K10"], ["AX"], ["K20"]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const escapedWildcardValue = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP("K~*",A1:A2,B1:B2,"NF",2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A2") {
+          return [["K*"], ["K20"]];
+        }
+        if (startRef === "B1" && endRef === "B2") {
+          return [["literal"], ["other"]];
+        }
+        return [];
+      }
+    });
+
+    expect(wildcardValue).toBe("A");
+    expect(escapedWildcardValue).toBe("literal");
+  });
+
+  it("evaluates XLOOKUP binary search modes via AST", () => {
+    const api = bootFormulaParser();
+    const binaryExact = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(20,A1:A3,B1:B3,"NF",0,2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[10], [20], [30]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const binaryNextSmaller = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(25,A1:A3,B1:B3,"NF",-1,2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[10], [20], [30]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const binaryDescendingNextLarger = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(25,A1:A3,B1:B3,"NF",1,-2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[30], [20], [10]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["C"], ["B"], ["A"]];
+        }
+        return [];
+      }
+    });
+
+    expect(binaryExact).toBe("B");
+    expect(binaryNextSmaller).toBe("B");
+    expect(binaryDescendingNextLarger).toBe("C");
+  });
+
+  it("handles XLOOKUP binary search edge cases via AST", () => {
+    const api = bootFormulaParser();
+    const ascendingTooSmall = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(5,A1:A3,B1:B3,"NF",-1,2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[10], [20], [30]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["A"], ["B"], ["C"]];
+        }
+        return [];
+      }
+    });
+    const descendingTooLarge = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(35,A1:A3,B1:B3,"NF",1,-2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[30], [20], [10]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["C"], ["B"], ["A"]];
+        }
+        return [];
+      }
+    });
+    const descendingNextSmaller = api.evaluateFormulaAst(api.parseFormula('=XLOOKUP(25,A1:A3,B1:B3,"NF",-1,-2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "A3") {
+          return [[30], [20], [10]];
+        }
+        if (startRef === "B1" && endRef === "B3") {
+          return [["C"], ["B"], ["A"]];
+        }
+        return [];
+      }
+    });
+
+    expect(ascendingTooSmall).toBe("NF");
+    expect(descendingTooLarge).toBe("NF");
+    expect(descendingNextSmaller).toBe("B");
+  });
+
+  it("evaluates approximate VLOOKUP and HLOOKUP via AST", () => {
+    const api = bootFormulaParser();
+    const vlookupApproxValue = api.evaluateFormulaAst(api.parseFormula("=VLOOKUP(25,A1:B3,2,TRUE)"), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "B3") {
+          return [
+            [10, "A"],
+            [20, "B"],
+            [30, "C"]
+          ];
+        }
+        return [];
+      }
+    });
+    const hlookupApproxValue = api.evaluateFormulaAst(api.parseFormula('=HLOOKUP("K25",A1:C2,2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "C2") {
+          return [
+            ["K10", "K20", "K30"],
+            ["A", "B", "C"]
+          ];
+        }
+        return [];
+      }
+    });
+
+    expect(vlookupApproxValue).toBe("B");
+    expect(hlookupApproxValue).toBe("B");
+  });
+
+  it("handles approximate VLOOKUP and HLOOKUP edge cases via AST", () => {
+    const api = bootFormulaParser();
+    const vlookupTooSmall = api.evaluateFormulaAst(api.parseFormula("=VLOOKUP(5,A1:B3,2,TRUE)"), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "B3") {
+          return [
+            [10, "A"],
+            [20, "B"],
+            [30, "C"]
+          ];
+        }
+        return [];
+      }
+    });
+    const hlookupExactDefault = api.evaluateFormulaAst(api.parseFormula('=HLOOKUP("K20",A1:C2,2)'), {
+      resolveRange(startRef, endRef) {
+        if (startRef === "A1" && endRef === "C2") {
+          return [
+            ["K10", "K20", "K30"],
+            ["A", "B", "C"]
+          ];
+        }
+        return [];
+      }
+    });
+
+    expect(vlookupTooSmall).toBe("#N/A");
+    expect(hlookupExactDefault).toBe("B");
+  });
+
   it("evaluates EOMONTH via AST", () => {
     const api = bootFormulaParser();
     const eoMonthValue = api.evaluateFormulaAst(api.parseFormula("=EOMONTH(DATE(2024,3,17),1)"));

--- a/docs/xlsx2md/xlsx-formula-subset.md
+++ b/docs/xlsx2md/xlsx-formula-subset.md
@@ -40,6 +40,40 @@
 
 この方針により、`xlsx2md` は Excel 数式の完全互換ではなく、Markdown 変換に必要な範囲での実務的な補完を目指す。
 
+### 数式解決の優先順
+
+`xlsx2md` における数式解決は、現在は次の優先順を前提とする。
+
+1. `cached value`
+2. `AST evaluator`
+3. 従来の文字列ベース resolver
+4. `fallback_formula` または式文字列保持
+
+補足:
+
+- `cached value` が存在する場合は、それを最優先で採用する
+- `cached value` が欠損している場合のみ、`AST evaluator` を先に試す
+- `AST evaluator` で未対応、または評価不能な場合は、従来の文字列ベース resolver へフォールバックする
+- それでも解けない場合に限り、`fallback_formula` として保持する
+
+この順序により、既存の実装資産を活かしながら、対応済みサブセットを段階的に AST 側へ寄せる。
+
+### 既存 resolver の位置づけ
+
+既存の文字列ベース resolver は、当面は削除対象ではない。
+
+- 現時点では、`AST evaluator` が未対応の式を救うための互換 fallback として必要である
+- `local-data` の実戦ブックで、想定外の式や Excel 特有の揺れに対する安全装置として機能する
+- したがって、短期的には「安全のために残す」方針を採る
+
+一方で、中長期的な方向性は次の通りである。
+
+- 主要ケースは `AST evaluator` 側へ段階的に寄せる
+- `existing resolver` の担当範囲は観測しながら縮小する
+- 実データ上で依存が薄くなった段階で、互換 fallback として最小限へ絞る
+
+要するに、`existing resolver` は今は必要だが、将来的には主役ではなく後方互換の安全装置へ寄せていく。
+
 ## 対応対象
 
 ### 1. 基本トークン
@@ -258,7 +292,8 @@ Primary
 ### 現行方針
 
 - `cached value` を最優先
-- 解ける式だけを自前解決
+- `cached value` 欠損時は `AST evaluator` を先に試す
+- `AST evaluator` が未対応または失敗時のみ、従来の文字列ベース resolver を使う
 - 解けない式は `fallback_formula`
 
 ### 次段方針
@@ -388,7 +423,11 @@ Primary
 
 - `ROW / COLUMN` の引数なし形は、現在セル参照が分かる文脈でのみ AST evaluator が対応する
 - 文脈なしでの `ROW() / COLUMN()` をどう扱うか
-- `VLOOKUP / HLOOKUP` の近似一致をどう扱うか
+- `VLOOKUP / HLOOKUP` の近似一致は AST evaluator で最小対応済み
+- `XLOOKUP` の `match_mode / search_mode` は最小対応済み
+- `XLOOKUP` の wildcard `match_mode=2` は最小対応済み
+- `XLOOKUP` の binary search `search_mode=2/-2` は最小対応済み
+- 近似一致の境界条件や未ソート範囲をどこまで扱うか
 - 既存の文字列ベース resolver と AST evaluator の優先順をどこまで入れ替えるか
 - `space` intersection を扱うか
 - 配列定数をどの段階で扱うか

--- a/docs/xlsx2md/xlsx2md-src.html
+++ b/docs/xlsx2md/xlsx2md-src.html
@@ -96,18 +96,22 @@ limitations under the License.
         <lht-error-alert id="errorAlert"></lht-error-alert>
       </section>
 
-      <section class="md-section md-grid md-grid--result">
-        <div class="md-panel md-stack-sm">
-          <h2 class="md-section-title">解析サマリー</h2>
-          <div id="analysisSummary" class="md-summary-list">まだ変換していません。</div>
-        </div>
-
+      <section class="md-section md-stack-md">
         <div class="md-panel md-stack-sm">
           <h2 class="md-section-title">Markdown</h2>
           <div id="previewModeBanner" class="md-caption" hidden>`raw` / `both` モードでは、表示値以外の情報を含む場合があります。</div>
           <lht-preview-output id="markdownPreview" preview-id="markdownOutput" preview-tag="pre" placeholder="ここに Markdown が表示されます"></lht-preview-output>
         </div>
       </section>
+
+      <details class="md-section md-accordion">
+        <summary class="md-accordion-summary">
+          <span class="md-section-title">解析サマリー</span>
+        </summary>
+        <div class="md-accordion-body">
+          <div id="analysisSummary" class="md-summary-list">まだ変換していません。</div>
+        </div>
+      </details>
 
       <details class="md-section md-accordion">
         <summary class="md-accordion-summary">

--- a/docs/xlsx2md/xlsx2md.html
+++ b/docs/xlsx2md/xlsx2md.html
@@ -1477,18 +1477,22 @@ lht-preview-output {
         <lht-error-alert id="errorAlert"></lht-error-alert>
       </section>
 
-      <section class="md-section md-grid md-grid--result">
-        <div class="md-panel md-stack-sm">
-          <h2 class="md-section-title">解析サマリー</h2>
-          <div id="analysisSummary" class="md-summary-list">まだ変換していません。</div>
-        </div>
-
+      <section class="md-section md-stack-md">
         <div class="md-panel md-stack-sm">
           <h2 class="md-section-title">Markdown</h2>
           <div id="previewModeBanner" class="md-caption" hidden>`raw` / `both` モードでは、表示値以外の情報を含む場合があります。</div>
           <lht-preview-output id="markdownPreview" preview-id="markdownOutput" preview-tag="pre" placeholder="ここに Markdown が表示されます"></lht-preview-output>
         </div>
       </section>
+
+      <details class="md-section md-accordion">
+        <summary class="md-accordion-summary">
+          <span class="md-section-title">解析サマリー</span>
+        </summary>
+        <div class="md-accordion-body">
+          <div id="analysisSummary" class="md-summary-list">まだ変換していません。</div>
+        </div>
+      </details>
 
       <details class="md-section md-accordion">
         <summary class="md-accordion-summary">
@@ -4540,51 +4544,142 @@ if (!customElements.get("lht-page-menu")) {
         return (_d = source[columnNumber - 1]) !== null && _d !== void 0 ? _d : null;
     }
     function evaluateVLookup(args, context) {
-        var _a;
+        var _a, _b, _c;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
         const columnNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
+        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
         if (approximate) {
-            throw new Error("Approximate VLOOKUP is not supported");
+            let matchedRow = null;
+            for (const row of table) {
+                if (looselyEquals(row[0], lookupValue)) {
+                    return (_a = row[columnNumber - 1]) !== null && _a !== void 0 ? _a : "#N/A";
+                }
+                if (compareValues(row[0], lookupValue) <= 0) {
+                    matchedRow = row;
+                }
+            }
+            return matchedRow ? (_b = matchedRow[columnNumber - 1]) !== null && _b !== void 0 ? _b : "#N/A" : "#N/A";
         }
         for (const row of table) {
             if (looselyEquals(row[0], lookupValue)) {
-                return (_a = row[columnNumber - 1]) !== null && _a !== void 0 ? _a : "#N/A";
+                return (_c = row[columnNumber - 1]) !== null && _c !== void 0 ? _c : "#N/A";
             }
         }
         return "#N/A";
     }
     function evaluateHLookup(args, context) {
-        var _a, _b, _c;
+        var _a, _b, _c, _d, _e;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const table = normalizeToMatrix(evaluateFormulaAst(args[1], context));
         const rowNumber = Math.max(1, Math.floor(toNumber(evaluateFormulaAst(args[2], context))));
-        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : false;
-        if (approximate) {
-            throw new Error("Approximate HLOOKUP is not supported");
-        }
+        const approximate = args[3] ? toBoolean(evaluateFormulaAst(args[3], context)) : true;
         const headerRow = (_a = table[0]) !== null && _a !== void 0 ? _a : [];
         const targetRow = (_b = table[rowNumber - 1]) !== null && _b !== void 0 ? _b : [];
+        if (approximate) {
+            let matchedIndex = -1;
+            for (let index = 0; index < headerRow.length; index += 1) {
+                if (looselyEquals(headerRow[index], lookupValue)) {
+                    return (_c = targetRow[index]) !== null && _c !== void 0 ? _c : "#N/A";
+                }
+                if (compareValues(headerRow[index], lookupValue) <= 0) {
+                    matchedIndex = index;
+                }
+            }
+            return matchedIndex >= 0 ? (_d = targetRow[matchedIndex]) !== null && _d !== void 0 ? _d : "#N/A" : "#N/A";
+        }
         for (let index = 0; index < headerRow.length; index += 1) {
             if (looselyEquals(headerRow[index], lookupValue)) {
-                return (_c = targetRow[index]) !== null && _c !== void 0 ? _c : "#N/A";
+                return (_e = targetRow[index]) !== null && _e !== void 0 ? _e : "#N/A";
             }
         }
         return "#N/A";
     }
     function evaluateXLookup(args, context) {
-        var _a;
+        var _a, _b, _c, _d, _e;
         const lookupValue = evaluateFormulaAst(args[0], context);
         const lookupArray = flattenValues(evaluateFormulaAst(args[1], context));
         const returnArray = flattenValues(evaluateFormulaAst(args[2], context));
         const notFoundValue = args[3] ? evaluateFormulaAst(args[3], context) : "#N/A";
-        for (let index = 0; index < lookupArray.length; index += 1) {
+        const matchMode = args[4] ? Math.trunc(toNumber(evaluateFormulaAst(args[4], context))) : 0;
+        const searchMode = args[5] ? Math.trunc(toNumber(evaluateFormulaAst(args[5], context))) : 1;
+        if (searchMode === 2 || searchMode === -2) {
+            const matchedIndex = findXLookupBinaryIndex(lookupArray, lookupValue, matchMode, searchMode);
+            return matchedIndex >= 0 ? (_a = returnArray[matchedIndex]) !== null && _a !== void 0 ? _a : notFoundValue : notFoundValue;
+        }
+        const indices = searchMode === -1
+            ? Array.from({ length: lookupArray.length }, (_, index) => lookupArray.length - 1 - index)
+            : Array.from({ length: lookupArray.length }, (_, index) => index);
+        for (const index of indices) {
             if (looselyEquals(lookupArray[index], lookupValue)) {
-                return (_a = returnArray[index]) !== null && _a !== void 0 ? _a : notFoundValue;
+                return (_b = returnArray[index]) !== null && _b !== void 0 ? _b : notFoundValue;
             }
         }
+        if (matchMode === 2) {
+            const matcher = createExcelWildcardMatcher(lookupValue);
+            if (!matcher) {
+                return notFoundValue;
+            }
+            for (const index of indices) {
+                if (matcher(toText(lookupArray[index]))) {
+                    return (_c = returnArray[index]) !== null && _c !== void 0 ? _c : notFoundValue;
+                }
+            }
+            return notFoundValue;
+        }
+        if (matchMode === -1) {
+            let matchedIndex = -1;
+            for (const index of indices) {
+                if (compareValues(lookupArray[index], lookupValue) <= 0) {
+                    matchedIndex = index;
+                    if (searchMode === -1) {
+                        break;
+                    }
+                }
+            }
+            return matchedIndex >= 0 ? (_d = returnArray[matchedIndex]) !== null && _d !== void 0 ? _d : notFoundValue : notFoundValue;
+        }
+        if (matchMode === 1) {
+            let matchedIndex = -1;
+            for (const index of indices) {
+                if (compareValues(lookupArray[index], lookupValue) >= 0) {
+                    matchedIndex = index;
+                    break;
+                }
+            }
+            return matchedIndex >= 0 ? (_e = returnArray[matchedIndex]) !== null && _e !== void 0 ? _e : notFoundValue : notFoundValue;
+        }
         return notFoundValue;
+    }
+    function findXLookupBinaryIndex(lookupArray, lookupValue, matchMode, searchMode) {
+        const descending = searchMode === -2;
+        let low = 0;
+        let high = lookupArray.length - 1;
+        let fallbackIndex = -1;
+        while (low <= high) {
+            const mid = Math.floor((low + high) / 2);
+            const compare = compareValues(lookupArray[mid], lookupValue);
+            if (looselyEquals(lookupArray[mid], lookupValue)) {
+                return mid;
+            }
+            if (matchMode === -1) {
+                if (compare <= 0 && (fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) > 0)) {
+                    fallbackIndex = mid;
+                }
+            }
+            else if (matchMode === 1) {
+                if (compare >= 0 && (fallbackIndex < 0 || compareValues(lookupArray[mid], lookupArray[fallbackIndex]) < 0)) {
+                    fallbackIndex = mid;
+                }
+            }
+            if ((!descending && compare < 0) || (descending && compare > 0)) {
+                low = mid + 1;
+            }
+            else {
+                high = mid - 1;
+            }
+        }
+        return fallbackIndex;
     }
     function evaluateText(args, context) {
         const value = evaluateFormulaAst(args[0], context);
@@ -4611,6 +4706,36 @@ if (!customElements.get("lht-page-menu")) {
             return `${parts.year}${separator}${parts.month}${separator}${parts.day}`;
         }
         return toText(value);
+    }
+    function createExcelWildcardMatcher(patternValue) {
+        const pattern = toText(patternValue);
+        if (!pattern) {
+            return null;
+        }
+        let regexText = "^";
+        for (let index = 0; index < pattern.length; index += 1) {
+            const char = pattern[index];
+            if (char === "~" && index + 1 < pattern.length) {
+                regexText += escapeRegExp(pattern[index + 1]);
+                index += 1;
+                continue;
+            }
+            if (char === "*") {
+                regexText += ".*";
+                continue;
+            }
+            if (char === "?") {
+                regexText += ".";
+                continue;
+            }
+            regexText += escapeRegExp(char);
+        }
+        regexText += "$";
+        const regex = new RegExp(regexText, "i");
+        return (value) => regex.test(String(value !== null && value !== void 0 ? value : ""));
+    }
+    function escapeRegExp(value) {
+        return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     }
     function evaluateToday(context) {
         var _a;
@@ -8864,6 +8989,9 @@ if (!customElements.get("lht-page-menu")) {
         }
         getElement("markdownOutput").textContent = markdown;
     }
+    function createMarkdownChunkLabel(fileName) {
+        return String(fileName || "").replace(/\.md$/i, "");
+    }
     function clearError() {
         const errorAlert = getElement("errorAlert");
         if (typeof errorAlert.clear === "function") {
@@ -8915,7 +9043,9 @@ if (!customElements.get("lht-page-menu")) {
             updatePreviewModeBanner(getSelectedOutputMode());
             return;
         }
-        const combinedMarkdown = currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n");
+        const combinedMarkdown = currentFiles
+            .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+            .join("\n\n");
         const outputMode = ((_a = currentFiles[0]) === null || _a === void 0 ? void 0 : _a.summary.outputMode) || "display";
         updatePreviewModeBanner(outputMode);
         setSummaryHtml(renderAnalysisSummary(currentFiles, (currentWorkbook === null || currentWorkbook === void 0 ? void 0 : currentWorkbook.name) || "workbook.xlsx"));
@@ -8933,7 +9063,9 @@ if (!customElements.get("lht-page-menu")) {
         const suffix = outputMode === "display" ? "" : `_${outputMode}`;
         return {
             fileName: `${((currentWorkbook === null || currentWorkbook === void 0 ? void 0 : currentWorkbook.name) || "workbook").replace(/\.xlsx$/i, "")}_all${suffix}.md`,
-            content: currentFiles.map((file) => `<!-- ${file.fileName} -->\n${file.markdown}`).join("\n\n")
+            content: currentFiles
+                .map((file) => `<!-- ${createMarkdownChunkLabel(file.fileName)} -->\n${file.markdown}`)
+                .join("\n\n")
         };
     }
     function downloadCurrentMarkdown() {
@@ -8973,6 +9105,23 @@ if (!customElements.get("lht-page-menu")) {
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
         showToast("ZIP を保存しました");
     }
+    function convertCurrentWorkbook(showSuccessToast = true) {
+        clearError();
+        if (!currentWorkbook) {
+            showError("先に xlsx ファイルを読み込んでください");
+            return;
+        }
+        try {
+            currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
+            renderCurrentSelection();
+            if (showSuccessToast) {
+                showToast("Markdown を生成しました");
+            }
+        }
+        catch (error) {
+            showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
+        }
+    }
     async function loadWorkbookFromFile(file) {
         clearError();
         setLoading(true, "xlsx を読み込んでいます");
@@ -8980,13 +9129,8 @@ if (!customElements.get("lht-page-menu")) {
             const arrayBuffer = await file.arrayBuffer();
             currentWorkbook = await xlsx2md.parseWorkbook(arrayBuffer, file.name);
             currentFiles = [];
-            setSummaryText(`${file.name} を読み込みました。変換ボタンを押してください。`);
-            setScoreSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-            setFormulaSummaryHtml('<div class="md-summary-empty">まだ変換していません。</div>');
-            setPreviewMarkdown("");
-            getElement("downloadBtn").disabled = true;
-            getElement("exportZipBtn").disabled = true;
-            showToast("xlsx を読み込みました");
+            convertCurrentWorkbook(false);
+            showToast("xlsx を読み込み、Markdown を生成しました");
         }
         catch (error) {
             currentWorkbook = null;
@@ -9015,19 +9159,7 @@ if (!customElements.get("lht-page-menu")) {
     }
     function bindActions() {
         getElement("convertBtn").addEventListener("click", () => {
-            clearError();
-            if (!currentWorkbook) {
-                showError("先に xlsx ファイルを読み込んでください");
-                return;
-            }
-            try {
-                currentFiles = xlsx2md.convertWorkbookToMarkdownFiles(currentWorkbook, getOptions());
-                renderCurrentSelection();
-                showToast("Markdown を生成しました");
-            }
-            catch (error) {
-                showError(error instanceof Error ? error.message : "Markdown 生成に失敗しました");
-            }
+            convertCurrentWorkbook(true);
         });
         getElement("downloadBtn").addEventListener("click", () => {
             downloadCurrentMarkdown();


### PR DESCRIPTION
## 概要

`xlsx2md` を中心に次の更新が行われています。

- UI を全シート前提で簡素化
- ファイル選択後に自動で Markdown 生成まで進むように改善
- 解析サマリーの配置を見直し、アコーディオン化
- 連結 Markdown に付けるコメントを「分割 md ファイル名風」から「識別子」へ変更
- Excel 数式の AST parser / evaluator を継続拡張
- 数式サブセット設計メモと TODO の整理

## 変更内容

### UI / UX の整理

以下のファイルが更新されています。

- `docs/xlsx2md/xlsx2md-src.html`
- `docs/xlsx2md/src/xlsx2md/ts/main.ts`
- `docs/xlsx2md/src/xlsx2md/css/app.css`
- `docs/xlsx2md/xlsx2md.html`

会話内で確認できた更新内容:

- `表示シート` ドロップダウンを削除
- 変換は常に全シート対象に統一
- 単一シート前提の保存分岐、`sheetSummary`、シート切替イベントを削除
- `変換設定`
- `表候補スコア`
- `数式診断` をアコーディオン化し、既定で閉じる構成へ整理
- `Markdown` を先に表示し、`解析サマリー` はその下のアコーディオンへ移動
- `.xlsx` ファイル選択後、読み込み完了したら自動で `Markdown へ変換` 相当の処理を実行するように変更

### Markdown 出力の識別コメント変更

以下のファイルが更新されています。

- `docs/xlsx2md/src/xlsx2md/ts/main.ts`

会話内で確認できた更新内容:

- 連結 Markdown の先頭コメントから `.md` 拡張子を外し、
  - 変更前: `<!-- ...課題.md -->`
  - 変更後: `<!-- ...課題 -->` のように、一意識別子として扱う形式へ統一
- この変更はプレビュー表示と保存時の両方に適用

### 数式 AST parser / evaluator の拡張

以下のファイルが更新されています。

- `docs/xlsx2md/src/xlsx2md/ts/formula/tokenizer.ts`
- `docs/xlsx2md/src/xlsx2md/ts/formula/parser.ts`
- `docs/xlsx2md/src/xlsx2md/ts/formula/evaluator.ts`
- `docs/xlsx2md/src/xlsx2md/ts/core.ts`
- `docs/xlsx2md/tests/xlsx2md-formula-parser.test.js`
- `docs/xlsx2md/tests/xlsx2md-main.test.js`

会話内で確認できた更新内容:

- parser 側
  - 絶対参照
  - sheet-scope name
  - error constant
  - row qualifier 付き structured reference
  - `?` を含む列名
  - `%` に対応
- evaluator 側
  - `ROW()` / `COLUMN()` の引数なし形を、現在セル参照が分かる文脈で対応
  - `VLOOKUP / HLOOKUP` の近似一致を最小対応
  - `XLOOKUP`
    - `match_mode=-1/1`
    - `search_mode=-1`
    - wildcard `match_mode=2`
    - binary search `search_mode=2/-2` を最小対応
  - `XLOOKUP` binary search の境界条件テストを追加
- `core.ts` では、数式解決を `AST evaluator` 先行で試し、未対応時は既存 resolver にフォールバックする構成を維持

### 文書・メモ整理

以下のファイルが更新されています。

- `docs/xlsx2md/xlsx-formula-subset.md`
- `TODO.md`
- `docs/xlsx2md/README.md`

会話内で確認できた更新内容:

- `cached value -> AST evaluator -> 既存 resolver -> fallback_formula` の優先順を明文化
- `existing resolver` は短期的には削除せず、安全装置として維持する方針を明記
- `existing resolver` は中長期的には AST evaluator へ段階移行し、後方互換 fallback へ寄せる方針を整理
- `TODO` に `数式未対応 / レイアウト未対応 / 方針未確定` を追記
- `formula parser test` 件数更新
- `XLOOKUP` binary search の最小対応をメモへ反映

## テスト

会話内で確認できた実行結果:

- `npm run build:xlsx2md`
- `npm run test:unit -- docs/xlsx2md/tests/xlsx2md-formula-parser.test.js`
- `npm run test:unit -- docs/xlsx2md/tests/xlsx2md-main.test.js`

確認時点の件数:

- `docs/xlsx2md/tests/xlsx2md-formula-parser.test.js`: `45 tests`
- `docs/xlsx2md/tests/xlsx2md-main.test.js`: `23 tests`

## 補足

- `existing resolver` は現時点では削除対象ではなく、AST 側未対応ケースの安全装置として扱う方針です。
- `XLOOKUP` は `wildcard` と `binary search` まで最小対応済みですが、未ソート範囲の扱いなどは引き続き要整理です。