### PR TITLE
`xlsx2md` にグラフメタデータ抽出を追加し、README / spec を現状に同期

### DIFF
--- a/docs/xlsx2md/src/xlsx2md/js/core.js
+++ b/docs/xlsx2md/src/xlsx2md/js/core.js
@@ -865,6 +865,97 @@
         }
         return imageAssets;
     }
+    function parseChartType(chartDoc) {
+        const typeMap = [
+            { localName: "barChart", label: "棒グラフ" },
+            { localName: "lineChart", label: "折れ線グラフ" },
+            { localName: "pieChart", label: "円グラフ" },
+            { localName: "doughnutChart", label: "ドーナツグラフ" },
+            { localName: "areaChart", label: "面グラフ" },
+            { localName: "scatterChart", label: "散布図" },
+            { localName: "radarChart", label: "レーダーチャート" },
+            { localName: "bubbleChart", label: "バブルチャート" }
+        ];
+        const matched = typeMap
+            .filter((entry) => getElementsByLocalName(chartDoc, entry.localName).length > 0)
+            .map((entry) => entry.label);
+        if (matched.length === 0)
+            return "グラフ";
+        if (matched.length === 1)
+            return matched[0];
+        return `${matched.join(" + ")} (複合)`;
+    }
+    function parseChartTitle(chartDoc) {
+        const richText = getElementsByLocalName(chartDoc, "t")
+            .map((node) => getTextContent(node))
+            .filter(Boolean);
+        if (richText.length > 0) {
+            return richText.join("").trim();
+        }
+        return "";
+    }
+    function parseChartSeries(chartDoc) {
+        return getElementsByLocalName(chartDoc, "ser").map((seriesNode) => {
+            const nameRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "f");
+            const nameValue = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "v");
+            const nameText = getElementsByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "t")
+                .map((node) => getTextContent(node))
+                .join("")
+                .trim();
+            const catRef = getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "strRef") || seriesNode, "f")
+                || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "numRef") || seriesNode, "f");
+            const valRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "f")
+                || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "numRef") || seriesNode, "f");
+            return {
+                name: nameText || getTextContent(nameValue) || getTextContent(nameRef) || "系列",
+                categoriesRef: getTextContent(catRef),
+                valuesRef: getTextContent(valRef)
+            };
+        });
+    }
+    function parseDrawingCharts(files, sheetName, sheetPath) {
+        const sheetRels = parseRelationships(files, buildRelsPath(sheetPath), sheetPath);
+        const charts = [];
+        for (const drawingPath of sheetRels.values()) {
+            if (!/\/drawings\/.+\.xml$/i.test(drawingPath))
+                continue;
+            const drawingBytes = files.get(drawingPath);
+            if (!drawingBytes)
+                continue;
+            const drawingDoc = xmlToDocument(decodeXmlText(drawingBytes));
+            const drawingRels = parseRelationships(files, buildRelsPath(drawingPath), drawingPath);
+            const anchors = getElementsByLocalName(drawingDoc, "oneCellAnchor").concat(getElementsByLocalName(drawingDoc, "twoCellAnchor"));
+            for (const anchor of anchors) {
+                const from = getFirstChildByLocalName(anchor, "from");
+                const colNode = getFirstChildByLocalName(from || anchor, "col");
+                const rowNode = getFirstChildByLocalName(from || anchor, "row");
+                const col = Number(getTextContent(colNode)) + 1;
+                const row = Number(getTextContent(rowNode)) + 1;
+                if (!Number.isFinite(col) || !Number.isFinite(row) || col <= 0 || row <= 0) {
+                    continue;
+                }
+                const chartNode = getFirstChildByLocalName(anchor, "graphicFrame");
+                const chartRef = getElementsByLocalName(chartNode || anchor, "chart")[0] || null;
+                const relId = (chartRef === null || chartRef === void 0 ? void 0 : chartRef.getAttribute("r:id")) || (chartRef === null || chartRef === void 0 ? void 0 : chartRef.getAttribute("id")) || "";
+                const chartPath = drawingRels.get(relId) || "";
+                if (!chartPath)
+                    continue;
+                const chartBytes = files.get(chartPath);
+                if (!chartBytes)
+                    continue;
+                const chartDoc = xmlToDocument(decodeXmlText(chartBytes));
+                charts.push({
+                    sheetName,
+                    anchor: `${colToLetters(col)}${row}`,
+                    chartPath,
+                    title: parseChartTitle(chartDoc),
+                    chartType: parseChartType(chartDoc),
+                    series: parseChartSeries(chartDoc)
+                });
+            }
+        }
+        return charts;
+    }
     function extractCellOutputValue(cellElement, sharedStrings, cellStyle, formulaOverride = "") {
         const type = (cellElement.getAttribute("t") || "").trim();
         const valueNode = cellElement.getElementsByTagName("v")[0] || null;
@@ -3042,6 +3133,7 @@
         const merges = Array.from(doc.getElementsByTagName("mergeCell")).map((mergeElement) => parseRangeRef(mergeElement.getAttribute("ref") || ""));
         const tables = parseWorksheetTables(files, doc, sheetName, sheetPath);
         const images = parseDrawingImages(files, sheetName, sheetPath);
+        const charts = parseDrawingCharts(files, sheetName, sheetPath);
         let maxRow = 0;
         let maxCol = 0;
         for (const cell of cells) {
@@ -3064,6 +3156,7 @@
             merges,
             tables,
             images,
+            charts,
             maxRow,
             maxCol
         };
@@ -3306,6 +3399,7 @@
         return true;
     }
     function extractSectionBlocks(sheet, tables, narrativeBlocks) {
+        const charts = sheet.charts || [];
         const anchors = [];
         for (const block of narrativeBlocks) {
             anchors.push({
@@ -3325,6 +3419,17 @@
         }
         for (const image of sheet.images) {
             const anchor = parseCellAddress(image.anchor);
+            if (anchor.row > 0 && anchor.col > 0) {
+                anchors.push({
+                    startRow: anchor.row,
+                    startCol: anchor.col,
+                    endRow: anchor.row,
+                    endCol: anchor.col
+                });
+            }
+        }
+        for (const chart of charts) {
+            const anchor = parseCellAddress(chart.anchor);
             if (anchor.row > 0 && anchor.col > 0) {
                 anchors.push({
                     startRow: anchor.row,
@@ -3567,6 +3672,7 @@
     }
     function convertSheetToMarkdown(workbook, sheet, options = {}) {
         var _a;
+        const charts = sheet.charts || [];
         const treatFirstRowAsHeader = options.treatFirstRowAsHeader !== false;
         const tables = detectTableCandidates(sheet);
         const narrativeBlocks = extractNarrativeBlocks(sheet, tables, options);
@@ -3652,6 +3758,33 @@
                 ].join("\n"))
             ].join("\n")
             : "";
+        const chartSection = charts.length > 0
+            ? [
+                "",
+                "## グラフ",
+                "",
+                ...charts.map((chart, index) => {
+                    const lines = [
+                        `### グラフ${String(index + 1).padStart(3, "0")} (${chart.anchor})`,
+                        `- タイトル: ${chart.title || "(なし)"}`,
+                        `- 種別: ${chart.chartType}`
+                    ];
+                    if (chart.series.length > 0) {
+                        lines.push("- 系列:");
+                        for (const series of chart.series) {
+                            lines.push(`  - ${series.name}`);
+                            if (series.categoriesRef) {
+                                lines.push(`    - categories: ${series.categoriesRef}`);
+                            }
+                            if (series.valuesRef) {
+                                lines.push(`    - values: ${series.valuesRef}`);
+                            }
+                        }
+                    }
+                    return lines.join("\n");
+                })
+            ].join("\n")
+            : "";
         const markdown = [
             `# ${sheet.name}`,
             "",
@@ -3662,6 +3795,7 @@
             "## 本文",
             "",
             body || "_抽出できる本文はありませんでした。_",
+            chartSection,
             imageSection
         ].join("\n");
         return {
@@ -3675,6 +3809,7 @@
                 narrativeBlocks: narrativeBlocks.length,
                 merges: sheet.merges.length,
                 images: sheet.images.length,
+                charts: charts.length,
                 cells: sheet.cells.length,
                 tableScores: tables.map((table) => ({
                     range: formatRange(table.startRow, table.startCol, table.endRow, table.endCol),
@@ -3700,6 +3835,7 @@
             `地の文ブロック: ${markdownFile.summary.narrativeBlocks}`,
             `結合セル範囲: ${markdownFile.summary.merges}`,
             `画像: ${markdownFile.summary.images}`,
+            `グラフ: ${markdownFile.summary.charts}`,
             `解析セル数: ${markdownFile.summary.cells}`,
             `数式 resolved: ${resolvedCount}`,
             `数式 fallback_formula: ${fallbackCount}`,

--- a/docs/xlsx2md/src/xlsx2md/ts/core.ts
+++ b/docs/xlsx2md/src/xlsx2md/ts/core.ts
@@ -70,6 +70,7 @@
     merges: MergeRange[];
     tables: ParsedTable[];
     images: ParsedImageAsset[];
+    charts: ParsedChartAsset[];
     maxRow: number;
     maxCol: number;
   };
@@ -81,6 +82,19 @@
     anchor: string;
     data: Uint8Array;
     mediaPath: string;
+  };
+
+  type ParsedChartAsset = {
+    sheetName: string;
+    anchor: string;
+    chartPath: string;
+    title: string;
+    chartType: string;
+    series: {
+      name: string;
+      categoriesRef: string;
+      valuesRef: string;
+    }[];
   };
 
   type ParsedWorkbook = {
@@ -156,6 +170,7 @@
       narrativeBlocks: number;
       merges: number;
       images: number;
+      charts: number;
       cells: number;
       tableScores: TableScoreDetail[];
       formulaDiagnostics: FormulaDiagnostic[];
@@ -1121,6 +1136,104 @@
     }
 
     return imageAssets;
+  }
+
+  function parseChartType(chartDoc: Document): string {
+    const typeMap: Array<{ localName: string; label: string }> = [
+      { localName: "barChart", label: "棒グラフ" },
+      { localName: "lineChart", label: "折れ線グラフ" },
+      { localName: "pieChart", label: "円グラフ" },
+      { localName: "doughnutChart", label: "ドーナツグラフ" },
+      { localName: "areaChart", label: "面グラフ" },
+      { localName: "scatterChart", label: "散布図" },
+      { localName: "radarChart", label: "レーダーチャート" },
+      { localName: "bubbleChart", label: "バブルチャート" }
+    ];
+    const matched = typeMap
+      .filter((entry) => getElementsByLocalName(chartDoc, entry.localName).length > 0)
+      .map((entry) => entry.label);
+    if (matched.length === 0) return "グラフ";
+    if (matched.length === 1) return matched[0];
+    return `${matched.join(" + ")} (複合)`;
+  }
+
+  function parseChartTitle(chartDoc: Document): string {
+    const richText = getElementsByLocalName(chartDoc, "t")
+      .map((node) => getTextContent(node))
+      .filter(Boolean);
+    if (richText.length > 0) {
+      return richText.join("").trim();
+    }
+    return "";
+  }
+
+  function parseChartSeries(chartDoc: Document): ParsedChartAsset["series"] {
+    return getElementsByLocalName(chartDoc, "ser").map((seriesNode) => {
+      const nameRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "f");
+      const nameValue = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "v");
+      const nameText = getElementsByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "t")
+        .map((node) => getTextContent(node))
+        .join("")
+        .trim();
+      const catRef = getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "strRef") || seriesNode, "f")
+        || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "numRef") || seriesNode, "f");
+      const valRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "f")
+        || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "numRef") || seriesNode, "f");
+      return {
+        name: nameText || getTextContent(nameValue) || getTextContent(nameRef) || "系列",
+        categoriesRef: getTextContent(catRef),
+        valuesRef: getTextContent(valRef)
+      };
+    });
+  }
+
+  function parseDrawingCharts(
+    files: Map<string, Uint8Array>,
+    sheetName: string,
+    sheetPath: string
+  ): ParsedChartAsset[] {
+    const sheetRels = parseRelationships(files, buildRelsPath(sheetPath), sheetPath);
+    const charts: ParsedChartAsset[] = [];
+
+    for (const drawingPath of sheetRels.values()) {
+      if (!/\/drawings\/.+\.xml$/i.test(drawingPath)) continue;
+      const drawingBytes = files.get(drawingPath);
+      if (!drawingBytes) continue;
+      const drawingDoc = xmlToDocument(decodeXmlText(drawingBytes));
+      const drawingRels = parseRelationships(files, buildRelsPath(drawingPath), drawingPath);
+      const anchors = getElementsByLocalName(drawingDoc, "oneCellAnchor").concat(getElementsByLocalName(drawingDoc, "twoCellAnchor"));
+
+      for (const anchor of anchors) {
+        const from = getFirstChildByLocalName(anchor, "from");
+        const colNode = getFirstChildByLocalName(from || anchor, "col");
+        const rowNode = getFirstChildByLocalName(from || anchor, "row");
+        const col = Number(getTextContent(colNode)) + 1;
+        const row = Number(getTextContent(rowNode)) + 1;
+        if (!Number.isFinite(col) || !Number.isFinite(row) || col <= 0 || row <= 0) {
+          continue;
+        }
+
+        const chartNode = getFirstChildByLocalName(anchor, "graphicFrame");
+        const chartRef = getElementsByLocalName(chartNode || anchor, "chart")[0] || null;
+        const relId = chartRef?.getAttribute("r:id") || chartRef?.getAttribute("id") || "";
+        const chartPath = drawingRels.get(relId) || "";
+        if (!chartPath) continue;
+        const chartBytes = files.get(chartPath);
+        if (!chartBytes) continue;
+        const chartDoc = xmlToDocument(decodeXmlText(chartBytes));
+
+        charts.push({
+          sheetName,
+          anchor: `${colToLetters(col)}${row}`,
+          chartPath,
+          title: parseChartTitle(chartDoc),
+          chartType: parseChartType(chartDoc),
+          series: parseChartSeries(chartDoc)
+        });
+      }
+    }
+
+    return charts;
   }
 
   function extractCellOutputValue(
@@ -3765,6 +3878,7 @@
     const merges = Array.from(doc.getElementsByTagName("mergeCell")).map((mergeElement) => parseRangeRef(mergeElement.getAttribute("ref") || ""));
     const tables = parseWorksheetTables(files, doc, sheetName, sheetPath);
     const images = parseDrawingImages(files, sheetName, sheetPath);
+    const charts = parseDrawingCharts(files, sheetName, sheetPath);
     let maxRow = 0;
     let maxCol = 0;
     for (const cell of cells) {
@@ -3783,6 +3897,7 @@
       merges,
       tables,
       images,
+      charts,
       maxRow,
       maxCol
     };
@@ -4025,6 +4140,7 @@
   }
 
   function extractSectionBlocks(sheet: ParsedSheet, tables: TableCandidate[], narrativeBlocks: NarrativeBlock[]): SectionBlock[] {
+    const charts = sheet.charts || [];
     const anchors: Array<{ startRow: number; startCol: number; endRow: number; endCol: number }> = [];
 
     for (const block of narrativeBlocks) {
@@ -4047,6 +4163,18 @@
 
     for (const image of sheet.images) {
       const anchor = parseCellAddress(image.anchor);
+      if (anchor.row > 0 && anchor.col > 0) {
+        anchors.push({
+          startRow: anchor.row,
+          startCol: anchor.col,
+          endRow: anchor.row,
+          endCol: anchor.col
+        });
+      }
+    }
+
+    for (const chart of charts) {
+      const anchor = parseCellAddress(chart.anchor);
       if (anchor.row > 0 && anchor.col > 0) {
         anchors.push({
           startRow: anchor.row,
@@ -4317,6 +4445,7 @@
   }
 
   function convertSheetToMarkdown(workbook: ParsedWorkbook, sheet: ParsedSheet, options: MarkdownOptions = {}): MarkdownFile {
+    const charts = sheet.charts || [];
     const treatFirstRowAsHeader = options.treatFirstRowAsHeader !== false;
     const tables = detectTableCandidates(sheet);
     const narrativeBlocks = extractNarrativeBlocks(sheet, tables, options);
@@ -4411,6 +4540,33 @@
         ].join("\n"))
       ].join("\n")
       : "";
+    const chartSection = charts.length > 0
+      ? [
+        "",
+        "## グラフ",
+        "",
+        ...charts.map((chart, index) => {
+          const lines = [
+            `### グラフ${String(index + 1).padStart(3, "0")} (${chart.anchor})`,
+            `- タイトル: ${chart.title || "(なし)"}`,
+            `- 種別: ${chart.chartType}`
+          ];
+          if (chart.series.length > 0) {
+            lines.push("- 系列:");
+            for (const series of chart.series) {
+              lines.push(`  - ${series.name}`);
+              if (series.categoriesRef) {
+                lines.push(`    - categories: ${series.categoriesRef}`);
+              }
+              if (series.valuesRef) {
+                lines.push(`    - values: ${series.valuesRef}`);
+              }
+            }
+          }
+          return lines.join("\n");
+        })
+      ].join("\n")
+      : "";
     const markdown = [
       `# ${sheet.name}`,
       "",
@@ -4421,6 +4577,7 @@
       "## 本文",
       "",
       body || "_抽出できる本文はありませんでした。_",
+      chartSection,
       imageSection
     ].join("\n");
 
@@ -4435,6 +4592,7 @@
         narrativeBlocks: narrativeBlocks.length,
         merges: sheet.merges.length,
         images: sheet.images.length,
+        charts: charts.length,
         cells: sheet.cells.length,
         tableScores: tables.map((table) => ({
           range: formatRange(table.startRow, table.startCol, table.endRow, table.endCol),
@@ -4462,6 +4620,7 @@
       `地の文ブロック: ${markdownFile.summary.narrativeBlocks}`,
       `結合セル範囲: ${markdownFile.summary.merges}`,
       `画像: ${markdownFile.summary.images}`,
+      `グラフ: ${markdownFile.summary.charts}`,
       `解析セル数: ${markdownFile.summary.cells}`,
       `数式 resolved: ${resolvedCount}`,
       `数式 fallback_formula: ${fallbackCount}`,

--- a/docs/xlsx2md/tests/xlsx2md-main.test.js
+++ b/docs/xlsx2md/tests/xlsx2md-main.test.js
@@ -285,6 +285,112 @@ describe("xlsx2md core", () => {
     expect(markdownFile.markdown).toContain("| 12 | 和暦 | value12 | 令和8年3月17日 | 和暦 |");
   });
 
+  it("extracts chart metadata blocks from drawing charts", async () => {
+    const api = bootCore();
+    const workbookXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <sheets>
+          <sheet name="ChartSheet" sheetId="1" r:id="rId1"/>
+        </sheets>
+      </workbook>`;
+    const workbookRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+      </Relationships>`;
+    const sheetXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <sheetData>
+          <row r="1"><c r="A1" t="inlineStr"><is><t>Chart Sample</t></is></c></row>
+        </sheetData>
+        <drawing r:id="rId1"/>
+      </worksheet>`;
+    const sheetRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/>
+      </Relationships>`;
+    const drawingXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+        <xdr:twoCellAnchor>
+          <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>17</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+          <xdr:to><xdr:col>7</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>34</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+          <xdr:graphicFrame>
+            <xdr:nvGraphicFramePr><xdr:cNvPr id="2" name="Chart 1"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr>
+            <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+                <c:chart r:id="rId1"/>
+              </a:graphicData>
+            </a:graphic>
+          </xdr:graphicFrame>
+          <xdr:clientData/>
+        </xdr:twoCellAnchor>
+      </xdr:wsDr>`;
+    const drawingRels = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+        <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+      </Relationships>`;
+    const chartXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+        <c:chart>
+          <c:title><c:tx><c:rich><a:p><a:r><a:t>Sample Sales Chart</a:t></a:r></a:p></c:rich></c:tx></c:title>
+          <c:plotArea>
+            <c:barChart>
+              <c:ser>
+                <c:tx><c:v>Series A</c:v></c:tx>
+                <c:cat><c:strRef><c:f>ChartSheet!$B$3:$B$6</c:f></c:strRef></c:cat>
+                <c:val><c:numRef><c:f>ChartSheet!$E$3:$E$6</c:f></c:numRef></c:val>
+              </c:ser>
+              <c:ser>
+                <c:tx><c:v>Series B</c:v></c:tx>
+                <c:cat><c:strRef><c:f>ChartSheet!$B$3:$B$6</c:f></c:strRef></c:cat>
+                <c:val><c:numRef><c:f>ChartSheet!$D$3:$D$6</c:f></c:numRef></c:val>
+              </c:ser>
+            </c:barChart>
+          </c:plotArea>
+        </c:chart>
+      </c:chartSpace>`;
+    const arrayBuffer = createStoredZip([
+      { name: "[Content_Types].xml", data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+          <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+          <Default Extension="xml" ContentType="application/xml"/>
+        </Types>` },
+      { name: "_rels/.rels", data: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+          <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+        </Relationships>` },
+      { name: "xl/workbook.xml", data: workbookXml },
+      { name: "xl/_rels/workbook.xml.rels", data: workbookRels },
+      { name: "xl/worksheets/sheet1.xml", data: sheetXml },
+      { name: "xl/worksheets/_rels/sheet1.xml.rels", data: sheetRels },
+      { name: "xl/drawings/drawing1.xml", data: drawingXml },
+      { name: "xl/drawings/_rels/drawing1.xml.rels", data: drawingRels },
+      { name: "xl/charts/chart1.xml", data: chartXml }
+    ]);
+
+    const workbook = await api.parseWorkbook(arrayBuffer, "chart-sample.xlsx");
+    const markdownFile = api.convertWorkbookToMarkdownFiles(workbook, {
+      treatFirstRowAsHeader: true,
+      trimText: true,
+      removeEmptyRows: true,
+      removeEmptyColumns: true
+    })[0];
+
+    expect(workbook.sheets[0].charts).toHaveLength(1);
+    expect(workbook.sheets[0].charts[0].anchor).toBe("B18");
+    expect(workbook.sheets[0].charts[0].title).toBe("Sample Sales Chart");
+    expect(workbook.sheets[0].charts[0].chartType).toContain("棒グラフ");
+    expect(workbook.sheets[0].charts[0].series).toHaveLength(2);
+    expect(markdownFile.summary.charts).toBe(1);
+    expect(markdownFile.markdown).toContain("## グラフ");
+    expect(markdownFile.markdown).toContain("### グラフ001 (B18)");
+    expect(markdownFile.markdown).toContain("- タイトル: Sample Sales Chart");
+    expect(markdownFile.markdown).toContain("- 種別: 棒グラフ");
+    expect(markdownFile.markdown).toContain("  - Series A");
+    expect(markdownFile.markdown).toContain("    - categories: ChartSheet!$B$3:$B$6");
+    expect(markdownFile.markdown).toContain("    - values: ChartSheet!$E$3:$E$6");
+  });
+
   it("parses the merge-pattern fixture workbook with concrete merge expectations", async () => {
     const api = bootCore();
     const fixtureName = "merge-pattern-sample01.xlsx";

--- a/docs/xlsx2md/xlsx2md.html
+++ b/docs/xlsx2md/xlsx2md.html
@@ -6364,6 +6364,97 @@ if (!customElements.get("lht-page-menu")) {
         }
         return imageAssets;
     }
+    function parseChartType(chartDoc) {
+        const typeMap = [
+            { localName: "barChart", label: "棒グラフ" },
+            { localName: "lineChart", label: "折れ線グラフ" },
+            { localName: "pieChart", label: "円グラフ" },
+            { localName: "doughnutChart", label: "ドーナツグラフ" },
+            { localName: "areaChart", label: "面グラフ" },
+            { localName: "scatterChart", label: "散布図" },
+            { localName: "radarChart", label: "レーダーチャート" },
+            { localName: "bubbleChart", label: "バブルチャート" }
+        ];
+        const matched = typeMap
+            .filter((entry) => getElementsByLocalName(chartDoc, entry.localName).length > 0)
+            .map((entry) => entry.label);
+        if (matched.length === 0)
+            return "グラフ";
+        if (matched.length === 1)
+            return matched[0];
+        return `${matched.join(" + ")} (複合)`;
+    }
+    function parseChartTitle(chartDoc) {
+        const richText = getElementsByLocalName(chartDoc, "t")
+            .map((node) => getTextContent(node))
+            .filter(Boolean);
+        if (richText.length > 0) {
+            return richText.join("").trim();
+        }
+        return "";
+    }
+    function parseChartSeries(chartDoc) {
+        return getElementsByLocalName(chartDoc, "ser").map((seriesNode) => {
+            const nameRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "f");
+            const nameValue = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "v");
+            const nameText = getElementsByLocalName(getFirstChildByLocalName(seriesNode, "tx") || seriesNode, "t")
+                .map((node) => getTextContent(node))
+                .join("")
+                .trim();
+            const catRef = getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "strRef") || seriesNode, "f")
+                || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "cat") || seriesNode, "numRef") || seriesNode, "f");
+            const valRef = getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "f")
+                || getFirstChildByLocalName(getFirstChildByLocalName(getFirstChildByLocalName(seriesNode, "val") || seriesNode, "numRef") || seriesNode, "f");
+            return {
+                name: nameText || getTextContent(nameValue) || getTextContent(nameRef) || "系列",
+                categoriesRef: getTextContent(catRef),
+                valuesRef: getTextContent(valRef)
+            };
+        });
+    }
+    function parseDrawingCharts(files, sheetName, sheetPath) {
+        const sheetRels = parseRelationships(files, buildRelsPath(sheetPath), sheetPath);
+        const charts = [];
+        for (const drawingPath of sheetRels.values()) {
+            if (!/\/drawings\/.+\.xml$/i.test(drawingPath))
+                continue;
+            const drawingBytes = files.get(drawingPath);
+            if (!drawingBytes)
+                continue;
+            const drawingDoc = xmlToDocument(decodeXmlText(drawingBytes));
+            const drawingRels = parseRelationships(files, buildRelsPath(drawingPath), drawingPath);
+            const anchors = getElementsByLocalName(drawingDoc, "oneCellAnchor").concat(getElementsByLocalName(drawingDoc, "twoCellAnchor"));
+            for (const anchor of anchors) {
+                const from = getFirstChildByLocalName(anchor, "from");
+                const colNode = getFirstChildByLocalName(from || anchor, "col");
+                const rowNode = getFirstChildByLocalName(from || anchor, "row");
+                const col = Number(getTextContent(colNode)) + 1;
+                const row = Number(getTextContent(rowNode)) + 1;
+                if (!Number.isFinite(col) || !Number.isFinite(row) || col <= 0 || row <= 0) {
+                    continue;
+                }
+                const chartNode = getFirstChildByLocalName(anchor, "graphicFrame");
+                const chartRef = getElementsByLocalName(chartNode || anchor, "chart")[0] || null;
+                const relId = (chartRef === null || chartRef === void 0 ? void 0 : chartRef.getAttribute("r:id")) || (chartRef === null || chartRef === void 0 ? void 0 : chartRef.getAttribute("id")) || "";
+                const chartPath = drawingRels.get(relId) || "";
+                if (!chartPath)
+                    continue;
+                const chartBytes = files.get(chartPath);
+                if (!chartBytes)
+                    continue;
+                const chartDoc = xmlToDocument(decodeXmlText(chartBytes));
+                charts.push({
+                    sheetName,
+                    anchor: `${colToLetters(col)}${row}`,
+                    chartPath,
+                    title: parseChartTitle(chartDoc),
+                    chartType: parseChartType(chartDoc),
+                    series: parseChartSeries(chartDoc)
+                });
+            }
+        }
+        return charts;
+    }
     function extractCellOutputValue(cellElement, sharedStrings, cellStyle, formulaOverride = "") {
         const type = (cellElement.getAttribute("t") || "").trim();
         const valueNode = cellElement.getElementsByTagName("v")[0] || null;
@@ -8541,6 +8632,7 @@ if (!customElements.get("lht-page-menu")) {
         const merges = Array.from(doc.getElementsByTagName("mergeCell")).map((mergeElement) => parseRangeRef(mergeElement.getAttribute("ref") || ""));
         const tables = parseWorksheetTables(files, doc, sheetName, sheetPath);
         const images = parseDrawingImages(files, sheetName, sheetPath);
+        const charts = parseDrawingCharts(files, sheetName, sheetPath);
         let maxRow = 0;
         let maxCol = 0;
         for (const cell of cells) {
@@ -8563,6 +8655,7 @@ if (!customElements.get("lht-page-menu")) {
             merges,
             tables,
             images,
+            charts,
             maxRow,
             maxCol
         };
@@ -8805,6 +8898,7 @@ if (!customElements.get("lht-page-menu")) {
         return true;
     }
     function extractSectionBlocks(sheet, tables, narrativeBlocks) {
+        const charts = sheet.charts || [];
         const anchors = [];
         for (const block of narrativeBlocks) {
             anchors.push({
@@ -8824,6 +8918,17 @@ if (!customElements.get("lht-page-menu")) {
         }
         for (const image of sheet.images) {
             const anchor = parseCellAddress(image.anchor);
+            if (anchor.row > 0 && anchor.col > 0) {
+                anchors.push({
+                    startRow: anchor.row,
+                    startCol: anchor.col,
+                    endRow: anchor.row,
+                    endCol: anchor.col
+                });
+            }
+        }
+        for (const chart of charts) {
+            const anchor = parseCellAddress(chart.anchor);
             if (anchor.row > 0 && anchor.col > 0) {
                 anchors.push({
                     startRow: anchor.row,
@@ -9066,6 +9171,7 @@ if (!customElements.get("lht-page-menu")) {
     }
     function convertSheetToMarkdown(workbook, sheet, options = {}) {
         var _a;
+        const charts = sheet.charts || [];
         const treatFirstRowAsHeader = options.treatFirstRowAsHeader !== false;
         const tables = detectTableCandidates(sheet);
         const narrativeBlocks = extractNarrativeBlocks(sheet, tables, options);
@@ -9151,6 +9257,33 @@ if (!customElements.get("lht-page-menu")) {
                 ].join("\n"))
             ].join("\n")
             : "";
+        const chartSection = charts.length > 0
+            ? [
+                "",
+                "## グラフ",
+                "",
+                ...charts.map((chart, index) => {
+                    const lines = [
+                        `### グラフ${String(index + 1).padStart(3, "0")} (${chart.anchor})`,
+                        `- タイトル: ${chart.title || "(なし)"}`,
+                        `- 種別: ${chart.chartType}`
+                    ];
+                    if (chart.series.length > 0) {
+                        lines.push("- 系列:");
+                        for (const series of chart.series) {
+                            lines.push(`  - ${series.name}`);
+                            if (series.categoriesRef) {
+                                lines.push(`    - categories: ${series.categoriesRef}`);
+                            }
+                            if (series.valuesRef) {
+                                lines.push(`    - values: ${series.valuesRef}`);
+                            }
+                        }
+                    }
+                    return lines.join("\n");
+                })
+            ].join("\n")
+            : "";
         const markdown = [
             `# ${sheet.name}`,
             "",
@@ -9161,6 +9294,7 @@ if (!customElements.get("lht-page-menu")) {
             "## 本文",
             "",
             body || "_抽出できる本文はありませんでした。_",
+            chartSection,
             imageSection
         ].join("\n");
         return {
@@ -9174,6 +9308,7 @@ if (!customElements.get("lht-page-menu")) {
                 narrativeBlocks: narrativeBlocks.length,
                 merges: sheet.merges.length,
                 images: sheet.images.length,
+                charts: charts.length,
                 cells: sheet.cells.length,
                 tableScores: tables.map((table) => ({
                     range: formatRange(table.startRow, table.startCol, table.endRow, table.endCol),
@@ -9199,6 +9334,7 @@ if (!customElements.get("lht-page-menu")) {
             `地の文ブロック: ${markdownFile.summary.narrativeBlocks}`,
             `結合セル範囲: ${markdownFile.summary.merges}`,
             `画像: ${markdownFile.summary.images}`,
+            `グラフ: ${markdownFile.summary.charts}`,
             `解析セル数: ${markdownFile.summary.cells}`,
             `数式 resolved: ${resolvedCount}`,
             `数式 fallback_formula: ${fallbackCount}`,


### PR DESCRIPTION
## 概要

`xlsx2md` を中心に、Excel グラフを画像ではなく意味情報として扱う最小実装と、関連ドキュメントの同期が行われています。

## 変更内容

### グラフメタデータ抽出の追加

以下のファイルが更新されています。

- `docs/xlsx2md/src/xlsx2md/ts/core.ts`
- `docs/xlsx2md/src/xlsx2md/js/core.js`
- `docs/xlsx2md/xlsx2md.html`

確認できた主な更新内容:

- `ParsedSheet` に `charts` を追加
- `drawing` 内の `chart` 参照をたどって、`xl/charts/*.xml` を読む処理を追加
- Markdown に `## グラフ` セクションを追加
- 最小実装として、以下を抽出して出力
  - アンカー位置
  - グラフタイトル
  - グラフ種別
  - 系列名
  - `categories` 参照範囲
  - `values` 参照範囲
- `summary` に `charts` 件数を追加
- 既存の手書き `sheet` オブジェクトを使うテストが壊れないよう、`sheet.charts` 未定義時の後方互換も追加

### テスト追加と見直し

以下のファイルが更新されています。

- `docs/xlsx2md/tests/xlsx2md-main.test.js`

確認できた主な更新内容:

- `drawing -> chart XML -> Markdown` の最小ケースを固定する unit test を追加
- テストは実データの値を直接使わず、手作りの最小 chart XML を使っている
- タイトルや系列名も、実データ由来ではなく汎用的な値へ差し替え済み
  - `Sample Sales Chart`
  - `Series A`
  - `Series B`

確認結果として、以下が実行されています。

- `npm run build:xlsx2md`
- `npm run test:unit -- docs/xlsx2md/tests/xlsx2md-main.test.js`

確認時点で `docs/xlsx2md/tests/xlsx2md-main.test.js` は `28 tests` 成功です。

### ドキュメント更新

以下のファイルが更新されています。

- `docs/xlsx2md/README.md`
- `docs/xlsx2md/xlsx2md-spec.md`
- `docs/xlsx2md/local-data-review.md`
- `TODO.md`

確認できた主な更新内容:

- README を現状説明寄りへ整理
  - `現在の状態`
  - `主な特徴`
  - `既知の制約` を追加
- `既知の制約` に、少なくとも以下を記載
  - `spill / dynamic array` は最小対応段階
  - 配列定数と `space intersection` は限定対応
  - フォーム風領域は保守的に扱う
  - カレンダー / ボード / ダッシュボード系は分解優先
  - evaluator は完全再実装ではなく補助
- README の構成図を、現状の `formula/`、`references/`、`fixtures/`、`local-data/` を含む内容へ更新
- spec に、現行 UI と出力仕様を同期
  - `.xlsx` 選択後の自動変換
  - 全シート前提
  - 解析系アコーディオン
  - 連結 Markdown の識別コメント
- `local-data-review.md` と `TODO.md` に、フォーム風領域を保守的に扱う現時点の判断を記録