### PR TITLE
ffmpeg 生成UIの自動更新化と prompt-gen 定義の見直し

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@
 - [横展開] music/git 以外の全アプリでも `lht-preview-output`（プレビュー表示＋コピー導線）を適用し、表示領域の重複実装を共通化する
 - [横展開] music/git 以外の全アプリでも `lht-command-block`（コマンド表示ブロック）を適用し、コマンド表示・コピー導線を共通化する
 - [ffmpeg] `docs/ffmpeg/ffmpeg-youtube-mkv-gen.html` を YouTube 専用命名から汎用寄りへ再設計する（ツール名・説明文・spec・出力プリセット差分の整理）
+- [ffmpeg][UI方針] 入力変更だけで確定できるコマンド生成については、生成ボタンを省略し、自動更新へ寄せられるかを各ツールで見直す
 - [mikuproject][仕様検討] `CSV + ParentID` を「まず押さえるべき、よくある交換形式」の第1候補として整理する。最小列は `ID / ParentID / Name`、実用候補は `Start / Finish / PredecessorID / Resource / PercentComplete / WBS` を含めて比較する
 - [mikuproject][仕様検討] `Mermaid + gantt` を可視化・共有向けの片方向エクスポート候補として整理する。`ProjectModel -> Mermaid gantt` の最小出力対象を `Task / Milestone / Start / Finish / Predecessor` 中心で定義し、落ちる情報を明記する
 - [ルール横展開] 表示制御属性は `active` に統一し、既存の `md-hidden` / `md-visible` 依存を段階的に削減する
@@ -49,6 +50,8 @@
 - [prompt-gen][仕様検討] 追加定義の削除 UI は初版で「追加ボタン全削除」のみとし、個別削除は次段階に回す
 - [prompt-gen][仕様検討] 追加ボタンの投入 UI を決める（JSON 入力欄、取り込みボタン、エラー表示、保存完了通知）
 - [prompt-gen][仕様検討] Single-file Web App 方針のまま成立することを確認し、README / prompt README への反映要否を整理する
+- [prompt-gen][名称見直し] `A863: 説明文をわかりやすく整理` は意図に対してやや弱いため、タイトル・見出し・話題ラベル導出を含む役割が伝わる名称へ見直す
+- [prompt-gen][仕様検討] `A851` `A854` `A861` `A862` `A863` に幻想防止を入れるかどうかを検討する
 - [prompt-gen][仕様検討] 出力オプション候補を整理する。スイッチや選択UIで切り替え可能なものを優先し、本文そのものの差し替えが必要なものとは分けて扱う
 - [prompt-gen][仕様検討][出力オプション候補] `Markdown出力` 系: 形式保証をどこまで共通オプション化できるか整理する（見出し順、必須項目、空欄時の書き方、箇条書き数など）
 - [prompt-gen][仕様検討][出力オプション候補] `幻想防止` 系: 情報不足時の挙動を共通オプション化できるか整理する（不明と書く、追加質問する、条件不足なら出力を控える等）

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen-src.html
@@ -210,7 +210,6 @@ Licensed under the Apache License, Version 2.0
 
     <!-- 2. 測定フェーズ -->
     <h2 class="md-section-title md-section-title--lg">2. 測定フェーズコマンド</h2>
-    <button onclick="generateAnalyzeCmd()" class="md-button md-button--primary md-field-block">測定用コマンド生成</button>
     <div class="md-field-block">
       <lht-command-block command-id="analyzeCmd"></lht-command-block>
     </div>
@@ -233,7 +232,6 @@ Licensed under the Apache License, Version 2.0
     </div>
 
     <div class="md-tab-panel" data-tab="tab-gain" id="finish-gain" hidden>
-      <button onclick="generateGainCmd()" class="md-button md-button--primary md-field-block">単純ゲインコマンド生成</button>
       <lht-command-block command-id="gainCmd"></lht-command-block>
     </div>
   </div>

