### PR TITLE
Git作業一覧の最終アクセス順ソート改善と git-pseudo-squash の Gitカレントディレクトリコピー対応

### DIFF
--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -312,6 +312,14 @@ limitations under the License.
           <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
         </svg>
       </button>
+      <button id="copyGitCurrentDirBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="7" width="14" height="12" rx="2"></rect>
+          <rect x="13" y="3" width="8" height="8" rx="2"></rect>
+          <path d="M15.5 7h3"></path>
+          <path d="M17 5.5v3"></path>
+        </svg>
+      </button>
     </div>
 
     <lht-toast id="toast"></lht-toast>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -2781,6 +2781,14 @@ lht-index-card-link {
           <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
         </svg>
       </button>
+      <button id="copyGitCurrentDirBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
+        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="7" width="14" height="12" rx="2"></rect>
+          <rect x="13" y="3" width="8" height="8" rx="2"></rect>
+          <path d="M15.5 7h3"></path>
+          <path d="M17 5.5v3"></path>
+        </svg>
+      </button>
     </div>
 
     <lht-toast id="toast"></lht-toast>
@@ -5664,6 +5672,7 @@ if (!customElements.get("lht-page-menu")) {
     const UI_SQUASH_REMOTE_STORAGE_KEY = "gitPseudoSquash.ui.squashRemote";
     const UI_USE_CURRENT_BRANCH_STORAGE_KEY = "gitPseudoSquash.ui.useCurrentBranch";
     const WORK_LIST_STORAGE_KEY = "gitWorkList.entries";
+    const WORK_LIST_MEMO_STORAGE_KEY = "gitWorkList.memos";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
     let baseBranchDefaultSuggestions = [];
     let baseBranchCurrentSuggestions = [];
@@ -5701,6 +5710,74 @@ if (!customElements.get("lht-page-menu")) {
 
     function readCurrentQueryParams() {
       return new URLSearchParams(window.location.search || "");
+    }
+
+    function buildWorkListMemoKey(repoUrl, baseBranch) {
+      return `${normalizeRepoUrl(repoUrl)}::${String(baseBranch || "").trim()}`;
+    }
+
+    function normalizeWorkListMemos(rawMemos) {
+      if (!rawMemos || typeof rawMemos !== "object" || Array.isArray(rawMemos)) {
+        return {};
+      }
+      const nextMemos = {};
+      Object.entries(rawMemos).forEach(([key, value]) => {
+        const normalizedKey = String(key || "").trim();
+        if (!normalizedKey) return;
+        if (typeof value === "string") {
+          const normalizedMemo = value.trim();
+          if (normalizedMemo) {
+            nextMemos[normalizedKey] = {
+              memo: normalizedMemo,
+              gitCurrentDir: ""
+            };
+          }
+          return;
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) return;
+        const normalizedMemo = String(value.memo || "").trim();
+        const normalizedGitCurrentDir = String(value.gitCurrentDir || "").trim();
+        if (normalizedMemo || normalizedGitCurrentDir) {
+          nextMemos[normalizedKey] = {
+            memo: normalizedMemo,
+            gitCurrentDir: normalizedGitCurrentDir
+          };
+        }
+      });
+      return nextMemos;
+    }
+
+    function loadWorkListMemos() {
+      try {
+        const raw = localStorage.getItem(WORK_LIST_MEMO_STORAGE_KEY);
+        if (!raw) return {};
+        return normalizeWorkListMemos(JSON.parse(raw));
+      } catch (_) {
+        return {};
+      }
+    }
+
+    function getGitCurrentDirectoryForCurrentContext() {
+      const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
+      const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
+      if (!repoUrl || !baseBranch) return "";
+      const memoKey = buildWorkListMemoKey(repoUrl, baseBranch);
+      return String(loadWorkListMemos()[memoKey]?.gitCurrentDir || "").trim();
+    }
+
+    function updateGitCurrentDirectoryAction() {
+      const button = document.getElementById("copyGitCurrentDirBtn");
+      if (!button) return;
+      const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
+      if (gitCurrentDir) {
+        button.dataset.gitCurrentDir = gitCurrentDir;
+        button.title = gitCurrentDir;
+        button.classList.remove("md-hidden");
+        return;
+      }
+      delete button.dataset.gitCurrentDir;
+      button.title = "git カレントディレクトリをコピー";
+      button.classList.add("md-hidden");
     }
 
     function applyQueryParams() {
@@ -5760,6 +5837,7 @@ if (!customElements.get("lht-page-menu")) {
           setSwitchSelected("lockOrigin", false);
         }
       }
+      updateGitCurrentDirectoryAction();
     }
 
     function createWorkBranchListEntryId() {
@@ -5782,7 +5860,8 @@ if (!customElements.get("lht-page-menu")) {
         locked: raw?.locked === true,
         remoteName: String(raw?.remoteName || "origin").trim() || "origin",
         createdAt: Number(raw?.createdAt || raw?.updatedAt || Date.now()),
-        updatedAt: Number(raw?.updatedAt || Date.now())
+        updatedAt: Number(raw?.updatedAt || Date.now()),
+        lastOpenedAt: Number(raw?.lastOpenedAt || 0)
       };
     }
 
@@ -5902,6 +5981,7 @@ if (!customElements.get("lht-page-menu")) {
         entry.baseBranch === baseBranch &&
         entry.compareBranch === compareBranch
       ));
+      const now = Date.now();
       const nextEntry = normalizeWorkBranchListEntry({
         id: existingIndex >= 0 ? entries[existingIndex].id : createWorkBranchListEntryId(),
         repoUrl,
@@ -5912,8 +5992,9 @@ if (!customElements.get("lht-page-menu")) {
         compareUseHead: getUseCurrentBranchSelected(),
         locked: existingIndex >= 0 ? entries[existingIndex].locked === true : false,
         remoteName,
-        createdAt: existingIndex >= 0 ? entries[existingIndex].createdAt : Date.now(),
-        updatedAt: Date.now()
+        createdAt: existingIndex >= 0 ? entries[existingIndex].createdAt : now,
+        updatedAt: now,
+        lastOpenedAt: now
       });
 
       if (existingIndex >= 0) {
@@ -5948,6 +6029,13 @@ if (!customElements.get("lht-page-menu")) {
       const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
       if (!isOpenableExternalUrl(repoUrl)) return;
       window.open(repoUrl, "_blank", "noopener,noreferrer");
+    }
+
+    function copyGitCurrentDirectory() {
+      const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
+      if (!gitCurrentDir) return;
+      copyPlainText(gitCurrentDir);
+      showToast("git カレントディレクトリをコピーしました");
     }
 
     function buildBranchDiffUrlFromPlannedDiff() {
@@ -6487,6 +6575,20 @@ if (!customElements.get("lht-page-menu")) {
       button.addEventListener("click", openRepoUrl);
     }
 
+    function setupCopyGitCurrentDirectoryButton() {
+      const button = document.getElementById("copyGitCurrentDirBtn");
+      if (!button) return;
+      button.addEventListener("click", copyGitCurrentDirectory);
+      const sync = () => updateGitCurrentDirectoryAction();
+      ["repoUrl", "squashBaseBranch"].forEach((id) => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("input", sync);
+        element.addEventListener("change", sync);
+      });
+      updateGitCurrentDirectoryAction();
+    }
+
     applyQueryParams();
     setupBaseBranchSuggestions();
     setupBaseBranchCombobox();
@@ -6506,6 +6608,7 @@ if (!customElements.get("lht-page-menu")) {
     setupWorkBranchListButton();
     setupBranchDiffButton();
     setupOpenRepoUrlButton();
+    setupCopyGitCurrentDirectoryButton();
     setupCodeSelectAll();
   </script>
 </body>

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -4389,6 +4389,12 @@ if (!customElements.get("lht-page-menu")) {
       ].join("::");
     }
 
+    function compareEntriesByRecentOrder(left, right) {
+      const openedDiff = Number(right?.lastOpenedAt || 0) - Number(left?.lastOpenedAt || 0);
+      if (openedDiff !== 0) return openedDiff;
+      return Number(right?.createdAt || 0) - Number(left?.createdAt || 0);
+    }
+
     function groupEntriesByBase(visibleEntries) {
       const groupedMap = new Map();
       visibleEntries.forEach((entry) => {
@@ -4420,6 +4426,7 @@ if (!customElements.get("lht-page-menu")) {
         return;
       });
       groupedMap.forEach((group) => {
+        group.entries.sort(compareEntriesByRecentOrder);
         group.lastOpenedAt = Math.max(0, ...group.entries.map((entry) => Number(entry.lastOpenedAt || 0)));
         group.createdAt = Math.max(0, ...group.entries.map((entry) => Number(entry.createdAt || 0)));
       });
@@ -4848,11 +4855,7 @@ if (!customElements.get("lht-page-menu")) {
       const list = document.getElementById("entriesList");
       if (!list) return;
       const visibleGroups = groupEntriesByBase(entries.slice())
-        .sort((left, right) => {
-          const openedDiff = Number(right.lastOpenedAt || 0) - Number(left.lastOpenedAt || 0);
-          if (openedDiff !== 0) return openedDiff;
-          return Number(right.createdAt || 0) - Number(left.createdAt || 0);
-        });
+        .sort(compareEntriesByRecentOrder);
       const visibleEntries = visibleGroups.flatMap((group) => group.entries);
 
       updateEmptyGuide(visibleEntries.length);

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -728,6 +728,7 @@
     const UI_SQUASH_REMOTE_STORAGE_KEY = "gitPseudoSquash.ui.squashRemote";
     const UI_USE_CURRENT_BRANCH_STORAGE_KEY = "gitPseudoSquash.ui.useCurrentBranch";
     const WORK_LIST_STORAGE_KEY = "gitWorkList.entries";
+    const WORK_LIST_MEMO_STORAGE_KEY = "gitWorkList.memos";
     const RECENT_ACTIONS_KEY = "gitWorkList.recentActions";
     let baseBranchDefaultSuggestions = [];
     let baseBranchCurrentSuggestions = [];
@@ -765,6 +766,74 @@
 
     function readCurrentQueryParams() {
       return new URLSearchParams(window.location.search || "");
+    }
+
+    function buildWorkListMemoKey(repoUrl, baseBranch) {
+      return `${normalizeRepoUrl(repoUrl)}::${String(baseBranch || "").trim()}`;
+    }
+
+    function normalizeWorkListMemos(rawMemos) {
+      if (!rawMemos || typeof rawMemos !== "object" || Array.isArray(rawMemos)) {
+        return {};
+      }
+      const nextMemos = {};
+      Object.entries(rawMemos).forEach(([key, value]) => {
+        const normalizedKey = String(key || "").trim();
+        if (!normalizedKey) return;
+        if (typeof value === "string") {
+          const normalizedMemo = value.trim();
+          if (normalizedMemo) {
+            nextMemos[normalizedKey] = {
+              memo: normalizedMemo,
+              gitCurrentDir: ""
+            };
+          }
+          return;
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) return;
+        const normalizedMemo = String(value.memo || "").trim();
+        const normalizedGitCurrentDir = String(value.gitCurrentDir || "").trim();
+        if (normalizedMemo || normalizedGitCurrentDir) {
+          nextMemos[normalizedKey] = {
+            memo: normalizedMemo,
+            gitCurrentDir: normalizedGitCurrentDir
+          };
+        }
+      });
+      return nextMemos;
+    }
+
+    function loadWorkListMemos() {
+      try {
+        const raw = localStorage.getItem(WORK_LIST_MEMO_STORAGE_KEY);
+        if (!raw) return {};
+        return normalizeWorkListMemos(JSON.parse(raw));
+      } catch (_) {
+        return {};
+      }
+    }
+
+    function getGitCurrentDirectoryForCurrentContext() {
+      const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
+      const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
+      if (!repoUrl || !baseBranch) return "";
+      const memoKey = buildWorkListMemoKey(repoUrl, baseBranch);
+      return String(loadWorkListMemos()[memoKey]?.gitCurrentDir || "").trim();
+    }
+
+    function updateGitCurrentDirectoryAction() {
+      const button = document.getElementById("copyGitCurrentDirBtn");
+      if (!button) return;
+      const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
+      if (gitCurrentDir) {
+        button.dataset.gitCurrentDir = gitCurrentDir;
+        button.title = gitCurrentDir;
+        button.classList.remove("md-hidden");
+        return;
+      }
+      delete button.dataset.gitCurrentDir;
+      button.title = "git カレントディレクトリをコピー";
+      button.classList.add("md-hidden");
     }
 
     function applyQueryParams() {
@@ -824,6 +893,7 @@
           setSwitchSelected("lockOrigin", false);
         }
       }
+      updateGitCurrentDirectoryAction();
     }
 
     function createWorkBranchListEntryId() {
@@ -846,7 +916,8 @@
         locked: raw?.locked === true,
         remoteName: String(raw?.remoteName || "origin").trim() || "origin",
         createdAt: Number(raw?.createdAt || raw?.updatedAt || Date.now()),
-        updatedAt: Number(raw?.updatedAt || Date.now())
+        updatedAt: Number(raw?.updatedAt || Date.now()),
+        lastOpenedAt: Number(raw?.lastOpenedAt || 0)
       };
     }
 
@@ -966,6 +1037,7 @@
         entry.baseBranch === baseBranch &&
         entry.compareBranch === compareBranch
       ));
+      const now = Date.now();
       const nextEntry = normalizeWorkBranchListEntry({
         id: existingIndex >= 0 ? entries[existingIndex].id : createWorkBranchListEntryId(),
         repoUrl,
@@ -976,8 +1048,9 @@
         compareUseHead: getUseCurrentBranchSelected(),
         locked: existingIndex >= 0 ? entries[existingIndex].locked === true : false,
         remoteName,
-        createdAt: existingIndex >= 0 ? entries[existingIndex].createdAt : Date.now(),
-        updatedAt: Date.now()
+        createdAt: existingIndex >= 0 ? entries[existingIndex].createdAt : now,
+        updatedAt: now,
+        lastOpenedAt: now
       });
 
       if (existingIndex >= 0) {
@@ -1012,6 +1085,13 @@
       const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
       if (!isOpenableExternalUrl(repoUrl)) return;
       window.open(repoUrl, "_blank", "noopener,noreferrer");
+    }
+
+    function copyGitCurrentDirectory() {
+      const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
+      if (!gitCurrentDir) return;
+      copyPlainText(gitCurrentDir);
+      showToast("git カレントディレクトリをコピーしました");
     }
 
     function buildBranchDiffUrlFromPlannedDiff() {
@@ -1551,6 +1631,20 @@
       button.addEventListener("click", openRepoUrl);
     }
 
+    function setupCopyGitCurrentDirectoryButton() {
+      const button = document.getElementById("copyGitCurrentDirBtn");
+      if (!button) return;
+      button.addEventListener("click", copyGitCurrentDirectory);
+      const sync = () => updateGitCurrentDirectoryAction();
+      ["repoUrl", "squashBaseBranch"].forEach((id) => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("input", sync);
+        element.addEventListener("change", sync);
+      });
+      updateGitCurrentDirectoryAction();
+    }
+
     applyQueryParams();
     setupBaseBranchSuggestions();
     setupBaseBranchCombobox();
