### PR TITLE
Git 作業一覧と Git pseudo-squash の操作性を改善

### DIFF
--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -153,6 +153,12 @@ limitations under the License.
           <lht-help-tooltip label="作業開始の説明">
             基点から作業ブランチを切るステップです。この下で作成コマンドを生成します。
           </lht-help-tooltip>
+          <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" onclick="copyBackupBranchCommand()" title="backup 用ブランチ作成コマンドをコピー" aria-label="backup 用ブランチ作成コマンドをコピー">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+            </svg>
+            <span>Backup</span>
+          </button>
         </span>
       </div>
       <lht-command-block command-id="createBranchCmd"></lht-command-block>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -2622,6 +2622,12 @@ lht-index-card-link {
           <lht-help-tooltip label="作業開始の説明">
             基点から作業ブランチを切るステップです。この下で作成コマンドを生成します。
           </lht-help-tooltip>
+          <button type="button" class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" onclick="copyBackupBranchCommand()" title="backup 用ブランチ作成コマンドをコピー" aria-label="backup 用ブランチ作成コマンドをコピー">
+            <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <use href="#md-icon-copy" xlink:href="#md-icon-copy"></use>
+            </svg>
+            <span>Backup</span>
+          </button>
         </span>
       </div>
       <lht-command-block command-id="createBranchCmd"></lht-command-block>
@@ -5302,13 +5308,33 @@ if (!customElements.get("lht-page-menu")) {
         ? element.value
         : element.textContent;
       if (!text) return;
+      copyPlainText(text);
+      showToast("コピーしました");
+    }
+
+    function copyPlainText(text) {
+      if (!text) return;
       const temp = document.createElement("textarea");
       temp.value = text;
       document.body.appendChild(temp);
       temp.select();
       document.execCommand("copy");
       document.body.removeChild(temp);
-      showToast("コピーしました");
+    }
+
+    function formatBackupBranchTimestamp(date = new Date()) {
+      const year = String(date.getFullYear());
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const hours = String(date.getHours()).padStart(2, "0");
+      const minutes = String(date.getMinutes()).padStart(2, "0");
+      return `${year}-${month}-${day}-${hours}${minutes}`;
+    }
+
+    function copyBackupBranchCommand() {
+      const command = `git branch backup/${formatBackupBranchTimestamp()}`;
+      copyPlainText(command);
+      showToast("Backup 用ブランチ作成コマンドをコピーしました");
     }
 
     function showToast(message) {

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1212,7 +1212,7 @@ lht-index-card-link {
 .md-entry-head {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 1rem;
   flex-wrap: wrap;
 }
@@ -1221,6 +1221,8 @@ lht-index-card-link {
   min-width: 0;
   display: grid;
   gap: 0.35rem;
+  flex: 0 1 auto;
+  max-width: 100%;
 }
 
 .md-entry-title-row {
@@ -1239,6 +1241,7 @@ lht-index-card-link {
 
 .md-entry-base-box .md-ref-value {
   margin-left: 0;
+  font-size: 1.02rem;
 }
 
 .md-entry-title {
@@ -4343,7 +4346,8 @@ if (!customElements.get("lht-page-menu")) {
         locked: raw?.locked === true,
         remoteName: entryType === "git" ? (String(raw?.remoteName || "origin").trim() || "origin") : "",
         createdAt: Number(raw?.createdAt || raw?.updatedAt || Date.now()),
-        updatedAt: Number(raw?.updatedAt || Date.now())
+        updatedAt: Number(raw?.updatedAt || Date.now()),
+        lastOpenedAt: Number(raw?.lastOpenedAt || 0)
       };
     }
 
@@ -4402,6 +4406,8 @@ if (!customElements.get("lht-page-menu")) {
           baseBranch: entry.baseBranch,
           baseScope: entry.baseScope,
           remoteName: entry.remoteName,
+          createdAt: Number(entry.createdAt || 0),
+          lastOpenedAt: Number(entry.lastOpenedAt || 0),
           memoKey,
           memo: String(memos[memoKey]?.memo || "").trim(),
           gitCurrentDir: String(memos[memoKey]?.gitCurrentDir || "").trim(),
@@ -4411,6 +4417,11 @@ if (!customElements.get("lht-page-menu")) {
         createdGroup.displayName = isGitEntry(entry)
           ? buildDisplayName(entry)
           : buildUrlOnlyDisplayTitle(createdGroup.repoUrl, createdGroup.memo);
+        return;
+      });
+      groupedMap.forEach((group) => {
+        group.lastOpenedAt = Math.max(0, ...group.entries.map((entry) => Number(entry.lastOpenedAt || 0)));
+        group.createdAt = Math.max(0, ...group.entries.map((entry) => Number(entry.createdAt || 0)));
       });
       return Array.from(groupedMap.values());
     }
@@ -4470,6 +4481,34 @@ if (!customElements.get("lht-page-menu")) {
     function markToolUsed(entryId, tool) {
       recentActions = updateRecentActions(recentActions, entryId, tool);
       saveRecentActions();
+    }
+
+    function markEntryOpened(entryId) {
+      const entryIndex = entries.findIndex((item) => item.id === entryId);
+      if (entryIndex < 0) return;
+      entries[entryIndex] = {
+        ...entries[entryIndex],
+        lastOpenedAt: Date.now()
+      };
+      saveEntries();
+      renderEntries();
+    }
+
+    function markGroupOpened(groupKey) {
+      if (!groupKey) return;
+      const now = Date.now();
+      let changed = false;
+      entries = entries.map((entry) => {
+        if (buildGroupKey(entry) !== groupKey) return entry;
+        changed = true;
+        return {
+          ...entry,
+          lastOpenedAt: now
+        };
+      });
+      if (!changed) return;
+      saveEntries();
+      renderEntries();
     }
 
     function openBranchDiff(entry) {
@@ -4656,7 +4695,7 @@ if (!customElements.get("lht-page-menu")) {
               </div>
               <div class="md-entry-url-row">
                 <div class="md-entry-url">${escapeHtml(group.repoUrl)}</div>
-                ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
+                ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-group-key="${escapeHtml(group.key)}" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
               </div>
             </div>
             ${baseSection}
@@ -4774,6 +4813,7 @@ if (!customElements.get("lht-page-menu")) {
               </div>
             </div>
             <div class="md-entry-actions md-work-row__actions">
+              <button type="button" class="md-button md-button--surface" data-action="open-url-only-entry">${getButtonIconSvg("open-external")}<span>開く</span></button>
               <button type="button" class="md-button md-button--surface" data-action="edit-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("edit")}<span>変更</span></button>
               <button type="button" class="md-button md-button--danger" data-action="delete-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("delete")}<span>削除</span></button>
               <button type="button" class="md-button ${entry.locked ? "md-button--lock-active" : "md-button--surface"}" data-action="toggle-lock">${getButtonIconSvg(entry.locked ? "lock" : "unlock")}<span>${entry.locked ? "解除" : "ロック"}</span></button>
@@ -4807,10 +4847,13 @@ if (!customElements.get("lht-page-menu")) {
     function renderEntries() {
       const list = document.getElementById("entriesList");
       if (!list) return;
-      const visibleEntries = entries
-        .slice()
-        .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0));
-      const visibleGroups = groupEntriesByBase(visibleEntries);
+      const visibleGroups = groupEntriesByBase(entries.slice())
+        .sort((left, right) => {
+          const openedDiff = Number(right.lastOpenedAt || 0) - Number(left.lastOpenedAt || 0);
+          if (openedDiff !== 0) return openedDiff;
+          return Number(right.createdAt || 0) - Number(left.createdAt || 0);
+        });
+      const visibleEntries = visibleGroups.flatMap((group) => group.entries);
 
       updateEmptyGuide(visibleEntries.length);
       updatePrimaryActionsState();
@@ -4889,6 +4932,7 @@ if (!customElements.get("lht-page-menu")) {
       if (action === "open-repo-url") {
         const repoUrl = button.getAttribute("data-repo-url");
         if (!isOpenableExternalUrl(repoUrl)) return;
+        markGroupOpened(button.getAttribute("data-group-key"));
         window.open(repoUrl, "_blank", "noopener,noreferrer");
         return;
       }
@@ -4900,12 +4944,19 @@ if (!customElements.get("lht-page-menu")) {
 
       if (action === "open-branch-diff") {
         markToolUsed(entryId, "branch-diff");
+        markEntryOpened(entryId);
         openBranchDiff(entry);
         return;
       }
       if (action === "open-pseudo-squash") {
         markToolUsed(entryId, "pseudo-squash");
+        markEntryOpened(entryId);
         openPseudoSquash(entry);
+        return;
+      }
+      if (action === "open-url-only-entry") {
+        markEntryOpened(entryId);
+        openRepoUrl(entry);
         return;
       }
       if (action === "edit-entry") {

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -372,13 +372,33 @@
         ? element.value
         : element.textContent;
       if (!text) return;
+      copyPlainText(text);
+      showToast("コピーしました");
+    }
+
+    function copyPlainText(text) {
+      if (!text) return;
       const temp = document.createElement("textarea");
       temp.value = text;
       document.body.appendChild(temp);
       temp.select();
       document.execCommand("copy");
       document.body.removeChild(temp);
-      showToast("コピーしました");
+    }
+
+    function formatBackupBranchTimestamp(date = new Date()) {
+      const year = String(date.getFullYear());
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const hours = String(date.getHours()).padStart(2, "0");
+      const minutes = String(date.getMinutes()).padStart(2, "0");
+      return `${year}-${month}-${day}-${hours}${minutes}`;
+    }
+
+    function copyBackupBranchCommand() {
+      const command = `git branch backup/${formatBackupBranchTimestamp()}`;
+      copyPlainText(command);
+      showToast("Backup 用ブランチ作成コマンドをコピーしました");
     }
 
     function showToast(message) {

--- a/docs/git/src/git-work-list/css/app.css
+++ b/docs/git/src/git-work-list/css/app.css
@@ -136,7 +136,7 @@
 .md-entry-head {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 1rem;
   flex-wrap: wrap;
 }
@@ -145,6 +145,8 @@
   min-width: 0;
   display: grid;
   gap: 0.35rem;
+  flex: 0 1 auto;
+  max-width: 100%;
 }
 
 .md-entry-title-row {
@@ -163,6 +165,7 @@
 
 .md-entry-base-box .md-ref-value {
   margin-left: 0;
+  font-size: 1.02rem;
 }
 
 .md-entry-title {

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -350,7 +350,8 @@
         locked: raw?.locked === true,
         remoteName: entryType === "git" ? (String(raw?.remoteName || "origin").trim() || "origin") : "",
         createdAt: Number(raw?.createdAt || raw?.updatedAt || Date.now()),
-        updatedAt: Number(raw?.updatedAt || Date.now())
+        updatedAt: Number(raw?.updatedAt || Date.now()),
+        lastOpenedAt: Number(raw?.lastOpenedAt || 0)
       };
     }
 
@@ -409,6 +410,8 @@
           baseBranch: entry.baseBranch,
           baseScope: entry.baseScope,
           remoteName: entry.remoteName,
+          createdAt: Number(entry.createdAt || 0),
+          lastOpenedAt: Number(entry.lastOpenedAt || 0),
           memoKey,
           memo: String(memos[memoKey]?.memo || "").trim(),
           gitCurrentDir: String(memos[memoKey]?.gitCurrentDir || "").trim(),
@@ -418,6 +421,11 @@
         createdGroup.displayName = isGitEntry(entry)
           ? buildDisplayName(entry)
           : buildUrlOnlyDisplayTitle(createdGroup.repoUrl, createdGroup.memo);
+        return;
+      });
+      groupedMap.forEach((group) => {
+        group.lastOpenedAt = Math.max(0, ...group.entries.map((entry) => Number(entry.lastOpenedAt || 0)));
+        group.createdAt = Math.max(0, ...group.entries.map((entry) => Number(entry.createdAt || 0)));
       });
       return Array.from(groupedMap.values());
     }
@@ -477,6 +485,34 @@
     function markToolUsed(entryId, tool) {
       recentActions = updateRecentActions(recentActions, entryId, tool);
       saveRecentActions();
+    }
+
+    function markEntryOpened(entryId) {
+      const entryIndex = entries.findIndex((item) => item.id === entryId);
+      if (entryIndex < 0) return;
+      entries[entryIndex] = {
+        ...entries[entryIndex],
+        lastOpenedAt: Date.now()
+      };
+      saveEntries();
+      renderEntries();
+    }
+
+    function markGroupOpened(groupKey) {
+      if (!groupKey) return;
+      const now = Date.now();
+      let changed = false;
+      entries = entries.map((entry) => {
+        if (buildGroupKey(entry) !== groupKey) return entry;
+        changed = true;
+        return {
+          ...entry,
+          lastOpenedAt: now
+        };
+      });
+      if (!changed) return;
+      saveEntries();
+      renderEntries();
     }
 
     function openBranchDiff(entry) {
@@ -663,7 +699,7 @@
               </div>
               <div class="md-entry-url-row">
                 <div class="md-entry-url">${escapeHtml(group.repoUrl)}</div>
-                ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
+                ${isOpenableExternalUrl(group.repoUrl) ? `<button type="button" class="md-entry-link-btn" data-action="open-repo-url" data-group-key="${escapeHtml(group.key)}" data-repo-url="${escapeHtml(group.repoUrl)}" title="URL を開く" aria-label="URL を開く">${getButtonIconSvg("open-external")}</button>` : ""}
               </div>
             </div>
             ${baseSection}
@@ -781,6 +817,7 @@
               </div>
             </div>
             <div class="md-entry-actions md-work-row__actions">
+              <button type="button" class="md-button md-button--surface" data-action="open-url-only-entry">${getButtonIconSvg("open-external")}<span>開く</span></button>
               <button type="button" class="md-button md-button--surface" data-action="edit-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("edit")}<span>変更</span></button>
               <button type="button" class="md-button md-button--danger" data-action="delete-entry" ${entry.locked ? "disabled" : ""}>${getButtonIconSvg("delete")}<span>削除</span></button>
               <button type="button" class="md-button ${entry.locked ? "md-button--lock-active" : "md-button--surface"}" data-action="toggle-lock">${getButtonIconSvg(entry.locked ? "lock" : "unlock")}<span>${entry.locked ? "解除" : "ロック"}</span></button>
@@ -814,10 +851,13 @@
     function renderEntries() {
       const list = document.getElementById("entriesList");
       if (!list) return;
-      const visibleEntries = entries
-        .slice()
-        .sort((left, right) => Number(right.createdAt || 0) - Number(left.createdAt || 0));
-      const visibleGroups = groupEntriesByBase(visibleEntries);
+      const visibleGroups = groupEntriesByBase(entries.slice())
+        .sort((left, right) => {
+          const openedDiff = Number(right.lastOpenedAt || 0) - Number(left.lastOpenedAt || 0);
+          if (openedDiff !== 0) return openedDiff;
+          return Number(right.createdAt || 0) - Number(left.createdAt || 0);
+        });
+      const visibleEntries = visibleGroups.flatMap((group) => group.entries);
 
       updateEmptyGuide(visibleEntries.length);
       updatePrimaryActionsState();
@@ -896,6 +936,7 @@
       if (action === "open-repo-url") {
         const repoUrl = button.getAttribute("data-repo-url");
         if (!isOpenableExternalUrl(repoUrl)) return;
+        markGroupOpened(button.getAttribute("data-group-key"));
         window.open(repoUrl, "_blank", "noopener,noreferrer");
         return;
       }
@@ -907,12 +948,19 @@
 
       if (action === "open-branch-diff") {
         markToolUsed(entryId, "branch-diff");
+        markEntryOpened(entryId);
         openBranchDiff(entry);
         return;
       }
       if (action === "open-pseudo-squash") {
         markToolUsed(entryId, "pseudo-squash");
+        markEntryOpened(entryId);
         openPseudoSquash(entry);
+        return;
+      }
+      if (action === "open-url-only-entry") {
+        markEntryOpened(entryId);
+        openRepoUrl(entry);
         return;
       }
       if (action === "edit-entry") {

--- a/docs/index-src.html
+++ b/docs/index-src.html
@@ -1086,10 +1086,10 @@
       </h2>
       <p class="md-section-subtitle">よく使うツールへのショートカット</p>
       <div class="md-grid md-grid-3 md-section">
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
         <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="生成AIプロンプト作成" desc="生成AIに引き渡す定型プロンプトの作成を支援します。"></lht-index-card-link>
         <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
-        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
+        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
       </div>
       </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2137,10 +2137,10 @@ lht-index-card-link {
       </h2>
       <p class="md-section-subtitle">よく使うツールへのショートカット</p>
       <div class="md-grid md-grid-3 md-section">
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
         <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="生成AIプロンプト作成" desc="生成AIに引き渡す定型プロンプトの作成を支援します。"></lht-index-card-link>
         <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
-        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
+        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
       </div>
       </section>
 


### PR DESCRIPTION
## 概要
`docs/index*`、`docs/git/git-work-list*`、`docs/git/git-pseudo-squash*` に変更があります。 主に、Quick Access の並び順調整、Git 作業一覧の表示/並び順改善、URLのみ項目の導線追加、Git pseudo-squash の Backup ボタン追加が含まれます。

## 変更内容
- Quick Access の並び順を調整
  - `Git 作業一覧` を先頭へ移動
  - `find検索` の表記を `find 検索` に変更
- Git 作業一覧の表示を調整
  - `基準` ボックスまわりの配置を変更
  - `基準` ブランチ名のフォントサイズを調整
- Git 作業一覧の並び順を変更
  - `createdAt` ベースの並びから、`lastOpenedAt` ベースの並びへ変更
  - `比較` / `Squash` / URL を開いた操作に応じて `lastOpenedAt` を更新
- `URLのみ` の項目に `開く` ボタンを追加
  - `変更` ボタンの左に追加
- Git pseudo-squash に `Backup` ボタンを追加
  - `作業開始 (基準ブランチから作成)` の右に追加
  - クリックで `git branch backup/YYYY-MM-DD-HHmm` 形式のコマンドをコピーする処理を追加

## 変更ファイル
- `docs/index-src.html`
- `docs/index.html`
- `docs/git/src/git-work-list/js/main.js`
- `docs/git/src/git-work-list/css/app.css`
- `docs/git/git-work-list.html`
- `docs/git/git-pseudo-squash-src.html`
- `docs/git/src/git-pseudo-squash/js/main.js`
- `docs/git/git-pseudo-squash.html`

## 補足
- 生成済み HTML も同一コミットに含まれています