--- a/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html
@@ -2355,7 +2355,6 @@ lht-index-card-link {
 
     <!-- 2. 測定フェーズ -->
     <h2 class="md-section-title md-section-title--lg">2. 測定フェーズコマンド</h2>
-    <button onclick="generateAnalyzeCmd()" class="md-button md-button--primary md-field-block">測定用コマンド生成</button>
     <div class="md-field-block">
       <lht-command-block command-id="analyzeCmd"></lht-command-block>
     </div>
@@ -2378,7 +2377,6 @@ lht-index-card-link {
     </div>
 
     <div class="md-tab-panel" data-tab="tab-gain" id="finish-gain" hidden>
-      <button onclick="generateGainCmd()" class="md-button md-button--primary md-field-block">単純ゲインコマンド生成</button>
       <lht-command-block command-id="gainCmd"></lht-command-block>
     </div>
   </div>
@@ -4512,10 +4510,15 @@ if (!customElements.get("lht-page-menu")) {
   <script>
     function generateAnalyzeCmd() {
       const filename = document.getElementById("filename").value.trim();
-      if (!filename) return alert("ファイル名を入力してください。");
+      const analyzeNode = document.getElementById("analyzeCmd");
+      if (!analyzeNode) return;
+      if (!filename) {
+        analyzeNode.textContent = "";
+        return;
+      }
       const outFile = filename.replace(/\.WAV$/i, "-loudnorm-meta.json");
       const cmd = `ffmpeg -i ${filename} -af loudnorm=print_format=json -f null - 2>&1 | tee ${outFile}`;
-      document.getElementById("analyzeCmd").textContent = cmd;
+      analyzeNode.textContent = cmd;
     }
 
     function extractJson(text) {
@@ -4591,56 +4594,70 @@ ${outFile}`;
       }
     }
 
-    function generateGainCmd() {
+    function buildGainCommand({ silent = false } = {}) {
+      const raw = document.getElementById("jsonInput").value;
+      const filenameInput = document.getElementById("filename");
+      let inputFile = filenameInput.value.trim();
+
+      let json;
       try {
-        const raw = document.getElementById("jsonInput").value;
         const extracted = extractJson(raw);
-        const json = JSON.parse(extracted);
-
-        const filenameInput = document.getElementById("filename");
-        let inputFile = filenameInput.value.trim();
-
-        if (!inputFile) {
-          const match = raw.match(/from '([^']+\.(wav|WAV|flac|aiff))'/);
-          if (match) {
-            inputFile = match[1];
-            filenameInput.value = inputFile;
-          } else {
-            alert("ファイル名を入力してください（または ffmpeg 出力に含まれる必要があります）。");
-            return;
-          }
-        }
-
-        const targetTP = Number(document.getElementById("gainTargetTp").value);
-        if (isNaN(targetTP)) {
-          alert("目標TPは数値で入力してください。");
-          return;
-        }
-
-        const inputTP = Number(json.input_tp);
-        if (isNaN(inputTP)) {
-          alert("input_tp が解析できません。ffmpeg 出力を確認してください。");
-          return;
-        }
-
-        const gain = Math.round((targetTP - inputTP) * 10) / 10;
-        const gainLabel = `${gain >= 0 ? "+" : ""}${gain}dB`;
-        const useCompressor = document.getElementById("gainUseCompressor").checked;
-
-        const { ar, sample_fmt, codec, rezTag } = getRezConfig();
-        const tpTag = `tp${targetTP.toFixed(1).replace(".", "p")}`;
-        const compTag = useCompressor ? "comp" : "plain";
-        const outFile = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${gainLabel}.wav`);
-        const outFileWithComp = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${compTag}-${gainLabel}.wav`);
-        const filter = useCompressor
-          ? `volume=${gainLabel},acompressor=threshold=-20dB:ratio=2.5:attack=8:release=150`
-          : `volume=${gainLabel}`;
-        const cmd = `ffmpeg -i ${inputFile} -af "${filter}" -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFileWithComp}`;
-
-        document.getElementById("gainCmd").textContent = cmd;
+        json = JSON.parse(extracted);
       } catch (e) {
-        alert("正しい JSON を含む ffmpeg 出力を貼り付けてください。\n" + e.message);
+        if (!silent) {
+          alert("正しい JSON を含む ffmpeg 出力を貼り付けてください。\n" + e.message);
+        }
+        return null;
       }
+
+      if (!inputFile) {
+        const match = raw.match(/from '([^']+\.(wav|WAV|flac|aiff))'/);
+        if (match) {
+          inputFile = match[1];
+          filenameInput.value = inputFile;
+        } else {
+          if (!silent) {
+            alert("ファイル名を入力してください（または ffmpeg 出力に含まれる必要があります）。");
+          }
+          return null;
+        }
+      }
+
+      const targetTP = Number(document.getElementById("gainTargetTp").value);
+      if (isNaN(targetTP)) {
+        if (!silent) {
+          alert("目標TPは数値で入力してください。");
+        }
+        return null;
+      }
+
+      const inputTP = Number(json.input_tp);
+      if (isNaN(inputTP)) {
+        if (!silent) {
+          alert("input_tp が解析できません。ffmpeg 出力を確認してください。");
+        }
+        return null;
+      }
+
+      const gain = Math.round((targetTP - inputTP) * 10) / 10;
+      const gainLabel = `${gain >= 0 ? "+" : ""}${gain}dB`;
+      const useCompressor = document.getElementById("gainUseCompressor").checked;
+
+      const { ar, sample_fmt, codec, rezTag } = getRezConfig();
+      const tpTag = `tp${targetTP.toFixed(1).replace(".", "p")}`;
+      const compTag = useCompressor ? "comp" : "plain";
+      const outFileWithComp = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${compTag}-${gainLabel}.wav`);
+      const filter = useCompressor
+        ? `volume=${gainLabel},acompressor=threshold=-20dB:ratio=2.5:attack=8:release=150`
+        : `volume=${gainLabel}`;
+      return `ffmpeg -i ${inputFile} -af "${filter}" -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFileWithComp}`;
+    }
+
+    function generateGainCmd({ silent = false } = {}) {
+      const gainNode = document.getElementById("gainCmd");
+      if (!gainNode) return;
+      const cmd = buildGainCommand({ silent });
+      gainNode.textContent = cmd || "";
     }
 
     function showToast(message) {
@@ -4676,6 +4693,40 @@ ${outFile}`;
     });
 
     setActiveTab("tab-icu");
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const filenameInput = document.getElementById("filename");
+      if (filenameInput) {
+        filenameInput.addEventListener("input", generateAnalyzeCmd);
+        filenameInput.addEventListener("change", generateAnalyzeCmd);
+        filenameInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        filenameInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const jsonInput = document.getElementById("jsonInput");
+      if (jsonInput) {
+        jsonInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        jsonInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const gainTargetTpInput = document.getElementById("gainTargetTp");
+      if (gainTargetTpInput) {
+        gainTargetTpInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        gainTargetTpInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const hiresSwitch = document.getElementById("hires");
+      if (hiresSwitch) {
+        hiresSwitch.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const gainUseCompressorSwitch = document.getElementById("gainUseCompressor");
+      if (gainUseCompressorSwitch) {
+        gainUseCompressorSwitch.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+      generateAnalyzeCmd();
+      generateGainCmd({ silent: true });
+    });
   </script>
 </body>
 </html>

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen-src.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen-src.html
@@ -80,10 +80,6 @@ limitations under the License.
       help-text="出力ファイル名の連番に利用します。"
     ></lht-text-field-help>
 
-    <button onclick="generateClipCommand()" class="md-button md-button--primary md-field-block">
-      切り出しコマンド生成
-    </button>
-
     <lht-command-block command-id="clipCmd"></lht-command-block>
 
     <div id="toast" class="md-snackbar md-hidden">

--- a/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
+++ b/docs/ffmpeg/ffmpeg-trim-cmdline-gen.html
@@ -2127,10 +2127,6 @@ lht-index-card-link {
       help-text="出力ファイル名の連番に利用します。"
     ></lht-text-field-help>
 
-    <button onclick="generateClipCommand()" class="md-button md-button--primary md-field-block">
-      切り出しコマンド生成
-    </button>
-
     <lht-command-block command-id="clipCmd"></lht-command-block>
 
     <div id="toast" class="md-snackbar md-hidden">
@@ -4276,8 +4272,12 @@ if (!customElements.get("lht-page-menu")) {
       const startInput = document.getElementById("start").value.trim();
       const endInput = document.getElementById("end").value.trim();
       const partNumber = document.getElementById("partNumber").value.trim() || "1";
-
-      if (!fileInput) return alert("入力ファイル名を入力してください。");
+      const commandNode = document.getElementById("clipCmd");
+      if (!commandNode) return;
+      if (!fileInput) {
+        commandNode.textContent = "";
+        return;
+      }
 
       const startSec = startInput ? parseTime(startInput) : NaN;
       const endSec = endInput ? parseTime(endInput) : NaN;
@@ -4303,7 +4303,7 @@ if (!customElements.get("lht-page-menu")) {
       const outFile = `${baseName}-part${partNumber}.${extension}`;
       const cmd = `ffmpeg${ssPart} -i ${fileInput}${tPart} -c copy ${outFile}`;
 
-      document.getElementById("clipCmd").textContent = cmd;
+      commandNode.textContent = cmd;
     }
 
     function showToast(message) {
@@ -4316,6 +4316,16 @@ if (!customElements.get("lht-page-menu")) {
         toast.classList.add("md-hidden");
       }, 2000);
     }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      ["filename", "start", "end", "partNumber"].forEach((id) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.addEventListener("input", generateClipCommand);
+        input.addEventListener("change", generateClipCommand);
+      });
+      generateClipCommand();
+    });
   </script>
 </body>
 </html>

--- a/docs/ffmpeg/src/ffmpeg-loudnorm-cmdline-gen/js/main.js
+++ b/docs/ffmpeg/src/ffmpeg-loudnorm-cmdline-gen/js/main.js
@@ -1,9 +1,14 @@
     function generateAnalyzeCmd() {
       const filename = document.getElementById("filename").value.trim();
-      if (!filename) return alert("ファイル名を入力してください。");
+      const analyzeNode = document.getElementById("analyzeCmd");
+      if (!analyzeNode) return;
+      if (!filename) {
+        analyzeNode.textContent = "";
+        return;
+      }
       const outFile = filename.replace(/\.WAV$/i, "-loudnorm-meta.json");
       const cmd = `ffmpeg -i ${filename} -af loudnorm=print_format=json -f null - 2>&1 | tee ${outFile}`;
-      document.getElementById("analyzeCmd").textContent = cmd;
+      analyzeNode.textContent = cmd;
     }
 
     function extractJson(text) {
@@ -79,56 +84,70 @@ ${outFile}`;
       }
     }
 
