### PR TITLE
feat: `text2spreadsheetml` を追加し SpreadsheetML 2003 XML 生成に対応

### DIFF
--- a/docs/index-src.html
+++ b/docs/index-src.html
@@ -1122,6 +1122,7 @@
         <lht-index-card-link href="password/password-gen.html" icon="🛡️" title="パスワードジェネレーター" desc="選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。"></lht-index-card-link>
         <lht-index-card-link href="text/text-viewer.html" icon="📄" title="テキスト表示" desc="テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。"></lht-index-card-link>
         <lht-index-card-link href="text/file-rename-cmdline-gen.html" icon="🏷️" title="ファイル名連番リネーム" desc="ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。"></lht-index-card-link>
+        <lht-index-card-link href="text/text2spreadsheetml.html" icon="📊" title="text2spreadsheetml" desc="ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。MVP では全セルを String として安全側へ出力します。"></lht-index-card-link>
         <lht-index-card-link href="text/japanese-romaji-guide.html" icon="🔤" title="日本語ローマ字メモ" desc="旅券ローマ字を中心に、ヘボン式・訓令式・日本式（理論寄り）を比較しながら、かなをローマ字に変換します。"></lht-index-card-link>
         <lht-index-card-link href="https://igapyon.github.io/xlsx2md/xlsx2md.html" icon="📘" title="xlsx2md" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
       </div>

--- a/docs/text/text2spreadsheetml-spec.md
+++ b/docs/text/text2spreadsheetml-spec.md
@@ -1,0 +1,400 @@
+# text2spreadsheetml.html 仕様書
+
+## 概要
+
+ベタテキスト、CSV ファイル、TAB 区切りファイルを入力として受け取り、SpreadsheetML 2003 XML Spreadsheet 形式の `.xml` を生成するツール。
+
+- ローカル完結の single-file web app とする
+- 生成結果は Excel で開ける SpreadsheetML 2003 を対象とする
+- MVP では「表データを壊さず 1 シートの XML を生成する」ことを最優先とする
+
+補足:
+
+- 本仕様書では `SpreadsheetML 2003` を正式名称として扱う
+- 「Excel 2004 でも開ける XML」という説明は UI 上の補助説明として許容する
+
+## 配置先
+
+`docs/text/text2spreadsheetml.html`
+
+## フロー定義
+
+- 操作ステップは 4 段階
+- 最終的な XML 出力表示と保存操作は結果表示セクションとして扱う
+
+1. ステップ1: 入力方式の選択
+2. ステップ2: テキストまたはファイルの入力
+3. ステップ3: 読み取り設定と表プレビュー確認
+4. 結果表示: SpreadsheetML 2003 XML の生成と保存
+
+## 画面構成
+
+### タイトル
+
+`📊 text2spreadsheetml`
+
+### タイトル横 `?` 説明
+
+`ベタテキスト、CSV、TAB区切りテキストを SpreadsheetML 2003 XML に変換します。Excel で開ける 1 シートの XML をローカルで生成できます`
+
+## ステップ1: 入力方式の選択
+
+### 入力項目
+
+- 入力方式（必須）
+  - ラベル: `入力方式`
+  - 選択肢:
+    - `ベタテキスト`
+    - `CSV ファイル`
+    - `TAB 区切りファイル`
+  - 初期値: `ベタテキスト`
+  - ツールチップ:
+    - `貼り付けテキストか、CSV/TSV ファイルかを選択します。どの入力方式でも内部的には表データとして扱います`
+
+### 表示切替仕様
+
+- `ベタテキスト` 選択時:
+  - テキスト入力欄を表示
+  - その中で `直接入力` または `テキストファイル` を選べる
+- `CSV ファイル` 選択時:
+  - ファイル入力欄を表示
+  - テキスト入力欄は非表示
+  - 区切り文字は `,` に固定
+- `TAB 区切りファイル` 選択時:
+  - ファイル入力欄を表示
+  - テキスト入力欄は非表示
+  - 区切り文字は `\t` に固定
+
+## ステップ2: データ入力
+
+### ベタテキスト入力時
+
+- 入力方法（必須）
+  - 選択肢:
+    - `直接入力`
+    - `テキストファイル`
+  - 初期値: `直接入力`
+
+- 入力テキスト（必須 / textarea）
+  - ラベル: `入力テキスト`
+  - 行数目安: 12
+  - プレースホルダー:
+    - `name,age,joined`
+    - `Alice,30,2026-03-01`
+    - `Bob,28,2026-03-15`
+  - ツールチップ:
+    - `区切り文字付きの表テキストを貼り付けます。CSV 風、TAB 区切り、パイプ区切りなどを読み取り設定に合わせて解釈します`
+
+- テキストファイル（`テキストファイル` 選択時のみ必須 / file）
+  - ラベル: `テキストファイル`
+  - 受け付け:
+    - `.txt,.csv,.tsv,text/plain,text/csv,text/tab-separated-values`
+  - ツールチップ:
+    - `区切り文字付きのテキストファイルをブラウザ内で読み込みます。読み込み後はベタテキストと同じ処理系へ渡します`
+
+### ファイル入力時
+
+- 入力ファイル（必須 / file）
+  - ラベル: `入力ファイル`
+  - 受け付け:
+    - `CSV ファイル` 選択時: `.csv,text/csv`
+    - `TAB 区切りファイル` 選択時: `.tsv,.txt,text/tab-separated-values,text/plain`
+  - ツールチップ:
+    - `ローカルファイルをブラウザ内で読み込みます。サーバ送信は行いません`
+
+### ファイル読込仕様
+
+- `FileReader` で UTF-8 として読み込む
+- 文字化けの可能性がある場合は注意メッセージを表示する
+- ファイル読込後は内部的にテキストへ展開し、以降はベタテキスト入力と同じ処理系へ渡す
+
+## ステップ3: 読み取り設定とプレビュー
+
+### 入力項目
+
+- 区切り文字（ベタテキスト時のみ必須）
+  - ラベル: `区切り文字`
+  - 選択肢:
+    - `カンマ (, )`
+    - `TAB`
+    - `半角空白`
+    - `パイプ (|)`
+    - `セミコロン (;)`
+  - 初期値: `半角空白`
+  - ツールチップ:
+    - `ベタテキストをどの区切り文字で列分割するかを指定します`
+
+### 半角空白区切り仕様
+
+- `区切り文字 = 半角空白` の場合:
+  - 半角空白 1 個以上の連続を 1 区切りとして扱う
+  - 例: `A B C` と `A   B   C` は同じ 3 列として解釈する
+- TAB や全角空白は半角空白区切りには含めない
+- `trimCells = ON` の場合は行頭・行末の半角空白も除去してから分割する
+
+- 1行目をヘッダとして扱う（checkbox）
+  - ラベル: `1行目をヘッダとして扱う`
+  - 初期値: `ON`
+
+- 空行を無視（checkbox）
+  - ラベル: `空行を無視`
+  - 初期値: `ON`
+
+- 各セルの前後空白を trim（checkbox）
+  - ラベル: `各セルの前後空白を trim`
+  - 初期値: `ON`
+
+- ダブルクォート付き CSV を解釈（checkbox）
+  - ラベル: `ダブルクォート付き CSV を解釈`
+  - 初期値:
+    - `CSV ファイル`: `ON`
+  - 表示条件:
+    - `CSV ファイル` 選択時のみ表示
+  - ツールチップ:
+    - `CSV の \"...\" による囲み、カンマや改行を含むセルを解釈します。MVP では CSV 向けの簡易対応とします`
+
+- シート名（必須）
+  - ラベル: `シート名`
+  - 初期値: `Sheet1`
+  - プレースホルダー: `Sheet1`
+
+- Workbook 名（任意）
+  - ラベル: `Workbook 名`
+  - 初期値: `text2spreadsheetml`
+  - プレースホルダー: `text2spreadsheetml`
+
+### プレビュー表示
+
+- 読み取り設定の変更時に自動更新する
+- 表示内容:
+  - 行数
+  - 列数
+  - ヘッダ行の内容
+  - 文字列固定で出力する旨の表示
+  - 先頭 20 行までの表プレビュー
+
+### 列名仕様
+
+- `1行目をヘッダとして扱う = ON` の場合:
+  - 1 行目を列名として扱う
+  - XML 上はヘッダも通常セルとして 1 行目に出力する
+- `OFF` の場合:
+  - 列名は内部表示用に `Column1`, `Column2`, ... を補う
+
+### 列数仕様
+
+- 基本は各行の列数を揃えて扱う
+- 最大列数に満たない行は末尾空セルで補完する
+- 最大列数を超える行は存在しない前提でパースする
+- CSV 引用符不整合などにより正常に列分割できない場合はエラー表示する
+
+## データ型仕様
+
+### 型モード
+
+- `文字列固定`
+  - すべて `String`
+- `限定数値推論`
+  - 列単位で `String` / `Number` を判定する
+
+### 限定数値推論のルール
+
+- 判定対象はデータ行のみとする
+- 空セルは判定対象から除外する
+- 列内に 1 つでも `先頭ゼロ付き整数` が存在する場合、その列全体を `String` にフォールバックする
+  - 例: `00123`, `0123`, `-012`
+- 上記に該当せず、列内の非空セルがすべて数値形式に一致する場合、その列全体を `Number` とする
+- それ以外は `String`
+
+### 数値形式
+
+- `-?(0|[1-9][0-9]*)(\.[0-9]+)?`
+- 例:
+  - `0` → `Number`
+  - `12` → `Number`
+  - `-3` → `Number`
+  - `0.5` → `Number`
+  - `-0.5` → `Number`
+  - `00123` → `String`
+
+### 型方針
+
+- 既定値は `文字列固定`
+- コード値や ID を壊したくない場合は `文字列固定` を使う
+- 数値列を Excel 側でそのまま扱いたい場合は `限定数値推論` を使う
+
+## ステップ4: SpreadsheetML 2003 XML 出力
+
+### 出力（自動更新）
+
+- 入力または設定変更時に自動再生成する
+- 表示内容:
+  - SpreadsheetML 2003 XML 本文
+  - 生成サマリ
+    - シート名
+    - 行数
+    - 列数
+    - 生成セル数
+
+### XML 仕様
+
+- XML 宣言を含む
+- 生成対象は 1 Workbook / 1 Worksheet
+- 最低限含める要素:
+  - `Workbook`
+  - `DocumentProperties`
+  - `Styles`
+  - `Worksheet`
+  - `Table`
+  - `Row`
+  - `Cell`
+  - `Data`
+
+### 名前空間方針
+
+- SpreadsheetML 2003 として妥当な名前空間を付与する
+- `ss:` 接頭辞を利用して `ss:Type` などを出力する
+
+### セル出力仕様
+
+- 各セルは `Cell > Data` で出力する
+- `Data` の `ss:Type` は型モードと列判定結果に従う
+- 空セルは基本的に空の `Cell` として出力してよい
+- XML 特殊文字は必ずエスケープする
+  - `&`
+  - `<`
+  - `>`
+  - `"`
+  - `'`
+
+### スタイル仕様
+
+- MVP では最小限の既定スタイルのみ出力する
+- 少なくとも以下を定義する
+  - `Default`
+  - `Header`（ヘッダあり時）
+
+### ヘッダ行スタイル
+
+- `1行目をヘッダとして扱う = ON` の場合:
+  - 1 行目セルに `Header` スタイルを適用してよい
+- `OFF` の場合:
+  - 全行 `Default`
+
+## 保存機能
+
+### 出力機能
+
+- `.xml` ダウンロードボタン
+
+### 保存ファイル名
+
+- 既定値:
+  - `text2spreadsheetml.xml`
+- Workbook 名が入力されている場合:
+  - サニタイズして `${workbookName}.xml`
+
+### サニタイズ方針
+
+- ファイル名に使えない文字は `_` に置換する
+- 空白は `_` へ置換してよい
+
+## エラー・注意方針
+
+- 入力が空の場合は XML 生成を抑止する
+- 正常にパースできない場合は XML 生成を抑止する
+- エラー例:
+  - 入力テキストが空
+  - ファイル未選択
+  - CSV 引用符の不整合
+  - シート名が空
+- 警告例:
+  - 列数が行ごとに不一致
+  - UTF-8 以外の可能性
+
+## UI 実装方針
+
+- 基本はボタンレス自動更新
+- 必須項目は `md-required`
+- 説明は `?` ツールチップに集約
+- XML 表示は `md-code-block` + `md-copy-button`
+- ファイル入力時も、読み込み完了後は同じ再生成関数へ流す
+
+## localStorage 永続化仕様
+
+以下の入力値を `localStorage` に保存し、次回アクセス時に復元する。
+
+- `inputMode`（入力方式）
+- `delimiter`（区切り文字）
+- `typeInferenceMode`（項目型）
+- `hasHeader`（ヘッダ有無）
+- `ignoreEmptyLines`（空行無視）
+- `trimCells`（trim）
+- `csvQuoteMode`（CSV 引用符解釈）
+- `sheetName`（シート名）
+- `workbookName`（Workbook 名）
+
+キー:
+
+- `text2spreadsheetml.ui.inputMode`
+- `text2spreadsheetml.ui.delimiter`
+- `text2spreadsheetml.ui.typeInferenceMode`
+- `text2spreadsheetml.ui.hasHeader`
+- `text2spreadsheetml.ui.ignoreEmptyLines`
+- `text2spreadsheetml.ui.trimCells`
+- `text2spreadsheetml.ui.csvQuoteMode`
+- `text2spreadsheetml.ui.sheetName`
+- `text2spreadsheetml.ui.workbookName`
+
+保存タイミング:
+
+- 対象項目の `input/change` イベントで保存
+- `localStorage` 例外は握りつぶして継続
+
+復元タイミング:
+
+- 初期化時に読み込み
+- 復元後に再生成を実行
+
+### 設定クリア仕様
+
+- 「設定をクリア」ボタンで上記キーを削除する
+- 確認ダイアログ文言:
+  - `ローカルに保存されているこのツールの設定をクリアします。よろしいですか？`
+- クリア後は以下既定値で UI を更新し、再生成する
+  - `inputMode = "text"`
+  - `delimiter = "space"`
+  - `typeInferenceMode = "string"`
+  - `hasHeader = true`
+  - `ignoreEmptyLines = true`
+  - `trimCells = true`
+  - `csvQuoteMode = false`
+  - `sheetName = "Sheet1"`
+  - `workbookName = "text2spreadsheetml"`
+
+## 非対応（MVP）
+
+- 複数シート
+- 数式
+- セル結合
+- 複雑な装飾
+- 罫線や色の詳細編集
+- フィルタ
+- ソート条件
+- 複雑な CSV 方言の完全互換
+- 文字コード自動判定
+
+## 想定 JavaScript 関数
+
+- `regenerateAll()` - すべての出力再生成
+- `readInputSource()` - 入力方式ごとのテキスト取得
+- `parseDelimitedText(text, options)` - 表データへパース
+- `parseCsvWithQuotes(text, options)` - CSV 引用符対応パース
+- `normalizeRows(rows, options)` - 行列数調整
+- `inferColumnTypes(previewModel, options)` - 列単位の型推論
+- `buildWorkbookModel(parsed, options)` - Workbook 用内部モデル生成
+- `generateSpreadsheetMlXml(model)` - SpreadsheetML 2003 XML 生成
+- `escapeXml(value)` - XML エスケープ
+- `downloadXml(filename, xml)` - ダウンロード
+- `copyToClipboard(elementId)` - コピー
+- `showToast(message)` - トースト