@@ -1570,4 +1664,5 @@
     setupWorkBranchListButton();
     setupBranchDiffButton();
     setupOpenRepoUrlButton();
+    setupCopyGitCurrentDirectoryButton();
     setupCodeSelectAll();

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -393,6 +393,12 @@
       ].join("::");
     }
 
+    function compareEntriesByRecentOrder(left, right) {
+      const openedDiff = Number(right?.lastOpenedAt || 0) - Number(left?.lastOpenedAt || 0);
+      if (openedDiff !== 0) return openedDiff;
+      return Number(right?.createdAt || 0) - Number(left?.createdAt || 0);
+    }
+
     function groupEntriesByBase(visibleEntries) {
       const groupedMap = new Map();
       visibleEntries.forEach((entry) => {
@@ -424,6 +430,7 @@
         return;
       });
       groupedMap.forEach((group) => {
+        group.entries.sort(compareEntriesByRecentOrder);
         group.lastOpenedAt = Math.max(0, ...group.entries.map((entry) => Number(entry.lastOpenedAt || 0)));
         group.createdAt = Math.max(0, ...group.entries.map((entry) => Number(entry.createdAt || 0)));
       });
@@ -852,11 +859,7 @@
       const list = document.getElementById("entriesList");
       if (!list) return;
       const visibleGroups = groupEntriesByBase(entries.slice())
-        .sort((left, right) => {
-          const openedDiff = Number(right.lastOpenedAt || 0) - Number(left.lastOpenedAt || 0);
-          if (openedDiff !== 0) return openedDiff;
-          return Number(right.createdAt || 0) - Number(left.createdAt || 0);
-        });
+        .sort(compareEntriesByRecentOrder);
       const visibleEntries = visibleGroups.flatMap((group) => group.entries);
 
       updateEmptyGuide(visibleEntries.length);

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -38,6 +38,7 @@ function mountGitPseudoSquashDom() {
     <button id="openBranchDiffBtn" type="button">compare</button>
     <button id="saveToWorkBranchListBtn" type="button">save</button>
     <button id="openRepoUrlBtn" type="button">open</button>
+    <button id="copyGitCurrentDirBtn" type="button" class="md-hidden">copy dir</button>
     <div id="toast"></div>
     <dialog id="normalizeDiffDialog"></dialog>
     <div id="normalizeDiffBefore"></div>
@@ -121,6 +122,7 @@ describe("git-pseudo-squash main", () => {
     window.alert = vi.fn();
     window.__LHT_NAVIGATE__ = vi.fn();
     window.open = vi.fn();
+    document.execCommand = vi.fn(() => true);
     window.history.replaceState({}, "", "/docs/git/git-pseudo-squash.html");
   });
 
@@ -332,6 +334,7 @@ PR本文:
   });
 
   it("adds current pseudo-squash settings to git-work-list and navigates back", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1700000000000);
     bootGitPseudoSquashPage();
 
     document.getElementById("repoUrl").value = "https://example.com/repo-a";