-    function generateGainCmd() {
+    function buildGainCommand({ silent = false } = {}) {
+      const raw = document.getElementById("jsonInput").value;
+      const filenameInput = document.getElementById("filename");
+      let inputFile = filenameInput.value.trim();
+
+      let json;
       try {
-        const raw = document.getElementById("jsonInput").value;
         const extracted = extractJson(raw);
-        const json = JSON.parse(extracted);
-
-        const filenameInput = document.getElementById("filename");
-        let inputFile = filenameInput.value.trim();
-
-        if (!inputFile) {
-          const match = raw.match(/from '([^']+\.(wav|WAV|flac|aiff))'/);
-          if (match) {
-            inputFile = match[1];
-            filenameInput.value = inputFile;
-          } else {
-            alert("ファイル名を入力してください（または ffmpeg 出力に含まれる必要があります）。");
-            return;
-          }
-        }
-
-        const targetTP = Number(document.getElementById("gainTargetTp").value);
-        if (isNaN(targetTP)) {
-          alert("目標TPは数値で入力してください。");
-          return;
-        }
-
-        const inputTP = Number(json.input_tp);
-        if (isNaN(inputTP)) {
-          alert("input_tp が解析できません。ffmpeg 出力を確認してください。");
-          return;
-        }
-
-        const gain = Math.round((targetTP - inputTP) * 10) / 10;
-        const gainLabel = `${gain >= 0 ? "+" : ""}${gain}dB`;
-        const useCompressor = document.getElementById("gainUseCompressor").checked;
-
-        const { ar, sample_fmt, codec, rezTag } = getRezConfig();
-        const tpTag = `tp${targetTP.toFixed(1).replace(".", "p")}`;
-        const compTag = useCompressor ? "comp" : "plain";
-        const outFile = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${gainLabel}.wav`);
-        const outFileWithComp = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${compTag}-${gainLabel}.wav`);
-        const filter = useCompressor
-          ? `volume=${gainLabel},acompressor=threshold=-20dB:ratio=2.5:attack=8:release=150`
-          : `volume=${gainLabel}`;
-        const cmd = `ffmpeg -i ${inputFile} -af "${filter}" -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFileWithComp}`;
-
-        document.getElementById("gainCmd").textContent = cmd;
+        json = JSON.parse(extracted);
       } catch (e) {
-        alert("正しい JSON を含む ffmpeg 出力を貼り付けてください。\n" + e.message);
+        if (!silent) {
+          alert("正しい JSON を含む ffmpeg 出力を貼り付けてください。\n" + e.message);
+        }
+        return null;
       }
