### PR TITLE
git-pseudo-squashでURLのbaseBranchを履歴より優先するよう修正

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -6409,10 +6409,12 @@ if (!customElements.get("lht-page-menu")) {
     function loadPersistedBaseBranch() {
       const input = document.getElementById("squashBaseBranch");
       if (!input) return;
+      const params = readCurrentQueryParams();
+      const queryBaseBranch = String(params.get("baseBranch") || "").trim();
       try {
         const stored = localStorage.getItem(BASE_BRANCH_STORAGE_KEY);
         const history = getStoredBaseBranchHistory();
-        const restored = stored && stored.trim() ? stored.trim() : (history[0] || "");
+        const restored = queryBaseBranch || (stored && stored.trim() ? stored.trim() : (history[0] || ""));
         if (restored) {
           input.value = restored;
           if (!history.includes(restored)) {

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -1473,10 +1473,12 @@
     function loadPersistedBaseBranch() {
       const input = document.getElementById("squashBaseBranch");
       if (!input) return;
+      const params = readCurrentQueryParams();
+      const queryBaseBranch = String(params.get("baseBranch") || "").trim();
       try {
         const stored = localStorage.getItem(BASE_BRANCH_STORAGE_KEY);
         const history = getStoredBaseBranchHistory();
-        const restored = stored && stored.trim() ? stored.trim() : (history[0] || "");
+        const restored = queryBaseBranch || (stored && stored.trim() ? stored.trim() : (history[0] || ""));
         if (restored) {
           input.value = restored;
           if (!history.includes(restored)) {

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -497,6 +497,32 @@ window.__gitPseudoSquashTest = {
     expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
   });
 
+  it("prioritizes query baseBranch over persisted base-branch history", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitPseudoSquash.squashBaseBranch", "devel");
+    localStorage.setItem("gitPseudoSquash.squashBaseBranchHistory", '["devel","main"]');
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel2&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(document.getElementById("squashBaseBranch").value).toBe("devel2");
+  });
+
   it("builds branch-diff URL with HEAD when current branch mode is enabled", () => {
     bootGitPseudoSquashPage();
 


### PR DESCRIPTION
### 概要
`git-pseudo-squash` の基点ブランチ復元処理を見直し、URL クエリの `baseBranch` がある場合は localStorage の保存値や履歴より優先して反映するよう修正しました。

### 変更内容
- `docs/git/src/git-pseudo-squash/js/main.js`
  - `loadPersistedBaseBranch()` で `baseBranch` クエリを読み取り、保存済みの基点ブランチ値より優先して適用するよう変更
- `docs/git/tests/git-pseudo-squash-main.test.js`
  - 保存済み履歴があっても、クエリの `baseBranch` が優先されることを確認するテストを追加
- `docs/git/git-pseudo-squash.html`
  - 生成物を更新

### 確認
- 対象コミットの差分上、テスト追加が含まれています
- 対象コミットの差分上、`git-pseudo-squash` 本体と生成 HTML の更新が含まれています