@@ -352,14 +355,17 @@ PR本文:
     expect(savedEntries[0].compareScope).toBe("local");
     expect(savedEntries[0].compareUseHead).toBe(true);
     expect(savedEntries[0].remoteName).toBe("upstream");
+    expect(savedEntries[0].lastOpenedAt).toBe(1700000000000);
     expect(getSavedJsonByKey("gitWorkList.recentActions")).toEqual({
       "branch-diff": [],
       "pseudo-squash": [savedEntries[0].id]
     });
     expect(window.__LHT_NAVIGATE__).toHaveBeenCalledWith("git-work-list.html");
+    nowSpy.mockRestore();
   });
 
   it("keeps lock state when updating an existing work-branch-list entry", () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1700000001234);
     localStorage.setItem("gitWorkList.entries", JSON.stringify([
       {
         id: "existing-id",
@@ -371,7 +377,8 @@ PR本文:
         compareUseHead: false,
         locked: true,
         remoteName: "origin",
-        updatedAt: 1
+        updatedAt: 1,
+        lastOpenedAt: 9
       }
     ]));
 
@@ -388,10 +395,12 @@ PR本文:
     expect(savedEntries[0].id).toBe("existing-id");
     expect(savedEntries[0].locked).toBe(true);
     expect(savedEntries[0].createdAt).toBe(1);