+
+      if (!inputFile) {
+        const match = raw.match(/from '([^']+\.(wav|WAV|flac|aiff))'/);
+        if (match) {
+          inputFile = match[1];
+          filenameInput.value = inputFile;
+        } else {
+          if (!silent) {
+            alert("ファイル名を入力してください（または ffmpeg 出力に含まれる必要があります）。");
+          }
+          return null;
+        }
+      }
+
+      const targetTP = Number(document.getElementById("gainTargetTp").value);
+      if (isNaN(targetTP)) {
+        if (!silent) {
+          alert("目標TPは数値で入力してください。");
+        }
+        return null;
+      }
+
+      const inputTP = Number(json.input_tp);
+      if (isNaN(inputTP)) {
+        if (!silent) {
+          alert("input_tp が解析できません。ffmpeg 出力を確認してください。");
+        }
+        return null;
+      }
+
+      const gain = Math.round((targetTP - inputTP) * 10) / 10;
+      const gainLabel = `${gain >= 0 ? "+" : ""}${gain}dB`;
+      const useCompressor = document.getElementById("gainUseCompressor").checked;
+
+      const { ar, sample_fmt, codec, rezTag } = getRezConfig();
+      const tpTag = `tp${targetTP.toFixed(1).replace(".", "p")}`;
+      const compTag = useCompressor ? "comp" : "plain";
+      const outFileWithComp = inputFile.replace(/\.(wav|WAV|flac|aiff)$/i, `-gain-${rezTag}-${tpTag}-${compTag}-${gainLabel}.wav`);
+      const filter = useCompressor
+        ? `volume=${gainLabel},acompressor=threshold=-20dB:ratio=2.5:attack=8:release=150`
+        : `volume=${gainLabel}`;
+      return `ffmpeg -i ${inputFile} -af "${filter}" -ar ${ar} -sample_fmt ${sample_fmt} -c:a ${codec} ${outFileWithComp}`;
+    }
+
+    function generateGainCmd({ silent = false } = {}) {
+      const gainNode = document.getElementById("gainCmd");
+      if (!gainNode) return;
+      const cmd = buildGainCommand({ silent });
+      gainNode.textContent = cmd || "";
     }
 
     function showToast(message) {
@@ -164,3 +183,37 @@ ${outFile}`;
     });
 
     setActiveTab("tab-icu");
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const filenameInput = document.getElementById("filename");
+      if (filenameInput) {
+        filenameInput.addEventListener("input", generateAnalyzeCmd);
+        filenameInput.addEventListener("change", generateAnalyzeCmd);
+        filenameInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        filenameInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const jsonInput = document.getElementById("jsonInput");
+      if (jsonInput) {
+        jsonInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        jsonInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const gainTargetTpInput = document.getElementById("gainTargetTp");
+      if (gainTargetTpInput) {
+        gainTargetTpInput.addEventListener("input", () => generateGainCmd({ silent: true }));
+        gainTargetTpInput.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const hiresSwitch = document.getElementById("hires");
+      if (hiresSwitch) {
+        hiresSwitch.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+
+      const gainUseCompressorSwitch = document.getElementById("gainUseCompressor");
+      if (gainUseCompressorSwitch) {
+        gainUseCompressorSwitch.addEventListener("change", () => generateGainCmd({ silent: true }));
+      }
+      generateAnalyzeCmd();
+      generateGainCmd({ silent: true });
+    });

--- a/docs/ffmpeg/src/ffmpeg-trim-cmdline-gen/js/main.js
+++ b/docs/ffmpeg/src/ffmpeg-trim-cmdline-gen/js/main.js
@@ -12,8 +12,12 @@
       const startInput = document.getElementById("start").value.trim();
       const endInput = document.getElementById("end").value.trim();
       const partNumber = document.getElementById("partNumber").value.trim() || "1";
-
-      if (!fileInput) return alert("入力ファイル名を入力してください。");
+      const commandNode = document.getElementById("clipCmd");
+      if (!commandNode) return;
+      if (!fileInput) {
+        commandNode.textContent = "";
+        return;
+      }
 
       const startSec = startInput ? parseTime(startInput) : NaN;
       const endSec = endInput ? parseTime(endInput) : NaN;
@@ -39,7 +43,7 @@
       const outFile = `${baseName}-part${partNumber}.${extension}`;
       const cmd = `ffmpeg${ssPart} -i ${fileInput}${tPart} -c copy ${outFile}`;
 
-      document.getElementById("clipCmd").textContent = cmd;
+      commandNode.textContent = cmd;
     }
 
     function showToast(message) {
@@ -52,3 +56,13 @@
         toast.classList.add("md-hidden");
       }, 2000);
     }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      ["filename", "start", "end", "partNumber"].forEach((id) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.addEventListener("input", generateClipCommand);
+        input.addEventListener("change", generateClipCommand);
+      });
+      generateClipCommand();
+    });

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -5000,7 +5000,7 @@ ${getSoftHallucinationPreventionInstruction()}`
     },
     {
         id: "co-writing-tech-post-request",
-        label: "851: いがぴょんのテック投稿執筆支援",
+        label: "851: いがぴょんのテック系執筆支援",
         keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
         requiresCommitId: false,
         buildBody: () => `# 統合プロンプト
@@ -5551,10 +5551,13 @@ Hind Legs & Tail
     },
     {
         id: "ai-prompt-writing-request",
-        label: "854: 生成AIプロンプト作文",
+        label: "854: 構造化された生成AIプロンプトの作文",
         keywords: ["ai prompt", "prompt writing", "prompt design", "llm prompt", "system prompt", "instruction writing", "生成AI", "プロンプト", "作文", "プロンプト作文", "指示文", "設計", "ぷろんぷと", "さくぶん", "しじぶん"],
         requiresCommitId: false,
-        buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトを作文します。
+        outputMarkdown: true,
+        buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトの作文を支援してください。この依頼は、完成したプロンプトを一方的に出力することだけを目的とするものではなく、必要に応じて構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てていくためのものです。
+
+ここで作成するのは、「# Context」、「# Instructions」、「# Examples」という構造を持った生成AIプロンプトです。背景や意図は「# Context」、生成AIに実際にさせたい内容は「# Instructions」、期待する入出力や文体の例は「# Examples」に整理して記述してください。
 
 まず最初に、これから何をするためのプロンプトなのか、どのような構造のプロンプトなのか、何を重視するプロンプトなのかが伝わる短いリード文またはリード段落を置いてください。
 
@@ -5562,6 +5565,7 @@ Hind Legs & Tail
 
 「# Context」には、必要に応じて次のような内容を記述してください。
 
+- 一発出力ではなく、対話的に構築していくものであるという前提
 - これからどのような二層構造のプロンプトを作文するのかという冒頭説明
 - 何をするためのプロンプトなのかという短いリード文
 - なぜこのコンテキストやプロンプトを作成するのか
@@ -5579,6 +5583,10 @@ Hind Legs & Tail
 
 「# Instructions」には、必要に応じて次のような内容を記述してください。
 
+- まず構成案を示すこと
+- 次に不足点や曖昧な点を整理すること
+- 必要ならユーザーに確認すること
+- その後に完成版のプロンプト本文を組み立てること
 - 生成AIに何をさせたいのか
 - 生成AIに何をさせたくないのか
 - どの観点や優先順位で判断してほしいのか
@@ -5593,6 +5601,8 @@ Hind Legs & Tail
 
 - 「# Context」と「# Instructions」を混ぜず、背景説明と実施内容を分けて書く
 - 冒頭には、全体像がすぐ分かる短いリード文またはリード段落を置く
+- これは完成したプロンプトの一発出力ではなく、プロンプト作文を支援する依頼であることを意識する
+- 必要に応じて、構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てる
 - 「# Context」は、生成AIに直接命令するには曖昧でもよいが、全体像や意図を伝える役割を持つ
 - 「# Instructions」は、生成AIが実際に行動へ移せるだけの具体性を持たせる
 - 「# Examples」は原則として追加し、期待する例を示す
@@ -5600,11 +5610,12 @@ Hind Legs & Tail
 - ただし、箇条書きについては体言止めになってもよい
 - 抽象語だけで済ませず、必要なら判断基準や優先順位を書く
 - 後から見返して修正しやすいように、背景、方針、制約、出力形式、実施手順を分離して書く
+- 良いプロンプトの基準として、人間が読んで理解できること、生成AIが誤解しにくいこと、構造が分離されていることを意識する
 `
     },
     {
         id: "qiita-article-writing-request",
-        label: "861: Qiita記事作文",
+        label: "861: いがぴょんのQiita記事作文",
         keywords: ["qiita", "qiita article", "tech article", "markdown article", "article draft", "記事作文", "記事執筆", "技術記事", "qiita記事", "qiita投稿", "きじさくぶん", "きじしっぴつ", "ぎじゅつきじ", "とうこう"],
         requiresCommitId: false,
         requiresSubject: true,
@@ -5669,7 +5680,7 @@ Hind Legs & Tail
     },
     {
         id: "note-article-writing-request",
-        label: "862: Note記事作文",
+        label: "862: いがぴょんのNote記事作文",
         keywords: ["note", "note article", "essay", "column", "markdown article", "article draft", "記事作文", "記事執筆", "note記事", "note投稿", "読み物", "コラム", "えっせい", "きじさくぶん", "きじしっぴつ", "よみもの"],
         requiresCommitId: false,
         requiresSubject: true,
@@ -5740,6 +5751,7 @@ Hind Legs & Tail
         label: "863: 説明文をわかりやすく整理",
         keywords: ["explanation", "clarity", "clear writing", "plain language", "title", "heading", "topic label", "説明", "説明文", "わかりやすく", "整理", "タイトル", "見出し", "話題ラベル", "ぶんしょう", "せつめい", "わかりやすい", "せいり", "みだし"],
         requiresCommitId: false,
+        outputMarkdown: true,
         buildBody: () => `これから、技術作文や技術説明の文章を整理します。
 
 まず前提として、技術者が技術作文で陥りがちなパターンを、以下のように示します。

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -861,7 +861,7 @@ ${getSoftHallucinationPreventionInstruction()}`
     },
     {
         id: "co-writing-tech-post-request",
-        label: "851: いがぴょんのテック投稿執筆支援",
+        label: "851: いがぴょんのテック系執筆支援",
         keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
         requiresCommitId: false,
         buildBody: () => `# 統合プロンプト
@@ -1412,10 +1412,13 @@ Hind Legs & Tail
     },
     {
         id: "ai-prompt-writing-request",
-        label: "854: 生成AIプロンプト作文",
+        label: "854: 構造化された生成AIプロンプトの作文",
         keywords: ["ai prompt", "prompt writing", "prompt design", "llm prompt", "system prompt", "instruction writing", "生成AI", "プロンプト", "作文", "プロンプト作文", "指示文", "設計", "ぷろんぷと", "さくぶん", "しじぶん"],
         requiresCommitId: false,
-        buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトを作文します。
+        outputMarkdown: true,
+        buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトの作文を支援してください。この依頼は、完成したプロンプトを一方的に出力することだけを目的とするものではなく、必要に応じて構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てていくためのものです。
+
+ここで作成するのは、「# Context」、「# Instructions」、「# Examples」という構造を持った生成AIプロンプトです。背景や意図は「# Context」、生成AIに実際にさせたい内容は「# Instructions」、期待する入出力や文体の例は「# Examples」に整理して記述してください。
 
 まず最初に、これから何をするためのプロンプトなのか、どのような構造のプロンプトなのか、何を重視するプロンプトなのかが伝わる短いリード文またはリード段落を置いてください。
 
@@ -1423,6 +1426,7 @@ Hind Legs & Tail
 
 「# Context」には、必要に応じて次のような内容を記述してください。
 
+- 一発出力ではなく、対話的に構築していくものであるという前提
 - これからどのような二層構造のプロンプトを作文するのかという冒頭説明
 - 何をするためのプロンプトなのかという短いリード文
 - なぜこのコンテキストやプロンプトを作成するのか
@@ -1440,6 +1444,10 @@ Hind Legs & Tail
 
 「# Instructions」には、必要に応じて次のような内容を記述してください。
 
+- まず構成案を示すこと
+- 次に不足点や曖昧な点を整理すること
+- 必要ならユーザーに確認すること
+- その後に完成版のプロンプト本文を組み立てること
 - 生成AIに何をさせたいのか
 - 生成AIに何をさせたくないのか
 - どの観点や優先順位で判断してほしいのか
@@ -1454,6 +1462,8 @@ Hind Legs & Tail
 
 - 「# Context」と「# Instructions」を混ぜず、背景説明と実施内容を分けて書く
 - 冒頭には、全体像がすぐ分かる短いリード文またはリード段落を置く
+- これは完成したプロンプトの一発出力ではなく、プロンプト作文を支援する依頼であることを意識する
+- 必要に応じて、構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てる
 - 「# Context」は、生成AIに直接命令するには曖昧でもよいが、全体像や意図を伝える役割を持つ
 - 「# Instructions」は、生成AIが実際に行動へ移せるだけの具体性を持たせる
 - 「# Examples」は原則として追加し、期待する例を示す
@@ -1461,11 +1471,12 @@ Hind Legs & Tail
 - ただし、箇条書きについては体言止めになってもよい
 - 抽象語だけで済ませず、必要なら判断基準や優先順位を書く
 - 後から見返して修正しやすいように、背景、方針、制約、出力形式、実施手順を分離して書く
+- 良いプロンプトの基準として、人間が読んで理解できること、生成AIが誤解しにくいこと、構造が分離されていることを意識する
 `
     },
     {
         id: "qiita-article-writing-request",
-        label: "861: Qiita記事作文",
+        label: "861: いがぴょんのQiita記事作文",
         keywords: ["qiita", "qiita article", "tech article", "markdown article", "article draft", "記事作文", "記事執筆", "技術記事", "qiita記事", "qiita投稿", "きじさくぶん", "きじしっぴつ", "ぎじゅつきじ", "とうこう"],
         requiresCommitId: false,
         requiresSubject: true,
@@ -1530,7 +1541,7 @@ Hind Legs & Tail
     },
     {
         id: "note-article-writing-request",
-        label: "862: Note記事作文",
+        label: "862: いがぴょんのNote記事作文",
         keywords: ["note", "note article", "essay", "column", "markdown article", "article draft", "記事作文", "記事執筆", "note記事", "note投稿", "読み物", "コラム", "えっせい", "きじさくぶん", "きじしっぴつ", "よみもの"],
         requiresCommitId: false,
         requiresSubject: true,
@@ -1601,6 +1612,7 @@ Hind Legs & Tail
         label: "863: 説明文をわかりやすく整理",
         keywords: ["explanation", "clarity", "clear writing", "plain language", "title", "heading", "topic label", "説明", "説明文", "わかりやすく", "整理", "タイトル", "見出し", "話題ラベル", "ぶんしょう", "せつめい", "わかりやすい", "せいり", "みだし"],
         requiresCommitId: false,
+        outputMarkdown: true,
         buildBody: () => `これから、技術作文や技術説明の文章を整理します。
 
 まず前提として、技術者が技術作文で陥りがちなパターンを、以下のように示します。

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -890,7 +890,7 @@ ${getSoftHallucinationPreventionInstruction()}`
   },
   {
     id: "co-writing-tech-post-request",
-    label: "851: いがぴょんのテック投稿執筆支援",
+    label: "851: いがぴょんのテック系執筆支援",
     keywords: ["writing", "co-writing", "draft", "blog", "facebook", "post", "tech blog", "伴走", "執筆", "投稿", "下書き", "文体", "ブログ", "facebook投稿", "日本語文章", "伴走執筆", "igapyon", "いがぴょん", "伊賀", "てっく", "とうこう", "ばんそう", "しっぴつ", "したがき", "ぶんたい", "ぶろぐ", "にほんごぶんしょう"],
     requiresCommitId: false,
     buildBody: () => `# 統合プロンプト
@@ -1442,10 +1442,13 @@ Hind Legs & Tail
   },
   {
     id: "ai-prompt-writing-request",
-    label: "854: 生成AIプロンプト作文",
+    label: "854: 構造化された生成AIプロンプトの作文",
     keywords: ["ai prompt", "prompt writing", "prompt design", "llm prompt", "system prompt", "instruction writing", "生成AI", "プロンプト", "作文", "プロンプト作文", "指示文", "設計", "ぷろんぷと", "さくぶん", "しじぶん"],
     requiresCommitId: false,
-    buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトを作文します。
+    outputMarkdown: true,
+    buildBody: () => `これから、生成AIのみならず人間も理解できるよう、前半は人間向けの説明、後半は生成AI向けの本文、必要に応じて例を示す補助セクションも持つ、構造化された生成AIプロンプトの作文を支援してください。この依頼は、完成したプロンプトを一方的に出力することだけを目的とするものではなく、必要に応じて構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てていくためのものです。
+
+ここで作成するのは、「# Context」、「# Instructions」、「# Examples」という構造を持った生成AIプロンプトです。背景や意図は「# Context」、生成AIに実際にさせたい内容は「# Instructions」、期待する入出力や文体の例は「# Examples」に整理して記述してください。
 
 まず最初に、これから何をするためのプロンプトなのか、どのような構造のプロンプトなのか、何を重視するプロンプトなのかが伝わる短いリード文またはリード段落を置いてください。
 
@@ -1453,6 +1456,7 @@ Hind Legs & Tail
 
 「# Context」には、必要に応じて次のような内容を記述してください。
 
+- 一発出力ではなく、対話的に構築していくものであるという前提
 - これからどのような二層構造のプロンプトを作文するのかという冒頭説明
 - 何をするためのプロンプトなのかという短いリード文
 - なぜこのコンテキストやプロンプトを作成するのか
@@ -1470,6 +1474,10 @@ Hind Legs & Tail
 
 「# Instructions」には、必要に応じて次のような内容を記述してください。
 
+- まず構成案を示すこと
+- 次に不足点や曖昧な点を整理すること
+- 必要ならユーザーに確認すること
+- その後に完成版のプロンプト本文を組み立てること
 - 生成AIに何をさせたいのか
 - 生成AIに何をさせたくないのか
 - どの観点や優先順位で判断してほしいのか
@@ -1484,6 +1492,8 @@ Hind Legs & Tail
 
 - 「# Context」と「# Instructions」を混ぜず、背景説明と実施内容を分けて書く
 - 冒頭には、全体像がすぐ分かる短いリード文またはリード段落を置く
+- これは完成したプロンプトの一発出力ではなく、プロンプト作文を支援する依頼であることを意識する
+- 必要に応じて、構成案、不足点、改善案を示しながら、最終的に実際に使えるプロンプト本文まで組み立てる
 - 「# Context」は、生成AIに直接命令するには曖昧でもよいが、全体像や意図を伝える役割を持つ
 - 「# Instructions」は、生成AIが実際に行動へ移せるだけの具体性を持たせる
 - 「# Examples」は原則として追加し、期待する例を示す
@@ -1491,11 +1501,12 @@ Hind Legs & Tail
 - ただし、箇条書きについては体言止めになってもよい
 - 抽象語だけで済ませず、必要なら判断基準や優先順位を書く
 - 後から見返して修正しやすいように、背景、方針、制約、出力形式、実施手順を分離して書く
+- 良いプロンプトの基準として、人間が読んで理解できること、生成AIが誤解しにくいこと、構造が分離されていることを意識する
 `
   },
   {
     id: "qiita-article-writing-request",
-    label: "861: Qiita記事作文",
+    label: "861: いがぴょんのQiita記事作文",
     keywords: ["qiita", "qiita article", "tech article", "markdown article", "article draft", "記事作文", "記事執筆", "技術記事", "qiita記事", "qiita投稿", "きじさくぶん", "きじしっぴつ", "ぎじゅつきじ", "とうこう"],
     requiresCommitId: false,
     requiresSubject: true,
@@ -1561,7 +1572,7 @@ Hind Legs & Tail
   },
   {
     id: "note-article-writing-request",
-    label: "862: Note記事作文",
+    label: "862: いがぴょんのNote記事作文",
     keywords: ["note", "note article", "essay", "column", "markdown article", "article draft", "記事作文", "記事執筆", "note記事", "note投稿", "読み物", "コラム", "えっせい", "きじさくぶん", "きじしっぴつ", "よみもの"],
     requiresCommitId: false,
     requiresSubject: true,
@@ -1633,6 +1644,7 @@ Hind Legs & Tail
     label: "863: 説明文をわかりやすく整理",
     keywords: ["explanation", "clarity", "clear writing", "plain language", "title", "heading", "topic label", "説明", "説明文", "わかりやすく", "整理", "タイトル", "見出し", "話題ラベル", "ぶんしょう", "せつめい", "わかりやすい", "せいり", "みだし"],
     requiresCommitId: false,
+    outputMarkdown: true,
     buildBody: () => `これから、技術作文や技術説明の文章を整理します。
 
 まず前提として、技術者が技術作文で陥りがちなパターンを、以下のように示します。

--- a/docs/prompt/tests/prompt-gen-main.test.js
+++ b/docs/prompt/tests/prompt-gen-main.test.js
@@ -1393,7 +1393,7 @@ describe("prompt-gen main", () => {
 
     expect(document.querySelectorAll(".md-chip-button")).toHaveLength(1);
     expect(promptArgsSection.classList.contains("md-hidden")).toBe(true);
-    expect(promptOutput.textContent).toContain("生成AIプロンプトを作文します");
+    expect(promptOutput.textContent).toContain("構造化された生成AIプロンプトの作文を支援してください");
     expect(promptOutput.textContent).toContain("人間向けの説明");
   });
 


### PR DESCRIPTION
### 概要

ffmpeg 系ツールの一部で、入力変更時にコマンドを自動更新するように見直しました。あわせて、`prompt-gen` の定義とラベルを更新し、関連テストと生成物を追従させています。

### 変更内容

- `FFmpeg 切り出しコマンドジェネレータ`
  - `切り出しコマンド生成` ボタンを削除
  - `filename` `start` `end` `partNumber` の変更時に `clipCmd` を自動更新するよう変更
  - 入力ファイル名が空の場合はコマンド表示を空にするよう変更
- `FFmpeg Loudnorm スクリプトジェネレータ`
  - `測定用コマンド生成` ボタンを削除
  - `filename` の変更時に `analyzeCmd` を自動更新するよう変更
  - `単純ゲインコマンド生成` ボタンを削除
  - `filename` `jsonInput` `gainTargetTp` `gainUseCompressor` `hires` の変更時に `gainCmd` を自動更新するよう変更
  - 単純ゲイン側は、入力不足や JSON 不正時に `null` を返す `buildGainCommand` を追加し、`generateGainCmd` から利用する形へ整理
- `TODO.md`
  - ffmpeg 系について、入力変更だけで確定できるコマンド生成は生成ボタンを省略し、自動更新へ寄せられるかを見直す項目を追加
  - `prompt-gen` について、`A863` の名称見直しと、`A851` `A854` `A861` `A862` `A863` への幻想防止適用検討を追加
- `prompt-gen`
  - `A851` を `851: いがぴょんのテック系執筆支援` に変更
  - `A854` を `854: 構造化された生成AIプロンプトの作文` に変更
  - `A854` に `outputMarkdown: true` を追加
  - `A854` の文面を、`# Context` / `# Instructions` / `# Examples` を持つ構造化プロンプトの作文支援として見直し
  - `A861` を `861: いがぴょんのQiita記事作文` に変更
  - `A862` を `862: いがぴょんのNote記事作文` に変更
  - `A863` に `outputMarkdown: true` を追加
- 生成物更新
  - `docs/ffmpeg/ffmpeg-trim-cmdline-gen.html`
  - `docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html`
  - `docs/prompt/prompt-gen.html`
  - `docs/prompt/src/prompt-gen/js/prompt-definitions.js`
- テスト更新
  - `docs/prompt/tests/prompt-gen-main.test.js` の A854 期待値を更新

### 変更ファイル

- `TODO.md`
- `docs/ffmpeg/ffmpeg-trim-cmdline-gen-src.html`
- `docs/ffmpeg/src/ffmpeg-trim-cmdline-gen/js/main.js`
- `docs/ffmpeg/ffmpeg-trim-cmdline-gen.html`
- `docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen-src.html`
- `docs/ffmpeg/src/ffmpeg-loudnorm-cmdline-gen/js/main.js`
- `docs/ffmpeg/ffmpeg-loudnorm-cmdline-gen.html`
- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
- `docs/prompt/src/prompt-gen/js/prompt-definitions.js`
- `docs/prompt/prompt-gen.html`
- `docs/prompt/tests/prompt-gen-main.test.js`