--- a/docs/text/text2spreadsheetml-src.html
+++ b/docs/text/text2spreadsheetml-src.html
@@ -1,0 +1,1391 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>text2spreadsheetml</title>
+  <link rel="stylesheet" href="../../lht-cmn/css/components.css">
+  <script src="../../lht-cmn/vendor/material-web-outlined-text-field.bundle.js"></script>
+  <script src="../../lht-cmn/js/components.js" defer></script>
+  <style>
+    :root {
+      --md-danger: #b3261e;
+      --md-sys-color-background: #f6f4f8;
+      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.28);
+      --md-sys-color-on-primary: #ffffff;
+      --md-sys-color-on-surface: #1c1b1f;
+      --md-sys-color-on-surface-variant: #49454f;
+      --md-sys-color-outline: #c8c5d0;
+      --md-sys-color-primary: #6200ee;
+      --md-sys-color-surface: #ffffff;
+      --md-sys-color-surface-variant: #f4f1f7;
+      --md-typography-body-small: 0.875rem;
+    }
+
+    body {
+      margin: 0;
+      background: var(--md-sys-color-background);
+      color: var(--md-sys-color-on-surface);
+      font-family: "Hiragino Sans", "Yu Gothic UI", "Yu Gothic", sans-serif;
+    }
+
+    .md-page {
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    .md-shell {
+      max-width: 1120px;
+      margin: 0 auto;
+      background: var(--md-sys-color-surface);
+      border: 1px solid #ece7f3;
+      border-radius: 20px;
+      box-shadow: 0 8px 24px rgba(26, 20, 34, 0.08);
+      padding: 28px;
+      position: relative;
+    }
+
+    .md-headline {
+      font-size: 1.65rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin: 0 0 1.2rem;
+      padding-right: 2.8rem;
+    }
+
+    .md-section {
+      margin-top: 28px;
+    }
+
+    .md-section-title {
+      font-size: 1.05rem;
+      font-weight: 700;
+      margin: 0 0 0.75rem;
+    }
+
+    .md-grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .md-grid-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .md-card {
+      border: 1px solid #ece7f3;
+      border-radius: 18px;
+      background: #fcfbfd;
+      padding: 18px;
+      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.04);
+    }
+
+    .md-label {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.3rem;
+      font-weight: 600;
+      margin-bottom: 0.35rem;
+    }
+
+    .md-required {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.14rem 0.4rem;
+      border-radius: 999px;
+      font-size: 0.54rem;
+      font-weight: 700;
+      background: #eceaf1;
+      color: #49454f;
+    }
+
+    .md-input,
+    .md-select,
+    .md-textarea,
+    .md-file {
+      width: 100%;
+      box-sizing: border-box;
+      border-radius: 12px;
+      border: 1px solid var(--md-sys-color-outline);
+      background: #fff;
+      padding: 0.78rem 0.82rem;
+      font-size: 0.95rem;
+      color: var(--md-sys-color-on-surface);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+
+    .md-file {
+      padding: 0.62rem 0.82rem;
+    }
+
+    .md-textarea {
+      min-height: 13rem;
+      resize: vertical;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      line-height: 1.45;
+    }
+
+    .md-input:focus,
+    .md-select:focus,
+    .md-textarea:focus,
+    .md-file:focus {
+      outline: none;
+      border-color: var(--md-sys-color-primary);
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
+    }
+
+    .md-row {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      align-items: start;
+    }
+
+    .md-row + .md-row {
+      margin-top: 16px;
+    }
+
+    .md-field {
+      min-width: 0;
+      display: block;
+    }
+
+    .md-field > lht-text-field-help,
+    .md-field > lht-select-help {
+      display: block;
+    }
+
+    .md-radio-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .md-radio {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      border: 1px solid #e1dbea;
+      border-radius: 999px;
+      background: #fff;
+      padding: 0.58rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.92rem;
+    }
+
+    .md-radio input {
+      margin: 0;
+    }
+
+    .md-checks {
+      display: grid;
+      gap: 10px;
+    }
+
+    .md-check-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 0.93rem;
+    }
+
+    .md-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .md-button {
+      border: none;
+      border-radius: 999px;
+      padding: 0.72rem 1.15rem;
+      font-size: 0.93rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+
+    .md-button:hover {
+      transform: translateY(-1px);
+    }
+
+    .md-button--primary {
+      background: var(--md-sys-color-primary);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(98, 0, 238, 0.24);
+    }
+
+    .md-button--primary:hover {
+      background: #5400d1;
+    }
+
+    .md-button--secondary {
+      background: #efe7fb;
+      color: #4c347a;
+    }
+
+    .md-button--secondary:hover {
+      background: #e6daf8;
+    }
+
+    .md-button--surface {
+      background: #f5f2f8;
+      color: #3d3845;
+    }
+
+    .md-button--surface:hover {
+      background: #eee9f3;
+    }
+
+    .md-code-block {
+      position: relative;
+      margin-top: 0.5rem;
+    }
+
+    .md-code {
+      display: block;
+      white-space: pre;
+      overflow-x: auto;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      border-radius: 14px;
+      padding: 0.95rem;
+      padding-right: 3rem;
+      min-height: 5rem;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+
+    .md-copy-button {
+      position: absolute;
+      top: 0.55rem;
+      right: 0.55rem;
+      width: 34px;
+      height: 34px;
+      border: none;
+      border-radius: 17px;
+      background: #f7f2fa;
+      cursor: pointer;
+    }
+
+    .md-copy-button:hover {
+      background: #efe8f5;
+    }
+
+    .md-meta {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .md-metric {
+      border: 1px solid #e7e2eb;
+      border-radius: 14px;
+      padding: 0.85rem 0.9rem;
+      background: #fff;
+    }
+
+    .md-metric-label {
+      font-size: 0.77rem;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
+    .md-metric-value {
+      margin-top: 0.28rem;
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .md-table-wrap {
+      overflow: auto;
+      border: 1px solid #e7e2eb;
+      border-radius: 14px;
+      background: #fff;
+    }
+
+    .md-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    .md-table th,
+    .md-table td {
+      border-bottom: 1px solid #eee8f2;
+      border-right: 1px solid #f1edf5;
+      padding: 0.55rem 0.65rem;
+      vertical-align: top;
+      text-align: left;
+      white-space: pre-wrap;
+      word-break: break-word;
+      min-width: 6rem;
+    }
+
+    .md-table th {
+      background: #f1f8f4;
+      font-weight: 700;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    .md-note,
+    .md-warning,
+    .md-error {
+      margin: 0.5rem 0 0;
+      font-size: 0.88rem;
+      line-height: 1.45;
+    }
+
+    .md-note {
+      color: #5f5a6b;
+    }
+
+    .md-warning {
+      color: #8a5300;
+    }
+
+    .md-error {
+      color: var(--md-danger);
+    }
+
+    .md-info-chip {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      color: #4a4458;
+      background: transparent;
+    }
+
+    .md-info-icon {
+      width: 18px;
+      height: 18px;
+    }
+
+    .md-tooltip-group {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .md-tooltip-content {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 0.5rem;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 150ms ease;
+      z-index: 50;
+      width: min(28rem, 88vw);
+    }
+
+    .md-tooltip-group:hover .md-tooltip-content {
+      opacity: 1;
+    }
+
+    .md-tooltip {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      font-size: 0.8125rem;
+      line-height: 1.35;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    }
+
+    .md-hidden {
+      display: none !important;
+    }
+
+    .md-snackbar-host {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+      z-index: 200;
+    }
+
+    .md-snackbar-host.md-visible {
+      opacity: 1;
+    }
+
+    .md-snackbar {
+      background: #2b2831;
+      color: #f7f4fb;
+      border-radius: 12px;
+      padding: 0.72rem 1rem;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      font-size: 0.88rem;
+    }
+
+    @media (max-width: 900px) {
+      .md-grid-2,
+      .md-row,
+      .md-meta {
+        grid-template-columns: 1fr;
+      }
+
+      .md-page {
+        padding: 16px;
+      }
+
+      .md-shell {
+        padding: 20px;
+      }
+    }
+  </style>
+</head>
+<body class="md-page">
+  <main>
+    <section class="md-shell">
+      <lht-page-hero
+        title="text2spreadsheetml"
+        subtitle="ベタテキスト、CSV、TAB区切りファイルから SpreadsheetML 2003 XML を生成します。"
+        icon="📊"
+        help-label="text2spreadsheetml の説明"
+        help-wide
+        menu-home-href="../index.html"
+        menu-home-label="トップへ戻る">
+        ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。<br><br>
+        MVP では値を壊さないことを優先し、全セルを `String` として出力します。数値や日付の型変換は行わず、Excel 上で後から必要に応じて操作する前提です。
+      </lht-page-hero>
+
+      <section class="md-section md-card">
+        <h2 class="md-section-title">入力方式</h2>
+        <div class="md-radio-group">
+          <label class="md-radio"><input type="radio" name="inputMode" value="text" checked>ベタテキスト</label>
+          <label class="md-radio"><input type="radio" name="inputMode" value="csv">CSV ファイル</label>
+          <label class="md-radio"><input type="radio" name="inputMode" value="tsv">TAB 区切りファイル</label>
+        </div>
+        <p class="md-note">MVP では、どの入力方式でも内部的には表データへ正規化してから 1 シートの SpreadsheetML 2003 を生成します。</p>
+      </section>
+
+      <section class="md-section md-grid md-grid-2">
+        <div class="md-card">
+          <h2 class="md-section-title">入力データ</h2>
+
+          <div id="textInputSection">
+            <div class="md-radio-group" style="margin-bottom: 12px;">
+              <label class="md-radio"><input type="radio" name="textInputMode" value="direct" checked>直接入力</label>
+              <label class="md-radio"><input type="radio" name="textInputMode" value="file">テキストファイル</label>
+            </div>
+            <lht-text-field-help
+              field-id="inputText"
+              label="入力テキスト"
+              type="textarea"
+              rows="12"
+              required
+              placeholder="name,age,joined&#10;Alice,30,2026-03-01&#10;Bob,28,2026-03-15"
+              help-text="区切り文字付きの表テキストを貼り付けます。CSV風、TAB区切り、パイプ区切りなどを読み取り設定に合わせて解釈します。">
+            </lht-text-field-help>
+            <div id="textFileInputSection" class="md-hidden" style="margin-top: 12px;">
+              <lht-file-select
+                input-id="textInputFile"
+                button-id="textInputFileButton"
+                file-name-id="textInputFileName"
+                button-label="テキストファイルを選択"
+                accept=".txt,.csv,.tsv,text/plain,text/csv,text/tab-separated-values"
+                placeholder="未選択"
+                show-file-name>
+              </lht-file-select>
+              <p id="textFileStatus" class="md-note">テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。</p>
+            </div>
+          </div>
+
+          <div id="fileInputSection" class="md-hidden">
+            <lht-file-select
+              input-id="inputFile"
+              button-id="inputFileButton"
+              file-name-id="inputFileName"
+              button-label="入力ファイルを選択"
+              accept=".csv,.tsv,.txt,text/csv,text/tab-separated-values,text/plain"
+              placeholder="未選択"
+              show-file-name>
+            </lht-file-select>
+            <p id="fileStatus" class="md-note">ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。</p>
+          </div>
+
+          <div class="md-actions" style="margin-top: 14px;">
+            <button type="button" class="md-button md-button--secondary" onclick="applySample()">サンプル投入</button>
+            <button type="button" class="md-button md-button--surface" onclick="clearUiPreferences()">設定をクリア</button>
+          </div>
+        </div>
+
+        <div class="md-card">
+          <h2 class="md-section-title">読み取り設定</h2>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-select-help field-id="delimiterSelect" label="区切り文字" help-text="ベタテキストをどの区切り文字で列分割するかを指定します。">
+                <script type="application/json" slot="options">[
+                  { "value": "comma", "label": "カンマ (,)" },
+                  { "value": "tab", "label": "TAB" },
+                  { "value": "space", "label": "半角空白", "selected": true },
+                  { "value": "pipe", "label": "パイプ (|)" },
+                  { "value": "semicolon", "label": "セミコロン (;)" }
+                ]</script>
+              </lht-select-help>
+            </div>
+            <div class="md-field">
+              <lht-text-field-help field-id="sheetName" label="シート名" required value="Sheet1" placeholder="Sheet1" help-text="SpreadsheetML 2003 で出力するワークシート名です。"></lht-text-field-help>
+            </div>
+          </div>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-text-field-help field-id="workbookName" label="Workbook 名" value="text2spreadsheetml" placeholder="text2spreadsheetml" help-text="DocumentProperties の Title と保存ファイル名の初期値に使います。"></lht-text-field-help>
+            </div>
+            <div class="md-field">
+              <lht-text-field-help field-id="downloadFilename" label="保存ファイル名" value="text2spreadsheetml.xml" placeholder="text2spreadsheetml.xml" help-text=".xml 保存時のファイル名です。未入力時は Workbook 名から補います。"></lht-text-field-help>
+            </div>
+          </div>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-select-help field-id="typeInferenceMode" label="項目型" help-text="文字列固定か、限定数値推論かを選びます。限定数値推論では、先頭ゼロ付き整数が1つでもある列は String にフォールバックします。">
+                <script type="application/json" slot="options">[
+                  { "value": "string", "label": "文字列固定", "selected": true },
+                  { "value": "limitedNumeric", "label": "限定数値推論" }
+                ]</script>
+              </lht-select-help>
+            </div>
+          </div>
+          <div class="md-checks" style="margin-top: 10px;">
+            <lht-switch-help switch-id="hasHeader" label="1行目をヘッダとして扱う" checked></lht-switch-help>
+            <lht-switch-help switch-id="ignoreEmptyLines" label="空行を無視" checked></lht-switch-help>
+            <lht-switch-help switch-id="trimCells" label="各セルの前後空白を trim" checked></lht-switch-help>
+            <div id="csvQuoteModeWrap" class="md-hidden">
+              <lht-switch-help switch-id="csvQuoteMode" label="ダブルクォート付き CSV を解釈" help-label="ダブルクォート付き CSV の説明">CSV の `&quot;...&quot;` による囲みを解釈します。MVP では CSV 向けの簡易対応です。</lht-switch-help>
+            </div>
+          </div>
+          <p class="md-note">文字列固定では全セル `String`、限定数値推論では列単位で `Number` / `String` を判定します。</p>
+          <p id="configWarning" class="md-warning"></p>
+        </div>
+      </section>
+
+      <section class="md-section md-card">
+        <h2 class="md-section-title">プレビュー</h2>
+        <div class="md-meta">
+          <div class="md-metric"><div class="md-metric-label">行数</div><div id="rowCount" class="md-metric-value">0</div></div>
+          <div class="md-metric"><div class="md-metric-label">列数</div><div id="columnCount" class="md-metric-value">0</div></div>
+          <div class="md-metric"><div class="md-metric-label">ヘッダ</div><div id="headerState" class="md-metric-value">OFF</div></div>
+          <div class="md-metric"><div class="md-metric-label">セル型</div><div id="cellTypeModeLabel" class="md-metric-value">String</div></div>
+        </div>
+        <p id="columnTypeSummary" class="md-note"></p>
+        <p id="parseError" class="md-error"></p>
+        <p id="parseWarning" class="md-warning"></p>
+        <div class="md-table-wrap" style="margin-top: 12px;">
+          <table class="md-table">
+            <thead id="previewHead"></thead>
+            <tbody id="previewBody"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="md-section md-card">
+        <h2 class="md-section-title">SpreadsheetML 2003 XML</h2>
+        <div class="md-actions">
+          <button type="button" class="md-button md-button--primary" onclick="downloadGeneratedXml()">.xml を保存</button>
+        </div>
+        <lht-command-block command-id="xmlOutput"></lht-command-block>
+      </section>
+    </section>
+  </main>
+
+  <lht-toast id="toast"></lht-toast>
+
+  <script>
+    const STORAGE_KEYS = {
+      inputMode: "text2spreadsheetml.ui.inputMode",
+      textInputMode: "text2spreadsheetml.ui.textInputMode",
+      delimiter: "text2spreadsheetml.ui.delimiter",
+      typeInferenceMode: "text2spreadsheetml.ui.typeInferenceMode",
+      hasHeader: "text2spreadsheetml.ui.hasHeader",
+      ignoreEmptyLines: "text2spreadsheetml.ui.ignoreEmptyLines",
+      trimCells: "text2spreadsheetml.ui.trimCells",
+      csvQuoteMode: "text2spreadsheetml.ui.csvQuoteMode",
+      sheetName: "text2spreadsheetml.ui.sheetName",
+      workbookName: "text2spreadsheetml.ui.workbookName",
+      downloadFilename: "text2spreadsheetml.ui.downloadFilename",
+      inputText: "text2spreadsheetml.ui.inputText"
+    };
+
+    let currentFileText = "";
+    let currentFileName = "";
+    let latestGeneratedXml = "";
+
+    function getStoredString(key) {
+      try {
+        const value = localStorage.getItem(key);
+        return value == null ? null : value;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    function getStoredBoolean(key) {
+      const raw = getStoredString(key);
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return null;
+    }
+
+    function setStoredValue(key, value) {
+      try {
+        localStorage.setItem(key, String(value));
+      } catch (error) {
+        // localStorage が使えない環境でも継続
+      }
+    }
+
+    function showToast(message) {
+      const host = document.getElementById("toast");
+      if (!host) return;
+      if (typeof host.show === "function") {
+        host.show(message, 1800);
+        return;
+      }
+    }
+
+    function copyToClipboard(elementId) {
+      const element = document.getElementById(elementId);
+      if (!element) return;
+      const text = element.textContent || "";
+      if (!text) {
+        showToast("コピーする内容がありません");
+        return;
+      }
+      navigator.clipboard.writeText(text)
+        .then(() => showToast("コピーしました"))
+        .catch(() => showToast("コピーに失敗しました"));
+    }
+
+    function getInputMode() {
+      const checked = document.querySelector('input[name="inputMode"]:checked');
+      return checked ? checked.value : "text";
+    }
+
+    function getTextInputMode() {
+      const checked = document.querySelector('input[name="textInputMode"]:checked');
+      return checked ? checked.value : "direct";
+    }
+
+    function getDelimiterValue() {
+      const value = document.getElementById("delimiterSelect")?.value || "comma";
+      switch (value) {
+        case "tab":
+          return "\t";
+        case "space":
+          return " ";
+        case "pipe":
+          return "|";
+        case "semicolon":
+          return ";";
+        default:
+          return ",";
+      }
+    }
+
+    function updateInputModeUi() {
+      const inputMode = getInputMode();
+      const textInputSection = document.getElementById("textInputSection");
+      const fileInputSection = document.getElementById("fileInputSection");
+      const textFileInputSection = document.getElementById("textFileInputSection");
+      const inputText = document.getElementById("inputText");
+      const delimiterSelect = document.getElementById("delimiterSelect");
+      const csvQuoteMode = document.getElementById("csvQuoteMode");
+      const csvQuoteModeWrap = document.getElementById("csvQuoteModeWrap");
+      const textInputMode = getTextInputMode();
+
+      textInputSection.classList.toggle("md-hidden", inputMode !== "text");
+      fileInputSection.classList.toggle("md-hidden", inputMode === "text");
+      textFileInputSection.classList.toggle("md-hidden", !(inputMode === "text" && textInputMode === "file"));
+      inputText.classList.toggle("md-hidden", !(inputMode === "text" && textInputMode === "direct"));
+      csvQuoteModeWrap.classList.toggle("md-hidden", inputMode !== "csv");
+
+      if (inputMode === "csv") {
+        delimiterSelect.value = "comma";
+        delimiterSelect.disabled = true;
+        csvQuoteMode.checked = true;
+      } else if (inputMode === "tsv") {
+        delimiterSelect.value = "tab";
+        delimiterSelect.disabled = true;
+        csvQuoteMode.checked = false;
+      } else {
+        if (!delimiterSelect.disabled && (delimiterSelect.value === "comma" || delimiterSelect.value === "tab")) {
+          delimiterSelect.value = "space";
+        }
+        delimiterSelect.disabled = false;
+      }
+
+      updateFileAccept();
+    }
+
+    function updateFileAccept() {
+      const inputFile = document.getElementById("inputFile");
+      if (!inputFile) return;
+      const inputMode = getInputMode();
+      if (inputMode === "csv") {
+        inputFile.setAttribute("accept", ".csv,text/csv");
+      } else if (inputMode === "tsv") {
+        inputFile.setAttribute("accept", ".tsv,.txt,text/tab-separated-values,text/plain");
+      } else {
+        inputFile.setAttribute("accept", ".csv,.tsv,.txt,text/csv,text/tab-separated-values,text/plain");
+      }
+    }
+
+    function sanitizeSheetName(value) {
+      const raw = String(value || "").trim() || "Sheet1";
+      return raw.replace(/[\\/:*?\[\]]/g, "_").slice(0, 31) || "Sheet1";
+    }
+
+    function sanitizeFilename(value) {
+      const base = String(value || "").trim() || "text2spreadsheetml.xml";
+      const normalized = base.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "_").replace(/\s+/g, "_");
+      return normalized.toLowerCase().endsWith(".xml") ? normalized : `${normalized}.xml`;
+    }
+
+    function escapeXml(value) {
+      return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+    }
+
+    function parseCsvWithQuotes(text) {
+      const rows = [];
+      let row = [];
+      let cell = "";
+      let inQuotes = false;
+
+      for (let index = 0; index < text.length; index += 1) {
+        const char = text[index];
+        const next = text[index + 1];
+
+        if (char === '"') {
+          if (inQuotes && next === '"') {
+            cell += '"';
+            index += 1;
+          } else {
+            inQuotes = !inQuotes;
+          }
+          continue;
+        }
+
+        if (char === "," && !inQuotes) {
+          row.push(cell);
+          cell = "";
+          continue;
+        }
+
+        if ((char === "\n" || char === "\r") && !inQuotes) {
+          if (char === "\r" && next === "\n") {
+            index += 1;
+          }
+          row.push(cell);
+          rows.push(row);
+          row = [];
+          cell = "";
+          continue;
+        }
+
+        cell += char;
+      }
+
+      if (inQuotes) {
+        throw new Error("CSV のダブルクォートが閉じられていません。");
+      }
+
+      row.push(cell);
+      rows.push(row);
+      return rows;
+    }
+
+    function parseDelimitedText(text, options) {
+      const normalized = String(text || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      if (options.csvQuoteMode && options.delimiter === ",") {
+        return parseCsvWithQuotes(normalized);
+      }
+      if (options.delimiter === " ") {
+        return normalized.split("\n").map((line) => {
+          const trimmedLine = options.trimCells ? line.trim() : line;
+          if (!trimmedLine) return [""];
+          return trimmedLine.split(/ +/);
+        });
+      }
+      return normalized.split("\n").map((line) => line.split(options.delimiter));
+    }
+
+    function normalizeRows(rows, options) {
+      const warnings = [];
+      const filtered = [];
+
+      rows.forEach((row) => {
+        const cells = Array.isArray(row) ? row.slice() : [];
+        const values = options.trimCells
+          ? cells.map((cell) => String(cell).trim())
+          : cells.map((cell) => String(cell));
+        const isCompletelyEmpty = values.every((cell) => cell === "");
+        if (options.ignoreEmptyLines && isCompletelyEmpty) {
+          return;
+        }
+        filtered.push(values);
+      });
+
+      let maxColumns = 0;
+      filtered.forEach((row) => {
+        if (row.length > maxColumns) maxColumns = row.length;
+      });
+
+      if (!filtered.length) {
+        return { rows: [], maxColumns: 0, warnings };
+      }
+
+      filtered.forEach((row, rowIndex) => {
+        if (row.length !== maxColumns) {
+          warnings.push(`行 ${rowIndex + 1} の列数が揃っていないため、末尾を空セルで補完しました。`);
+        }
+        while (row.length < maxColumns) {
+          row.push("");
+        }
+      });
+
+      return { rows: filtered, maxColumns, warnings };
+    }
+
+    function buildPreviewModel(rows, options) {
+      const normalized = normalizeRows(rows, options);
+      const allRows = normalized.rows;
+      const headerLabels = [];
+      const dataRows = [];
+
+      if (!allRows.length) {
+        return {
+          headerLabels,
+          dataRows,
+          warnings: normalized.warnings,
+          rowCount: 0,
+          columnCount: 0
+        };
+      }
+
+      if (options.hasHeader) {
+        allRows[0].forEach((value) => headerLabels.push(value || ""));
+        allRows.slice(1).forEach((row) => dataRows.push(row));
+      } else {
+        for (let index = 0; index < normalized.maxColumns; index += 1) {
+          headerLabels.push(`Column${index + 1}`);
+        }
+        allRows.forEach((row) => dataRows.push(row));
+      }
+
+      return {
+        headerLabels,
+        dataRows,
+        warnings: normalized.warnings,
+        rowCount: dataRows.length + (options.hasHeader ? 1 : 0),
+        columnCount: normalized.maxColumns
+      };
+    }
+
+    function isLeadingZeroInteger(value) {
+      return /^-?0\d+$/.test(value);
+    }
+
+    function isNumericCandidate(value) {
+      return /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value);
+    }
+
+    function inferColumnTypes(previewModel, options) {
+      const columnTypes = Array.from({ length: previewModel.columnCount }, () => "String");
+      const warnings = [];
+
+      if (options.typeInferenceMode !== "limitedNumeric") {
+        return { columnTypes, warnings };
+      }
+
+      for (let index = 0; index < previewModel.columnCount; index += 1) {
+        const values = previewModel.dataRows
+          .map((row) => row[index] || "")
+          .filter((value) => value !== "");
+
+        if (!values.length) continue;
+
+        if (values.some((value) => isLeadingZeroInteger(value))) {
+          warnings.push(`${previewModel.headerLabels[index] || `Column${index + 1}`} は先頭ゼロ付き整数を含むため String に固定しました。`);
+          continue;
+        }
+
+        if (values.every((value) => isNumericCandidate(value))) {
+          columnTypes[index] = "Number";
+        }
+      }
+
+      return { columnTypes, warnings };
+    }
+
+    function buildWorkbookModel(previewModel, options) {
+      const inferred = inferColumnTypes(previewModel, options);
+      const rows = [];
+      if (options.hasHeader) {
+        rows.push({
+          isHeader: true,
+          cells: previewModel.headerLabels.map((value) => ({ value, type: "String" }))
+        });
+      }
+      previewModel.dataRows.forEach((row) => {
+        rows.push({
+          isHeader: false,
+          cells: row.map((value, index) => ({
+            value,
+            type: inferred.columnTypes[index] || "String"
+          }))
+        });
+      });
+      return {
+        workbookName: options.workbookName,
+        sheetName: options.sheetName,
+        rows,
+        columnTypes: inferred.columnTypes,
+        inferenceWarnings: inferred.warnings
+      };
+    }
+
+    function generateSpreadsheetMlXml(model) {
+      const createdIso = new Date().toISOString();
+      const rowsXml = model.rows.map((row) => {
+        const cellsXml = row.cells.map((cell) => {
+          const styleId = row.isHeader ? ' ss:StyleID="Header"' : "";
+          return `      <Cell${styleId}><Data ss:Type="${cell.type}">${escapeXml(cell.value)}</Data></Cell>`;
+        }).join("\n");
+        return `    <Row>\n${cellsXml}\n    </Row>`;
+      }).join("\n");
+
+      return `<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:html="http://www.w3.org/TR/REC-html40">
+  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
+    <Author>local-html-tools</Author>
+    <LastAuthor>local-html-tools</LastAuthor>
+    <Created>${escapeXml(createdIso)}</Created>
+    <Company>local-html-tools</Company>
+    <Title>${escapeXml(model.workbookName)}</Title>
+  </DocumentProperties>
+  <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
+    <ProtectStructure>False</ProtectStructure>
+    <ProtectWindows>False</ProtectWindows>
+  </ExcelWorkbook>
+  <Styles>
+    <Style ss:ID="Default" ss:Name="Normal">
+      <Alignment ss:Vertical="Bottom"/>
+      <Borders/>
+      <Font ss:FontName="Calibri" ss:Size="11"/>
+      <Interior/>
+      <NumberFormat/>
+      <Protection/>
+    </Style>
+    <Style ss:ID="Header">
+      <Font ss:Bold="1"/>
+      <Interior ss:Color="#E7F4EE" ss:Pattern="Solid"/>
+    </Style>
+  </Styles>
+  <Worksheet ss:Name="${escapeXml(model.sheetName)}">
+    <Table>
+${rowsXml}
+    </Table>
+  </Worksheet>
+</Workbook>`;
+    }
+
+    function renderPreview(previewModel, options) {
+      const previewHead = document.getElementById("previewHead");
+      const previewBody = document.getElementById("previewBody");
+      const rowCount = document.getElementById("rowCount");
+      const columnCount = document.getElementById("columnCount");
+      const headerState = document.getElementById("headerState");
+      const cellTypeModeLabel = document.getElementById("cellTypeModeLabel");
+      const columnTypeSummary = document.getElementById("columnTypeSummary");
+      const inferred = inferColumnTypes(previewModel, options);
+
+      rowCount.textContent = String(previewModel.rowCount);
+      columnCount.textContent = String(previewModel.columnCount);
+      headerState.textContent = options.hasHeader ? "ON" : "OFF";
+      cellTypeModeLabel.textContent = options.typeInferenceMode === "limitedNumeric" ? "列判定" : "String";
+      columnTypeSummary.textContent = previewModel.columnCount
+        ? inferred.columnTypes.map((type, index) => `${previewModel.headerLabels[index] || `Column${index + 1}`}=${type}`).join(" / ")
+        : "";
+
+      if (!previewModel.columnCount) {
+        previewHead.innerHTML = "";
+        previewBody.innerHTML = '<tr><td>ここにプレビューが表示されます</td></tr>';
+        columnTypeSummary.textContent = "";
+        return;
+      }
+
+      previewHead.innerHTML = `<tr>${previewModel.headerLabels.map((cell) => `<th>${escapeXml(cell || "")}</th>`).join("")}</tr>`;
+
+      const rowsForPreview = previewModel.dataRows.slice(0, 20);
+      previewBody.innerHTML = rowsForPreview.map((row) => {
+        return `<tr>${row.map((cell) => `<td>${escapeXml(cell || "")}</td>`).join("")}</tr>`;
+      }).join("");
+    }
+
+    function getSourceText() {
+      const inputMode = getInputMode();
+      if (inputMode === "text") {
+        if (getTextInputMode() === "file") {
+          return currentFileText;
+        }
+        return document.getElementById("inputText")?.value || "";
+      }
+      return currentFileText;
+    }
+
+    function updateDownloadFilenameFromWorkbook() {
+      const workbookName = document.getElementById("workbookName")?.value || "text2spreadsheetml";
+      const filenameInput = document.getElementById("downloadFilename");
+      if (!filenameInput) return;
+      const currentValue = filenameInput.value.trim();
+      if (!currentValue || currentValue === "text2spreadsheetml.xml" || currentValue === sanitizeFilename(`${workbookName}.xml`)) {
+        filenameInput.value = sanitizeFilename(`${workbookName}.xml`);
+      }
+    }
+
+    function regenerateAll() {
+      updateInputModeUi();
+
+      const parseError = document.getElementById("parseError");
+      const parseWarning = document.getElementById("parseWarning");
+      const configWarning = document.getElementById("configWarning");
+      const xmlOutput = document.getElementById("xmlOutput");
+
+      parseError.textContent = "";
+      parseWarning.textContent = "";
+      configWarning.textContent = "";
+
+      const inputMode = getInputMode();
+      const options = {
+        delimiter: getDelimiterValue(),
+        typeInferenceMode: document.getElementById("typeInferenceMode")?.value || "string",
+        hasHeader: !!document.getElementById("hasHeader")?.checked,
+        ignoreEmptyLines: !!document.getElementById("ignoreEmptyLines")?.checked,
+        trimCells: !!document.getElementById("trimCells")?.checked,
+        csvQuoteMode: !!document.getElementById("csvQuoteMode")?.checked,
+        sheetName: sanitizeSheetName(document.getElementById("sheetName")?.value || "Sheet1"),
+        workbookName: (document.getElementById("workbookName")?.value || "text2spreadsheetml").trim() || "text2spreadsheetml"
+      };
+
+      const sourceText = getSourceText();
+      if (!sourceText.trim()) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        renderPreview({ headerLabels: [], dataRows: [], rowCount: 0, columnCount: 0 }, options);
+        if (inputMode === "text" && getTextInputMode() === "direct") {
+          parseError.textContent = "入力テキストを入れてください。";
+        } else {
+          parseError.textContent = "入力ファイルを選択してください。";
+        }
+        return;
+      }
+
+      const rawSheetName = (document.getElementById("sheetName")?.value || "").trim();
+      if (!rawSheetName) {
+        configWarning.textContent = "シート名が空のため、Sheet1 を使用します。";
+      } else if (rawSheetName !== options.sheetName) {
+        configWarning.textContent = `シート名は SpreadsheetML 向けに ${options.sheetName} へ調整して出力します。`;
+      }
+
+      let rows;
+      try {
+        rows = parseDelimitedText(sourceText, options);
+      } catch (error) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        renderPreview({ headerLabels: [], dataRows: [], rowCount: 0, columnCount: 0 }, options);
+        parseError.textContent = error instanceof Error ? error.message : "入力データの解析に失敗しました。";
+        return;
+      }
+
+      const previewModel = buildPreviewModel(rows, options);
+      renderPreview(previewModel, options);
+
+      if (!previewModel.columnCount) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        parseError.textContent = "表データとして解釈できる内容がありません。";
+        return;
+      }
+
+      if (previewModel.warnings.length) {
+        parseWarning.textContent = Array.from(new Set(previewModel.warnings)).slice(0, 3).join(" ");
+      }
+
+      const model = buildWorkbookModel(previewModel, options);
+      if (model.inferenceWarnings.length) {
+        parseWarning.textContent = [parseWarning.textContent, ...model.inferenceWarnings].filter(Boolean).join(" ");
+      }
+      latestGeneratedXml = generateSpreadsheetMlXml(model);
+      xmlOutput.textContent = latestGeneratedXml;
+    }
+
+    function downloadGeneratedXml() {
+      if (!latestGeneratedXml) {
+        showToast("保存する XML がありません");
+        return;
+      }
+      const filenameInput = document.getElementById("downloadFilename");
+      const filename = sanitizeFilename(filenameInput?.value || "text2spreadsheetml.xml");
+      if (filenameInput) filenameInput.value = filename;
+      const blob = new Blob([latestGeneratedXml], { type: "application/xml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+      showToast(".xml を保存しました");
+    }
+
+    function applySample() {
+      const sample = [
+        "id,name,joined,note",
+        "001,Alice,2026-03-01,first user",
+        "002,Bob,2026-03-15,keep as string",
+        "003,Carol,2026-03-20,\"quoted, sample\""
+      ].join("\n");
+      const textInput = document.getElementById("inputText");
+      const modeRadio = document.querySelector('input[name="inputMode"][value="text"]');
+      const textModeRadio = document.querySelector('input[name="textInputMode"][value="direct"]');
+      if (modeRadio) modeRadio.checked = true;
+      if (textModeRadio) textModeRadio.checked = true;
+      if (textInput) textInput.value = sample;
+      currentFileText = "";
+      currentFileName = "";
+      document.getElementById("textInputFile").value = "";
+      document.getElementById("textFileStatus").textContent = "テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      document.getElementById("delimiterSelect").value = "comma";
+      document.getElementById("typeInferenceMode").value = "string";
+      document.getElementById("csvQuoteMode").checked = true;
+      updateInputModeUi();
+      regenerateAll();
+    }
+
+    function clearUiPreferences() {
+      const confirmed = confirm("ローカルに保存されているこのツールの設定をクリアします。よろしいですか？");
+      if (!confirmed) return;
+      Object.values(STORAGE_KEYS).forEach((key) => {
+        try {
+          localStorage.removeItem(key);
+        } catch (error) {
+          // 継続
+        }
+      });
+      const defaultMode = document.querySelector('input[name="inputMode"][value="text"]');
+      const defaultTextInputMode = document.querySelector('input[name="textInputMode"][value="direct"]');
+      if (defaultMode) defaultMode.checked = true;
+      if (defaultTextInputMode) defaultTextInputMode.checked = true;
+      document.getElementById("delimiterSelect").value = "space";
+      document.getElementById("typeInferenceMode").value = "string";
+      document.getElementById("hasHeader").checked = true;
+      document.getElementById("ignoreEmptyLines").checked = true;
+      document.getElementById("trimCells").checked = true;
+      document.getElementById("csvQuoteMode").checked = false;
+      document.getElementById("sheetName").value = "Sheet1";
+      document.getElementById("workbookName").value = "text2spreadsheetml";
+      document.getElementById("downloadFilename").value = "text2spreadsheetml.xml";
+      document.getElementById("inputText").value = "";
+      document.getElementById("inputFile").value = "";
+      document.getElementById("textInputFile").value = "";
+      document.getElementById("fileStatus").textContent = "ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      document.getElementById("textFileStatus").textContent = "テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      currentFileText = "";
+      currentFileName = "";
+      regenerateAll();
+      showToast("設定をクリアしました");
+    }
+
+    function loadPersistedInputs() {
+      const inputMode = getStoredString(STORAGE_KEYS.inputMode);
+      const textInputMode = getStoredString(STORAGE_KEYS.textInputMode);
+      const delimiter = getStoredString(STORAGE_KEYS.delimiter);
+      const typeInferenceMode = getStoredString(STORAGE_KEYS.typeInferenceMode);
+      const sheetName = getStoredString(STORAGE_KEYS.sheetName);
+      const workbookName = getStoredString(STORAGE_KEYS.workbookName);
+      const downloadFilename = getStoredString(STORAGE_KEYS.downloadFilename);
+      const inputText = getStoredString(STORAGE_KEYS.inputText);
+
+      if (inputMode) {
+        const radio = document.querySelector(`input[name="inputMode"][value="${inputMode}"]`);
+        if (radio) radio.checked = true;
+      }
+      if (textInputMode) {
+        const radio = document.querySelector(`input[name="textInputMode"][value="${textInputMode}"]`);
+        if (radio) radio.checked = true;
+      }
+      if (delimiter && document.querySelector(`#delimiterSelect option[value="${delimiter}"]`)) {
+        document.getElementById("delimiterSelect").value = delimiter;
+      }
+      if (typeInferenceMode && document.querySelector(`#typeInferenceMode option[value="${typeInferenceMode}"]`)) {
+        document.getElementById("typeInferenceMode").value = typeInferenceMode;
+      }
+      const hasHeader = getStoredBoolean(STORAGE_KEYS.hasHeader);
+      const ignoreEmptyLines = getStoredBoolean(STORAGE_KEYS.ignoreEmptyLines);
+      const trimCells = getStoredBoolean(STORAGE_KEYS.trimCells);
+      const csvQuoteMode = getStoredBoolean(STORAGE_KEYS.csvQuoteMode);
+      if (hasHeader !== null) document.getElementById("hasHeader").checked = hasHeader;
+      if (ignoreEmptyLines !== null) document.getElementById("ignoreEmptyLines").checked = ignoreEmptyLines;
+      if (trimCells !== null) document.getElementById("trimCells").checked = trimCells;
+      if (csvQuoteMode !== null) document.getElementById("csvQuoteMode").checked = csvQuoteMode;
+      if (sheetName !== null) document.getElementById("sheetName").value = sheetName;
+      if (workbookName !== null) document.getElementById("workbookName").value = workbookName;
+      if (downloadFilename !== null) document.getElementById("downloadFilename").value = downloadFilename;
+      if (inputText !== null) document.getElementById("inputText").value = inputText;
+    }
+
+    function savePersistedInputs() {
+      setStoredValue(STORAGE_KEYS.inputMode, getInputMode());
+      setStoredValue(STORAGE_KEYS.textInputMode, getTextInputMode());
+      setStoredValue(STORAGE_KEYS.delimiter, document.getElementById("delimiterSelect").value);
+      setStoredValue(STORAGE_KEYS.typeInferenceMode, document.getElementById("typeInferenceMode").value);
+      setStoredValue(STORAGE_KEYS.hasHeader, document.getElementById("hasHeader").checked);
+      setStoredValue(STORAGE_KEYS.ignoreEmptyLines, document.getElementById("ignoreEmptyLines").checked);
+      setStoredValue(STORAGE_KEYS.trimCells, document.getElementById("trimCells").checked);
+      setStoredValue(STORAGE_KEYS.csvQuoteMode, document.getElementById("csvQuoteMode").checked);
+      setStoredValue(STORAGE_KEYS.sheetName, document.getElementById("sheetName").value);
+      setStoredValue(STORAGE_KEYS.workbookName, document.getElementById("workbookName").value);
+      setStoredValue(STORAGE_KEYS.downloadFilename, document.getElementById("downloadFilename").value);
+      setStoredValue(STORAGE_KEYS.inputText, document.getElementById("inputText").value);
+    }
+
+    function handleFileInputChange(event, statusId = "fileStatus") {
+      const file = event.target.files && event.target.files[0];
+      const fileStatus = document.getElementById(statusId);
+      currentFileText = "";
+      currentFileName = "";
+
+      if (!file) {
+        fileStatus.textContent = "ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+        regenerateAll();
+        return;
+      }
+
+      currentFileName = file.name;
+      const reader = new FileReader();
+      reader.onload = () => {
+        currentFileText = typeof reader.result === "string" ? reader.result : "";
+        fileStatus.textContent = `${file.name} を読み込みました。`;
+        if (!document.getElementById("workbookName").value.trim() || document.getElementById("workbookName").value === "text2spreadsheetml") {
+          const suggested = file.name.replace(/\.[^.]+$/, "");
+          document.getElementById("workbookName").value = suggested || "text2spreadsheetml";
+          updateDownloadFilenameFromWorkbook();
+        }
+        regenerateAll();
+        savePersistedInputs();
+      };
+      reader.onerror = () => {
+        fileStatus.textContent = `${file.name} の読み込みに失敗しました。`;
+        regenerateAll();
+      };
+      reader.readAsText(file, "UTF-8");
+    }
+
+    function setupEvents() {
+      document.querySelectorAll('input[name="inputMode"]').forEach((radio) => {
+        radio.addEventListener("change", () => {
+          updateInputModeUi();
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      document.querySelectorAll('input[name="textInputMode"]').forEach((radio) => {
+        radio.addEventListener("change", () => {
+          updateInputModeUi();
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      [
+        "delimiterSelect",
+        "typeInferenceMode",
+        "hasHeader",
+        "ignoreEmptyLines",
+        "trimCells",
+        "csvQuoteMode",
+        "sheetName",
+        "downloadFilename",
+        "inputText"
+      ].forEach((id) => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("input", () => {
+          savePersistedInputs();
+          regenerateAll();
+        });
+        element.addEventListener("change", () => {
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      const workbookName = document.getElementById("workbookName");
+      workbookName.addEventListener("input", () => {
+        updateDownloadFilenameFromWorkbook();
+        savePersistedInputs();
+        regenerateAll();
+      });
+      workbookName.addEventListener("change", () => {
+        updateDownloadFilenameFromWorkbook();
+        savePersistedInputs();
+        regenerateAll();
+      });
+
+      document.getElementById("inputFile").addEventListener("change", (event) => handleFileInputChange(event, "fileStatus"));
+      document.getElementById("textInputFile").addEventListener("change", (event) => handleFileInputChange(event, "textFileStatus"));
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      loadPersistedInputs();
+      updateInputModeUi();
+      updateDownloadFilenameFromWorkbook();
+      setupEvents();
+      regenerateAll();
+    });
+  </script>
+</body>
+</html>

--- a/docs/text/text2spreadsheetml.html
+++ b/docs/text/text2spreadsheetml.html
@@ -1,67 +1,74 @@
+<!--
+Copyright 2026 Toshiki Iga
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <!DOCTYPE html>
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>local-html-tools</title>
+  <title>text2spreadsheetml</title>
   
   
   
   <style>
-    /* local-html-tools MD3 Token Spec v1.0.0 (2026-02-08) */
     :root {
       --md-danger: #b3261e;
-      --md-state-layer: rgba(98, 0, 238, 0.12);
       --md-sys-color-background: #f6f4f8;
-      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.35);
+      --md-sys-color-focus-ring: rgba(98, 0, 238, 0.28);
       --md-sys-color-on-primary: #ffffff;
-      --md-sys-color-on-secondary: #00332c;
       --md-sys-color-on-surface: #1c1b1f;
       --md-sys-color-on-surface-variant: #49454f;
-      --md-sys-color-on-tertiary: #FFFFFF;
-      --md-sys-color-on-tertiary-container: #3d2e5a;
       --md-sys-color-outline: #c8c5d0;
       --md-sys-color-primary: #6200ee;
-      --md-sys-color-secondary: #03dac6;
-      --md-sys-color-shadow: rgba(0, 0, 0, 0.2);
-      --md-sys-color-state-layer: rgba(98, 0, 238, 0.08);
       --md-sys-color-surface: #ffffff;
       --md-sys-color-surface-variant: #f4f1f7;
-      --md-sys-color-tertiary: #7D5260;
-      --md-sys-color-tertiary-container: #f3e8fd;
-      --md-typography-body-medium: 1rem;
       --md-typography-body-small: 0.875rem;
-      --md-typography-headline-large: 1.85rem;
-      --md-typography-title-medium: 1.1rem;
-      --md-typography-title-small: 1.05rem;
-      --status-later: #ff9800;
-      --status-ok: #4caf50;
-      --status-todo: #00bcd4;
     }
 
-    /* local-html-tools MD3 Core Spec v1.0.2 (2026-02-08) */
+    body {
+      margin: 0;
+      background: var(--md-sys-color-background);
+      color: var(--md-sys-color-on-surface);
+      font-family: "Hiragino Sans", "Yu Gothic UI", "Yu Gothic", sans-serif;
+    }
+
     .md-page {
-      background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); padding: 24px; min-height: 100vh;
+      min-height: 100vh;
+      padding: 24px;
     }
 
     .md-shell {
-      max-width: 980px; margin: 0 auto;
-    }
-
-    .md-card {
+      max-width: 1120px;
+      margin: 0 auto;
       background: var(--md-sys-color-surface);
-      border-radius: 18px;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 16px 30px rgba(0, 0, 0, 0.06);
-      border: 1px solid #e9e3f0;
+      border: 1px solid #ece7f3;
+      border-radius: 20px;
+      box-shadow: 0 8px 24px rgba(26, 20, 34, 0.08);
       padding: 28px;
+      position: relative;
     }
 
     .md-headline {
-      font-size: 1.8rem; font-weight: 700; margin-bottom: 0.75rem;
-    }
-
-    .md-subtitle {
-      color: var(--md-sys-color-on-surface-variant); font-size: 0.95rem;
+      font-size: 1.65rem;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin: 0 0 1.2rem;
+      padding-right: 2.8rem;
     }
 
     .md-section {
@@ -69,20 +76,34 @@
     }
 
     .md-section-title {
-      font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+      font-size: 1.05rem;
+      font-weight: 700;
+      margin: 0 0 0.75rem;
     }
 
     .md-grid {
-      display: grid; gap: 16px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .md-grid-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .md-card {
+      border: 1px solid #ece7f3;
+      border-radius: 18px;
+      background: #fcfbfd;
+      padding: 18px;
+      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.04);
     }
 
     .md-label {
       display: flex;
-      flex-wrap: wrap;
       align-items: center;
-      gap: 0.35rem;
+      flex-wrap: wrap;
+      gap: 0.3rem;
       font-weight: 600;
-      color: var(--md-sys-color-on-surface);
       margin-bottom: 0.35rem;
     }
 
@@ -90,76 +111,286 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 0.15rem 0.4rem;
+      padding: 0.14rem 0.4rem;
       border-radius: 999px;
       font-size: 0.54rem;
-      font-weight: 600;
-      background: #ECEAF1;
-      color: #49454F;
+      font-weight: 700;
+      background: #eceaf1;
+      color: #49454f;
     }
 
-    .md-input, .md-textarea {
+    .md-input,
+    .md-select,
+    .md-textarea,
+    .md-file {
       width: 100%;
+      box-sizing: border-box;
       border-radius: 12px;
       border: 1px solid var(--md-sys-color-outline);
-      background: var(--md-sys-color-surface);
-      padding: 0.75rem;
+      background: #fff;
+      padding: 0.78rem 0.82rem;
       font-size: 0.95rem;
       color: var(--md-sys-color-on-surface);
       transition: border-color 150ms ease, box-shadow 150ms ease;
     }
 
-    .md-textarea {
-      min-height: 6.5rem;
+    .md-file {
+      padding: 0.62rem 0.82rem;
     }
 
-    .md-input:focus, .md-textarea:focus {
+    .md-textarea {
+      min-height: 13rem;
+      resize: vertical;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      line-height: 1.45;
+    }
+
+    .md-input:focus,
+    .md-select:focus,
+    .md-textarea:focus,
+    .md-file:focus {
       outline: none;
       border-color: var(--md-sys-color-primary);
-      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
+      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
     }
 
-    .md-field-block {
-      margin-bottom: 1rem;
+    .md-row {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      align-items: start;
+    }
+
+    .md-row + .md-row {
+      margin-top: 16px;
+    }
+
+    .md-field {
+      min-width: 0;
+      display: block;
+    }
+
+    .md-field > lht-text-field-help,
+    .md-field > lht-select-help {
+      display: block;
+    }
+
+    .md-radio-group {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .md-radio {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      border: 1px solid #e1dbea;
+      border-radius: 999px;
+      background: #fff;
+      padding: 0.58rem 0.9rem;
+      cursor: pointer;
+      font-size: 0.92rem;
+    }
+
+    .md-radio input {
+      margin: 0;
+    }
+
+    .md-checks {
+      display: grid;
+      gap: 10px;
+    }
+
+    .md-check-row {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      font-size: 0.93rem;
+    }
+
+    .md-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: center;
     }
 
     .md-button {
-      border-radius: 999px;
-      padding: 0.6rem 1.2rem;
-      font-weight: 600;
-      font-size: 0.95rem;
       border: none;
-      background: transparent;
+      border-radius: 999px;
+      padding: 0.72rem 1.15rem;
+      font-size: 0.93rem;
+      font-weight: 700;
       cursor: pointer;
-      transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+      transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+    }
+
+    .md-button:hover {
+      transform: translateY(-1px);
     }
 
     .md-button--primary {
       background: var(--md-sys-color-primary);
-      color: var(--md-sys-color-on-primary);
-      box-shadow: 0 3px 8px rgba(98, 0, 238, 0.28);
+      color: #fff;
+      box-shadow: 0 4px 12px rgba(98, 0, 238, 0.24);
     }
 
     .md-button--primary:hover {
-      background: #4f00c9;
+      background: #5400d1;
     }
 
-    .md-icon-btn {
-      width: 40px;
-      height: 40px;
-      border-radius: 20px;
-      display: flex;
+    .md-button--secondary {
+      background: #efe7fb;
+      color: #4c347a;
+    }
+
+    .md-button--secondary:hover {
+      background: #e6daf8;
+    }
+
+    .md-button--surface {
+      background: #f5f2f8;
+      color: #3d3845;
+    }
+
+    .md-button--surface:hover {
+      background: #eee9f3;
+    }
+
+    .md-code-block {
+      position: relative;
+      margin-top: 0.5rem;
+    }
+
+    .md-code {
+      display: block;
+      white-space: pre;
+      overflow-x: auto;
+      background: var(--md-sys-color-surface-variant);
+      border: 1px solid #e5e0ec;
+      border-radius: 14px;
+      padding: 0.95rem;
+      padding-right: 3rem;
+      min-height: 5rem;
+      font-size: 0.9rem;
+      line-height: 1.45;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+
+    .md-copy-button {
+      position: absolute;
+      top: 0.55rem;
+      right: 0.55rem;
+      width: 34px;
+      height: 34px;
+      border: none;
+      border-radius: 17px;
+      background: #f7f2fa;
+      cursor: pointer;
+    }
+
+    .md-copy-button:hover {
+      background: #efe8f5;
+    }
+
+    .md-meta {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .md-metric {
+      border: 1px solid #e7e2eb;
+      border-radius: 14px;
+      padding: 0.85rem 0.9rem;
+      background: #fff;
+    }
+
+    .md-metric-label {
+      font-size: 0.77rem;
+      color: var(--md-sys-color-on-surface-variant);
+    }
+
+    .md-metric-value {
+      margin-top: 0.28rem;
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+
+    .md-table-wrap {
+      overflow: auto;
+      border: 1px solid #e7e2eb;
+      border-radius: 14px;
+      background: #fff;
+    }
+
+    .md-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+
+    .md-table th,
+    .md-table td {
+      border-bottom: 1px solid #eee8f2;
+      border-right: 1px solid #f1edf5;
+      padding: 0.55rem 0.65rem;
+      vertical-align: top;
+      text-align: left;
+      white-space: pre-wrap;
+      word-break: break-word;
+      min-width: 6rem;
+    }
+
+    .md-table th {
+      background: #f1f8f4;
+      font-weight: 700;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    .md-note,
+    .md-warning,
+    .md-error {
+      margin: 0.5rem 0 0;
+      font-size: 0.88rem;
+      line-height: 1.45;
+    }
+
+    .md-note {
+      color: #5f5a6b;
+    }
+
+    .md-warning {
+      color: #8a5300;
+    }
+
+    .md-error {
+      color: var(--md-danger);
+    }
+
+    .md-info-chip {
+      display: inline-flex;
       align-items: center;
       justify-content: center;
-      background: #f0edf5;
-      color: #3f3b46;
-      border: none;
-      cursor: pointer;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+      width: 22px;
+      height: 22px;
+      border-radius: 9999px;
+      color: #4a4458;
+      background: transparent;
+    }
+
+    .md-info-icon {
+      width: 18px;
+      height: 18px;
     }
 
     .md-tooltip-group {
-      position: relative; display: inline-flex; align-items: center;
+      position: relative;
+      display: inline-flex;
+      align-items: center;
     }
 
     .md-tooltip-content {
@@ -172,8 +403,7 @@
       pointer-events: none;
       transition: opacity 150ms ease;
       z-index: 50;
-      width: 20rem;
-      max-width: 90vw;
+      width: min(28rem, 88vw);
     }
 
     .md-tooltip-group:hover .md-tooltip-content {
@@ -186,855 +416,52 @@
       border-radius: 12px;
       padding: 0.75rem 1rem;
       font-size: 0.8125rem;
-      font-weight: 400;
       line-height: 1.35;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-      border: 1px solid rgba(255, 255, 255, 0.08);
-    }
-
-    .md-info-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 22px;
-      height: 22px;
-      border-radius: 9999px;
-      background: transparent;
-      color: #4a4458;
-      margin-left: 0.2rem;
-    }
-
-    .md-info-icon {
-      width: 18px; height: 18px;
-    }
-
-    .md-code-block {
-      position: relative; margin-top: 0.5rem;
-    }
-
-    .md-code {
-      display: block;
-      padding: 0.75rem;
-      padding-right: 2.5rem;
-      border-radius: 12px;
-      overflow-x: auto;
-      white-space: pre;
-      background: var(--md-sys-color-surface-variant);
-      border: 1px solid #e5e0ec;
-      color: #1f1b2d;
-      min-height: 2.5rem;
-    }
-
-    .md-copy-button {
-      position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
-      width: 32px;
-      height: 32px;
-      border-radius: 16px;
-      background: #f7f2fa;
-      border: none;
-      cursor: pointer;
-    }
-
-    .md-snackbar {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: #2b2831;
-      color: #f7f4fb;
-      padding: 0.6rem 1rem;
-      border-radius: 12px;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
-      font-size: 0.85rem;
-    }
-
-    .md-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border-radius: 999px;
-      padding: 2px 10px;
-      font-size: 0.7rem;
-      font-weight: 700;
-      background: rgba(98, 0, 238, 0.12);
-      color: var(--md-sys-color-primary);
-      margin-left: 6px;
-    }
-
-    .md-section-wrap {
-      display: grid; gap: 1.75rem;
-    }
-
-    .md-section-card {
-      padding: 1.25rem 1.25rem 1.5rem;
-      border-radius: 24px;
-      background: var(--md-sys-color-surface);
-      border: 1px solid #ece7f3;
-      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
-    }
-
-    .md-section-subtitle {
-      font-size: var(--md-typography-body-small);
-      color: #6a6675;
-      margin-bottom: 1rem;
-    }
-
-    .md-section-title--spaced {
-      margin-top: 1rem;
-    }
-
-    .md-grid-3 {
-      grid-template-columns: repeat(1, minmax(0, 1fr));
-    }
-
-    .md-card-head {
-      display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
-    }
-
-    .md-card-title {
-      font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35;
-    }
-
-    .md-card-arrow {
-      color: #8f8a98; font-size: 1.2rem;
-    }
-
-    .md-card-desc {
-      margin-top: 0.5rem;
-      font-size: var(--md-typography-body-small);
-      color: #5f5a6b;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-    .md-info-chip:focus-visible {
-      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
-    }
-
-    .md-tooltip--wide {
-      width: min(32rem, 90vw);
-    }
-
-    .md-tooltip--rich {
-      border: 1px solid rgba(255, 255, 255, 0.08);
-    }
-
-    .md-menu-button {
-      position: absolute; top: 16px; right: 16px;
-    }
-
-    .md-menu-panel {
-      position: absolute;
-      top: 56px;
-      right: 16px;
-      background: var(--md-sys-color-surface);
-      border: 1px solid #e6e1ee;
-      border-radius: 12px;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-      padding: 4px 0;
-      min-width: 160px;
-      z-index: 20;
-    }
-
-    .md-menu-link {
-      display: block; padding: 8px 16px; color: var(--md-sys-color-on-surface);
-    }
-
-    .md-menu-link:hover {
-      background: #f2edf8;
-    }
-
-    .md-headline__icon {
-      margin-right: 0.5rem;
-    }
-
-    .md-section-title--lg {
-      font-size: 1.1rem;
-    }
-
-    .md-input, .md-select, .md-textarea {
-      display: block;
-      width: 100%;
-      border-radius: 12px;
-      border: 1px solid var(--md-sys-color-outline);
-      background: var(--md-sys-color-surface);
-      padding: 0.75rem;
-      font-size: 0.95rem;
-      color: var(--md-sys-color-on-surface);
-      transition: border-color 150ms ease, box-shadow 150ms ease;
-      box-sizing: border-box;
-    }
-
-    .md-input:focus, .md-select:focus, .md-textarea:focus {
-      outline: none;
-      border-color: var(--md-sys-color-primary);
-      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
-    }
-
-    .md-icon-btn:hover {
-      background: #e6e1ee;
-    }
-
-    .md-icon-btn--small {
-      width: 32px; height: 32px; border-radius: 16px;
-    }
-
-    .md-icon-btn--surface {
-      background: #f7f2fa;
-    }
-
-    .md-snackbar.md-visible {
-      opacity: 1; pointer-events: auto;
     }
 
     .md-hidden {
-      display: none;
-    }
-
-        .md-sr-only {
-          position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0;
-        }
-        .md-preview .md-sr-only { display: none !important; }
-
-    .md-stack-sm > * + * {
-      margin-top: 0.75rem;
-    }
-
-    .md-radio-row { display: flex; align-items: flex-start; gap: 0.5rem; }
-    .md-radio {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-size: 0.95rem;
-      color: #3f3b46;
-    }
-
-    .md-radio input {
-      accent-color: var(--md-sys-color-primary);
-    }
-
-    .md-switch-label {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.6rem;
-      font-size: 0.95rem;
-      color: var(--md-sys-color-on-surface);
-    }
-
-    .md-switch {
-      position: relative;
-      width: 44px;
-      height: 24px;
-      background: #f0ebf7;
-      border-radius: 9999px;
-      display: inline-flex;
-      align-items: center;
-      padding: 2px;
-      transition: background 150ms ease, box-shadow 150ms ease;
-      box-shadow: inset 0 0 0 1px #cfc7dc;
-    }
-
-    .md-switch::after {
-      content: "";
-      width: 20px;
-      height: 20px;
-      border-radius: 9999px;
-      background: #ffffff;
-      position: absolute;
-      top: 2px;
-      left: 2px;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-      transition: transform 150ms ease, background 150ms ease;
-    }
-
-    .md-switch-input {
-      position: absolute; opacity: 0; pointer-events: none;
-    }
-
-    .md-switch-input:checked + .md-switch {
-      background: rgba(98, 0, 238, 0.32);
-      box-shadow: inset 0 0 0 1px rgba(98, 0, 238, 0.6);
-    }
-
-    .md-switch-input:checked + .md-switch::after {
-      transform: translateX(20px);
-      background: #ffffff;
-    }
-
-    .md-tab-list {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      border-bottom: 1px solid #e6e1ee;
-      margin-bottom: 1rem;
-    }
-
-    .md-tab-button {
-      border: 1px solid #e6e1ee;
-      border-bottom: none;
-      background: #f3f1f7;
-      padding: 0.4rem 0.9rem;
-      margin-bottom: -1px;
-      border-top-left-radius: 12px;
-      border-top-right-radius: 12px;
-      font-size: 0.875rem;
-      font-weight: 600;
-      color: #3f3b46;
-    }
-
-    .md-tab-button[aria-selected="true"] {
-      background: #ffffff;
-      border-color: #c8c5d0;
-      color: #1c1b1f;
-    }
-
-    .md-tab-panel {
-      border: 1px solid #e6e1ee;
-      border-top: none;
-      padding: 1rem;
-      background: #ffffff;
-      border-bottom-left-radius: 12px;
-      border-bottom-right-radius: 12px;
-      margin-bottom: 1rem;
-    }
-
-    .md-label--row {
-      margin-bottom: 0.5rem;
-    }
-
-    .md-input, .md-select {
-      display: block;
-      width: 100%;
-      border-radius: 12px;
-      border: 1px solid var(--md-sys-color-outline);
-      background: var(--md-sys-color-surface);
-      padding: 0.75rem;
-      font-size: 0.95rem;
-      color: var(--md-sys-color-on-surface);
-      transition: border-color 150ms ease, box-shadow 150ms ease;
-      box-sizing: border-box;
-    }
-
-    .md-input:focus, .md-select:focus {
-      outline: none;
-      border-color: var(--md-sys-color-primary);
-      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
-    }
-
-    .md-form-grid {
-      display: grid; gap: 0.75rem;
-    }
-
-    .md-button--tonal {
-      background: #f0edf5;
-      color: #3f3b46;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
-    }
-
-    .md-button--tonal:hover {
-      background: #e6e1ee;
-    }
-
-    .md-chip-row {
-      display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem;
-    }
-
-    .md-tooltip--narrow {
-      width: 18rem;
-    }
-
-    .md-surface-card {
-      max-width: 48rem; margin: 0 auto; padding: 24px; position: relative;
-    }
-
-    .md-choice {
-      display: flex;
-      align-items: center;
-      gap: 0.65rem;
-      padding: 0.25rem 0;
-    }
-
-    .md-input {
-      width: 100%;
-      padding: 0.65rem 0.75rem;
-      border-radius: 12px;
-      border: 1px solid var(--md-sys-color-outline);
-      background: var(--md-sys-color-surface);
-      font-size: 1rem;
-      color: var(--md-sys-color-on-surface);
-      transition: border-color 150ms ease, box-shadow 150ms ease;
-    }
-
-    .md-input:focus {
-      outline: none;
-      border-color: var(--md-sys-color-primary);
-      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
-    }
-
-    .md-button:hover {
-      box-shadow: 0 4px 10px rgba(98, 0, 238, 0.35);
-    }
-
-    .md-button:active {
-      opacity: 0.7;
-    }
-
-    .md-button--surface {
-      background: var(--md-sys-color-surface-variant); color: var(--md-sys-color-on-surface); border: 1px solid var(--md-sys-color-outline);
-    }
-
-    .md-button--secondary {
-      background: var(--md-sys-color-secondary); color: var(--md-sys-color-on-secondary); margin-bottom: 10px;
-    }
-
-    .md-button-row {
-      display: flex; gap: 15px; height: clamp(120px, 20vh, 220px); margin-bottom: 10px;
-    }
-
-    .md-button--hero {
-      font-size: clamp(1.2rem, 4vw, 1.6rem);
-    }
-
-    .md-field {
-      position: relative; min-width: 200px;
-    }
-
-    .md-field__label {
-      position: absolute;
-      top: -9px;
-      left: 12px;
-      padding: 0 6px;
-      background: var(--md-sys-color-surface);
-      font-size: 0.72rem;
-      font-weight: 600;
-      color: var(--md-sys-color-on-surface-variant);
-      letter-spacing: 0.02em;
-    }
-
-    .md-field .md-select {
-      appearance: none;
-      border-radius: 12px;
-      border: 1px solid var(--md-sys-color-outline);
-      background: var(--md-sys-color-surface);
-      padding: 0.8rem 2.2rem 0.8rem 0.9rem;
-      font-size: 0.9rem;
-      color: var(--md-sys-color-on-surface);
-      min-width: 200px;
-      line-height: 1.2;
-      background-image: linear-gradient(45deg, transparent 50%, #6c6775 50%), linear-gradient(135deg, #6c6775 50%, transparent 50%);
-      background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
-      background-size: 6px 6px, 6px 6px;
-      background-repeat: no-repeat;
-    }
-
-    .md-field .md-select:focus {
-      outline: none; border-color: var(--md-sys-color-primary); box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
-    }
-
-    .md-stack-md > * + * {
-      margin-top: 0.75rem;
-    }
-
-    .md-grid-2 {
-      grid-template-columns: repeat(1, minmax(0, 1fr));
-    }
-
-    .md-form-row {
-      display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;
-    }
-
-    .md-form-row--nowrap {
-      flex-wrap: nowrap;
-    }
-
-    .md-label--muted {
-      color: #3f3b46;
-    }
-
-    .md-label--block {
-      margin-bottom: 0.5rem;
+      display: none !important;
     }
 
     .md-snackbar-host {
       position: fixed;
-      right: 1.25rem;
-      bottom: 1.25rem;
-      padding: 0.5rem 1rem;
+      right: 20px;
+      bottom: 20px;
       opacity: 0;
       pointer-events: none;
-      transition: opacity 200ms ease;
+      transition: opacity 180ms ease;
+      z-index: 200;
     }
 
     .md-snackbar-host.md-visible {
-      opacity: 1; pointer-events: auto;
+      opacity: 1;
     }
 
-    .md-button:disabled {
-      background: #e6e1ee;
-      color: #9a94a7;
-      cursor: not-allowed;
-      box-shadow: none;
-    }
-
-    .md-textarea:focus {
-      outline: none;
-      border-color: var(--md-sys-color-primary);
-      box-shadow: 0 0 0 3px rgba(98, 0, 238, 0.2);
-    }
-
-    .md-input-block {
-      margin-bottom: 1rem;
-    }
-
-    .md-section-title-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-    }
-
-    .md-output-wrap {
-      position: relative;
-    }
-
-    .md-output {
-      background: var(--md-sys-color-surface-variant);
-    }
-
-    .md-stack-lg > * + * {
-      margin-top: 1.5rem;
-    }
-
-    .md-form-row--start {
-      align-items: flex-start;
-    }
-
-    .md-input:disabled, .md-select:disabled {
-      background: #f3f0f7;
-    }
-
-    .md-choice-card {
-      border: 1px solid #e2dcec;
-      border-radius: 16px;
-      padding: 1rem;
-      background: #ffffff;
-    }
-
-    .md-choice-card--muted {
-      background: #f7f3fb;
-    }
-
-    .md-choice-row {
-      display: flex; align-items: center; gap: 0.75rem;
-    }
-
-    .md-choice-row input {
-      margin: 0;
-    }
-
-    .md-choice-sub {
-      display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: #6a6675;
-    }
-
-    .md-choice-sub small {
-      font-size: 0.75rem; color: #7b7784;
-    }
-
-    .md-chip--primary {
-      background: #e2d9f7;
-      color: #4a1e9e;
-    }
-
-    .md-chip--warn {
-      background: #f7ece1;
-      color: #8a4b0f;
-    }
-
-    .md-field-stack {
-      display: flex; flex-direction: column; align-items: stretch; gap: 0.5rem;
-    }
-
-    .md-label--full {
-      width: 100%;
-    }
-
-    .md-switch-row {
-      display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem; color: var(--md-sys-color-on-surface); font-size: 0.95rem;
-    }
-
-    .md-input-wrap {
-      position: relative;
-      flex: 1 1 16rem;
-      min-width: 12rem;
-    }
-
-    .md-input-wrap .md-input {
-      padding-right: 3rem;
-    }
-
-    .md-input-action {
-      position: absolute;
-      top: 50%;
-      right: -0.5rem;
-      transform: translateY(-50%);
-      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
-    }
-
-    .md-field-stack .md-input, .md-field-stack .md-select {
-      flex: 0 0 auto;
-    }
-
-    .md-field--dropdown {
-      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23635b75' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
-      background-repeat: no-repeat;
-      background-position: right 0.75rem center;
-      background-size: 1rem 1rem;
-      padding-right: 2.25rem;
-    }
-
-    .md-select--inline {
-      flex: 1 1 18rem; min-width: 14rem;
-    }
-
-    .md-input.md-disabled, .md-select.md-disabled {
-      background: #f3f0f7;
-    }
-
-    .md-choice-inline {
-      display: flex; flex-wrap: wrap; gap: 1.25rem; row-gap: 0.5rem;
-    }
-
-    .md-choice-text {
-      font-size: 0.9rem; color: #4a4458;
-    }
-
-
-
-
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-    body { font-family: "Roboto", "Segoe UI", "Noto Sans JP", "Hiragino Sans", sans-serif; font-size: var(--md-typography-body-medium); line-height: 1.5; }
-
-    .md-page { background: var(--md-sys-color-background); color: var(--md-sys-color-on-surface); }
-    .md-container { max-width: 72rem; margin: 0 auto; padding: 1.5rem 1rem 2.5rem; }
-
-    .md-app-bar { margin-bottom: 1.75rem; }
-    .md-app-bar-inner {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 1.5rem;
-      padding: 1.25rem 1.5rem;
-      border-radius: 20px;
-      background: var(--md-sys-color-surface);
-      border: 1px solid #ede7f3;
-      box-shadow: 0 6px 20px rgba(41, 35, 58, 0.08);
-    }
-    .md-app-heading {
-      display: grid;
-      gap: 0.35rem;
-    }
-    .md-app-title {
-      display: flex;
-      align-items: center;
-      gap: 0.6rem;
-      font-size: var(--md-typography-headline-large);
-      font-weight: 700;
-      letter-spacing: -0.01em;
-    }
-    .md-app-supporting {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.45rem;
-      color: #5f5b67;
-      font-size: 0.98rem;
-      line-height: 1.45;
-    }
-    .md-app-meta { font-size: 0.95rem; color: #6a6675; }
-    .md-icon-inline { margin-right: 0.5rem; }
-    .md-section-wrap { display: grid; gap: 1.75rem; }
-
-    .md-card {
-      background: var(--md-sys-color-surface);
-      border-radius: 16px;
-      border: 1px solid #ece7f3;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 20px rgba(0, 0, 0, 0.06);
-    }
-
-    .md-info-card {
-      padding: 1.25rem 1.5rem;
-      margin-bottom: 1.75rem;
-      background: var(--md-sys-color-tertiary-container);
-      border-color: rgba(61, 46, 90, 0.08);
-      color: var(--md-sys-color-on-tertiary-container);
-    }
-    .md-info-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
-
-    .md-section-card {
-      padding: 1.25rem 1.25rem 1.5rem;
-      border-radius: 24px;
-      background: var(--md-sys-color-surface);
-      border: 1px solid #ece7f3;
-      box-shadow: 0 2px 10px rgba(41, 35, 58, 0.06);
-    }
-    .md-section-title {
-      font-size: var(--md-typography-title-medium);
-      font-weight: 600;
-      color: #3f3b46;
-      margin-bottom: 0.25rem;
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
-    }
-    .md-section-subtitle {
-      font-size: var(--md-typography-body-small);
-      color: #6a6675;
-      margin-bottom: 1rem;
-    }
-    .md-section-title--spaced { margin-top: 1rem; }
-
-    .md-grid { display: grid; gap: 1rem; }
-    .md-grid-3 { grid-template-columns: repeat(1, minmax(0, 1fr)); }
-    @media (min-width: 640px) {
-      .md-grid-3 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    }
-    @media (min-width: 1024px) {
-      .md-grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    }
-    .md-section { margin-bottom: 0; }
-    .md-divider { border: none; border-top: 1px solid #e2dcec; margin: 2.5rem 0 1.5rem; }
-
-    .md-footer { text-align: center; font-size: 0.875rem; color: #6a6675; padding-bottom: 1.5rem; }
-    .md-footer-links { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 1rem; }
-    .md-footer-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #4a3d6b; text-decoration: none; font-weight: 600; }
-    a { text-decoration: none; color: inherit; }
-    .md-footer-link:hover { color: #2f2347; }
-    .md-footer-sep { color: #c8c2d0; }
-    .md-footer-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 0.15rem 0.6rem;
-      border-radius: 9999px;
-      background: #f4eef8;
-      border: 1px solid #e0d8ea;
-      font-size: 0.7rem;
-      font-weight: 600;
-      color: #4a3d6b;
-    }
-    .md-footer-icon { width: 1rem; height: 1rem; }
-
-    .md-link-card {
-      position: relative;
-      display: block;
-      padding: 1rem;
-      border-radius: 16px;
-      background: var(--md-sys-color-surface);
-      border: 1px solid #ece7f3;
-      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
-      transition: box-shadow 150ms ease, border-color 150ms ease, background 150ms ease;
-      overflow: hidden;
-      outline: none;
-    }
-    .md-link-card:hover {
-      box-shadow: 0 6px 16px rgba(35, 29, 49, 0.12);
-      border-color: #d7cfee;
-    }
-    .md-link-card::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      background: var(--md-sys-color-state-layer);
-      opacity: 0;
-      transition: opacity 150ms ease;
-    }
-    .md-link-card:hover::after { opacity: 1; }
-    .md-link-card:focus-visible {
-      border-color: rgba(98, 0, 238, 0.55);
-      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring), 0 6px 16px rgba(35, 29, 49, 0.12);
-    }
-    .md-link-card:focus-visible::after { opacity: 1; }
-    .md-link-card:active::after { opacity: 0.18; }
-    .md-link-card > * { position: relative; z-index: 1; }
-
-    .md-card-head { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; }
-    .md-card-title { font-size: var(--md-typography-title-small); font-weight: 600; color: #2f2a35; }
-    .md-card-arrow { color: #8f8a98; font-size: 1.2rem; }
-    .md-link-card:hover .md-card-arrow { color: #6d6483; }
-
-    .md-card-desc {
-      margin-top: 0.5rem;
-      font-size: var(--md-typography-body-small);
-      color: #5f5a6b;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-    @media (hover: hover) and (pointer: fine) {
-      .md-link-card:hover,
-      .md-link-card:focus-visible {
-        overflow: visible;
-        z-index: 2;
-      }
-      .md-link-card:hover .md-card-desc,
-      .md-link-card:focus-visible .md-card-desc {
-        display: block;
-        -webkit-line-clamp: unset;
-        line-clamp: unset;
-        -webkit-box-orient: initial;
-        overflow: visible;
-      }
-    }
-
-    .md-tooltip-group { position: relative; display: inline-flex; align-items: center; }
-    .md-info-chip {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 22px;
-      height: 22px;
-      border-radius: 9999px;
-      background: #f0edf5;
-      color: #4a4458;
-      font-size: 0.75rem;
-      font-weight: 600;
-      outline: none;
-      border: none;
-      cursor: help;
-      padding: 0;
-    }
-    .md-info-chip:focus-visible {
-      box-shadow: 0 0 0 3px var(--md-sys-color-focus-ring);
-    }
-    .md-tooltip-content {
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      margin-top: 0.5rem;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 150ms ease;
-      z-index: 50;
-      width: min(32rem, 90vw);
-    }
-    .md-tooltip-group:hover .md-tooltip-content { opacity: 1; }
-    .md-tooltip--wide { width: min(32rem, 90vw); }
-    .md-tooltip {
+    .md-snackbar {
       background: #2b2831;
       color: #f7f4fb;
       border-radius: 12px;
-      padding: 0.75rem 1rem;
-      font-size: 0.8125rem;
-      font-weight: 400;
-      line-height: 1.5;
+      padding: 0.72rem 1rem;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+      font-size: 0.88rem;
     }
-    .md-tooltip--rich { border: 1px solid rgba(255, 255, 255, 0.08); }
+
+    @media (max-width: 900px) {
+      .md-grid-2,
+      .md-row,
+      .md-meta {
+        grid-template-columns: 1fr;
+      }
+
+      .md-page {
+        padding: 16px;
+      }
+
+      .md-shell {
+        padding: 20px;
+      }
+    }
   </style>
   <style>
 /*
@@ -2089,260 +1516,928 @@ lht-index-card-link {
   </style>
 </head>
 <body class="md-page">
-  <svg aria-hidden="true" class="md-icon-sprite" width="0" height="0" viewBox="0 0 0 0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0;overflow:hidden">
-    <defs>
-      <symbol id="md-icon-github" viewBox="0 0 16 16">
-        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
-      </symbol>
-      <symbol id="md-icon-globe" viewBox="0 0 24 24">
-        <circle cx="12" cy="12" r="9"/>
-        <path d="M3 12h18"/>
-        <path d="M12 3a14 14 0 0 1 0 18"/>
-        <path d="M12 3a14 14 0 0 0 0 18"/>
-      </symbol>
-    </defs>
-  </svg>
-  <div class="md-container">
-    <header class="md-app-bar">
-      <div class="md-app-bar-inner">
-        <div class="md-app-heading">
-          <div class="md-app-title">
-            <span aria-hidden="true" class="md-icon-inline">🗂️</span>
-            <span>local-html-tools</span>
+  <main>
+    <section class="md-shell">
+      <lht-page-hero
+        title="text2spreadsheetml"
+        subtitle="ベタテキスト、CSV、TAB区切りファイルから SpreadsheetML 2003 XML を生成します。"
+        icon="📊"
+        help-label="text2spreadsheetml の説明"
+        help-wide
+        menu-home-href="../index.html"
+        menu-home-label="トップへ戻る">
+        ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。<br><br>
+        MVP では値を壊さないことを優先し、全セルを `String` として出力します。数値や日付の型変換は行わず、Excel 上で後から必要に応じて操作する前提です。
+      </lht-page-hero>
+
+      <section class="md-section md-card">
+        <h2 class="md-section-title">入力方式</h2>
+        <div class="md-radio-group">
+          <label class="md-radio"><input type="radio" name="inputMode" value="text" checked>ベタテキスト</label>
+          <label class="md-radio"><input type="radio" name="inputMode" value="csv">CSV ファイル</label>
+          <label class="md-radio"><input type="radio" name="inputMode" value="tsv">TAB 区切りファイル</label>
+        </div>
+        <p class="md-note">MVP では、どの入力方式でも内部的には表データへ正規化してから 1 シートの SpreadsheetML 2003 を生成します。</p>
+      </section>
+
+      <section class="md-section md-grid md-grid-2">
+        <div class="md-card">
+          <h2 class="md-section-title">入力データ</h2>
+
+          <div id="textInputSection">
+            <div class="md-radio-group" style="margin-bottom: 12px;">
+              <label class="md-radio"><input type="radio" name="textInputMode" value="direct" checked>直接入力</label>
+              <label class="md-radio"><input type="radio" name="textInputMode" value="file">テキストファイル</label>
+            </div>
+            <lht-text-field-help
+              field-id="inputText"
+              label="入力テキスト"
+              type="textarea"
+              rows="12"
+              required
+              placeholder="name,age,joined&#10;Alice,30,2026-03-01&#10;Bob,28,2026-03-15"
+              help-text="区切り文字付きの表テキストを貼り付けます。CSV風、TAB区切り、パイプ区切りなどを読み取り設定に合わせて解釈します。">
+            </lht-text-field-help>
+            <div id="textFileInputSection" class="md-hidden" style="margin-top: 12px;">
+              <lht-file-select
+                input-id="textInputFile"
+                button-id="textInputFileButton"
+                file-name-id="textInputFileName"
+                button-label="テキストファイルを選択"
+                accept=".txt,.csv,.tsv,text/plain,text/csv,text/tab-separated-values"
+                placeholder="未選択"
+                show-file-name>
+              </lht-file-select>
+              <p id="textFileStatus" class="md-note">テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。</p>
+            </div>
           </div>
-          <div class="md-app-supporting">
-            <span>ウェブブラウザで動くローカルHTMLツール集（Single-file Web App）です。</span>
-            <lht-help-tooltip label="このツール集について" wide>
-              各ツール（HTMLファイル）をウェブブラウザで開くと、専用の入力画面が表示されます。必要な情報を入力するだけで、用途に応じたテキストやコマンドを生成できます。<br><br>
-              主な特徴:<br>
-              ・ローカル動作（サーバ不要）<br>
-              ・単一HTML配布（必要な資産を内包）<br>
-              ・入力から生成までを短手順で実行
-            </lht-help-tooltip>
+
+          <div id="fileInputSection" class="md-hidden">
+            <lht-file-select
+              input-id="inputFile"
+              button-id="inputFileButton"
+              file-name-id="inputFileName"
+              button-label="入力ファイルを選択"
+              accept=".csv,.tsv,.txt,text/csv,text/tab-separated-values,text/plain"
+              placeholder="未選択"
+              show-file-name>
+            </lht-file-select>
+            <p id="fileStatus" class="md-note">ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。</p>
+          </div>
+
+          <div class="md-actions" style="margin-top: 14px;">
+            <button type="button" class="md-button md-button--secondary" onclick="applySample()">サンプル投入</button>
+            <button type="button" class="md-button md-button--surface" onclick="clearUiPreferences()">設定をクリア</button>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-23</div>
-      </div>
-    </header>
 
-    <div class="md-section-wrap">
-
-
-
-
-
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">⚡</span>Quick Access
-      </h2>
-      <p class="md-section-subtitle">よく使うツールへのショートカット</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
-        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="生成AIプロンプト作成" desc="生成AIに引き渡す定型プロンプトの作成を支援します。"></lht-index-card-link>
-        <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
-        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
-      </div>
+        <div class="md-card">
+          <h2 class="md-section-title">読み取り設定</h2>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-select-help field-id="delimiterSelect" label="区切り文字" help-text="ベタテキストをどの区切り文字で列分割するかを指定します。">
+                <script type="application/json" slot="options">[
+                  { "value": "comma", "label": "カンマ (,)" },
+                  { "value": "tab", "label": "TAB" },
+                  { "value": "space", "label": "半角空白", "selected": true },
+                  { "value": "pipe", "label": "パイプ (|)" },
+                  { "value": "semicolon", "label": "セミコロン (;)" }
+                ]</script>
+              </lht-select-help>
+            </div>
+            <div class="md-field">
+              <lht-text-field-help field-id="sheetName" label="シート名" required value="Sheet1" placeholder="Sheet1" help-text="SpreadsheetML 2003 で出力するワークシート名です。"></lht-text-field-help>
+            </div>
+          </div>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-text-field-help field-id="workbookName" label="Workbook 名" value="text2spreadsheetml" placeholder="text2spreadsheetml" help-text="DocumentProperties の Title と保存ファイル名の初期値に使います。"></lht-text-field-help>
+            </div>
+            <div class="md-field">
+              <lht-text-field-help field-id="downloadFilename" label="保存ファイル名" value="text2spreadsheetml.xml" placeholder="text2spreadsheetml.xml" help-text=".xml 保存時のファイル名です。未入力時は Workbook 名から補います。"></lht-text-field-help>
+            </div>
+          </div>
+          <div class="md-row">
+            <div class="md-field">
+              <lht-select-help field-id="typeInferenceMode" label="項目型" help-text="文字列固定か、限定数値推論かを選びます。限定数値推論では、先頭ゼロ付き整数が1つでもある列は String にフォールバックします。">
+                <script type="application/json" slot="options">[
+                  { "value": "string", "label": "文字列固定", "selected": true },
+                  { "value": "limitedNumeric", "label": "限定数値推論" }
+                ]</script>
+              </lht-select-help>
+            </div>
+          </div>
+          <div class="md-checks" style="margin-top: 10px;">
+            <lht-switch-help switch-id="hasHeader" label="1行目をヘッダとして扱う" checked></lht-switch-help>
+            <lht-switch-help switch-id="ignoreEmptyLines" label="空行を無視" checked></lht-switch-help>
+            <lht-switch-help switch-id="trimCells" label="各セルの前後空白を trim" checked></lht-switch-help>
+            <div id="csvQuoteModeWrap" class="md-hidden">
+              <lht-switch-help switch-id="csvQuoteMode" label="ダブルクォート付き CSV を解釈" help-label="ダブルクォート付き CSV の説明">CSV の `&quot;...&quot;` による囲みを解釈します。MVP では CSV 向けの簡易対応です。</lht-switch-help>
+            </div>
+          </div>
+          <p class="md-note">文字列固定では全セル `String`、限定数値推論では列単位で `Number` / `String` を判定します。</p>
+          <p id="configWarning" class="md-warning"></p>
+        </div>
       </section>
 
-
-
-
-
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🧰</span>Git
-      </h3>
-      <p class="md-section-subtitle">Git操作の補助ツール</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。URL、基準ブランチ、作業ブランチ、ローカル/リモートの扱いを保存し、比較や squash への導線もまとめて扱えます。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-pseudo-squash.html" icon="🧩" title="Git pseudo-squash" desc="reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-branch-diff.html" icon="🧰" title="Git ブランチ比較" desc="2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-config-setup.html" icon="⚙️" title="Git ユーザー設定" desc="グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="git/git-config-advanced-setup.html" icon="🔧" title="Git 詳細設定" desc="core.autocrlf や push.default などのGit詳細設定をグローバル設定するコマンドを生成します。"></lht-index-card-link>
-      </div>
+      <section class="md-section md-card">
+        <h2 class="md-section-title">プレビュー</h2>
+        <div class="md-meta">
+          <div class="md-metric"><div class="md-metric-label">行数</div><div id="rowCount" class="md-metric-value">0</div></div>
+          <div class="md-metric"><div class="md-metric-label">列数</div><div id="columnCount" class="md-metric-value">0</div></div>
+          <div class="md-metric"><div class="md-metric-label">ヘッダ</div><div id="headerState" class="md-metric-value">OFF</div></div>
+          <div class="md-metric"><div class="md-metric-label">セル型</div><div id="cellTypeModeLabel" class="md-metric-value">String</div></div>
+        </div>
+        <p id="columnTypeSummary" class="md-note"></p>
+        <p id="parseError" class="md-error"></p>
+        <p id="parseWarning" class="md-warning"></p>
+        <div class="md-table-wrap" style="margin-top: 12px;">
+          <table class="md-table">
+            <thead id="previewHead"></thead>
+            <tbody id="previewBody"></tbody>
+          </table>
+        </div>
       </section>
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">📄</span>テキスト
-      </h3>
-      <p class="md-section-subtitle">テキスト表示/加工</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="プロンプト作成支援" desc="生成AIに引き渡す定型プロンプトの作成を支援します。PR 文面、Release 文面、レビュー依頼、引継ぎ、作業確認など、繰り返し使う依頼文を素早く揃えられます。"></lht-index-card-link>
-        <lht-index-card-link href="text/text-processing.html" icon="🧩" title="テキスト加工" desc="テキストを即時に変換・整形するためのツールです。入力内容に対して選択した変換オプションが順番に適用され、結果が出力欄に反映されます。文字の変換・行の変換・空白の変換を組み合わせて使えます。"></lht-index-card-link>
-        <lht-index-card-link href="password/password-gen.html" icon="🛡️" title="パスワードジェネレーター" desc="選択した文字種と文字数でパスワードを生成します。英大文字または英小文字は必須で、生成結果は英字から始まります。目視で認識しづらい文字は除外した設計になっています。"></lht-index-card-link>
-        <lht-index-card-link href="text/text-viewer.html" icon="📄" title="テキスト表示" desc="テキストをペーストして、読みやすく表示します。マークダウン形式にも対応しています。"></lht-index-card-link>
-        <lht-index-card-link href="text/file-rename-cmdline-gen.html" icon="🏷️" title="ファイル名連番リネーム" desc="ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。"></lht-index-card-link>
-        <lht-index-card-link href="text/text2spreadsheetml.html" icon="📊" title="text2spreadsheetml" desc="ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。MVP では全セルを String として安全側へ出力します。"></lht-index-card-link>
-        <lht-index-card-link href="text/japanese-romaji-guide.html" icon="🔤" title="日本語ローマ字メモ" desc="旅券ローマ字を中心に、ヘボン式・訓令式・日本式（理論寄り）を比較しながら、かなをローマ字に変換します。"></lht-index-card-link>
-        <lht-index-card-link href="https://igapyon.github.io/xlsx2md/xlsx2md.html" icon="📘" title="xlsx2md" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
-      </div>
+      <section class="md-section md-card">
+        <h2 class="md-section-title">SpreadsheetML 2003 XML</h2>
+        <div class="md-actions">
+          <button type="button" class="md-button md-button--primary" onclick="downloadGeneratedXml()">.xml を保存</button>
+        </div>
+        <lht-command-block command-id="xmlOutput"></lht-command-block>
       </section>
+    </section>
+  </main>
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🎼</span>Music
-      </h3>
-      <p class="md-section-subtitle">楽譜データの変換</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="music/musicxml-to-svg.html" icon="🎼" title="MusicXML → SVG 変換" desc="MusicXMLから楽譜SVGを生成し、SVGとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="music/musicxml-to-midi.html" icon="🥁" title="MusicXML → MIDI 変換" desc="MusicXMLからMIDIを生成し、.midとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="music/midi-to-musicxml.html" icon="🎹" title="MIDI → MusicXML 変換" desc="MIDIからMusicXMLを生成し、MusicXMLとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="music/musicxml-to-abc.html" icon="🎶" title="MusicXML → ABC 変換" desc="MusicXMLからABC記法を生成し、ABCとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="music/abc-to-musicxml.html" icon="🎵" title="ABC → MusicXML 変換" desc="ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="https://igapyon.github.io/mikuscore/mikuscore.html" icon="🎼" title="mikuscore" desc="mikuscore is a browser-based score format converter centered on MusicXML. It runs offline as a single-file web app."></lht-index-card-link>
-      </div>
-      </section>
+  <lht-toast id="toast"></lht-toast>
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🔍</span>検索
-      </h3>
-      <p class="md-section-subtitle">ローカル検索コマンド生成</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。条件（名前/拡張子/サイズ/更新日時/内容検索）を組み合わせて作れます。"></lht-index-card-link>
-      </div>
-      </section>
+  <script>
+    const STORAGE_KEYS = {
+      inputMode: "text2spreadsheetml.ui.inputMode",
+      textInputMode: "text2spreadsheetml.ui.textInputMode",
+      delimiter: "text2spreadsheetml.ui.delimiter",
+      typeInferenceMode: "text2spreadsheetml.ui.typeInferenceMode",
+      hasHeader: "text2spreadsheetml.ui.hasHeader",
+      ignoreEmptyLines: "text2spreadsheetml.ui.ignoreEmptyLines",
+      trimCells: "text2spreadsheetml.ui.trimCells",
+      csvQuoteMode: "text2spreadsheetml.ui.csvQuoteMode",
+      sheetName: "text2spreadsheetml.ui.sheetName",
+      workbookName: "text2spreadsheetml.ui.workbookName",
+      downloadFilename: "text2spreadsheetml.ui.downloadFilename",
+      inputText: "text2spreadsheetml.ui.inputText"
+    };
 
+    let currentFileText = "";
+    let currentFileName = "";
+    let latestGeneratedXml = "";
 
+    function getStoredString(key) {
+      try {
+        const value = localStorage.getItem(key);
+        return value == null ? null : value;
+      } catch (error) {
+        return null;
+      }
+    }
 
+    function getStoredBoolean(key) {
+      const raw = getStoredString(key);
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return null;
+    }
 
+    function setStoredValue(key, value) {
+      try {
+        localStorage.setItem(key, String(value));
+      } catch (error) {
+        // localStorage が使えない環境でも継続
+      }
+    }
 
+    function showToast(message) {
+      const host = document.getElementById("toast");
+      if (!host) return;
+      if (typeof host.show === "function") {
+        host.show(message, 1800);
+        return;
+      }
+    }
 
+    function copyToClipboard(elementId) {
+      const element = document.getElementById(elementId);
+      if (!element) return;
+      const text = element.textContent || "";
+      if (!text) {
+        showToast("コピーする内容がありません");
+        return;
+      }
+      navigator.clipboard.writeText(text)
+        .then(() => showToast("コピーしました"))
+        .catch(() => showToast("コピーに失敗しました"));
+    }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title md-section-title--spaced">
-        <span aria-hidden="true" class="md-icon-inline">🎬</span>メディア処理（FFmpeg）
-      </h2>
-      <p class="md-section-subtitle">FFmpeg向けコマンド生成</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="ffmpeg/ffmpeg-concat-cmdline-gen.html" icon="🧩" title="FFmpeg ファイル結合" desc="複数の.wavファイルを1つに結合するコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-loudnorm-cmdline-gen.html" icon="🔊" title="FFmpeg 音量正規化 (Loudnorm)" desc=".wavファイルの音量をラウドネス基準に合わせて正規化します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-trim-cmdline-gen.html" icon="✂️" title="FFmpeg 切り出し (Trim)" desc="音声/動画ファイルの一部を時間指定で切り出すコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-audio-convert-cmdline-gen.html" icon="🎧" title="FFmpeg 音声変換" desc="音声ファイルを指定の形式に変換するコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-youtube-mkv-gen.html" icon="📺" title="YouTube向け動画生成" desc="一枚の画像と音声ファイルから、YouTube投稿用の動画ファイル(.mkv)を生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-mp4-to-wav-gen.html" icon="🎵" title="MP4からWAV抽出" desc="mp4ファイルから音声をWAVとして取り出すコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-replace-audio-with-wav-gen.html" icon="🔁" title="MP4音声差し替え（WAV）" desc="動画の映像はそのままに、WAV音声へ差し替えるコマンドを生成します。"></lht-index-card-link>
-        <lht-index-card-link href="ffmpeg/ffmpeg-silence-detect-gen.html" icon="🔇" title="無音区間検出" desc="silencedetect で無音区間を検出するコマンドを生成します。"></lht-index-card-link>
-      </div>
-      </section>
+    function getInputMode() {
+      const checked = document.querySelector('input[name="inputMode"]:checked');
+      return checked ? checked.value : "text";
+    }
 
+    function getTextInputMode() {
+      const checked = document.querySelector('input[name="textInputMode"]:checked');
+      return checked ? checked.value : "direct";
+    }
 
+    function getDelimiterValue() {
+      const value = document.getElementById("delimiterSelect")?.value || "comma";
+      switch (value) {
+        case "tab":
+          return "\t";
+        case "space":
+          return " ";
+        case "pipe":
+          return "|";
+        case "semicolon":
+          return ";";
+        default:
+          return ",";
+      }
+    }
 
+    function updateInputModeUi() {
+      const inputMode = getInputMode();
+      const textInputSection = document.getElementById("textInputSection");
+      const fileInputSection = document.getElementById("fileInputSection");
+      const textFileInputSection = document.getElementById("textFileInputSection");
+      const inputText = document.getElementById("inputText");
+      const delimiterSelect = document.getElementById("delimiterSelect");
+      const csvQuoteMode = document.getElementById("csvQuoteMode");
+      const csvQuoteModeWrap = document.getElementById("csvQuoteModeWrap");
+      const textInputMode = getTextInputMode();
 
+      textInputSection.classList.toggle("md-hidden", inputMode !== "text");
+      fileInputSection.classList.toggle("md-hidden", inputMode === "text");
+      textFileInputSection.classList.toggle("md-hidden", !(inputMode === "text" && textInputMode === "file"));
+      inputText.classList.toggle("md-hidden", !(inputMode === "text" && textInputMode === "direct"));
+      csvQuoteModeWrap.classList.toggle("md-hidden", inputMode !== "csv");
 
+      if (inputMode === "csv") {
+        delimiterSelect.value = "comma";
+        delimiterSelect.disabled = true;
+        csvQuoteMode.checked = true;
+      } else if (inputMode === "tsv") {
+        delimiterSelect.value = "tab";
+        delimiterSelect.disabled = true;
+        csvQuoteMode.checked = false;
+      } else {
+        if (!delimiterSelect.disabled && (delimiterSelect.value === "comma" || delimiterSelect.value === "tab")) {
+          delimiterSelect.value = "space";
+        }
+        delimiterSelect.disabled = false;
+      }
 
+      updateFileAccept();
+    }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🌐</span>Web/URL
-      </h3>
-      <p class="md-section-subtitle">URL処理のユーティリティ</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="link/amazon-dp-extract.html" icon="🛒" title="Amazon dp 抽出" desc="Amazon URL から dp/ASIN を取り出します。"></lht-index-card-link>
-        <lht-index-card-link href="link/facebook-fbclid-remove.html" icon="🔗" title="Facebook識別子（fbclid）除去" desc="URL から Facebook識別子（fbclid）を除去します。"></lht-index-card-link>
-        <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
-        <lht-index-card-link href="link/url-encode-decode.html" icon="🔤" title="URL エンコード/デコード" desc="URLのエンコードとデコードを行います。"></lht-index-card-link>
-        <lht-index-card-link href="link/mime-base64.html" icon="📦" title="MIME Base64" desc="MIME Base64のエンコード/デコードを行います。"></lht-index-card-link>
-        <lht-index-card-link href="link/utm-remove.html" icon="🧹" title="UTM除去" desc="URL から utm_* パラメータを削除します。"></lht-index-card-link>
-      </div>
-      </section>
+    function updateFileAccept() {
+      const inputFile = document.getElementById("inputFile");
+      if (!inputFile) return;
+      const inputMode = getInputMode();
+      if (inputMode === "csv") {
+        inputFile.setAttribute("accept", ".csv,text/csv");
+      } else if (inputMode === "tsv") {
+        inputFile.setAttribute("accept", ".tsv,.txt,text/tab-separated-values,text/plain");
+      } else {
+        inputFile.setAttribute("accept", ".csv,.tsv,.txt,text/csv,text/tab-separated-values,text/plain");
+      }
+    }
 
+    function sanitizeSheetName(value) {
+      const raw = String(value || "").trim() || "Sheet1";
+      return raw.replace(/[\\/:*?\[\]]/g, "_").slice(0, 31) || "Sheet1";
+    }
 
+    function sanitizeFilename(value) {
+      const base = String(value || "").trim() || "text2spreadsheetml.xml";
+      const normalized = base.replace(/[<>:"/\\|?*\u0000-\u001F]/g, "_").replace(/\s+/g, "_");
+      return normalized.toLowerCase().endsWith(".xml") ? normalized : `${normalized}.xml`;
+    }
 
+    function escapeXml(value) {
+      return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+    }
 
+    function parseCsvWithQuotes(text) {
+      const rows = [];
+      let row = [];
+      let cell = "";
+      let inQuotes = false;
 
+      for (let index = 0; index < text.length; index += 1) {
+        const char = text[index];
+        const next = text[index + 1];
 
+        if (char === '"') {
+          if (inQuotes && next === '"') {
+            cell += '"';
+            index += 1;
+          } else {
+            inQuotes = !inQuotes;
+          }
+          continue;
+        }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">📊</span>Diagram
-      </h3>
-      <p class="md-section-subtitle">図表の作成・変換</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="diagram/mermaid-to-svg.html" icon="🧭" title="Mermaid → SVG 変換" desc="Mermaid記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
-        <lht-index-card-link href="diagram/graphviz-dot-to-svg.html" icon="🕸️" title="Graphviz DOT → SVG 変換" desc="Graphviz DOT記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
-      </div>
-      </section>
+        if (char === "," && !inQuotes) {
+          row.push(cell);
+          cell = "";
+          continue;
+        }
 
+        if ((char === "\n" || char === "\r") && !inQuotes) {
+          if (char === "\r" && next === "\n") {
+            index += 1;
+          }
+          row.push(cell);
+          rows.push(row);
+          row = [];
+          cell = "";
+          continue;
+        }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">🖼️</span>画像/SVG
-      </h3>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="img/img2svg.html" icon="🧩" title="画像 → SVG 変換" desc="画像ファイルをSVGに変換します。これは困難なことを実現するツールです。アイコン・ロゴのようなものはよく再現できますが、イラスト・写真などは技術的な理由から再現度が高くないことをあらかじめご承知ください。"></lht-index-card-link>
-      </div>
-      </section>
+        cell += char;
+      }
 
+      if (inQuotes) {
+        throw new Error("CSV のダブルクォートが閉じられていません。");
+      }
 
+      row.push(cell);
+      rows.push(row);
+      return rows;
+    }
 
+    function parseDelimitedText(text, options) {
+      const normalized = String(text || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      if (options.csvQuoteMode && options.delimiter === ",") {
+        return parseCsvWithQuotes(normalized);
+      }
+      if (options.delimiter === " ") {
+        return normalized.split("\n").map((line) => {
+          const trimmedLine = options.trimCells ? line.trim() : line;
+          if (!trimmedLine) return [""];
+          return trimmedLine.split(/ +/);
+        });
+      }
+      return normalized.split("\n").map((line) => line.split(options.delimiter));
+    }
 
+    function normalizeRows(rows, options) {
+      const warnings = [];
+      const filtered = [];
 
+      rows.forEach((row) => {
+        const cells = Array.isArray(row) ? row.slice() : [];
+        const values = options.trimCells
+          ? cells.map((cell) => String(cell).trim())
+          : cells.map((cell) => String(cell));
+        const isCompletelyEmpty = values.every((cell) => cell === "");
+        if (options.ignoreEmptyLines && isCompletelyEmpty) {
+          return;
+        }
+        filtered.push(values);
+      });
 
+      let maxColumns = 0;
+      filtered.forEach((row) => {
+        if (row.length > maxColumns) maxColumns = row.length;
+      });
 
+      if (!filtered.length) {
+        return { rows: [], maxColumns: 0, warnings };
+      }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title">
-        <span aria-hidden="true" class="md-icon-inline">📚</span>知識タイムライン
-      </h3>
-      <p class="md-section-subtitle">知識を時系列で俯瞰するツール</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="knowledge-timeline/composers.html" icon="🎼" title="クラシック作曲家タイムライン" desc="作曲家の生没年・主要作品・時代背景を同一時間軸で確認できます。"></lht-index-card-link>
-      </div>
-      </section>
+      filtered.forEach((row, rowIndex) => {
+        if (row.length !== maxColumns) {
+          warnings.push(`行 ${rowIndex + 1} の列数が揃っていないため、末尾を空セルで補完しました。`);
+        }
+        while (row.length < maxColumns) {
+          row.push("");
+        }
+      });
 
+      return { rows: filtered, maxColumns, warnings };
+    }
 
+    function buildPreviewModel(rows, options) {
+      const normalized = normalizeRows(rows, options);
+      const allRows = normalized.rows;
+      const headerLabels = [];
+      const dataRows = [];
 
+      if (!allRows.length) {
+        return {
+          headerLabels,
+          dataRows,
+          warnings: normalized.warnings,
+          rowCount: 0,
+          columnCount: 0
+        };
+      }
 
+      if (options.hasHeader) {
+        allRows[0].forEach((value) => headerLabels.push(value || ""));
+        allRows.slice(1).forEach((row) => dataRows.push(row));
+      } else {
+        for (let index = 0; index < normalized.maxColumns; index += 1) {
+          headerLabels.push(`Column${index + 1}`);
+        }
+        allRows.forEach((row) => dataRows.push(row));
+      }
 
+      return {
+        headerLabels,
+        dataRows,
+        warnings: normalized.warnings,
+        rowCount: dataRows.length + (options.hasHeader ? 1 : 0),
+        columnCount: normalized.maxColumns
+      };
+    }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title md-section-title--spaced">
-        <span aria-hidden="true" class="md-icon-inline">🧳</span>日々の生活
-      </h2>
-      <p class="md-section-subtitle">生活系の小ツール</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="life/japan-weather.html" icon="🌤️" title="Japan Weather" desc="地域と府県を選んで天気予報を表示します（オンライン取得）。"></lht-index-card-link>
-        <lht-index-card-link href="life/forgot-items-check.html" icon="✅" title="忘れ物チェック" desc="持ち物を順番に確認して、忘れ物を防ぎます。"></lht-index-card-link>
-      </div>
-      </section>
+    function isLeadingZeroInteger(value) {
+      return /^-?0\d+$/.test(value);
+    }
 
-      <section class="md-section-card">
-      <h2 class="md-section-title md-section-title--spaced">
-        <span aria-hidden="true" class="md-icon-inline">🧪</span>incubator
-      </h2>
-      <p class="md-section-subtitle">実験段階・育成中のツール</p>
-      <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="project/mikuproject.html" icon="📋" title="mikuproject" desc="MS Project XML を読み込み、内部モデル化、XML 再生成、Mermaid gantt / CSV 出力を試せる実験ツールです。"></lht-index-card-link>
-      </div>
-      </section>
+    function isNumericCandidate(value) {
+      return /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value);
+    }
 
-    </div>
+    function inferColumnTypes(previewModel, options) {
+      const columnTypes = Array.from({ length: previewModel.columnCount }, () => "String");
+      const warnings = [];
 
-    <hr class="md-divider">
-    <footer class="md-footer">
-      <div class="md-footer-links">
-        <a href="https://github.com/igapyon/local-html-tools" class="md-footer-link" target="_blank" rel="noopener noreferrer">
-          <svg aria-hidden="true" viewBox="0 0 16 16" class="md-footer-icon" fill="currentColor">
-            <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
-          </svg>
-          <span>GitHub</span>
-        </a>
-        <span class="md-footer-sep">|</span>
-        <a href="https://github.com/igapyon/local-html-tools/blob/main/THIRD_PARTY_NOTICES.md" class="md-footer-link" target="_blank" rel="noopener noreferrer">
-          <span class="md-footer-badge">Third-Party Notices</span>
-        </a>
-        <span class="md-footer-sep">|</span>
-        <a href="https://igapyon.github.io/local-html-tools/" class="md-footer-link" target="_blank" rel="noopener noreferrer">
-          <svg aria-hidden="true" viewBox="0 0 24 24" class="md-footer-icon" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <use href="#md-icon-globe" xlink:href="#md-icon-globe"></use>
-          </svg>
-          <span>GitHub Pages</span>
-        </a>
-      </div>
-    </footer>
-  </div>
+      if (options.typeInferenceMode !== "limitedNumeric") {
+        return { columnTypes, warnings };
+      }
+
+      for (let index = 0; index < previewModel.columnCount; index += 1) {
+        const values = previewModel.dataRows
+          .map((row) => row[index] || "")
+          .filter((value) => value !== "");
+
+        if (!values.length) continue;
+
+        if (values.some((value) => isLeadingZeroInteger(value))) {
+          warnings.push(`${previewModel.headerLabels[index] || `Column${index + 1}`} は先頭ゼロ付き整数を含むため String に固定しました。`);
+          continue;
+        }
+
+        if (values.every((value) => isNumericCandidate(value))) {
+          columnTypes[index] = "Number";
+        }
+      }
+
+      return { columnTypes, warnings };
+    }
+
+    function buildWorkbookModel(previewModel, options) {
+      const inferred = inferColumnTypes(previewModel, options);
+      const rows = [];
+      if (options.hasHeader) {
+        rows.push({
+          isHeader: true,
+          cells: previewModel.headerLabels.map((value) => ({ value, type: "String" }))
+        });
+      }
+      previewModel.dataRows.forEach((row) => {
+        rows.push({
+          isHeader: false,
+          cells: row.map((value, index) => ({
+            value,
+            type: inferred.columnTypes[index] || "String"
+          }))
+        });
+      });
+      return {
+        workbookName: options.workbookName,
+        sheetName: options.sheetName,
+        rows,
+        columnTypes: inferred.columnTypes,
+        inferenceWarnings: inferred.warnings
+      };
+    }
+
+    function generateSpreadsheetMlXml(model) {
+      const createdIso = new Date().toISOString();
+      const rowsXml = model.rows.map((row) => {
+        const cellsXml = row.cells.map((cell) => {
+          const styleId = row.isHeader ? ' ss:StyleID="Header"' : "";
+          return `      <Cell${styleId}><Data ss:Type="${cell.type}">${escapeXml(cell.value)}</Data></Cell>`;
+        }).join("\n");
+        return `    <Row>\n${cellsXml}\n    </Row>`;
+      }).join("\n");
+
+      return `<?xml version="1.0" encoding="UTF-8"?>
+<?mso-application progid="Excel.Sheet"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:html="http://www.w3.org/TR/REC-html40">
+  <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">
+    <Author>local-html-tools</Author>
+    <LastAuthor>local-html-tools</LastAuthor>
+    <Created>${escapeXml(createdIso)}</Created>
+    <Company>local-html-tools</Company>
+    <Title>${escapeXml(model.workbookName)}</Title>
+  </DocumentProperties>
+  <ExcelWorkbook xmlns="urn:schemas-microsoft-com:office:excel">
+    <ProtectStructure>False</ProtectStructure>
+    <ProtectWindows>False</ProtectWindows>
+  </ExcelWorkbook>
+  <Styles>
+    <Style ss:ID="Default" ss:Name="Normal">
+      <Alignment ss:Vertical="Bottom"/>
+      <Borders/>
+      <Font ss:FontName="Calibri" ss:Size="11"/>
+      <Interior/>
+      <NumberFormat/>
+      <Protection/>
+    </Style>
+    <Style ss:ID="Header">
+      <Font ss:Bold="1"/>
+      <Interior ss:Color="#E7F4EE" ss:Pattern="Solid"/>
+    </Style>
+  </Styles>
+  <Worksheet ss:Name="${escapeXml(model.sheetName)}">
+    <Table>
+${rowsXml}
+    </Table>
+  </Worksheet>
+</Workbook>`;
+    }
+
+    function renderPreview(previewModel, options) {
+      const previewHead = document.getElementById("previewHead");
+      const previewBody = document.getElementById("previewBody");
+      const rowCount = document.getElementById("rowCount");
+      const columnCount = document.getElementById("columnCount");
+      const headerState = document.getElementById("headerState");
+      const cellTypeModeLabel = document.getElementById("cellTypeModeLabel");
+      const columnTypeSummary = document.getElementById("columnTypeSummary");
+      const inferred = inferColumnTypes(previewModel, options);
+
+      rowCount.textContent = String(previewModel.rowCount);
+      columnCount.textContent = String(previewModel.columnCount);
+      headerState.textContent = options.hasHeader ? "ON" : "OFF";
+      cellTypeModeLabel.textContent = options.typeInferenceMode === "limitedNumeric" ? "列判定" : "String";
+      columnTypeSummary.textContent = previewModel.columnCount
+        ? inferred.columnTypes.map((type, index) => `${previewModel.headerLabels[index] || `Column${index + 1}`}=${type}`).join(" / ")
+        : "";
+
+      if (!previewModel.columnCount) {
+        previewHead.innerHTML = "";
+        previewBody.innerHTML = '<tr><td>ここにプレビューが表示されます</td></tr>';
+        columnTypeSummary.textContent = "";
+        return;
+      }
+
+      previewHead.innerHTML = `<tr>${previewModel.headerLabels.map((cell) => `<th>${escapeXml(cell || "")}</th>`).join("")}</tr>`;
+
+      const rowsForPreview = previewModel.dataRows.slice(0, 20);
+      previewBody.innerHTML = rowsForPreview.map((row) => {
+        return `<tr>${row.map((cell) => `<td>${escapeXml(cell || "")}</td>`).join("")}</tr>`;
+      }).join("");
+    }
+
+    function getSourceText() {
+      const inputMode = getInputMode();
+      if (inputMode === "text") {
+        if (getTextInputMode() === "file") {
+          return currentFileText;
+        }
+        return document.getElementById("inputText")?.value || "";
+      }
+      return currentFileText;
+    }
+
+    function updateDownloadFilenameFromWorkbook() {
+      const workbookName = document.getElementById("workbookName")?.value || "text2spreadsheetml";
+      const filenameInput = document.getElementById("downloadFilename");
+      if (!filenameInput) return;
+      const currentValue = filenameInput.value.trim();
+      if (!currentValue || currentValue === "text2spreadsheetml.xml" || currentValue === sanitizeFilename(`${workbookName}.xml`)) {
+        filenameInput.value = sanitizeFilename(`${workbookName}.xml`);
+      }
+    }
+
+    function regenerateAll() {
+      updateInputModeUi();
+
+      const parseError = document.getElementById("parseError");
+      const parseWarning = document.getElementById("parseWarning");
+      const configWarning = document.getElementById("configWarning");
+      const xmlOutput = document.getElementById("xmlOutput");
+
+      parseError.textContent = "";
+      parseWarning.textContent = "";
+      configWarning.textContent = "";
+
+      const inputMode = getInputMode();
+      const options = {
+        delimiter: getDelimiterValue(),
+        typeInferenceMode: document.getElementById("typeInferenceMode")?.value || "string",
+        hasHeader: !!document.getElementById("hasHeader")?.checked,
+        ignoreEmptyLines: !!document.getElementById("ignoreEmptyLines")?.checked,
+        trimCells: !!document.getElementById("trimCells")?.checked,
+        csvQuoteMode: !!document.getElementById("csvQuoteMode")?.checked,
+        sheetName: sanitizeSheetName(document.getElementById("sheetName")?.value || "Sheet1"),
+        workbookName: (document.getElementById("workbookName")?.value || "text2spreadsheetml").trim() || "text2spreadsheetml"
+      };
+
+      const sourceText = getSourceText();
+      if (!sourceText.trim()) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        renderPreview({ headerLabels: [], dataRows: [], rowCount: 0, columnCount: 0 }, options);
+        if (inputMode === "text" && getTextInputMode() === "direct") {
+          parseError.textContent = "入力テキストを入れてください。";
+        } else {
+          parseError.textContent = "入力ファイルを選択してください。";
+        }
+        return;
+      }
+
+      const rawSheetName = (document.getElementById("sheetName")?.value || "").trim();
+      if (!rawSheetName) {
+        configWarning.textContent = "シート名が空のため、Sheet1 を使用します。";
+      } else if (rawSheetName !== options.sheetName) {
+        configWarning.textContent = `シート名は SpreadsheetML 向けに ${options.sheetName} へ調整して出力します。`;
+      }
+
+      let rows;
+      try {
+        rows = parseDelimitedText(sourceText, options);
+      } catch (error) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        renderPreview({ headerLabels: [], dataRows: [], rowCount: 0, columnCount: 0 }, options);
+        parseError.textContent = error instanceof Error ? error.message : "入力データの解析に失敗しました。";
+        return;
+      }
+
+      const previewModel = buildPreviewModel(rows, options);
+      renderPreview(previewModel, options);
+
+      if (!previewModel.columnCount) {
+        latestGeneratedXml = "";
+        xmlOutput.textContent = "";
+        parseError.textContent = "表データとして解釈できる内容がありません。";
+        return;
+      }
+
+      if (previewModel.warnings.length) {
+        parseWarning.textContent = Array.from(new Set(previewModel.warnings)).slice(0, 3).join(" ");
+      }
+
+      const model = buildWorkbookModel(previewModel, options);
+      if (model.inferenceWarnings.length) {
+        parseWarning.textContent = [parseWarning.textContent, ...model.inferenceWarnings].filter(Boolean).join(" ");
+      }
+      latestGeneratedXml = generateSpreadsheetMlXml(model);
+      xmlOutput.textContent = latestGeneratedXml;
+    }
+
+    function downloadGeneratedXml() {
+      if (!latestGeneratedXml) {
+        showToast("保存する XML がありません");
+        return;
+      }
+      const filenameInput = document.getElementById("downloadFilename");
+      const filename = sanitizeFilename(filenameInput?.value || "text2spreadsheetml.xml");
+      if (filenameInput) filenameInput.value = filename;
+      const blob = new Blob([latestGeneratedXml], { type: "application/xml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+      showToast(".xml を保存しました");
+    }
+
+    function applySample() {
+      const sample = [
+        "id,name,joined,note",
+        "001,Alice,2026-03-01,first user",
+        "002,Bob,2026-03-15,keep as string",
+        "003,Carol,2026-03-20,\"quoted, sample\""
+      ].join("\n");
+      const textInput = document.getElementById("inputText");
+      const modeRadio = document.querySelector('input[name="inputMode"][value="text"]');
+      const textModeRadio = document.querySelector('input[name="textInputMode"][value="direct"]');
+      if (modeRadio) modeRadio.checked = true;
+      if (textModeRadio) textModeRadio.checked = true;
+      if (textInput) textInput.value = sample;
+      currentFileText = "";
+      currentFileName = "";
+      document.getElementById("textInputFile").value = "";
+      document.getElementById("textFileStatus").textContent = "テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      document.getElementById("delimiterSelect").value = "comma";
+      document.getElementById("typeInferenceMode").value = "string";
+      document.getElementById("csvQuoteMode").checked = true;
+      updateInputModeUi();
+      regenerateAll();
+    }
+
+    function clearUiPreferences() {
+      const confirmed = confirm("ローカルに保存されているこのツールの設定をクリアします。よろしいですか？");
+      if (!confirmed) return;
+      Object.values(STORAGE_KEYS).forEach((key) => {
+        try {
+          localStorage.removeItem(key);
+        } catch (error) {
+          // 継続
+        }
+      });
+      const defaultMode = document.querySelector('input[name="inputMode"][value="text"]');
+      const defaultTextInputMode = document.querySelector('input[name="textInputMode"][value="direct"]');
+      if (defaultMode) defaultMode.checked = true;
+      if (defaultTextInputMode) defaultTextInputMode.checked = true;
+      document.getElementById("delimiterSelect").value = "space";
+      document.getElementById("typeInferenceMode").value = "string";
+      document.getElementById("hasHeader").checked = true;
+      document.getElementById("ignoreEmptyLines").checked = true;
+      document.getElementById("trimCells").checked = true;
+      document.getElementById("csvQuoteMode").checked = false;
+      document.getElementById("sheetName").value = "Sheet1";
+      document.getElementById("workbookName").value = "text2spreadsheetml";
+      document.getElementById("downloadFilename").value = "text2spreadsheetml.xml";
+      document.getElementById("inputText").value = "";
+      document.getElementById("inputFile").value = "";
+      document.getElementById("textInputFile").value = "";
+      document.getElementById("fileStatus").textContent = "ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      document.getElementById("textFileStatus").textContent = "テキストファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+      currentFileText = "";
+      currentFileName = "";
+      regenerateAll();
+      showToast("設定をクリアしました");
+    }
+
+    function loadPersistedInputs() {
+      const inputMode = getStoredString(STORAGE_KEYS.inputMode);
+      const textInputMode = getStoredString(STORAGE_KEYS.textInputMode);
+      const delimiter = getStoredString(STORAGE_KEYS.delimiter);
+      const typeInferenceMode = getStoredString(STORAGE_KEYS.typeInferenceMode);
+      const sheetName = getStoredString(STORAGE_KEYS.sheetName);
+      const workbookName = getStoredString(STORAGE_KEYS.workbookName);
+      const downloadFilename = getStoredString(STORAGE_KEYS.downloadFilename);
+      const inputText = getStoredString(STORAGE_KEYS.inputText);
+
+      if (inputMode) {
+        const radio = document.querySelector(`input[name="inputMode"][value="${inputMode}"]`);
+        if (radio) radio.checked = true;
+      }
+      if (textInputMode) {
+        const radio = document.querySelector(`input[name="textInputMode"][value="${textInputMode}"]`);
+        if (radio) radio.checked = true;
+      }
+      if (delimiter && document.querySelector(`#delimiterSelect option[value="${delimiter}"]`)) {
+        document.getElementById("delimiterSelect").value = delimiter;
+      }
+      if (typeInferenceMode && document.querySelector(`#typeInferenceMode option[value="${typeInferenceMode}"]`)) {
+        document.getElementById("typeInferenceMode").value = typeInferenceMode;
+      }
+      const hasHeader = getStoredBoolean(STORAGE_KEYS.hasHeader);
+      const ignoreEmptyLines = getStoredBoolean(STORAGE_KEYS.ignoreEmptyLines);
+      const trimCells = getStoredBoolean(STORAGE_KEYS.trimCells);
+      const csvQuoteMode = getStoredBoolean(STORAGE_KEYS.csvQuoteMode);
+      if (hasHeader !== null) document.getElementById("hasHeader").checked = hasHeader;
+      if (ignoreEmptyLines !== null) document.getElementById("ignoreEmptyLines").checked = ignoreEmptyLines;
+      if (trimCells !== null) document.getElementById("trimCells").checked = trimCells;
+      if (csvQuoteMode !== null) document.getElementById("csvQuoteMode").checked = csvQuoteMode;
+      if (sheetName !== null) document.getElementById("sheetName").value = sheetName;
+      if (workbookName !== null) document.getElementById("workbookName").value = workbookName;
+      if (downloadFilename !== null) document.getElementById("downloadFilename").value = downloadFilename;
+      if (inputText !== null) document.getElementById("inputText").value = inputText;
+    }
+
+    function savePersistedInputs() {
+      setStoredValue(STORAGE_KEYS.inputMode, getInputMode());
+      setStoredValue(STORAGE_KEYS.textInputMode, getTextInputMode());
+      setStoredValue(STORAGE_KEYS.delimiter, document.getElementById("delimiterSelect").value);
+      setStoredValue(STORAGE_KEYS.typeInferenceMode, document.getElementById("typeInferenceMode").value);
+      setStoredValue(STORAGE_KEYS.hasHeader, document.getElementById("hasHeader").checked);
+      setStoredValue(STORAGE_KEYS.ignoreEmptyLines, document.getElementById("ignoreEmptyLines").checked);
+      setStoredValue(STORAGE_KEYS.trimCells, document.getElementById("trimCells").checked);
+      setStoredValue(STORAGE_KEYS.csvQuoteMode, document.getElementById("csvQuoteMode").checked);
+      setStoredValue(STORAGE_KEYS.sheetName, document.getElementById("sheetName").value);
+      setStoredValue(STORAGE_KEYS.workbookName, document.getElementById("workbookName").value);
+      setStoredValue(STORAGE_KEYS.downloadFilename, document.getElementById("downloadFilename").value);
+      setStoredValue(STORAGE_KEYS.inputText, document.getElementById("inputText").value);
+    }
+
+    function handleFileInputChange(event, statusId = "fileStatus") {
+      const file = event.target.files && event.target.files[0];
+      const fileStatus = document.getElementById(statusId);
+      currentFileText = "";
+      currentFileName = "";
+
+      if (!file) {
+        fileStatus.textContent = "ファイルを選択するとブラウザ内で読み込みます。サーバ送信は行いません。";
+        regenerateAll();
+        return;
+      }
+
+      currentFileName = file.name;
+      const reader = new FileReader();
+      reader.onload = () => {
+        currentFileText = typeof reader.result === "string" ? reader.result : "";
+        fileStatus.textContent = `${file.name} を読み込みました。`;
+        if (!document.getElementById("workbookName").value.trim() || document.getElementById("workbookName").value === "text2spreadsheetml") {
+          const suggested = file.name.replace(/\.[^.]+$/, "");
+          document.getElementById("workbookName").value = suggested || "text2spreadsheetml";
+          updateDownloadFilenameFromWorkbook();
+        }
+        regenerateAll();
+        savePersistedInputs();
+      };
+      reader.onerror = () => {
+        fileStatus.textContent = `${file.name} の読み込みに失敗しました。`;
+        regenerateAll();
+      };
+      reader.readAsText(file, "UTF-8");
+    }
+
+    function setupEvents() {
+      document.querySelectorAll('input[name="inputMode"]').forEach((radio) => {
+        radio.addEventListener("change", () => {
+          updateInputModeUi();
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      document.querySelectorAll('input[name="textInputMode"]').forEach((radio) => {
+        radio.addEventListener("change", () => {
+          updateInputModeUi();
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      [
+        "delimiterSelect",
+        "typeInferenceMode",
+        "hasHeader",
+        "ignoreEmptyLines",
+        "trimCells",
+        "csvQuoteMode",
+        "sheetName",
+        "downloadFilename",
+        "inputText"
+      ].forEach((id) => {
+        const element = document.getElementById(id);
+        if (!element) return;
+        element.addEventListener("input", () => {
+          savePersistedInputs();
+          regenerateAll();
+        });
+        element.addEventListener("change", () => {
+          savePersistedInputs();
+          regenerateAll();
+        });
+      });
+
+      const workbookName = document.getElementById("workbookName");
+      workbookName.addEventListener("input", () => {
+        updateDownloadFilenameFromWorkbook();
+        savePersistedInputs();
+        regenerateAll();
+      });
+      workbookName.addEventListener("change", () => {
+        updateDownloadFilenameFromWorkbook();
+        savePersistedInputs();
+        regenerateAll();
+      });
+
+      document.getElementById("inputFile").addEventListener("change", (event) => handleFileInputChange(event, "fileStatus"));
+      document.getElementById("textInputFile").addEventListener("change", (event) => handleFileInputChange(event, "textFileStatus"));
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      loadPersistedInputs();
+      updateInputModeUi();
+      updateDownloadFilenameFromWorkbook();
+      setupEvents();
+      regenerateAll();
+    });
+  </script>
   <script>
 (()=>{function s(o,e,t,r){var i=arguments.length,n=i<3?e:r===null?r=Object.getOwnPropertyDescriptor(e,t):r,a;if(typeof Reflect=="object"&&typeof Reflect.decorate=="function")n=Reflect.decorate(o,e,t,r);else for(var d=o.length-1;d>=0;d--)(a=o[d])&&(n=(i<3?a(n):i>3?a(e,t,n):a(e,t))||n);return i>3&&n&&Object.defineProperty(e,t,n),n}var E=o=>(e,t)=>{t!==void 0?t.addInitializer(()=>{customElements.define(o,e)}):customElements.define(o,e)};var Qe=globalThis,et=Qe.ShadowRoot&&(Qe.ShadyCSS===void 0||Qe.ShadyCSS.nativeShadow)&&"adoptedStyleSheets"in Document.prototype&&"replace"in CSSStyleSheet.prototype,Bt=Symbol(),$r=new WeakMap,Ne=class{constructor(e,t,r){if(this._$cssResult$=!0,r!==Bt)throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");this.cssText=e,this.t=t}get styleSheet(){let e=this.o,t=this.t;if(et&&e===void 0){let r=t!==void 0&&t.length===1;r&&(e=$r.get(t)),e===void 0&&((this.o=e=new CSSStyleSheet).replaceSync(this.cssText),r&&$r.set(t,e))}return e}toString(){return this.cssText}},Tr=o=>new Ne(typeof o=="string"?o:o+"",void 0,Bt),g=(o,...e)=>{let t=o.length===1?o[0]:e.reduce((r,i,n)=>r+(a=>{if(a._$cssResult$===!0)return a.cssText;if(typeof a=="number")return a;throw Error("Value passed to 'css' function must be a 'css' function result: "+a+". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.")})(i)+o[n+1],o[0]);return new Ne(t,o,Bt)},Sr=(o,e)=>{if(et)o.adoptedStyleSheets=e.map(t=>t instanceof CSSStyleSheet?t:t.styleSheet);else for(let t of e){let r=document.createElement("style"),i=Qe.litNonce;i!==void 0&&r.setAttribute("nonce",i),r.textContent=t.cssText,o.appendChild(r)}},Ft=et?o=>o:o=>o instanceof CSSStyleSheet?(e=>{let t="";for(let r of e.cssRules)t+=r.cssText;return Tr(t)})(o):o;var{is:Io,defineProperty:ko,getOwnPropertyDescriptor:Oo,getOwnPropertyNames:Ro,getOwnPropertySymbols:Po,getPrototypeOf:Lo}=Object,ce=globalThis,Ir=ce.trustedTypes,Do=Ir?Ir.emptyScript:"",zo=ce.reactiveElementPolyfillSupport,Be=(o,e)=>o,Fe={toAttribute(o,e){switch(e){case Boolean:o=o?Do:null;break;case Object:case Array:o=o==null?o:JSON.stringify(o)}return o},fromAttribute(o,e){let t=o;switch(e){case Boolean:t=o!==null;break;case Number:t=o===null?null:Number(o);break;case Object:case Array:try{t=JSON.parse(o)}catch{t=null}}return t}},tt=(o,e)=>!Io(o,e),kr={attribute:!0,type:String,converter:Fe,reflect:!1,useDefault:!1,hasChanged:tt};Symbol.metadata??(Symbol.metadata=Symbol("metadata")),ce.litPropertyMetadata??(ce.litPropertyMetadata=new WeakMap);var re=class extends HTMLElement{static addInitializer(e){this._$Ei(),(this.l??(this.l=[])).push(e)}static get observedAttributes(){return this.finalize(),this._$Eh&&[...this._$Eh.keys()]}static createProperty(e,t=kr){if(t.state&&(t.attribute=!1),this._$Ei(),this.prototype.hasOwnProperty(e)&&((t=Object.create(t)).wrapped=!0),this.elementProperties.set(e,t),!t.noAccessor){let r=Symbol(),i=this.getPropertyDescriptor(e,r,t);i!==void 0&&ko(this.prototype,e,i)}}static getPropertyDescriptor(e,t,r){let{get:i,set:n}=Oo(this.prototype,e)??{get(){return this[t]},set(a){this[t]=a}};return{get:i,set(a){let d=i?.call(this);n?.call(this,a),this.requestUpdate(e,d,r)},configurable:!0,enumerable:!0}}static getPropertyOptions(e){return this.elementProperties.get(e)??kr}static _$Ei(){if(this.hasOwnProperty(Be("elementProperties")))return;let e=Lo(this);e.finalize(),e.l!==void 0&&(this.l=[...e.l]),this.elementProperties=new Map(e.elementProperties)}static finalize(){if(this.hasOwnProperty(Be("finalized")))return;if(this.finalized=!0,this._$Ei(),this.hasOwnProperty(Be("properties"))){let t=this.properties,r=[...Ro(t),...Po(t)];for(let i of r)this.createProperty(i,t[i])}let e=this[Symbol.metadata];if(e!==null){let t=litPropertyMetadata.get(e);if(t!==void 0)for(let[r,i]of t)this.elementProperties.set(r,i)}this._$Eh=new Map;for(let[t,r]of this.elementProperties){let i=this._$Eu(t,r);i!==void 0&&this._$Eh.set(i,t)}this.elementStyles=this.finalizeStyles(this.styles)}static finalizeStyles(e){let t=[];if(Array.isArray(e)){let r=new Set(e.flat(1/0).reverse());for(let i of r)t.unshift(Ft(i))}else e!==void 0&&t.push(Ft(e));return t}static _$Eu(e,t){let r=t.attribute;return r===!1?void 0:typeof r=="string"?r:typeof e=="string"?e.toLowerCase():void 0}constructor(){super(),this._$Ep=void 0,this.isUpdatePending=!1,this.hasUpdated=!1,this._$Em=null,this._$Ev()}_$Ev(){this._$ES=new Promise(e=>this.enableUpdating=e),this._$AL=new Map,this._$E_(),this.requestUpdate(),this.constructor.l?.forEach(e=>e(this))}addController(e){(this._$EO??(this._$EO=new Set)).add(e),this.renderRoot!==void 0&&this.isConnected&&e.hostConnected?.()}removeController(e){this._$EO?.delete(e)}_$E_(){let e=new Map,t=this.constructor.elementProperties;for(let r of t.keys())this.hasOwnProperty(r)&&(e.set(r,this[r]),delete this[r]);e.size>0&&(this._$Ep=e)}createRenderRoot(){let e=this.shadowRoot??this.attachShadow(this.constructor.shadowRootOptions);return Sr(e,this.constructor.elementStyles),e}connectedCallback(){this.renderRoot??(this.renderRoot=this.createRenderRoot()),this.enableUpdating(!0),this._$EO?.forEach(e=>e.hostConnected?.())}enableUpdating(e){}disconnectedCallback(){this._$EO?.forEach(e=>e.hostDisconnected?.())}attributeChangedCallback(e,t,r){this._$AK(e,r)}_$ET(e,t){let r=this.constructor.elementProperties.get(e),i=this.constructor._$Eu(e,r);if(i!==void 0&&r.reflect===!0){let n=(r.converter?.toAttribute!==void 0?r.converter:Fe).toAttribute(t,r.type);this._$Em=e,n==null?this.removeAttribute(i):this.setAttribute(i,n),this._$Em=null}}_$AK(e,t){let r=this.constructor,i=r._$Eh.get(e);if(i!==void 0&&this._$Em!==i){let n=r.getPropertyOptions(i),a=typeof n.converter=="function"?{fromAttribute:n.converter}:n.converter?.fromAttribute!==void 0?n.converter:Fe;this._$Em=i;let d=a.fromAttribute(t,n.type);this[i]=d??this._$Ej?.get(i)??d,this._$Em=null}}requestUpdate(e,t,r,i=!1,n){if(e!==void 0){let a=this.constructor;if(i===!1&&(n=this[e]),r??(r=a.getPropertyOptions(e)),!((r.hasChanged??tt)(n,t)||r.useDefault&&r.reflect&&n===this._$Ej?.get(e)&&!this.hasAttribute(a._$Eu(e,r))))return;this.C(e,t,r)}this.isUpdatePending===!1&&(this._$ES=this._$EP())}C(e,t,{useDefault:r,reflect:i,wrapped:n},a){r&&!(this._$Ej??(this._$Ej=new Map)).has(e)&&(this._$Ej.set(e,a??t??this[e]),n!==!0||a!==void 0)||(this._$AL.has(e)||(this.hasUpdated||r||(t=void 0),this._$AL.set(e,t)),i===!0&&this._$Em!==e&&(this._$Eq??(this._$Eq=new Set)).add(e))}async _$EP(){this.isUpdatePending=!0;try{await this._$ES}catch(t){Promise.reject(t)}let e=this.scheduleUpdate();return e!=null&&await e,!this.isUpdatePending}scheduleUpdate(){return this.performUpdate()}performUpdate(){if(!this.isUpdatePending)return;if(!this.hasUpdated){if(this.renderRoot??(this.renderRoot=this.createRenderRoot()),this._$Ep){for(let[i,n]of this._$Ep)this[i]=n;this._$Ep=void 0}let r=this.constructor.elementProperties;if(r.size>0)for(let[i,n]of r){let{wrapped:a}=n,d=this[i];a!==!0||this._$AL.has(i)||d===void 0||this.C(i,void 0,n,d)}}let e=!1,t=this._$AL;try{e=this.shouldUpdate(t),e?(this.willUpdate(t),this._$EO?.forEach(r=>r.hostUpdate?.()),this.update(t)):this._$EM()}catch(r){throw e=!1,this._$EM(),r}e&&this._$AE(t)}willUpdate(e){}_$AE(e){this._$EO?.forEach(t=>t.hostUpdated?.()),this.hasUpdated||(this.hasUpdated=!0,this.firstUpdated(e)),this.updated(e)}_$EM(){this._$AL=new Map,this.isUpdatePending=!1}get updateComplete(){return this.getUpdateComplete()}getUpdateComplete(){return this._$ES}shouldUpdate(e){return!0}update(e){this._$Eq&&(this._$Eq=this._$Eq.forEach(t=>this._$ET(t,this[t]))),this._$EM()}updated(e){}firstUpdated(e){}};re.elementStyles=[],re.shadowRootOptions={mode:"open"},re[Be("elementProperties")]=new Map,re[Be("finalized")]=new Map,zo?.({ReactiveElement:re}),(ce.reactiveElementVersions??(ce.reactiveElementVersions=[])).push("2.1.2");var Mo={attribute:!0,type:String,converter:Fe,reflect:!1,hasChanged:tt},No=(o=Mo,e,t)=>{let{kind:r,metadata:i}=t,n=globalThis.litPropertyMetadata.get(i);if(n===void 0&&globalThis.litPropertyMetadata.set(i,n=new Map),r==="setter"&&((o=Object.create(o)).wrapped=!0),n.set(t.name,o),r==="accessor"){let{name:a}=t;return{set(d){let c=e.get.call(this);e.set.call(this,d),this.requestUpdate(a,c,o,!0,d)},init(d){return d!==void 0&&this.C(a,void 0,o,d),d}}}if(r==="setter"){let{name:a}=t;return function(d){let c=this[a];e.call(this,d),this.requestUpdate(a,c,o,!0,d)}}throw Error("Unsupported decorator location: "+r)};function l(o){return(e,t)=>typeof t=="object"?No(o,e,t):((r,i,n)=>{let a=i.hasOwnProperty(n);return i.constructor.createProperty(n,r),a?Object.getOwnPropertyDescriptor(i,n):void 0})(o,e,t)}function k(o){return l({...o,state:!0,attribute:!1})}var Q=(o,e,t)=>(t.configurable=!0,t.enumerable=!0,Reflect.decorate&&typeof e!="object"&&Object.defineProperty(o,e,t),t);function S(o,e){return(t,r,i)=>{let n=a=>a.renderRoot?.querySelector(o)??null;if(e){let{get:a,set:d}=typeof r=="object"?t:i??(()=>{let c=Symbol();return{get(){return this[c]},set(h){this[c]=h}}})();return Q(t,r,{get(){let c=a.call(this);return c===void 0&&(c=n(this),(c!==null||this.hasUpdated)&&d.call(this,c)),c}})}return Q(t,r,{get(){return n(this)}})}}var Bo;function Or(o){return(e,t)=>Q(e,t,{get(){return(this.renderRoot??Bo??(Bo=document.createDocumentFragment())).querySelectorAll(o)}})}function N(o){return(e,t)=>{let{slot:r,selector:i}=o??{},n="slot"+(r?`[name=${r}]`:":not([name])");return Q(e,t,{get(){let a=this.renderRoot?.querySelector(n),d=a?.assignedElements(o)??[];return i===void 0?d:d.filter(c=>c.matches(i))}})}}function rt(o){return(e,t)=>{let{slot:r}=o??{},i="slot"+(r?`[name=${r}]`:":not([name])");return Q(e,t,{get(){return this.renderRoot?.querySelector(i)?.assignedNodes(o)??[]}})}}var qe=globalThis,Rr=o=>o,ot=qe.trustedTypes,Pr=ot?ot.createPolicy("lit-html",{createHTML:o=>o}):void 0,qt="$lit$",oe=`lit$${Math.random().toFixed(9).slice(2)}$`,Vt="?"+oe,Fo=`<${Vt}>`,_e=document,Ve=()=>_e.createComment(""),He=o=>o===null||typeof o!="object"&&typeof o!="function",Ht=Array.isArray,Br=o=>Ht(o)||typeof o?.[Symbol.iterator]=="function",Ut=`[ 	
 \f\r]`,Ue=/<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g,Lr=/-->/g,Dr=/>/g,ye=RegExp(`>|${Ut}(?:([^\\s"'>=/]+)(${Ut}*=${Ut}*(?:[^ 	

--- a/scripts/build-text.mjs
+++ b/scripts/build-text.mjs
@@ -24,6 +24,11 @@ const TARGETS = [
     id: "text-viewer",
     srcHtml: "docs/text/text-viewer-src.html",
     outHtml: "docs/text/text-viewer.html"
+  },
+  {
+    id: "text2spreadsheetml",
+    srcHtml: "docs/text/text2spreadsheetml-src.html",
+    outHtml: "docs/text/text2spreadsheetml.html"
   }
 ];
 


### PR DESCRIPTION
### 概要

`text2spreadsheetml` を追加し、ベタテキスト・CSV ファイル・TAB 区切りファイルから `SpreadsheetML 2003 XML Spreadsheet` 形式の `.xml` を生成できるようにします。あわせて、テキスト系ビルド対象とトップページ導線を追加します。

### 変更内容

- `docs/text/text2spreadsheetml-src.html` を追加
- `docs/text/text2spreadsheetml.html` を追加
- `docs/text/text2spreadsheetml-spec.md` を追加
- `scripts/build-text.mjs` に `text2spreadsheetml` のビルド対象を追加
- `docs/index-src.html` / `docs/index.html` に `text2spreadsheetml` への導線を追加

### 追加したツールの内容

- 入力方式として `ベタテキスト`、`CSV ファイル`、`TAB 区切りファイル` に対応
- `ベタテキスト` では `直接入力` と `テキストファイル` を選択可能
- ローカル完結の single-file web app として SpreadsheetML 2003 XML を生成
- `半角空白` 区切りを含む区切り文字設定に対応
- `文字列固定` と `限定数値推論` の型モードを定義
- `localStorage` による入力値・設定値の保存と復元に対応

### MVP 方針

- 「表データを壊さず 1 シートの XML を生成する」ことを最優先とする
- `SpreadsheetML 2003` を正式名称として扱う