+    expect(savedEntries[0].lastOpenedAt).toBe(1700000001234);
     expect(getSavedJsonByKey("gitWorkList.recentActions")).toEqual({
       "branch-diff": [],
       "pseudo-squash": ["existing-id"]
     });
+    nowSpy.mockRestore();
   });
 
   it("applies repo, branch, scope, and remote from URL params", () => {
@@ -472,6 +481,31 @@ window.__gitPseudoSquashTest = {
     expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
   });
 
+  it("prioritizes query useCurrentBranch=true over persisted current-branch preference", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitPseudoSquash.ui.useCurrentBranch", "false");
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel&workBranch=feature-a&useCurrentBranch=true"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
+  });
+
   it("prioritizes query useCurrentBranch=false over persisted current-branch preference", () => {
     installLocalStorageMock();
     localStorage.setItem("gitPseudoSquash.ui.useCurrentBranch", "true");
@@ -495,6 +529,54 @@ window.__gitPseudoSquashTest = {
     new Function(instrumentedCode)();
 
     expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(false);
+  });
+
+  it("keeps current-branch mode on by default when query and persisted value are both absent", () => {
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
+  });
+
+  it("keeps current-branch mode on when persisted value is invalid", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitPseudoSquash.ui.useCurrentBranch", "broken");
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?baseBranch=devel&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
   });
 
   it("prioritizes query baseBranch over persisted base-branch history", () => {
@@ -570,5 +652,80 @@ window.__gitPseudoSquashTest = {
     document.getElementById("openRepoUrlBtn").click();
 
     expect(window.open).toHaveBeenCalledWith("https://example.com/repo-a", "_blank", "noopener,noreferrer");
+  });
+
+  it("shows git current directory copy button when saved in git-work-list memos", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::devel": {
+        memo: "memo",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    }));
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    const copyButton = document.getElementById("copyGitCurrentDirBtn");
+    expect(copyButton.classList.contains("md-hidden")).toBe(false);
+    expect(copyButton.title).toBe("/tmp/repo-a");
+  });
+
+  it("copies git current directory from the URL row action button", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::devel": {
+        memo: "memo",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    }));
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    document.getElementById("copyGitCurrentDirBtn").click();
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(document.getElementById("toast").show).toHaveBeenCalledWith("git カレントディレクトリをコピーしました", 2200);
+  });
+
+  it("keeps git current directory copy button hidden when no saved path exists", () => {
+    bootGitPseudoSquashPage();
+
+    document.getElementById("repoUrl").value = "https://example.com/repo-a";
+    document.getElementById("squashBaseBranch").value = "devel";
+    document.getElementById("repoUrl").dispatchEvent(new Event("input"));
+
+    expect(document.getElementById("copyGitCurrentDirBtn").classList.contains("md-hidden")).toBe(true);
   });
 });

--- a/docs/git/tests/git-work-list-main.test.js
+++ b/docs/git/tests/git-work-list-main.test.js
@@ -388,6 +388,39 @@ describe("git-work-list main", () => {
     expect(document.getElementById("entriesList").textContent).toContain("feature-b");
   });
 
+  it("sorts work rows within the same group by last opened time", () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "devel",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "local",
+        remoteName: "origin",
+        createdAt: 1,
+        lastOpenedAt: 10
+      },
+      {
+        id: "b",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "devel",
+        baseScope: "remote",
+        compareBranch: "feature-b",
+        compareScope: "local",
+        remoteName: "origin",
+        createdAt: 2,
+        lastOpenedAt: 20
+      }
+    ]));
+
+    bootPage();
+
+    const workRows = Array.from(document.querySelectorAll(".md-entry-group .md-work-row .md-ref-value"))
+      .map((node) => node.textContent.trim());
+    expect(workRows).toEqual(["feature-b", "feature-a"]);
+  });
+
   it("shows a newly added entry at the top of the list", () => {
     localStorage.setItem("gitWorkList.entries", JSON.stringify([
       {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-19</div>
+        <div class="md-app-meta">更新日: 2026-03-20</div>
       </div>
     </header>
 


### PR DESCRIPTION
### 概要

- `Git 作業一覧` で、作業行および基準ブランチ単位の表示順を最終アクセス時刻ベースで扱えるように調整しました。
- `git-pseudo-squash` に、`Git 作業一覧` のメモに保存された `gitCurrentDir` をコピーするボタンを追加しました。
- `現在ブランチで作業` スイッチの URL パラメータ優先と既定値に関するテストを追加しました。
- `docs/index.html` の更新日表示を `2026-03-20` に更新しました。

### 変更内容

- `docs/git/src/git-work-list/js/main.js`
  - `lastOpenedAt` と `createdAt` を使う共通比較関数を追加
  - 同一グループ内の作業行を最終アクセス順で並べるよう変更
  - 基準ブランチ単位のグループも同じ比較関数で並べるよう変更

- `docs/git/src/git-pseudo-squash/js/main.js`
  - `gitWorkList.memos` から `repoUrl` と `baseBranch` に対応する `gitCurrentDir` を取得する処理を追加
  - `gitCurrentDir` がある場合のみ表示するコピーボタンの制御を追加
  - 一覧へ保存するエントリに `lastOpenedAt` を含め、保存時に更新するよう変更
  - `useCurrentBranch` に関する URL パラメータ・保存値・既定値確認のテスト対象を補強

- `docs/git/git-pseudo-squash-src.html`
  - リポジトリ URL 右側に `git カレントディレクトリをコピー` ボタンを追加
  - 初期状態は非表示

- `docs/git/tests/git-work-list-main.test.js`
  - 同一グループ内で最終アクセス時刻順に作業行が並ぶことを確認するテストを追加

- `docs/git/tests/git-pseudo-squash-main.test.js`
  - 一覧保存時に `lastOpenedAt` が更新されることを確認するテストを追加
  - `useCurrentBranch=true/false` のクエリ優先、および既定 ON を確認するテストを追加
  - `gitCurrentDir` コピーボタンの表示・コピー動作・非表示条件を確認するテストを追加