### PR TITLE
mikuproject に `.xlsx` 入出力基盤と WBS 向け XLSX export を追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-24</div>
+        <div class="md-app-meta">更新日: 2026-03-27</div>
       </div>
     </header>
 

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -1,0 +1,62 @@
+# TODO
+
+## mikuproject
+
+- `MS Project XML` を意味の基軸として扱う
+- `ProjectModel` を内部の中立表現として扱う
+- `.xlsx` は確認・可視化・帳票化のための周辺表現として扱う
+- `.xlsx` 編集結果を `ProjectModel` へ戻し、必要に応じて `MS Project XML` へ再出力できる構成を目指す
+- `MS Project XML` を中心に据えたまま、`.xlsx` 入出力を追加する
+- `.xlsx` の正本化は避け、内部モデル `ProjectModel` を中心に扱う
+- まずは `.xlsx export` を優先し、`ProjectModel -> .xlsx` を成立させる
+- その後に `.xlsx import` を検討し、`.xlsx -> ProjectModel` を設計する
+- `.xlsx` は、構造忠実な汎用 workbook と、表示専用の WBS workbook を分けて扱う
+- 初期検討時のみ `docs/project/local-data/WBS_Template_analysis.md` を参照し、その後は依存しない
+- `mikuproject-spec.md` に `.xlsx` 対応方針を追記する
+- `.xlsx` 入出力で保持する最小フィールド集合を定義する
+- `mikuproject-spec.md` では、現在の editable 列 coverage をシート別の一覧で追えるように保つ
+- round-trip の観点で、`xml -> model -> xlsx` と `xlsx -> model -> xml` の扱いを切り分ける
+- `.xlsx import` では編集可能な列を限定し、部分更新として `ProjectModel` へ反映する
+- まずは `Tasks` シートを起点に、限定列 import を成立させる
+- `Start / Finish / PercentComplete / PercentWorkComplete` など、戻しやすい項目から優先対応する
+- `Tasks` で import 実績を作った後に `Resources / Assignments` へ対象を広げる
+- `Resources` では `Name / Group / MaxUnits` などの戻しやすい項目から優先対応する
+- `Assignments` では `Units / Work / PercentWorkComplete` などの戻しやすい項目から優先対応する
+- `Project` シートでは `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart` を限定 import 対象として扱う
+- `Calendars` シートでは、まず `Name / IsBaseCalendar / BaseCalendarUID` のみを限定 import 対象として扱う
+- 複雑な `Calendar / Baseline / TimephasedData / ExtendedAttributes` は後段で扱う
+- `.xlsx` 対応用のテストデータとテスト戦略を追加する
+- `ProjectModel -> workbook -> .xlsx -> workbook -> ProjectModel` の統合経路を継続的に確認する
+- `project-xlsx.ts` で `ProjectModel -> XlsxWorkbookModel` の変換方針を詰める
+- `project-xlsx.ts` で結合セルを使う箇所を設計する
+- `Project` シートに結合付きの見出し行やセクション見出しを追加する
+- `Tasks / Resources / Assignments / Calendars` シートのレイアウト方針を整理する
+- 上記シート粒度が `MS Project XML` / `ProjectModel` の構造に由来することを明記する
+- Excel 側の独自都合ではなく、まずは `MS Project XML` の構造に忠実な workbook 構成を優先する
+- WBS 帳票的な見せ方は、別ビュー・別 workbook として export を継続改善する
+- `WBS XLSX Export` では、必要に応じて `YYYY-MM-DD` 形式の祝日を UI から指定できるように保つ
+- WBS sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として日付帯へ反映する
+- `build-project-xlsx-sample.mjs` を静的 workbook 直書きから `project-xlsx.ts` 利用へ切り替える
+- `MS Project XML -> ProjectModel -> XlsxWorkbookModel -> .xlsx` のサンプル生成経路へ寄せる
+- UI 上で `.xlsx import` の反映件数と差分要約を分かるようにする
+- 次は `.xlsx import` の差分要約を、行単位またはシート単位でさらに見やすく整理する
+- 次は `Resources / Assignments` の import 差分も UI 上で追いやすくする
+- `.xlsx import` の差分要約は、同一行の複数変更を1ブロックで見せる
+- 次はシート別の件数表示や、更新対象ごとの折りたたみなし一覧を検討する
+- `.xlsx import` の差分要約には、`Tasks / Resources / Assignments` の件数も先頭表示する
+- 次は変更が 0 件だったシートをどこまで表示するかを整理する
+- 変更があったシートを前面に出し、変更なしのシートは補助表示へ下げる
+- 次は `Resources / Assignments` にも変更があるケースの UI 表示確認を追加する
+- 画面上の `.xlsx import` 説明文は、実際の編集可能列と差分要約の見え方に合わせて保守する
+- 次は `Tasks.Start / Finish` のような日付変更が UI 差分要約で分かることを固定する
+- `.xlsx import` 後に、更新済み XML を `XML Export` で保存できる導線を画面上で分かるようにする
+- `.xlsx import` で変更が 0 件だった場合は、XML が未変更であることを明示する
+- 対象外列や未対応シートを編集しても反映しないことを、画面文言とテストで明確にする
+- `Calendars` の `WeekDays / Exceptions / WorkWeeks` は、当面は反映対象外として扱う
+- 現在の editable 列 coverage を保ちながら、次段でどのシート・列を import 対象に広げるかを整理する
+- 画面上の `.xlsx import` 説明は、`反映対象` と `現在は反映しないもの` を分けて読めるように保つ
+- 次は `Calendars` など未対応シートを本当に import 対象へ広げるか、引き続き無視対象に留めるかを整理する
+- `.xlsx import` 後に validation メッセージが必要なケースも UI テストで固定する
+- `Calendars.BaseCalendarUID` のような参照系 warning も、`.xlsx import` の差分要約と validation を並べて確認できるように保つ
+- `.xlsx import` による `Start > Finish` のような日付整合性エラーも UI テストで固定する
+- validation が残る状態でも `XML Export` でその時点の XML を保存できることをテストで固定する

--- a/docs/project/mikuproject-spec.md
+++ b/docs/project/mikuproject-spec.md
@@ -15,6 +15,9 @@
 - このリポジトリ流儀の single-file web app とする
 - ローカルで動作する HTML ツールとして構築する
 - まずは UI よりも、MS Project XML の入出力と内部モデル化を優先する
+- `MS Project XML` を意味の基軸として扱う
+- 内部では `ProjectModel` を中立表現として扱う
+- `.xlsx` は確認・可視化・限定編集のための周辺表現として扱う
 - 仕様判断に迷った場合は、独自都合よりも `MS Project 仕様` に立ち返って判断する
 - `MS Project` 実機は未保有である
 
@@ -34,6 +37,62 @@ STEP 1 の目的は、`MS Project XML` を意味的に往復できる状態を�
 
 - 目標は「元の XML と完全一致」ではない
 - 目標は「意味的に往復できる」ことである
+
+## `.xlsx` の位置づけ
+
+`mikuproject` における `.xlsx` は、`MS Project XML` の代替正本ではない。
+
+- `MS Project XML` は意味の基軸
+- `ProjectModel` は内部の中立表現
+- `.xlsx` は確認・可視化・限定編集のための周辺表現
+
+したがって、`.xlsx` 対応は `MS Project XML` の仕様を置き換えるためではなく、`ProjectModel` を介した補助入出力として追加する。
+
+現時点で想定する経路は次のとおり。
+
+- `MS Project XML -> ProjectModel -> .xlsx`
+- `.xlsx -> ProjectModel -> MS Project XML`
+
+ただし、`.xlsx -> ProjectModel` は自由編集をそのまま受け入れるのではなく、編集可能な列を限定した部分更新として扱う。
+
+現時点の `.xlsx` 周りは、実装済みの限定 import/export として次のように整理できる。
+
+### 現状実装
+
+- 構造忠実な汎用 workbook export/import
+  - `Project / Tasks / Resources / Assignments / Calendars` を `ProjectModel` 構造に沿って扱う
+- 表示専用の `WBS` workbook export
+  - `Tasks` 中心の別 workbook として `.xlsx` 出力できる
+  - 現時点では export 専用であり、import は扱わない
+  - `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を UI から指定できる
+  - 指定した祝日は WBS 日付帯で祝日色として表示する
+  - sample 生成では、`Calendar.Exceptions` のうち `WorkingTimes` を持たない日付例外を祝日候補として WBS workbook へ反映する
+
+現時点で `XLSX Import` の反映対象としている列は次のとおり。
+
+- `Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`
+- `Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete`
+- `Resources`: `Name / Group / MaxUnits`
+- `Assignments`: `Units / Work / PercentWorkComplete`
+- `Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`
+
+一覧で見ると次のとおり。
+
+| Sheet | Editable Columns | Notes |
+| --- | --- | --- |
+| `Project` | `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart` | project 単位の部分更新として扱う |
+| `Tasks` | `Name / Start / Finish / PercentComplete / PercentWorkComplete` | `UID` をキーに部分更新する |
+| `Resources` | `Name / Group / MaxUnits` | `UID` をキーに部分更新する |
+| `Assignments` | `Units / Work / PercentWorkComplete` | `UID` をキーに部分更新する |
+| `Calendars` | `Name / IsBaseCalendar / BaseCalendarUID` | `UID` をキーに部分更新する |
+
+### 現時点で反映対象外のもの
+
+これ以外の列や、未対応シートの編集は、現在の `XLSX Import` では反映対象としない。特に `Calendars` では、`WeekDays / Exceptions / WorkWeeks` はまだ反映対象外とする。
+
+### UI 上の確認手段
+
+`XLSX Import` 後の validation では、`Calendars.BaseCalendarUID` が既存 Calendar を指していない場合や、自身を指している場合の warning も、差分要約と並べて確認できるようにする。
 
 ## STEP 1 の完了条件
 
@@ -64,6 +123,11 @@ preview / validation の現状メモ:
 注意:
 
 - これらは STEP 1 の主目的そのものではなく、意味的ラウンドトリップを確認しやすくするための補助機能である
+- `.xlsx` 表示や `.xlsx import/export` も、同様に確認と限定編集のための補助機能として扱う
+- `XLSX Import` の反映結果は、`Tasks / Resources / Assignments` ごとの件数と `UID` 単位の差分要約で確認できるようにする
+- `XLSX Import` 後も validation を走らせ、反映結果と検証メッセージを同時に確認できるようにする
+- validation では、`PercentComplete` の範囲外や `Start > Finish` のような編集結果も UI 上で追えるようにする
+- validation が残っていても、`XML Export` はその時点の XML をそのまま保存できるようにする
 
 ## STEP 1 の入力データ前提
 
@@ -257,6 +321,9 @@ STEP 1 では、MS Project XML のうち、次の情報を優先して扱う。
 ## STEP 1 で後回しにするもの
 
 STEP 1 では、次のようなものは後回し候補とする。
+
+- `.xlsx import` における自由編集の全面対応
+- `Calendars / Baseline / TimephasedData / ExtendedAttributes` の `.xlsx` 編集反映
 
 - 表示設定
 - UI レイアウト情報

--- a/docs/project/mikuproject-src.html
+++ b/docs/project/mikuproject-src.html
@@ -32,14 +32,67 @@
         <button id="exportMermaidBtn" type="button" class="md-button md-button--surface">Mermaid を生成</button>
         <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
         <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>
+        <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX Export</button>
+        <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
         <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
+        <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
         <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
         <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
         <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
+        <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
       </div>
 
       <div id="statusMessage" class="md-status">未実行</div>
-      <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+      <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
+      <div class="md-feedback-stack md-hidden" aria-label="import feedback">
+        <div class="md-feedback-stack__title">取込結果</div>
+        <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+        <div class="md-feedback-stack__label">検証メッセージ</div>
+        <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+        <div class="md-feedback-stack__label">差分要約</div>
+        <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
+      </div>
+
+      <section class="md-note-card" aria-label="XLSX import export notes">
+        <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+        <p class="md-note-card__text">
+          `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+        </p>
+        <p class="md-note-card__text">
+          現在の `XLSX Import` で反映するのは限定列のみです。
+        </p>
+        <p class="md-note-card__text">
+          反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+        </p>
+        <p class="md-note-card__text"><strong>反映対象</strong></p>
+        <ul class="md-note-list">
+          <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+          <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete`</li>
+          <li>`Resources`: `Name / Group / MaxUnits`</li>
+          <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+          <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+        </ul>
+        <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+        <ul class="md-note-list">
+          <li>対象外の列や未対応シートの編集</li>
+          <li>`Calendars` の `WeekDays / Exceptions / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+        </ul>
+      </section>
+
+      <section class="md-note-card" aria-label="WBS xlsx export options">
+        <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+        <p class="md-note-card__text">
+          `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。
+        </p>
+        <div class="md-form-grid">
+          <lht-text-field-help
+            field-id="wbsHolidayDatesInput"
+            label="WBS 祝日"
+            rows="3"
+            placeholder="2026-03-20&#10;2026-03-21"
+            help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+        </div>
+      </section>
 
       <div class="md-form-grid">
         <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
@@ -121,7 +174,10 @@
     <lht-toast id="toast"></lht-toast>
   </div>
   <script src="src/mikuproject/js/types.js"></script>
+  <script src="src/mikuproject/js/excel-io.js"></script>
   <script src="src/mikuproject/js/msproject-xml.js"></script>
+  <script src="src/mikuproject/js/project-xlsx.js"></script>
+  <script src="src/mikuproject/js/wbs-xlsx.js"></script>
   <script src="src/mikuproject/js/main.js"></script>
 </body>
 </html>

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -1148,6 +1148,63 @@ lht-index-card-link {
   font-weight: 600;
 }
 
+.md-save-state {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.md-save-state--dirty {
+  color: #8a5a1c;
+  background: #fff8ef;
+  border-color: #efcfaa;
+}
+
+.md-save-state--clean {
+  color: #225b4d;
+  background: #eefaf5;
+  border-color: #c7e6d9;
+}
+
+.md-feedback-stack {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(247, 250, 253, 0.92) 0%, rgba(255, 255, 255, 0.92) 100%);
+  border: 1px solid rgba(213, 222, 231, 0.75);
+}
+
+.md-feedback-stack.md-hidden {
+  display: none;
+}
+
+.md-feedback-stack__title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #28485a;
+}
+
+.md-feedback-stack__text {
+  color: #5d7482;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.md-feedback-stack__label {
+  margin-top: 2px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #607787;
+}
+
 .md-issues {
   border: 1px solid #efc9a6;
   border-radius: 16px;
@@ -1183,6 +1240,120 @@ lht-index-card-link {
 
 .md-issues__item + .md-issues__item {
   margin-top: 4px;
+}
+
+.md-note-card {
+  border: 1px solid #cfe2dc;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f3fbf9 0%, #ffffff 100%);
+  padding: 16px 18px;
+}
+
+.md-note-card__title {
+  margin: 0 0 8px;
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #1f4f4a;
+}
+
+.md-note-card__text {
+  margin: 0;
+  color: #3f5f5b;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.md-note-card__text + .md-note-card__text,
+.md-note-list + .md-note-card__text {
+  margin-top: 8px;
+}
+
+.md-note-list {
+  margin: 8px 0 0;
+  padding-left: 1.2rem;
+  color: #345450;
+  font-size: 0.86rem;
+}
+
+.md-note-list li + li {
+  margin-top: 4px;
+}
+
+.md-xlsx-summary {
+  border: 1px solid #cde3f5;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f5faff 0%, #ffffff 100%);
+  padding: 14px 16px;
+  color: #325067;
+}
+
+.md-xlsx-summary.md-hidden {
+  display: none;
+}
+
+.md-xlsx-summary__title {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.md-xlsx-summary__counts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.md-xlsx-summary__count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.8rem;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #e9f3fc;
+  color: #2c5570;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.md-xlsx-summary__unchanged {
+  margin-bottom: 10px;
+  color: #5b7382;
+  font-size: 0.84rem;
+}
+
+.md-xlsx-summary__section + .md-xlsx-summary__section {
+  margin-top: 12px;
+}
+
+.md-xlsx-summary__section-title {
+  margin-bottom: 6px;
+  font-weight: 700;
+  color: #2b5169;
+}
+
+.md-xlsx-summary__list {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.md-xlsx-summary__item + .md-xlsx-summary__item {
+  margin-top: 4px;
+}
+
+.md-xlsx-summary__item-title {
+  font-weight: 700;
+  color: #244559;
+}
+
+.md-xlsx-summary__item-body {
+  margin-top: 3px;
+  color: #466172;
+}
+
+.md-xlsx-summary__hint {
+  margin-top: 12px;
+  color: #516b7b;
+  font-size: 0.84rem;
 }
 
 .md-summary-grid {
@@ -1335,14 +1506,67 @@ lht-index-card-link {
         <button id="exportMermaidBtn" type="button" class="md-button md-button--surface">Mermaid を生成</button>
         <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
         <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>
+        <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX Export</button>
+        <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
         <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
+        <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
         <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
         <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
         <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
+        <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
       </div>
 
       <div id="statusMessage" class="md-status">未実行</div>
-      <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+      <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
+      <div class="md-feedback-stack md-hidden" aria-label="import feedback">
+        <div class="md-feedback-stack__title">取込結果</div>
+        <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+        <div class="md-feedback-stack__label">検証メッセージ</div>
+        <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+        <div class="md-feedback-stack__label">差分要約</div>
+        <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
+      </div>
+
+      <section class="md-note-card" aria-label="XLSX import export notes">
+        <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+        <p class="md-note-card__text">
+          `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+        </p>
+        <p class="md-note-card__text">
+          現在の `XLSX Import` で反映するのは限定列のみです。
+        </p>
+        <p class="md-note-card__text">
+          反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+        </p>
+        <p class="md-note-card__text"><strong>反映対象</strong></p>
+        <ul class="md-note-list">
+          <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+          <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete`</li>
+          <li>`Resources`: `Name / Group / MaxUnits`</li>
+          <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+          <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+        </ul>
+        <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+        <ul class="md-note-list">
+          <li>対象外の列や未対応シートの編集</li>
+          <li>`Calendars` の `WeekDays / Exceptions / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+        </ul>
+      </section>
+
+      <section class="md-note-card" aria-label="WBS xlsx export options">
+        <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+        <p class="md-note-card__text">
+          `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。
+        </p>
+        <div class="md-form-grid">
+          <lht-text-field-help
+            field-id="wbsHolidayDatesInput"
+            label="WBS 祝日"
+            rows="3"
+            placeholder="2026-03-20&#10;2026-03-21"
+            help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+        </div>
+      </section>
 
       <div class="md-form-grid">
         <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
@@ -1423,6 +1647,9 @@ lht-index-card-link {
 
     <lht-toast id="toast"></lht-toast>
   </div>
+  
+  
+  
   
   
   
@@ -5592,6 +5819,888 @@ if (!customElements.get("lht-page-menu")) {
 
   <script>
 (() => {
+    const TEXT_ENCODER = new TextEncoder();
+    const TEXT_DECODER = new TextDecoder();
+    const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
+    const CRC32_TABLE = buildCrc32Table();
+    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent"];
+    const HORIZONTAL_ALIGNS = ["left", "center", "right"];
+    const BORDER_STYLES = ["thin"];
+    const STYLE_KEY_DELIMITER = "::";
+    const DEFAULT_STYLE = { numberFormat: "general" };
+    class XlsxWorkbookCodec {
+        exportWorkbook(workbook) {
+            const normalizedWorkbook = normalizeWorkbook(workbook);
+            const entries = this.createWorkbookEntries(normalizedWorkbook);
+            return packZip(entries);
+        }
+        importWorkbook(bytes) {
+            const entries = this.unpackEntries(bytes);
+            return parseWorkbookEntries(entries);
+        }
+        listEntries(bytes) {
+            return Object.keys(this.unpackEntries(bytes)).sort();
+        }
+        unpackEntries(bytes) {
+            return unpackZip(bytes);
+        }
+        createWorkbookEntries(workbook) {
+            const styleBook = createStyleBook(workbook);
+            const worksheetRelationships = workbook.sheets.map((sheet, index) => ({
+                relationshipId: `rId${index + 1}`,
+                target: `worksheets/sheet${index + 1}.xml`,
+                name: sheet.name
+            }));
+            const worksheetEntries = workbook.sheets.map((sheet, index) => ({
+                name: `xl/worksheets/sheet${index + 1}.xml`,
+                data: encodeUtf8(buildWorksheetXml(sheet, styleBook))
+            }));
+            const entries = [
+                {
+                    name: "[Content_Types].xml",
+                    data: encodeUtf8(buildContentTypesXml(workbook.sheets.length, styleBook.styles.length > 1))
+                },
+                {
+                    name: "_rels/.rels",
+                    data: encodeUtf8(buildRootRelationshipsXml())
+                },
+                {
+                    name: "xl/_rels/workbook.xml.rels",
+                    data: encodeUtf8(buildWorkbookRelationshipsXml(worksheetRelationships, styleBook.styles.length > 1))
+                },
+                {
+                    name: "xl/workbook.xml",
+                    data: encodeUtf8(buildWorkbookXml(worksheetRelationships))
+                }
+            ];
+            if (styleBook.styles.length > 1) {
+                entries.push({
+                    name: "xl/styles.xml",
+                    data: encodeUtf8(buildStylesXml(styleBook.styles))
+                });
+            }
+            entries.push(...worksheetEntries);
+            return entries;
+        }
+    }
+    function normalizeWorkbook(workbook) {
+        if (!workbook || !Array.isArray(workbook.sheets) || workbook.sheets.length === 0) {
+            throw new Error("Workbook must contain at least one sheet");
+        }
+        const seenNames = new Set();
+        return {
+            sheets: workbook.sheets.map((sheet) => {
+                if (!sheet || typeof sheet.name !== "string") {
+                    throw new Error("Each sheet must have a valid sheet name");
+                }
+                validateSheetName(sheet.name);
+                const canonicalName = sheet.name.toLocaleLowerCase();
+                if (seenNames.has(canonicalName)) {
+                    throw new Error(`Duplicate sheet name is not allowed: ${sheet.name}`);
+                }
+                seenNames.add(canonicalName);
+                return {
+                    name: sheet.name,
+                    columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+                    mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+                    rows: Array.isArray(sheet.rows)
+                        ? sheet.rows.map((row) => ({
+                            height: normalizeOptionalPositiveNumber(row === null || row === void 0 ? void 0 : row.height, "Row height"),
+                            cells: Array.isArray(row === null || row === void 0 ? void 0 : row.cells)
+                                ? row.cells.map((cell) => normalizeCell(cell))
+                                : []
+                        }))
+                        : []
+                };
+            })
+        };
+    }
+    function normalizeColumn(column) {
+        if (!column) {
+            return {};
+        }
+        return {
+            width: normalizeOptionalPositiveNumber(column.width, "Column width")
+        };
+    }
+    function normalizeCell(cell) {
+        if (!cell) {
+            return {};
+        }
+        if (cell.value !== undefined && typeof cell.value !== "string" && typeof cell.value !== "number" && typeof cell.value !== "boolean") {
+            throw new Error("Cell value must be string, number, or boolean");
+        }
+        if (cell.formula !== undefined && typeof cell.formula !== "string") {
+            throw new Error("Cell formula must be a string");
+        }
+        if (cell.numberFormat !== undefined && !NUMBER_FORMATS.includes(cell.numberFormat)) {
+            throw new Error(`Unsupported cell number format: ${cell.numberFormat}`);
+        }
+        if (cell.horizontalAlign !== undefined && !HORIZONTAL_ALIGNS.includes(cell.horizontalAlign)) {
+            throw new Error(`Unsupported cell horizontal align: ${cell.horizontalAlign}`);
+        }
+        if (cell.border !== undefined && !BORDER_STYLES.includes(cell.border)) {
+            throw new Error(`Unsupported cell border: ${cell.border}`);
+        }
+        if (cell.fillColor !== undefined) {
+            assertColor(cell.fillColor);
+        }
+        return {
+            value: cell.value,
+            formula: cell.formula,
+            numberFormat: cell.numberFormat,
+            horizontalAlign: cell.horizontalAlign,
+            bold: cell.bold === true ? true : undefined,
+            fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
+            border: cell.border
+        };
+    }
+    function normalizeMergedRange(range) {
+        if (typeof range !== "string") {
+            throw new Error("Merged range must be a string");
+        }
+        const trimmed = range.trim().toUpperCase();
+        if (!/^[A-Z]+\d+:[A-Z]+\d+$/.test(trimmed)) {
+            throw new Error(`Invalid merged range: ${range}`);
+        }
+        return trimmed;
+    }
+    function normalizeOptionalPositiveNumber(value, label) {
+        if (value === undefined) {
+            return undefined;
+        }
+        if (!Number.isFinite(value) || value <= 0) {
+            throw new Error(`${label} must be a finite positive number`);
+        }
+        return value;
+    }
+    function validateSheetName(name) {
+        if (!name || !name.trim()) {
+            throw new Error("Sheet name must not be empty");
+        }
+        if (name.length > 31) {
+            throw new Error(`Sheet name is too long: ${name}`);
+        }
+        if (INVALID_SHEET_NAME_PATTERN.test(name)) {
+            throw new Error(`Sheet name contains invalid characters: ${name}`);
+        }
+        if (name.startsWith("'") || name.endsWith("'")) {
+            throw new Error(`Sheet name must not start or end with apostrophe: ${name}`);
+        }
+    }
+    function assertColor(color) {
+        if (!/^#?[0-9a-fA-F]{6}$/.test(color)) {
+            throw new Error(`Unsupported color format: ${color}`);
+        }
+    }
+    function normalizeColor(color) {
+        const hex = color.startsWith("#") ? color.slice(1) : color;
+        return `FF${hex.toUpperCase()}`;
+    }
+    function denormalizeColor(color) {
+        if (!color) {
+            return undefined;
+        }
+        const normalized = color.toUpperCase();
+        if (/^[0-9A-F]{8}$/.test(normalized)) {
+            return `#${normalized.slice(2)}`;
+        }
+        if (/^[0-9A-F]{6}$/.test(normalized)) {
+            return `#${normalized}`;
+        }
+        return undefined;
+    }
+    function buildContentTypesXml(sheetCount, includeStyles) {
+        const worksheetOverrides = Array.from({ length: sheetCount }, (_unused, index) => (`<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`)).join("");
+        const stylesOverride = includeStyles
+            ? `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>`
+            : "";
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  ${worksheetOverrides}
+  ${stylesOverride}
+</Types>`;
+    }
+    function buildRootRelationshipsXml() {
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`;
+    }
+    function buildWorkbookRelationshipsXml(relationships, includeStyles) {
+        const worksheetNodes = relationships.map((relationship) => (`<Relationship Id="${escapeXml(relationship.relationshipId)}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="${escapeXml(relationship.target)}"/>`)).join("");
+        const stylesNode = includeStyles
+            ? `<Relationship Id="rId${relationships.length + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`
+            : "";
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  ${worksheetNodes}
+  ${stylesNode}
+</Relationships>`;
+    }
+    function buildWorkbookXml(relationships) {
+        const sheets = relationships.map((relationship, index) => (`<sheet name="${escapeXml(relationship.name)}" sheetId="${index + 1}" r:id="${escapeXml(relationship.relationshipId)}"/>`)).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>${sheets}</sheets>
+</workbook>`;
+    }
+    function buildWorksheetXml(sheet, styleBook) {
+        const colsXml = buildColumnsXml(sheet.columns);
+        const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+        const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${colsXml}
+  <sheetData>${rows}</sheetData>
+  ${mergeCellsXml}
+</worksheet>`;
+    }
+    function buildColumnsXml(columns) {
+        if (!columns || columns.length === 0 || columns.every((column) => column.width === undefined)) {
+            return "";
+        }
+        const cols = columns.map((column, index) => (column.width !== undefined
+            ? `<col min="${index + 1}" max="${index + 1}" width="${formatNumber(column.width)}" customWidth="1"/>`
+            : "")).filter(Boolean).join("");
+        return cols ? `<cols>${cols}</cols>` : "";
+    }
+    function buildMergeCellsXml(mergedRanges) {
+        if (!mergedRanges || mergedRanges.length === 0) {
+            return "";
+        }
+        const mergeCells = mergedRanges
+            .map((range) => `<mergeCell ref="${range}"/>`)
+            .join("");
+        return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+    }
+    function buildWorksheetRowXml(row, rowIndex, styleBook) {
+        const cells = row.cells
+            .map((cell, cellIndex) => buildWorksheetCellXml(cell, rowIndex, cellIndex, styleBook))
+            .filter(Boolean)
+            .join("");
+        if (!cells) {
+            return "";
+        }
+        const heightAttributes = row.height !== undefined
+            ? ` ht="${formatNumber(row.height)}" customHeight="1"`
+            : "";
+        return `<row r="${rowIndex + 1}"${heightAttributes}>${cells}</row>`;
+    }
+    function buildWorksheetCellXml(cell, rowIndex, cellIndex, styleBook) {
+        const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
+        const styleIndex = resolveStyleIndex(cell, styleBook);
+        const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+        if (cell.formula !== undefined) {
+            const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
+            const valueXml = buildFormulaValueXml(cell.value);
+            const typeAttribute = getCellTypeAttribute(cell.value, true);
+            return `<c r="${reference}"${styleAttribute}${typeAttribute}>${formulaXml}${valueXml}</c>`;
+        }
+        if (cell.value === undefined) {
+            return "";
+        }
+        if (typeof cell.value === "string") {
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+        }
+        if (typeof cell.value === "number") {
+            return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
+        }
+        return `<c r="${reference}"${styleAttribute} t="b"><v>${cell.value ? "1" : "0"}</v></c>`;
+    }
+    function buildFormulaValueXml(value) {
+        if (value === undefined) {
+            return "";
+        }
+        if (typeof value === "string") {
+            return `<v>${escapeXml(value)}</v>`;
+        }
+        if (typeof value === "number") {
+            return `<v>${formatNumber(value)}</v>`;
+        }
+        return `<v>${value ? "1" : "0"}</v>`;
+    }
+    function getCellTypeAttribute(value, hasFormula) {
+        if (!hasFormula) {
+            return "";
+        }
+        if (typeof value === "string") {
+            return ` t="str"`;
+        }
+        if (typeof value === "boolean") {
+            return ` t="b"`;
+        }
+        return "";
+    }
+    function formatNumber(value) {
+        if (!Number.isFinite(value)) {
+            throw new Error(`Cell number must be finite: ${value}`);
+        }
+        return String(value);
+    }
+    function createStyleBook(workbook) {
+        const styles = [DEFAULT_STYLE];
+        const styleIndexByKey = new Map([[styleKey(DEFAULT_STYLE), 0]]);
+        for (const sheet of workbook.sheets) {
+            for (const row of sheet.rows) {
+                for (const cell of row.cells) {
+                    const descriptor = getStyleDescriptor(cell);
+                    if (!descriptor) {
+                        continue;
+                    }
+                    const key = styleKey(descriptor);
+                    if (!styleIndexByKey.has(key)) {
+                        styleIndexByKey.set(key, styles.length);
+                        styles.push(descriptor);
+                    }
+                }
+            }
+        }
+        return { styles, styleIndexByKey };
+    }
+    function getStyleDescriptor(cell) {
+        if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+            return null;
+        }
+        return {
+            numberFormat: cell.numberFormat || "general",
+            horizontalAlign: cell.horizontalAlign,
+            bold: cell.bold === true ? true : undefined,
+            fillColor: cell.fillColor,
+            border: cell.border
+        };
+    }
+    function styleKey(style) {
+        return [
+            style.numberFormat,
+            style.horizontalAlign || "",
+            style.bold ? "bold" : "",
+            style.fillColor || "",
+            style.border || ""
+        ].join(STYLE_KEY_DELIMITER);
+    }
+    function resolveStyleIndex(cell, styleBook) {
+        const descriptor = getStyleDescriptor(cell);
+        if (!descriptor) {
+            return 0;
+        }
+        return styleBook.styleIndexByKey.get(styleKey(descriptor)) || 0;
+    }
+    function buildStylesXml(styles) {
+        const fonts = dedupeDescriptors(styles.map((style) => ({ bold: style.bold })), fontKey, { bold: undefined });
+        const fills = dedupeDescriptors(styles.map((style) => ({ fillColor: style.fillColor })), fillKey, { fillColor: undefined });
+        const borders = dedupeDescriptors(styles.map((style) => ({ border: style.border })), borderKey, { border: undefined });
+        const styleNodes = styles.map((style) => {
+            const numFmtId = mapNumberFormatId(style.numberFormat);
+            const fontId = fonts.indexByKey.get(fontKey({ bold: style.bold })) || 0;
+            const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
+            const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
+            const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
+            const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+            const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
+            const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
+            const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
+            const alignmentNode = style.horizontalAlign
+                ? `<alignment horizontal="${style.horizontalAlign}"/>`
+                : "";
+            return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
+        }).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <numFmts count="0"/>
+  <fonts count="${fonts.items.length}">
+    ${fonts.items.map(buildFontXml).join("")}
+  </fonts>
+  <fills count="${fills.items.length}">
+    ${fills.items.map(buildFillXml).join("")}
+  </fills>
+  <borders count="${borders.items.length}">
+    ${borders.items.map(buildBorderXml).join("")}
+  </borders>
+  <cellStyleXfs count="1">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+  </cellStyleXfs>
+  <cellXfs count="${styles.length}">
+    ${styleNodes}
+  </cellXfs>
+  <cellStyles count="1">
+    <cellStyle name="Normal" xfId="0" builtinId="0"/>
+  </cellStyles>
+</styleSheet>`;
+    }
+    function dedupeDescriptors(items, keyFn, defaultItem) {
+        const uniqueItems = [defaultItem];
+        const indexByKey = new Map([[keyFn(defaultItem), 0]]);
+        for (const item of items) {
+            const key = keyFn(item);
+            if (!indexByKey.has(key)) {
+                indexByKey.set(key, uniqueItems.length);
+                uniqueItems.push(item);
+            }
+        }
+        return { items: uniqueItems, indexByKey };
+    }
+    function fontKey(font) {
+        return font.bold ? "bold" : "";
+    }
+    function fillKey(fill) {
+        return fill.fillColor || "";
+    }
+    function borderKey(border) {
+        return border.border || "";
+    }
+    function buildFontXml(font) {
+        return font.bold ? `<font><b/></font>` : `<font/>`;
+    }
+    function buildFillXml(fill) {
+        if (!fill.fillColor) {
+            return `<fill><patternFill patternType="none"/></fill>`;
+        }
+        return `<fill><patternFill patternType="solid"><fgColor rgb="${fill.fillColor}"/><bgColor indexed="64"/></patternFill></fill>`;
+    }
+    function buildBorderXml(border) {
+        if (!border.border) {
+            return `<border/>`;
+        }
+        return `<border><left style="${border.border}"/><right style="${border.border}"/><top style="${border.border}"/><bottom style="${border.border}"/><diagonal/></border>`;
+    }
+    function mapNumberFormatId(numberFormat) {
+        switch (numberFormat) {
+            case "integer":
+                return 1;
+            case "decimal":
+                return 2;
+            case "date":
+                return 14;
+            case "datetime":
+                return 22;
+            case "percent":
+                return 10;
+            case "general":
+            default:
+                return 0;
+        }
+    }
+    function parseWorkbookEntries(entries) {
+        const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
+        const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
+        const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+        const workbookDocument = parseXmlDocument(workbookXml);
+        const relationshipsDocument = parseXmlDocument(workbookRelsXml);
+        const styleBook = parseStylesXml(stylesXml);
+        const relationshipMap = new Map();
+        const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/package/2006/relationships", "Relationship"));
+        for (const relationshipElement of relationshipElements) {
+            const id = relationshipElement.getAttribute("Id");
+            const target = relationshipElement.getAttribute("Target");
+            if (id && target) {
+                relationshipMap.set(id, normalizeWorkbookTarget(target));
+            }
+        }
+        const sheetElements = Array.from(workbookDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "sheet"));
+        return {
+            sheets: sheetElements.map((sheetElement) => {
+                const name = sheetElement.getAttribute("name") || "";
+                validateSheetName(name);
+                const relationshipId = sheetElement.getAttributeNS("http://schemas.openxmlformats.org/officeDocument/2006/relationships", "id") || sheetElement.getAttribute("r:id");
+                if (!relationshipId) {
+                    throw new Error(`Worksheet relationship id is missing for sheet: ${name}`);
+                }
+                const target = relationshipMap.get(relationshipId);
+                if (!target) {
+                    throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
+                }
+                const worksheetXml = decodeRequiredEntry(entries, target);
+                return parseWorksheetXml(name, worksheetXml, styleBook);
+            })
+        };
+    }
+    function normalizeWorkbookTarget(target) {
+        return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
+    }
+    function parseWorksheetXml(name, xmlText, styleBook) {
+        const document = parseXmlDocument(xmlText);
+        const rowElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "row"));
+        return {
+            name,
+            columns: parseWorksheetColumns(document),
+            mergedRanges: parseWorksheetMergedRanges(document),
+            rows: rowElements.map((rowElement) => ({
+                height: parseOptionalNumber(rowElement.getAttribute("ht")),
+                cells: parseWorksheetRowCells(rowElement, styleBook)
+            }))
+        };
+    }
+    function parseWorksheetColumns(document) {
+        const colElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "col"));
+        if (colElements.length === 0) {
+            return undefined;
+        }
+        const columns = [];
+        for (const colElement of colElements) {
+            const min = Number(colElement.getAttribute("min") || "0");
+            const max = Number(colElement.getAttribute("max") || "0");
+            const width = parseOptionalNumber(colElement.getAttribute("width"));
+            for (let index = min; index <= max; index += 1) {
+                columns[index - 1] = { width };
+            }
+        }
+        while (columns.length > 0 && !columns[columns.length - 1]) {
+            columns.pop();
+        }
+        return columns.length > 0 ? columns.map((column) => column || {}) : undefined;
+    }
+    function parseWorksheetMergedRanges(document) {
+        const mergeCellElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "mergeCell"));
+        if (mergeCellElements.length === 0) {
+            return undefined;
+        }
+        return mergeCellElements
+            .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
+            .filter(Boolean);
+    }
+    function parseWorksheetRowCells(rowElement, styleBook) {
+        const cells = [];
+        const cellElements = Array.from(rowElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c")).filter((element) => element.parentElement === rowElement);
+        for (const cellElement of cellElements) {
+            const reference = cellElement.getAttribute("r") || "";
+            const columnIndex = decodeColumnReference(reference);
+            while (cells.length < columnIndex) {
+                cells.push({});
+            }
+            cells.push(parseWorksheetCell(cellElement, styleBook));
+        }
+        return cells;
+    }
+    function parseWorksheetCell(cellElement, styleBook) {
+        const type = cellElement.getAttribute("t") || "";
+        const styleIndex = Number(cellElement.getAttribute("s") || "0");
+        const formulaElement = findDirectChild(cellElement, "f");
+        const valueElement = findDirectChild(cellElement, "v");
+        const inlineStringElement = findDirectChild(cellElement, "is");
+        let value;
+        if (type === "inlineStr") {
+            const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
+            value = textElement ? (textElement.textContent || "") : "";
+        }
+        else if (type === "b") {
+            value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) === "1";
+        }
+        else if (type === "str") {
+            value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) || "";
+        }
+        else if (valueElement) {
+            const rawValue = valueElement.textContent || "";
+            value = rawValue === "" ? "" : Number(rawValue);
+        }
+        const style = styleBook[styleIndex] || DEFAULT_STYLE;
+        const cell = {};
+        if (style.numberFormat !== "general") {
+            cell.numberFormat = style.numberFormat;
+        }
+        if (style.horizontalAlign) {
+            cell.horizontalAlign = style.horizontalAlign;
+        }
+        if (style.bold) {
+            cell.bold = true;
+        }
+        if (style.fillColor) {
+            cell.fillColor = denormalizeColor(style.fillColor);
+        }
+        if (style.border) {
+            cell.border = style.border;
+        }
+        if (formulaElement) {
+            cell.formula = formulaElement.textContent || "";
+        }
+        if (value !== undefined) {
+            cell.value = value;
+        }
+        return cell;
+    }
+    function parseStylesXml(xmlText) {
+        if (!xmlText) {
+            return [DEFAULT_STYLE];
+        }
+        const document = parseXmlDocument(xmlText);
+        const fonts = parseFonts(document);
+        const fills = parseFills(document);
+        const borders = parseBorders(document);
+        const xfElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "xf")).filter((element) => { var _a; return ((_a = element.parentElement) === null || _a === void 0 ? void 0 : _a.localName) === "cellXfs"; });
+        if (xfElements.length === 0) {
+            return [DEFAULT_STYLE];
+        }
+        return xfElements.map((xfElement) => {
+            var _a, _b, _c;
+            const numFmtId = Number(xfElement.getAttribute("numFmtId") || "0");
+            const fontId = Number(xfElement.getAttribute("fontId") || "0");
+            const fillId = Number(xfElement.getAttribute("fillId") || "0");
+            const borderId = Number(xfElement.getAttribute("borderId") || "0");
+            const alignmentElement = findDirectChild(xfElement, "alignment");
+            const horizontalAlign = alignmentElement === null || alignmentElement === void 0 ? void 0 : alignmentElement.getAttribute("horizontal");
+            return {
+                numberFormat: parseNumberFormatId(numFmtId),
+                horizontalAlign: horizontalAlign || undefined,
+                bold: ((_a = fonts[fontId]) === null || _a === void 0 ? void 0 : _a.bold) ? true : undefined,
+                fillColor: (_b = fills[fillId]) === null || _b === void 0 ? void 0 : _b.fillColor,
+                border: (_c = borders[borderId]) === null || _c === void 0 ? void 0 : _c.border
+            };
+        });
+    }
+    function parseFonts(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "font")).map((fontElement) => ({
+            bold: findDirectChild(fontElement, "b") ? true : undefined
+        }));
+    }
+    function parseFills(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "fill")).map((fillElement) => {
+            const patternFill = findDirectChild(fillElement, "patternFill");
+            const fgColor = patternFill ? findDirectChild(patternFill, "fgColor") : null;
+            return {
+                fillColor: (fgColor === null || fgColor === void 0 ? void 0 : fgColor.getAttribute("rgb")) || undefined
+            };
+        });
+    }
+    function parseBorders(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "border")).map((borderElement) => {
+            const left = findDirectChild(borderElement, "left");
+            const style = left === null || left === void 0 ? void 0 : left.getAttribute("style");
+            return {
+                border: style && BORDER_STYLES.includes(style) ? style : undefined
+            };
+        });
+    }
+    function parseNumberFormatId(numFmtId) {
+        switch (numFmtId) {
+            case 1:
+                return "integer";
+            case 2:
+                return "decimal";
+            case 10:
+                return "percent";
+            case 14:
+                return "date";
+            case 22:
+                return "datetime";
+            default:
+                return "general";
+        }
+    }
+    function parseOptionalNumber(value) {
+        if (!value) {
+            return undefined;
+        }
+        return Number(value);
+    }
+    function findDirectChild(element, localName) {
+        for (const childNode of Array.from(element.childNodes)) {
+            if (childNode.nodeType !== Node.ELEMENT_NODE) {
+                continue;
+            }
+            const childElement = childNode;
+            if (childElement.localName === localName) {
+                return childElement;
+            }
+        }
+        return null;
+    }
+    function parseXmlDocument(xmlText) {
+        const document = new DOMParser().parseFromString(xmlText, "application/xml");
+        if (document.querySelector("parsererror")) {
+            throw new Error("Failed to parse XML document");
+        }
+        return document;
+    }
+    function decodeRequiredEntry(entries, name) {
+        const bytes = entries[name];
+        if (!bytes) {
+            throw new Error(`Required ZIP entry is missing: ${name}`);
+        }
+        return decodeUtf8(bytes);
+    }
+    function encodeUtf8(value) {
+        return TEXT_ENCODER.encode(value);
+    }
+    function decodeUtf8(bytes) {
+        return TEXT_DECODER.decode(bytes);
+    }
+    function escapeXml(value) {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&apos;");
+    }
+    function encodeColumnName(columnIndex) {
+        let current = columnIndex + 1;
+        let result = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            result = String.fromCharCode(65 + remainder) + result;
+            current = Math.floor((current - 1) / 26);
+        }
+        return result;
+    }
+    function decodeColumnReference(reference) {
+        const match = /^([A-Z]+)\d+$/i.exec(reference);
+        if (!match) {
+            throw new Error(`Invalid cell reference: ${reference}`);
+        }
+        const letters = match[1].toUpperCase();
+        let value = 0;
+        for (const character of letters) {
+            value = (value * 26) + (character.charCodeAt(0) - 64);
+        }
+        return value - 1;
+    }
+    function packZip(entries) {
+        const localParts = [];
+        const centralParts = [];
+        let offset = 0;
+        for (const entry of entries) {
+            const nameBytes = encodeUtf8(entry.name);
+            const crc32 = computeCrc32(entry.data);
+            const localHeader = new Uint8Array(30 + nameBytes.length);
+            const localView = new DataView(localHeader.buffer);
+            localView.setUint32(0, 0x04034b50, true);
+            localView.setUint16(4, 20, true);
+            localView.setUint16(6, 0, true);
+            localView.setUint16(8, 0, true);
+            localView.setUint16(10, 0, true);
+            localView.setUint16(12, 0, true);
+            localView.setUint32(14, crc32, true);
+            localView.setUint32(18, entry.data.byteLength, true);
+            localView.setUint32(22, entry.data.byteLength, true);
+            localView.setUint16(26, nameBytes.length, true);
+            localView.setUint16(28, 0, true);
+            localHeader.set(nameBytes, 30);
+            const centralHeader = new Uint8Array(46 + nameBytes.length);
+            const centralView = new DataView(centralHeader.buffer);
+            centralView.setUint32(0, 0x02014b50, true);
+            centralView.setUint16(4, 20, true);
+            centralView.setUint16(6, 20, true);
+            centralView.setUint16(8, 0, true);
+            centralView.setUint16(10, 0, true);
+            centralView.setUint16(12, 0, true);
+            centralView.setUint16(14, 0, true);
+            centralView.setUint32(16, crc32, true);
+            centralView.setUint32(20, entry.data.byteLength, true);
+            centralView.setUint32(24, entry.data.byteLength, true);
+            centralView.setUint16(28, nameBytes.length, true);
+            centralView.setUint16(30, 0, true);
+            centralView.setUint16(32, 0, true);
+            centralView.setUint16(34, 0, true);
+            centralView.setUint16(36, 0, true);
+            centralView.setUint32(38, 0, true);
+            centralView.setUint32(42, offset, true);
+            centralHeader.set(nameBytes, 46);
+            localParts.push(localHeader, entry.data);
+            centralParts.push(centralHeader);
+            offset += localHeader.byteLength + entry.data.byteLength;
+        }
+        const centralDirectoryOffset = offset;
+        const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+        const endOfCentralDirectory = new Uint8Array(22);
+        const endView = new DataView(endOfCentralDirectory.buffer);
+        endView.setUint32(0, 0x06054b50, true);
+        endView.setUint16(4, 0, true);
+        endView.setUint16(6, 0, true);
+        endView.setUint16(8, entries.length, true);
+        endView.setUint16(10, entries.length, true);
+        endView.setUint32(12, centralDirectorySize, true);
+        endView.setUint32(16, centralDirectoryOffset, true);
+        endView.setUint16(20, 0, true);
+        return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+    }
+    function unpackZip(bytes) {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const endOffset = findEndOfCentralDirectoryOffset(bytes);
+        const totalEntries = view.getUint16(endOffset + 10, true);
+        const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+        const entries = {};
+        let pointer = centralDirectoryOffset;
+        for (let index = 0; index < totalEntries; index += 1) {
+            if (view.getUint32(pointer, true) !== 0x02014b50) {
+                throw new Error("Invalid ZIP central directory header");
+            }
+            const compressionMethod = view.getUint16(pointer + 10, true);
+            const compressedSize = view.getUint32(pointer + 20, true);
+            const uncompressedSize = view.getUint32(pointer + 24, true);
+            const fileNameLength = view.getUint16(pointer + 28, true);
+            const extraLength = view.getUint16(pointer + 30, true);
+            const commentLength = view.getUint16(pointer + 32, true);
+            const localHeaderOffset = view.getUint32(pointer + 42, true);
+            const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+            const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+            if (localView.getUint32(0, true) !== 0x04034b50) {
+                throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+            }
+            const localFileNameLength = localView.getUint16(26, true);
+            const localExtraLength = localView.getUint16(28, true);
+            const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+            const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+            if (compressionMethod !== 0) {
+                throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+            }
+            if (compressedSize !== uncompressedSize) {
+                throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+            }
+            entries[fileName] = data;
+            pointer += 46 + fileNameLength + extraLength + commentLength;
+        }
+        return entries;
+    }
+    function findEndOfCentralDirectoryOffset(bytes) {
+        for (let index = bytes.byteLength - 22; index >= 0; index -= 1) {
+            if (bytes[index] === 0x50 &&
+                bytes[index + 1] === 0x4b &&
+                bytes[index + 2] === 0x05 &&
+                bytes[index + 3] === 0x06) {
+                return index;
+            }
+        }
+        throw new Error("ZIP end of central directory not found");
+    }
+    function concatUint8Arrays(parts) {
+        const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+        const result = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const part of parts) {
+            result.set(part, offset);
+            offset += part.byteLength;
+        }
+        return result;
+    }
+    function computeCrc32(bytes) {
+        let crc = 0xffffffff;
+        for (const byte of bytes) {
+            crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+        }
+        return (crc ^ 0xffffffff) >>> 0;
+    }
+    function buildCrc32Table() {
+        const table = new Uint32Array(256);
+        for (let index = 0; index < 256; index += 1) {
+            let value = index;
+            for (let bit = 0; bit < 8; bit += 1) {
+                value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+            }
+            table[index] = value >>> 0;
+        }
+        return table;
+    }
+    globalThis.__mikuprojectExcelIo = {
+        XlsxWorkbookCodec
+    };
+})();
+  </script>
+
+  <script>
+(() => {
     const SAMPLE_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <Project xmlns="http://schemas.microsoft.com/project">
   <Name>Sample Project</Name>
@@ -7811,14 +8920,882 @@ if (!customElements.get("lht-page-menu")) {
 
   <script>
 (() => {
+    const HEADER_FILL = "#D9EAF7";
+    function exportProjectWorkbook(model) {
+        return {
+            sheets: [
+                buildProjectSheet(model),
+                buildTasksSheet(model),
+                buildResourcesSheet(model),
+                buildAssignmentsSheet(model),
+                buildCalendarsSheet(model)
+            ]
+        };
+    }
+    function importProjectWorkbook(workbook, baseModel) {
+        return importProjectWorkbookDetailed(workbook, baseModel).model;
+    }
+    function importProjectWorkbookDetailed(workbook, baseModel) {
+        const nextModel = cloneProjectModel(baseModel);
+        const changes = [];
+        importProjectSheet(workbook, nextModel, changes);
+        importTasksSheet(workbook, nextModel, changes);
+        importResourcesSheet(workbook, nextModel, changes);
+        importAssignmentsSheet(workbook, nextModel, changes);
+        importCalendarsSheet(workbook, nextModel, changes);
+        return {
+            model: nextModel,
+            changes
+        };
+    }
+    function importProjectSheet(workbook, model, changes) {
+        const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+        if (!projectSheet) {
+            return;
+        }
+        const valueByField = new Map();
+        for (const row of projectSheet.rows.slice(3)) {
+            const field = readStringCell(row.cells[0]);
+            if (!field) {
+                continue;
+            }
+            valueByField.set(field, row.cells[1]);
+        }
+        const projectLabel = model.project.name;
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "name", "Name", readStringCell(valueByField.get("Name")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "title", "Title", readStringCell(valueByField.get("Title")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "author", "Author", readStringCell(valueByField.get("Author")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "company", "Company", readStringCell(valueByField.get("Company")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "startDate", "StartDate", readStringCell(valueByField.get("StartDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "finishDate", "FinishDate", readStringCell(valueByField.get("FinishDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "currentDate", "CurrentDate", readStringCell(valueByField.get("CurrentDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "statusDate", "StatusDate", readStringCell(valueByField.get("StatusDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "calendarUID", "CalendarUID", readStringCell(valueByField.get("CalendarUID")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerDay", "MinutesPerDay", readNumberCell(valueByField.get("MinutesPerDay")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+    }
+    function buildProjectSheet(model) {
+        const project = model.project;
+        const rows = [
+            titleRow("Project"),
+            titleRow("Basic Info"),
+            headerRow(["Field", "Value"]),
+            keyValueRow("Name", project.name),
+            keyValueRow("Title", project.title),
+            keyValueRow("Author", project.author),
+            keyValueRow("Company", project.company),
+            keyValueRow("StartDate", project.startDate),
+            keyValueRow("FinishDate", project.finishDate),
+            keyValueRow("CurrentDate", project.currentDate),
+            keyValueRow("StatusDate", project.statusDate),
+            titleRow("Settings"),
+            keyValueRow("CalendarUID", project.calendarUID),
+            keyValueRow("MinutesPerDay", project.minutesPerDay),
+            keyValueRow("MinutesPerWeek", project.minutesPerWeek),
+            keyValueRow("DaysPerMonth", project.daysPerMonth),
+            keyValueRow("ScheduleFromStart", project.scheduleFromStart),
+            keyValueRow("OutlineCodes", project.outlineCodes.length),
+            keyValueRow("WBSMasks", project.wbsMasks.length),
+            keyValueRow("ExtendedAttributes", project.extendedAttributes.length)
+        ];
+        return {
+            name: "Project",
+            columns: [{ width: 24 }, { width: 32 }],
+            mergedRanges: ["A1:B1", "A2:B2", "A11:B11"],
+            rows
+        };
+    }
+    function buildTasksSheet(model) {
+        return {
+            name: "Tasks",
+            columns: [
+                { width: 10 }, { width: 8 }, { width: 28 }, { width: 12 },
+                { width: 14 }, { width: 12 }, { width: 20 }, { width: 20 },
+                { width: 14 }, { width: 16 }, { width: 18 }, { width: 12 },
+                { width: 12 }, { width: 12 }, { width: 12 }, { width: 18 }
+            ],
+            mergedRanges: ["A1:P1", "A2:P2"],
+            rows: [
+                sectionTitleRow("Tasks", 16),
+                sectionTitleRow("Task List", 16),
+                headerRow([
+                    "UID", "ID", "Name", "OutlineLevel", "OutlineNumber", "WBS",
+                    "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete",
+                    "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors"
+                ]),
+                ...model.tasks.map((task) => ({
+                    cells: [
+                        cell(task.uid),
+                        cell(task.id),
+                        cell(task.name),
+                        cell(task.outlineLevel),
+                        cell(task.outlineNumber),
+                        cell(task.wbs),
+                        cell(task.start),
+                        cell(task.finish),
+                        cell(task.duration),
+                        cell(task.percentComplete),
+                        cell(task.percentWorkComplete),
+                        cell(task.milestone),
+                        cell(task.summary),
+                        cell(task.critical),
+                        cell(task.calendarUID),
+                        cell(task.predecessors.map((item) => item.predecessorUid).join(", "))
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildResourcesSheet(model) {
+        return {
+            name: "Resources",
+            columns: [
+                { width: 10 }, { width: 8 }, { width: 24 }, { width: 10 },
+                { width: 12 }, { width: 18 }, { width: 12 }, { width: 12 },
+                { width: 14 }, { width: 14 }, { width: 12 }, { width: 14 },
+                { width: 14 }, { width: 14 }
+            ],
+            mergedRanges: ["A1:N1", "A2:N2"],
+            rows: [
+                sectionTitleRow("Resources", 14),
+                sectionTitleRow("Resource List", 14),
+                headerRow([
+                    "UID", "ID", "Name", "Type", "Initials", "Group", "MaxUnits",
+                    "CalendarUID", "StandardRate", "OvertimeRate", "CostPerUse",
+                    "Work", "ActualWork", "RemainingWork"
+                ]),
+                ...model.resources.map((resource) => ({
+                    cells: [
+                        cell(resource.uid),
+                        cell(resource.id),
+                        cell(resource.name),
+                        cell(resource.type),
+                        cell(resource.initials),
+                        cell(resource.group),
+                        cell(resource.maxUnits),
+                        cell(resource.calendarUID),
+                        cell(resource.standardRate),
+                        cell(resource.overtimeRate),
+                        cell(resource.costPerUse),
+                        cell(resource.work),
+                        cell(resource.actualWork),
+                        cell(resource.remainingWork)
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildAssignmentsSheet(model) {
+        const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+        const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        return {
+            name: "Assignments",
+            columns: [
+                { width: 10 }, { width: 10 }, { width: 24 }, { width: 12 },
+                { width: 24 }, { width: 20 }, { width: 20 }, { width: 10 },
+                { width: 14 }, { width: 14 }, { width: 14 }, { width: 18 }
+            ],
+            mergedRanges: ["A1:L1", "A2:L2"],
+            rows: [
+                sectionTitleRow("Assignments", 12),
+                sectionTitleRow("Assignment List", 12),
+                headerRow([
+                    "UID", "TaskUID", "TaskName", "ResourceUID", "ResourceName", "Start",
+                    "Finish", "Units", "Work", "ActualWork", "RemainingWork", "PercentWorkComplete"
+                ]),
+                ...model.assignments.map((assignment) => ({
+                    cells: [
+                        cell(assignment.uid),
+                        cell(assignment.taskUid),
+                        cell(taskNameByUid.get(assignment.taskUid)),
+                        cell(assignment.resourceUid),
+                        cell(resourceNameByUid.get(assignment.resourceUid)),
+                        cell(assignment.start),
+                        cell(assignment.finish),
+                        cell(assignment.units),
+                        cell(assignment.work),
+                        cell(assignment.actualWork),
+                        cell(assignment.remainingWork),
+                        cell(assignment.percentWorkComplete)
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildCalendarsSheet(model) {
+        return {
+            name: "Calendars",
+            columns: [
+                { width: 10 }, { width: 24 }, { width: 14 }, { width: 16 },
+                { width: 10 }, { width: 12 }, { width: 10 }
+            ],
+            mergedRanges: ["A1:G1", "A2:G2"],
+            rows: [
+                sectionTitleRow("Calendars", 7),
+                sectionTitleRow("Calendar List", 7),
+                headerRow([
+                    "UID", "Name", "IsBaseCalendar", "BaseCalendarUID", "WeekDays", "Exceptions", "WorkWeeks"
+                ]),
+                ...model.calendars.map((calendar) => ({
+                    cells: [
+                        cell(calendar.uid),
+                        cell(calendar.name),
+                        cell(calendar.isBaseCalendar),
+                        cell(calendar.baseCalendarUID),
+                        cell(calendar.weekDays.length),
+                        cell(calendar.exceptions.length),
+                        cell(calendar.workWeeks.length)
+                    ]
+                }))
+            ]
+        };
+    }
+    function headerRow(labels) {
+        return {
+            height: 24,
+            cells: labels.map((label) => ({
+                value: label,
+                bold: true,
+                fillColor: HEADER_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            }))
+        };
+    }
+    function titleRow(title) {
+        return {
+            height: 28,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                {}
+            ]
+        };
+    }
+    function sectionTitleRow(title, columnCount) {
+        return {
+            height: 26,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function keyValueRow(label, value) {
+        return {
+            cells: [
+                {
+                    value: label,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin"
+                },
+                cell(value)
+            ]
+        };
+    }
+    function cell(value) {
+        if (value === undefined) {
+            return {};
+        }
+        return {
+            value,
+            border: "thin"
+        };
+    }
+    function cloneProjectModel(model) {
+        return JSON.parse(JSON.stringify(model));
+    }
+    function importTasksSheet(workbook, model, changes) {
+        const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+        if (!tasksSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(tasksSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const taskByUid = new Map(model.tasks.map((task) => [task.uid, task]));
+        for (const row of tasksSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const task = taskByUid.get(uid);
+            if (!task) {
+                continue;
+            }
+            const taskLabel = task.name;
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", readStringCellAt(row.cells, columnIndexByLabel.get("Start")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", readStringCellAt(row.cells, columnIndexByLabel.get("Finish")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+        }
+    }
+    function importResourcesSheet(workbook, model, changes) {
+        const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+        if (!resourcesSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(resourcesSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const resourceByUid = new Map(model.resources.map((resource) => [resource.uid, resource]));
+        for (const row of resourcesSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const resource = resourceByUid.get(uid);
+            if (!resource) {
+                continue;
+            }
+            const resourceLabel = resource.name;
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+        }
+    }
+    function importAssignmentsSheet(workbook, model, changes) {
+        const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+        if (!assignmentsSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(assignmentsSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const assignmentByUid = new Map(model.assignments.map((assignment) => [assignment.uid, assignment]));
+        for (const row of assignmentsSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const assignment = assignmentByUid.get(uid);
+            if (!assignment) {
+                continue;
+            }
+            const assignmentLabel = `TaskUID=${assignment.taskUid}`;
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "units", "Units", readNumberCellAt(row.cells, columnIndexByLabel.get("Units")));
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "work", "Work", readStringCellAt(row.cells, columnIndexByLabel.get("Work")));
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+        }
+    }
+    function importCalendarsSheet(workbook, model, changes) {
+        const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+        if (!calendarsSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(calendarsSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const calendarByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar]));
+        for (const row of calendarsSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const calendar = calendarByUid.get(uid);
+            if (!calendar) {
+                continue;
+            }
+            const calendarLabel = calendar.name;
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
+        }
+    }
+    function readHeaderMap(sheet, headerRowIndex) {
+        const headerRow = sheet.rows[headerRowIndex];
+        const columnIndexByLabel = new Map();
+        if (!headerRow) {
+            return columnIndexByLabel;
+        }
+        headerRow.cells.forEach((cell, index) => {
+            if (typeof cell.value === "string" && cell.value) {
+                columnIndexByLabel.set(cell.value, index);
+            }
+        });
+        return columnIndexByLabel;
+    }
+    function readStringCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readStringCell(cells[index]);
+    }
+    function readNumberCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readNumberCell(cells[index]);
+    }
+    function readBooleanCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readBooleanCell(cells[index]);
+    }
+    function readStringCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "string") {
+            return cell.value;
+        }
+        if (typeof cell.value === "number" || typeof cell.value === "boolean") {
+            return String(cell.value);
+        }
+        return undefined;
+    }
+    function readNumberCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "number" && Number.isFinite(cell.value)) {
+            return cell.value;
+        }
+        if (typeof cell.value === "string" && cell.value.trim() !== "") {
+            const parsed = Number(cell.value);
+            return Number.isFinite(parsed) ? parsed : undefined;
+        }
+        return undefined;
+    }
+    function readBooleanCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "boolean") {
+            return cell.value;
+        }
+        if (typeof cell.value === "number") {
+            return cell.value !== 0;
+        }
+        if (typeof cell.value === "string") {
+            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+                return true;
+            }
+            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+                return false;
+            }
+        }
+        return undefined;
+    }
+    function assignIfChanged(changes, scope, uid, label, target, key, field, value) {
+        if (value === undefined) {
+            return;
+        }
+        const before = target[key];
+        if (before === value) {
+            return;
+        }
+        target[key] = value;
+        changes.push({
+            scope,
+            uid,
+            label,
+            field,
+            before: before,
+            after: value
+        });
+    }
+    globalThis.__mikuprojectProjectXlsx = {
+        exportProjectWorkbook,
+        importProjectWorkbook,
+        importProjectWorkbookDetailed
+    };
+})();
+  </script>
+
+  <script>
+(() => {
+    const HEADER_FILL = "#D9EAF7";
+    const PHASE_FILL = "#EEF7E8";
+    const MILESTONE_FILL = "#FFF4E0";
+    const BAND_FILL = "#F4F7FB";
+    const ACTIVE_BAND_FILL = "#9FD5C9";
+    const PROGRESS_BAND_FILL = "#5BAE9C";
+    const WEEKEND_BAND_FILL = "#F1F1F1";
+    const TODAY_BAND_FILL = "#FFE6A7";
+    const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
+    const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
+    const HOLIDAY_BAND_FILL = "#FCE4EC";
+    function exportWbsWorkbook(model, options = {}) {
+        const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        const predecessorNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+        const calendarNameByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar.name]));
+        const resourceNamesByTaskUid = new Map();
+        const holidaySet = new Set((options.holidayDates || []).map((day) => day.slice(0, 10)));
+        for (const assignment of model.assignments) {
+            const resourceName = resourceNameByUid.get(assignment.resourceUid);
+            if (!resourceName) {
+                continue;
+            }
+            const resourceNames = resourceNamesByTaskUid.get(assignment.taskUid) || [];
+            if (!resourceNames.includes(resourceName)) {
+                resourceNames.push(resourceName);
+            }
+            resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
+        }
+        const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+        const fixedHeaders = [
+            "UID",
+            "ID",
+            "WBS",
+            "Kind",
+            "OutlineLevel",
+            "Name",
+            "Start",
+            "Finish",
+            "Duration",
+            "PercentComplete",
+            "PercentWorkComplete",
+            "Milestone",
+            "Summary",
+            "Critical",
+            "Owner",
+            "Calendar",
+            "Resources",
+            "Predecessors"
+        ];
+        const totalColumns = fixedHeaders.length + dateBand.length;
+        const lastColumnRef = columnName(totalColumns);
+        return {
+            sheets: [
+                {
+                    name: "WBS",
+                    columns: [
+                        { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
+                        { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+                        { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
+                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+                        ...dateBand.map(() => ({ width: 6 }))
+                    ],
+                    mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+                    rows: [
+                        sectionTitleRow("WBS", totalColumns),
+                        sectionTitleRow(model.project.name || "Project", totalColumns),
+                        infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
+                        infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
+                        sectionTitleRow("Task View", totalColumns),
+                        todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+                        headerRow([
+                            ...fixedHeaders,
+                            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+                        ]),
+                        ...model.tasks.map((task) => ({
+                            cells: [
+                                taskCell(task, task.uid, "center"),
+                                taskCell(task, task.id, "center"),
+                                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                                taskCell(task, classifyTaskKind(task), "center"),
+                                taskCell(task, task.outlineLevel, "center"),
+                                taskCell(task, formatTaskLabel(task)),
+                                taskCell(task, task.start),
+                                taskCell(task, task.finish),
+                                taskCell(task, task.duration, "center"),
+                                taskCell(task, task.percentComplete, "center"),
+                                taskCell(task, task.percentWorkComplete, "center"),
+                                taskCell(task, task.milestone, "center"),
+                                taskCell(task, task.summary, "center"),
+                                taskCell(task, task.critical, "center"),
+                                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
+                            ]
+                        }))
+                    ]
+                }
+            ]
+        };
+    }
+    function formatTaskLabel(task) {
+        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+    }
+    function classifyTaskKind(task) {
+        if (task.summary) {
+            return "phase";
+        }
+        if (task.milestone) {
+            return "milestone";
+        }
+        return "task";
+    }
+    function firstResourceName(resourceNames) {
+        if (!resourceNames || resourceNames.length === 0) {
+            return "";
+        }
+        return resourceNames[0];
+    }
+    function formatCalendarLabel(calendarUID, calendarNameByUid) {
+        if (!calendarUID) {
+            return "-";
+        }
+        const calendarName = calendarNameByUid.get(calendarUID);
+        return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+    }
+    function sectionTitleRow(title, columnCount) {
+        return {
+            height: 28,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function infoRow(text, columnCount) {
+        return {
+            height: 24,
+            cells: [
+                {
+                    value: text,
+                    border: "thin",
+                    horizontalAlign: "left"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function headerRow(labels) {
+        return {
+            height: 24,
+            cells: labels.map((label) => {
+                if (typeof label === "string") {
+                    return {
+                        value: label,
+                        bold: true,
+                        fillColor: HEADER_FILL,
+                        border: "thin",
+                        horizontalAlign: "center"
+                    };
+                }
+                return {
+                    border: "thin",
+                    horizontalAlign: "center",
+                    ...label
+                };
+            })
+        };
+    }
+    function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
+        return {
+            height: 22,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
+                    ? {
+                        value: "Today",
+                        bold: true,
+                        border: "thin",
+                        horizontalAlign: "right"
+                    }
+                    : {})),
+                ...dateBand.map((day) => ({
+                    value: isSameDay(day, currentDate) ? "▼" : "",
+                    bold: true,
+                    border: "thin",
+                    horizontalAlign: "center",
+                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+                }))
+            ]
+        };
+    }
+    function cell(value) {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin"
+        };
+    }
+    function taskCell(task, value, horizontalAlign = "left") {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin",
+            horizontalAlign,
+            bold: task.summary || task.milestone || false,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
+    function dateHeaderCell(day, currentDate, holidaySet) {
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        return {
+            value: formatDateLabel(day),
+            bold: true,
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+        };
+    }
+    function dateBandCell(task, day, currentDate, holidaySet) {
+        const active = includesDay(task.start, task.finish, day);
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        const complete = active && isCompletedDay(task, day);
+        return {
+            value: active ? "■" : "",
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: active
+                ? (complete
+                    ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
+                    : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
+                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+        };
+    }
+    function buildDateBand(startDate, finishDate) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [];
+        }
+        const days = [];
+        const cursor = new Date(start.getTime());
+        while (cursor.getTime() <= finish.getTime()) {
+            days.push(formatDateOnly(cursor));
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        return days;
+    }
+    function includesDay(startDate, finishDate, day) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        const target = parseDateOnly(day);
+        if (!start || !finish || !target) {
+            return false;
+        }
+        return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
+    }
+    function isCompletedDay(task, day) {
+        const start = parseDateOnly(task.start);
+        const finish = parseDateOnly(task.finish);
+        const target = parseDateOnly(day);
+        if (!start || !finish || !target) {
+            return false;
+        }
+        const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
+        if (totalDays <= 0) {
+            return false;
+        }
+        const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+        const completedDays = Math.floor(totalDays * (percent / 100));
+        const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
+        return dayIndex >= 0 && dayIndex < completedDays;
+    }
+    function isSameDay(day, other) {
+        return day === (other || "").slice(0, 10);
+    }
+    function isWeekend(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        const weekday = target.getDay();
+        return weekday === 0 || weekday === 6;
+    }
+    function parseDateOnly(value) {
+        if (!value || value.length < 10) {
+            return null;
+        }
+        const dateOnly = value.slice(0, 10);
+        const [yearText, monthText, dayText] = dateOnly.split("-");
+        const year = Number(yearText);
+        const month = Number(monthText);
+        const day = Number(dayText);
+        if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+            return null;
+        }
+        return new Date(year, month - 1, day);
+    }
+    function formatDateOnly(value) {
+        return [
+            value.getFullYear(),
+            String(value.getMonth() + 1).padStart(2, "0"),
+            String(value.getDate()).padStart(2, "0")
+        ].join("-");
+    }
+    function formatDateLabel(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+    }
+    function columnName(index) {
+        let current = index;
+        let name = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            name = String.fromCharCode(65 + remainder) + name;
+            current = Math.floor((current - 1) / 26);
+        }
+        return name;
+    }
+    globalThis.__mikuprojectWbsXlsx = {
+        exportWbsWorkbook
+    };
+})();
+  </script>
+
+  <script>
+(() => {
     const mikuprojectXml = globalThis.__mikuprojectXml;
     if (!mikuprojectXml) {
         throw new Error("mikuproject XML module is not loaded");
+    }
+    const mikuprojectExcelIo = globalThis.__mikuprojectExcelIo;
+    if (!mikuprojectExcelIo) {
+        throw new Error("mikuproject Excel IO module is not loaded");
+    }
+    const mikuprojectProjectXlsx = globalThis.__mikuprojectProjectXlsx;
+    if (!mikuprojectProjectXlsx) {
+        throw new Error("mikuproject Project XLSX module is not loaded");
+    }
+    const mikuprojectWbsXlsx = globalThis.__mikuprojectWbsXlsx;
+    if (!mikuprojectWbsXlsx) {
+        throw new Error("mikuproject WBS XLSX module is not loaded");
     }
     const mermaidApi = globalThis.mermaid;
     let currentModel = null;
     let currentMermaidSvg = "";
     let mermaidRenderCount = 0;
+    let lastSavedXmlText = "";
+    let lastSavedXmlStamp = "";
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -7828,6 +9805,31 @@ if (!customElements.get("lht-page-menu")) {
     }
     function getTextArea(id) {
         return getElement(id);
+    }
+    function parseWbsHolidayDates() {
+        const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+        if (!raw) {
+            return [];
+        }
+        const seen = new Set();
+        const holidays = [];
+        for (const token of raw.split(/[\s,、;]+/)) {
+            const value = token.trim();
+            if (!value) {
+                continue;
+            }
+            const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+            if (!match) {
+                continue;
+            }
+            const dateText = match[1];
+            if (seen.has(dateText)) {
+                continue;
+            }
+            seen.add(dateText);
+            holidays.push(dateText);
+        }
+        return holidays;
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -7911,6 +9913,35 @@ if (!customElements.get("lht-page-menu")) {
     }
     function setStatus(message) {
         getElement("statusMessage").textContent = message;
+    }
+    function formatSaveStamp(date) {
+        return [
+            date.getFullYear(),
+            String(date.getMonth() + 1).padStart(2, "0"),
+            String(date.getDate()).padStart(2, "0")
+        ].join("-") + " " + [
+            String(date.getHours()).padStart(2, "0"),
+            String(date.getMinutes()).padStart(2, "0")
+        ].join(":");
+    }
+    function updateXmlSaveState(isDirty) {
+        const node = getElement("xmlSaveState");
+        node.textContent = isDirty
+            ? "XML 保存状態: 未保存"
+            : `XML 保存状態: 保存済み (${lastSavedXmlStamp || "-"})`;
+        node.classList.toggle("md-save-state--dirty", isDirty);
+        node.classList.toggle("md-save-state--clean", !isDirty);
+    }
+    function markXmlDirty() {
+        updateXmlSaveState(true);
+    }
+    function markXmlSavedCurrent() {
+        lastSavedXmlText = getTextArea("xmlInput").value;
+        lastSavedXmlStamp = formatSaveStamp(new Date());
+        updateXmlSaveState(false);
+    }
+    function refreshXmlSaveState() {
+        updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
     }
     function renderPreviewList(containerId, items) {
         const container = getElement(containerId);
@@ -8019,9 +10050,12 @@ if (!customElements.get("lht-page-menu")) {
     }
     function renderValidationIssues(issues) {
         const container = getElement("validationIssues");
+        const label = container.previousElementSibling;
         if (issues.length === 0) {
             container.classList.add("md-hidden");
             container.innerHTML = "";
+            label === null || label === void 0 ? void 0 : label.classList.add("md-hidden");
+            updateFeedbackVisibility();
             return;
         }
         const sections = ["project", "tasks", "resources", "assignments", "calendars"];
@@ -8033,6 +10067,7 @@ if (!customElements.get("lht-page-menu")) {
             calendars: "Calendars"
         };
         container.classList.remove("md-hidden");
+        label === null || label === void 0 ? void 0 : label.classList.remove("md-hidden");
         container.innerHTML = `
       <div class="md-issues__title">検証メッセージ</div>
       ${sections
@@ -8052,6 +10087,115 @@ if (!customElements.get("lht-page-menu")) {
         })
             .join("")}
     `;
+        updateFeedbackVisibility();
+    }
+    function renderXlsxImportSummary(changes) {
+        const container = getElement("xlsxImportSummary");
+        const label = container.previousElementSibling;
+        if (changes.length === 0) {
+            container.classList.add("md-hidden");
+            container.innerHTML = "";
+            label === null || label === void 0 ? void 0 : label.classList.add("md-hidden");
+            updateFeedbackVisibility();
+            return;
+        }
+        const scopeLabel = {
+            project: "Project",
+            tasks: "Tasks",
+            resources: "Resources",
+            assignments: "Assignments",
+            calendars: "Calendars"
+        };
+        const scopeCounts = {
+            project: 0,
+            tasks: 0,
+            resources: 0,
+            assignments: 0,
+            calendars: 0
+        };
+        const groupedByScope = new Map();
+        const groupedChanges = new Map();
+        for (const change of changes) {
+            const groupKey = `${change.scope}:${change.uid}:${change.label}`;
+            const currentGroup = groupedChanges.get(groupKey);
+            if (currentGroup) {
+                currentGroup.items.push({
+                    field: change.field,
+                    before: change.before,
+                    after: change.after
+                });
+                continue;
+            }
+            groupedChanges.set(groupKey, {
+                scope: change.scope,
+                uid: change.uid,
+                label: change.label,
+                items: [{
+                        field: change.field,
+                        before: change.before,
+                        after: change.after
+                    }]
+            });
+            scopeCounts[change.scope] += 1;
+        }
+        for (const group of groupedChanges.values()) {
+            const scopedGroups = groupedByScope.get(group.scope) || [];
+            scopedGroups.push({
+                uid: group.uid,
+                label: group.label,
+                items: group.items
+            });
+            groupedByScope.set(group.scope, scopedGroups);
+        }
+        const changedScopes = ["project", "tasks", "resources", "assignments", "calendars"].filter((scope) => scopeCounts[scope] > 0);
+        const unchangedScopes = ["project", "tasks", "resources", "assignments", "calendars"].filter((scope) => scopeCounts[scope] === 0);
+        container.classList.remove("md-hidden");
+        label === null || label === void 0 ? void 0 : label.classList.remove("md-hidden");
+        container.innerHTML = `
+      <div class="md-xlsx-summary__title">XLSX Import 反映結果</div>
+      <div class="md-xlsx-summary__counts">
+        ${changedScopes.map((scope) => `<span class="md-xlsx-summary__count">${scopeLabel[scope]} ${scopeCounts[scope]}</span>`).join("")}
+      </div>
+      ${unchangedScopes.length > 0 ? `<div class="md-xlsx-summary__unchanged">変更なし: ${unchangedScopes.map((scope) => scopeLabel[scope]).join(", ")}</div>` : ""}
+      ${changedScopes.map((scope) => `
+        <div class="md-xlsx-summary__section">
+          <div class="md-xlsx-summary__section-title">${scopeLabel[scope]}</div>
+          <ul class="md-xlsx-summary__list">
+            ${(groupedByScope.get(scope) || []).map((group) => `
+              <li class="md-xlsx-summary__item">
+                <div class="md-xlsx-summary__item-title">UID=${group.uid} ${escapeHtml(group.label)}</div>
+                <div class="md-xlsx-summary__item-body">
+                  ${group.items.map((item) => `${escapeHtml(item.field)}: ${escapeHtml(formatChangeValue(item.before))} -> ${escapeHtml(formatChangeValue(item.after))}`).join(" / ")}
+                </div>
+              </li>
+            `).join("")}
+          </ul>
+        </div>
+      `).join("")}
+      <div class="md-xlsx-summary__hint">反映後の XML は更新済みです。必要なら XML Export で保存できます。</div>
+    `;
+        updateFeedbackVisibility();
+    }
+    function updateFeedbackVisibility() {
+        const stack = document.querySelector(".md-feedback-stack");
+        const validationIssues = getElement("validationIssues");
+        const xlsxImportSummary = getElement("xlsxImportSummary");
+        const shouldShow = !validationIssues.classList.contains("md-hidden") || !xlsxImportSummary.classList.contains("md-hidden");
+        stack === null || stack === void 0 ? void 0 : stack.classList.toggle("md-hidden", !shouldShow);
+    }
+    function formatChangeValue(value) {
+        if (value === undefined) {
+            return "(empty)";
+        }
+        return String(value);
+    }
+    function escapeHtml(value) {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
@@ -8128,6 +10272,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function loadSample() {
         getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+        markXmlDirty();
         setStatus("サンプル XML を読み込みました");
     }
     async function importXmlFromFile(file) {
@@ -8136,12 +10281,25 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         }
         const xmlText = await file.text();
         getTextArea("xmlInput").value = xmlText;
+        markXmlDirty();
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
         showToast("XML を読み込んで解析しました");
+    }
+    function ensureCurrentModel() {
+        if (currentModel) {
+            return currentModel;
+        }
+        const xmlText = getTextArea("xmlInput").value.trim();
+        if (!xmlText) {
+            throw new Error("内部モデルがありません");
+        }
+        currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        return currentModel;
     }
     function parseCurrentXml() {
         const xmlText = getTextArea("xmlInput").value.trim();
@@ -8153,6 +10311,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
         showToast("XML を解析しました");
     }
@@ -8162,7 +10321,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             return;
         }
         getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+        markXmlDirty();
         renderValidationIssues([]);
+        renderXlsxImportSummary([]);
         setStatus("内部モデルから XML を再生成しました");
         showToast("XML を再生成しました");
     }
@@ -8186,6 +10347,65 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus("内部モデルから CSV + ParentID を生成しました");
         showToast("CSV を生成しました");
     }
+    function exportCurrentXlsx() {
+        const model = ensureCurrentModel();
+        const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const bytes = codec.exportWorkbook(workbook);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-export-${stamp}.xlsx`);
+        setStatus("XLSX ファイルをエクスポートしました");
+        showToast("XLSX を保存しました");
+    }
+    function exportCurrentWbsXlsx() {
+        const model = ensureCurrentModel();
+        const holidayDates = parseWbsHolidayDates();
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const bytes = codec.exportWorkbook(workbook);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+        showToast("WBS XLSX を保存しました");
+    }
+    async function importXlsxFromFile(file) {
+        if (!file) {
+            return;
+        }
+        const baseModel = ensureCurrentModel();
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const workbook = codec.importWorkbook(bytes);
+        const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
+        currentModel = result.model;
+        const issues = mikuprojectXml.validateProjectModel(currentModel);
+        updateSummary(currentModel);
+        renderValidationIssues(issues);
+        renderXlsxImportSummary(result.changes);
+        if (result.changes.length > 0) {
+            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+            markXmlDirty();
+        }
+        const summaryText = result.changes.length > 0
+            ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+            : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+        setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
+        showToast("XLSX を反映しました");
+    }
     function parseCurrentCsv() {
         const csvText = getTextArea("csvInput").value.trim();
         if (!csvText) {
@@ -8196,6 +10416,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
         showToast("CSV を解析しました");
     }
@@ -8222,6 +10443,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         link.click();
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+        markXmlSavedCurrent();
         setStatus("XML ファイルをエクスポートしました");
         showToast("XML を保存しました");
     }
@@ -8298,6 +10520,22 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "CSV 生成に失敗しました");
             }
         });
+        getElement("exportXlsxBtn").addEventListener("click", () => {
+            try {
+                exportCurrentXlsx();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "XLSX エクスポートに失敗しました");
+            }
+        });
+        getElement("exportWbsXlsxBtn").addEventListener("click", () => {
+            try {
+                exportCurrentWbsXlsx();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+            }
+        });
         getElement("parseCsvBtn").addEventListener("click", () => {
             try {
                 parseCurrentCsv();
@@ -8305,6 +10543,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
             }
+        });
+        getElement("importXlsxBtn").addEventListener("click", () => {
+            getElement("importXlsxInput").click();
         });
         getElement("downloadXmlBtn").addEventListener("click", () => {
             try {
@@ -8337,11 +10578,30 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 }
             }
         });
+        getElement("importXlsxInput").addEventListener("change", async (event) => {
+            const input = event.target;
+            const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            try {
+                await importXlsxFromFile(file);
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+            }
+            finally {
+                if (input) {
+                    input.value = "";
+                }
+            }
+        });
+        getTextArea("xmlInput").addEventListener("input", () => {
+            refreshXmlSaveState();
+        });
     }
     function initialize() {
         bindEvents();
         updateSummary(null);
         renderValidationIssues([]);
+        renderXlsxImportSummary([]);
         updateMermaidSvgButton();
         clearMermaidError();
         loadSample();

--- a/docs/project/src/mikuproject/css/app.css
+++ b/docs/project/src/mikuproject/css/app.css
@@ -86,6 +86,63 @@
   font-weight: 600;
 }
 
+.md-save-state {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  border: 1px solid transparent;
+}
+
+.md-save-state--dirty {
+  color: #8a5a1c;
+  background: #fff8ef;
+  border-color: #efcfaa;
+}
+
+.md-save-state--clean {
+  color: #225b4d;
+  background: #eefaf5;
+  border-color: #c7e6d9;
+}
+
+.md-feedback-stack {
+  display: grid;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(247, 250, 253, 0.92) 0%, rgba(255, 255, 255, 0.92) 100%);
+  border: 1px solid rgba(213, 222, 231, 0.75);
+}
+
+.md-feedback-stack.md-hidden {
+  display: none;
+}
+
+.md-feedback-stack__title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #28485a;
+}
+
+.md-feedback-stack__text {
+  color: #5d7482;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.md-feedback-stack__label {
+  margin-top: 2px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #607787;
+}
+
 .md-issues {
   border: 1px solid #efc9a6;
   border-radius: 16px;
@@ -121,6 +178,120 @@
 
 .md-issues__item + .md-issues__item {
   margin-top: 4px;
+}
+
+.md-note-card {
+  border: 1px solid #cfe2dc;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f3fbf9 0%, #ffffff 100%);
+  padding: 16px 18px;
+}
+
+.md-note-card__title {
+  margin: 0 0 8px;
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: #1f4f4a;
+}
+
+.md-note-card__text {
+  margin: 0;
+  color: #3f5f5b;
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.md-note-card__text + .md-note-card__text,
+.md-note-list + .md-note-card__text {
+  margin-top: 8px;
+}
+
+.md-note-list {
+  margin: 8px 0 0;
+  padding-left: 1.2rem;
+  color: #345450;
+  font-size: 0.86rem;
+}
+
+.md-note-list li + li {
+  margin-top: 4px;
+}
+
+.md-xlsx-summary {
+  border: 1px solid #cde3f5;
+  border-radius: 16px;
+  background: linear-gradient(180deg, #f5faff 0%, #ffffff 100%);
+  padding: 14px 16px;
+  color: #325067;
+}
+
+.md-xlsx-summary.md-hidden {
+  display: none;
+}
+
+.md-xlsx-summary__title {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.md-xlsx-summary__counts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.md-xlsx-summary__count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.8rem;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: #e9f3fc;
+  color: #2c5570;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.md-xlsx-summary__unchanged {
+  margin-bottom: 10px;
+  color: #5b7382;
+  font-size: 0.84rem;
+}
+
+.md-xlsx-summary__section + .md-xlsx-summary__section {
+  margin-top: 12px;
+}
+
+.md-xlsx-summary__section-title {
+  margin-bottom: 6px;
+  font-weight: 700;
+  color: #2b5169;
+}
+
+.md-xlsx-summary__list {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.md-xlsx-summary__item + .md-xlsx-summary__item {
+  margin-top: 4px;
+}
+
+.md-xlsx-summary__item-title {
+  font-weight: 700;
+  color: #244559;
+}
+
+.md-xlsx-summary__item-body {
+  margin-top: 3px;
+  color: #466172;
+}
+
+.md-xlsx-summary__hint {
+  margin-top: 12px;
+  color: #516b7b;
+  font-size: 0.84rem;
 }
 
 .md-summary-grid {

--- a/docs/project/src/mikuproject/js/excel-io.js
+++ b/docs/project/src/mikuproject/js/excel-io.js
@@ -1,0 +1,879 @@
+(() => {
+    const TEXT_ENCODER = new TextEncoder();
+    const TEXT_DECODER = new TextDecoder();
+    const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
+    const CRC32_TABLE = buildCrc32Table();
+    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent"];
+    const HORIZONTAL_ALIGNS = ["left", "center", "right"];
+    const BORDER_STYLES = ["thin"];
+    const STYLE_KEY_DELIMITER = "::";
+    const DEFAULT_STYLE = { numberFormat: "general" };
+    class XlsxWorkbookCodec {
+        exportWorkbook(workbook) {
+            const normalizedWorkbook = normalizeWorkbook(workbook);
+            const entries = this.createWorkbookEntries(normalizedWorkbook);
+            return packZip(entries);
+        }
+        importWorkbook(bytes) {
+            const entries = this.unpackEntries(bytes);
+            return parseWorkbookEntries(entries);
+        }
+        listEntries(bytes) {
+            return Object.keys(this.unpackEntries(bytes)).sort();
+        }
+        unpackEntries(bytes) {
+            return unpackZip(bytes);
+        }
+        createWorkbookEntries(workbook) {
+            const styleBook = createStyleBook(workbook);
+            const worksheetRelationships = workbook.sheets.map((sheet, index) => ({
+                relationshipId: `rId${index + 1}`,
+                target: `worksheets/sheet${index + 1}.xml`,
+                name: sheet.name
+            }));
+            const worksheetEntries = workbook.sheets.map((sheet, index) => ({
+                name: `xl/worksheets/sheet${index + 1}.xml`,
+                data: encodeUtf8(buildWorksheetXml(sheet, styleBook))
+            }));
+            const entries = [
+                {
+                    name: "[Content_Types].xml",
+                    data: encodeUtf8(buildContentTypesXml(workbook.sheets.length, styleBook.styles.length > 1))
+                },
+                {
+                    name: "_rels/.rels",
+                    data: encodeUtf8(buildRootRelationshipsXml())
+                },
+                {
+                    name: "xl/_rels/workbook.xml.rels",
+                    data: encodeUtf8(buildWorkbookRelationshipsXml(worksheetRelationships, styleBook.styles.length > 1))
+                },
+                {
+                    name: "xl/workbook.xml",
+                    data: encodeUtf8(buildWorkbookXml(worksheetRelationships))
+                }
+            ];
+            if (styleBook.styles.length > 1) {
+                entries.push({
+                    name: "xl/styles.xml",
+                    data: encodeUtf8(buildStylesXml(styleBook.styles))
+                });
+            }
+            entries.push(...worksheetEntries);
+            return entries;
+        }
+    }
+    function normalizeWorkbook(workbook) {
+        if (!workbook || !Array.isArray(workbook.sheets) || workbook.sheets.length === 0) {
+            throw new Error("Workbook must contain at least one sheet");
+        }
+        const seenNames = new Set();
+        return {
+            sheets: workbook.sheets.map((sheet) => {
+                if (!sheet || typeof sheet.name !== "string") {
+                    throw new Error("Each sheet must have a valid sheet name");
+                }
+                validateSheetName(sheet.name);
+                const canonicalName = sheet.name.toLocaleLowerCase();
+                if (seenNames.has(canonicalName)) {
+                    throw new Error(`Duplicate sheet name is not allowed: ${sheet.name}`);
+                }
+                seenNames.add(canonicalName);
+                return {
+                    name: sheet.name,
+                    columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+                    mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+                    rows: Array.isArray(sheet.rows)
+                        ? sheet.rows.map((row) => ({
+                            height: normalizeOptionalPositiveNumber(row === null || row === void 0 ? void 0 : row.height, "Row height"),
+                            cells: Array.isArray(row === null || row === void 0 ? void 0 : row.cells)
+                                ? row.cells.map((cell) => normalizeCell(cell))
+                                : []
+                        }))
+                        : []
+                };
+            })
+        };
+    }
+    function normalizeColumn(column) {
+        if (!column) {
+            return {};
+        }
+        return {
+            width: normalizeOptionalPositiveNumber(column.width, "Column width")
+        };
+    }
+    function normalizeCell(cell) {
+        if (!cell) {
+            return {};
+        }
+        if (cell.value !== undefined && typeof cell.value !== "string" && typeof cell.value !== "number" && typeof cell.value !== "boolean") {
+            throw new Error("Cell value must be string, number, or boolean");
+        }
+        if (cell.formula !== undefined && typeof cell.formula !== "string") {
+            throw new Error("Cell formula must be a string");
+        }
+        if (cell.numberFormat !== undefined && !NUMBER_FORMATS.includes(cell.numberFormat)) {
+            throw new Error(`Unsupported cell number format: ${cell.numberFormat}`);
+        }
+        if (cell.horizontalAlign !== undefined && !HORIZONTAL_ALIGNS.includes(cell.horizontalAlign)) {
+            throw new Error(`Unsupported cell horizontal align: ${cell.horizontalAlign}`);
+        }
+        if (cell.border !== undefined && !BORDER_STYLES.includes(cell.border)) {
+            throw new Error(`Unsupported cell border: ${cell.border}`);
+        }
+        if (cell.fillColor !== undefined) {
+            assertColor(cell.fillColor);
+        }
+        return {
+            value: cell.value,
+            formula: cell.formula,
+            numberFormat: cell.numberFormat,
+            horizontalAlign: cell.horizontalAlign,
+            bold: cell.bold === true ? true : undefined,
+            fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
+            border: cell.border
+        };
+    }
+    function normalizeMergedRange(range) {
+        if (typeof range !== "string") {
+            throw new Error("Merged range must be a string");
+        }
+        const trimmed = range.trim().toUpperCase();
+        if (!/^[A-Z]+\d+:[A-Z]+\d+$/.test(trimmed)) {
+            throw new Error(`Invalid merged range: ${range}`);
+        }
+        return trimmed;
+    }
+    function normalizeOptionalPositiveNumber(value, label) {
+        if (value === undefined) {
+            return undefined;
+        }
+        if (!Number.isFinite(value) || value <= 0) {
+            throw new Error(`${label} must be a finite positive number`);
+        }
+        return value;
+    }
+    function validateSheetName(name) {
+        if (!name || !name.trim()) {
+            throw new Error("Sheet name must not be empty");
+        }
+        if (name.length > 31) {
+            throw new Error(`Sheet name is too long: ${name}`);
+        }
+        if (INVALID_SHEET_NAME_PATTERN.test(name)) {
+            throw new Error(`Sheet name contains invalid characters: ${name}`);
+        }
+        if (name.startsWith("'") || name.endsWith("'")) {
+            throw new Error(`Sheet name must not start or end with apostrophe: ${name}`);
+        }
+    }
+    function assertColor(color) {
+        if (!/^#?[0-9a-fA-F]{6}$/.test(color)) {
+            throw new Error(`Unsupported color format: ${color}`);
+        }
+    }
+    function normalizeColor(color) {
+        const hex = color.startsWith("#") ? color.slice(1) : color;
+        return `FF${hex.toUpperCase()}`;
+    }
+    function denormalizeColor(color) {
+        if (!color) {
+            return undefined;
+        }
+        const normalized = color.toUpperCase();
+        if (/^[0-9A-F]{8}$/.test(normalized)) {
+            return `#${normalized.slice(2)}`;
+        }
+        if (/^[0-9A-F]{6}$/.test(normalized)) {
+            return `#${normalized}`;
+        }
+        return undefined;
+    }
+    function buildContentTypesXml(sheetCount, includeStyles) {
+        const worksheetOverrides = Array.from({ length: sheetCount }, (_unused, index) => (`<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`)).join("");
+        const stylesOverride = includeStyles
+            ? `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>`
+            : "";
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  ${worksheetOverrides}
+  ${stylesOverride}
+</Types>`;
+    }
+    function buildRootRelationshipsXml() {
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`;
+    }
+    function buildWorkbookRelationshipsXml(relationships, includeStyles) {
+        const worksheetNodes = relationships.map((relationship) => (`<Relationship Id="${escapeXml(relationship.relationshipId)}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="${escapeXml(relationship.target)}"/>`)).join("");
+        const stylesNode = includeStyles
+            ? `<Relationship Id="rId${relationships.length + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`
+            : "";
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  ${worksheetNodes}
+  ${stylesNode}
+</Relationships>`;
+    }
+    function buildWorkbookXml(relationships) {
+        const sheets = relationships.map((relationship, index) => (`<sheet name="${escapeXml(relationship.name)}" sheetId="${index + 1}" r:id="${escapeXml(relationship.relationshipId)}"/>`)).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>${sheets}</sheets>
+</workbook>`;
+    }
+    function buildWorksheetXml(sheet, styleBook) {
+        const colsXml = buildColumnsXml(sheet.columns);
+        const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+        const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${colsXml}
+  <sheetData>${rows}</sheetData>
+  ${mergeCellsXml}
+</worksheet>`;
+    }
+    function buildColumnsXml(columns) {
+        if (!columns || columns.length === 0 || columns.every((column) => column.width === undefined)) {
+            return "";
+        }
+        const cols = columns.map((column, index) => (column.width !== undefined
+            ? `<col min="${index + 1}" max="${index + 1}" width="${formatNumber(column.width)}" customWidth="1"/>`
+            : "")).filter(Boolean).join("");
+        return cols ? `<cols>${cols}</cols>` : "";
+    }
+    function buildMergeCellsXml(mergedRanges) {
+        if (!mergedRanges || mergedRanges.length === 0) {
+            return "";
+        }
+        const mergeCells = mergedRanges
+            .map((range) => `<mergeCell ref="${range}"/>`)
+            .join("");
+        return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+    }
+    function buildWorksheetRowXml(row, rowIndex, styleBook) {
+        const cells = row.cells
+            .map((cell, cellIndex) => buildWorksheetCellXml(cell, rowIndex, cellIndex, styleBook))
+            .filter(Boolean)
+            .join("");
+        if (!cells) {
+            return "";
+        }
+        const heightAttributes = row.height !== undefined
+            ? ` ht="${formatNumber(row.height)}" customHeight="1"`
+            : "";
+        return `<row r="${rowIndex + 1}"${heightAttributes}>${cells}</row>`;
+    }
+    function buildWorksheetCellXml(cell, rowIndex, cellIndex, styleBook) {
+        const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
+        const styleIndex = resolveStyleIndex(cell, styleBook);
+        const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+        if (cell.formula !== undefined) {
+            const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
+            const valueXml = buildFormulaValueXml(cell.value);
+            const typeAttribute = getCellTypeAttribute(cell.value, true);
+            return `<c r="${reference}"${styleAttribute}${typeAttribute}>${formulaXml}${valueXml}</c>`;
+        }
+        if (cell.value === undefined) {
+            return "";
+        }
+        if (typeof cell.value === "string") {
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+        }
+        if (typeof cell.value === "number") {
+            return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
+        }
+        return `<c r="${reference}"${styleAttribute} t="b"><v>${cell.value ? "1" : "0"}</v></c>`;
+    }
+    function buildFormulaValueXml(value) {
+        if (value === undefined) {
+            return "";
+        }
+        if (typeof value === "string") {
+            return `<v>${escapeXml(value)}</v>`;
+        }
+        if (typeof value === "number") {
+            return `<v>${formatNumber(value)}</v>`;
+        }
+        return `<v>${value ? "1" : "0"}</v>`;
+    }
+    function getCellTypeAttribute(value, hasFormula) {
+        if (!hasFormula) {
+            return "";
+        }
+        if (typeof value === "string") {
+            return ` t="str"`;
+        }
+        if (typeof value === "boolean") {
+            return ` t="b"`;
+        }
+        return "";
+    }
+    function formatNumber(value) {
+        if (!Number.isFinite(value)) {
+            throw new Error(`Cell number must be finite: ${value}`);
+        }
+        return String(value);
+    }
+    function createStyleBook(workbook) {
+        const styles = [DEFAULT_STYLE];
+        const styleIndexByKey = new Map([[styleKey(DEFAULT_STYLE), 0]]);
+        for (const sheet of workbook.sheets) {
+            for (const row of sheet.rows) {
+                for (const cell of row.cells) {
+                    const descriptor = getStyleDescriptor(cell);
+                    if (!descriptor) {
+                        continue;
+                    }
+                    const key = styleKey(descriptor);
+                    if (!styleIndexByKey.has(key)) {
+                        styleIndexByKey.set(key, styles.length);
+                        styles.push(descriptor);
+                    }
+                }
+            }
+        }
+        return { styles, styleIndexByKey };
+    }
+    function getStyleDescriptor(cell) {
+        if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+            return null;
+        }
+        return {
+            numberFormat: cell.numberFormat || "general",
+            horizontalAlign: cell.horizontalAlign,
+            bold: cell.bold === true ? true : undefined,
+            fillColor: cell.fillColor,
+            border: cell.border
+        };
+    }
+    function styleKey(style) {
+        return [
+            style.numberFormat,
+            style.horizontalAlign || "",
+            style.bold ? "bold" : "",
+            style.fillColor || "",
+            style.border || ""
+        ].join(STYLE_KEY_DELIMITER);
+    }
+    function resolveStyleIndex(cell, styleBook) {
+        const descriptor = getStyleDescriptor(cell);
+        if (!descriptor) {
+            return 0;
+        }
+        return styleBook.styleIndexByKey.get(styleKey(descriptor)) || 0;
+    }
+    function buildStylesXml(styles) {
+        const fonts = dedupeDescriptors(styles.map((style) => ({ bold: style.bold })), fontKey, { bold: undefined });
+        const fills = dedupeDescriptors(styles.map((style) => ({ fillColor: style.fillColor })), fillKey, { fillColor: undefined });
+        const borders = dedupeDescriptors(styles.map((style) => ({ border: style.border })), borderKey, { border: undefined });
+        const styleNodes = styles.map((style) => {
+            const numFmtId = mapNumberFormatId(style.numberFormat);
+            const fontId = fonts.indexByKey.get(fontKey({ bold: style.bold })) || 0;
+            const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
+            const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
+            const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
+            const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+            const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
+            const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
+            const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
+            const alignmentNode = style.horizontalAlign
+                ? `<alignment horizontal="${style.horizontalAlign}"/>`
+                : "";
+            return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
+        }).join("");
+        return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <numFmts count="0"/>
+  <fonts count="${fonts.items.length}">
+    ${fonts.items.map(buildFontXml).join("")}
+  </fonts>
+  <fills count="${fills.items.length}">
+    ${fills.items.map(buildFillXml).join("")}
+  </fills>
+  <borders count="${borders.items.length}">
+    ${borders.items.map(buildBorderXml).join("")}
+  </borders>
+  <cellStyleXfs count="1">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+  </cellStyleXfs>
+  <cellXfs count="${styles.length}">
+    ${styleNodes}
+  </cellXfs>
+  <cellStyles count="1">
+    <cellStyle name="Normal" xfId="0" builtinId="0"/>
+  </cellStyles>
+</styleSheet>`;
+    }
+    function dedupeDescriptors(items, keyFn, defaultItem) {
+        const uniqueItems = [defaultItem];
+        const indexByKey = new Map([[keyFn(defaultItem), 0]]);
+        for (const item of items) {
+            const key = keyFn(item);
+            if (!indexByKey.has(key)) {
+                indexByKey.set(key, uniqueItems.length);
+                uniqueItems.push(item);
+            }
+        }
+        return { items: uniqueItems, indexByKey };
+    }
+    function fontKey(font) {
+        return font.bold ? "bold" : "";
+    }
+    function fillKey(fill) {
+        return fill.fillColor || "";
+    }
+    function borderKey(border) {
+        return border.border || "";
+    }
+    function buildFontXml(font) {
+        return font.bold ? `<font><b/></font>` : `<font/>`;
+    }
+    function buildFillXml(fill) {
+        if (!fill.fillColor) {
+            return `<fill><patternFill patternType="none"/></fill>`;
+        }
+        return `<fill><patternFill patternType="solid"><fgColor rgb="${fill.fillColor}"/><bgColor indexed="64"/></patternFill></fill>`;
+    }
+    function buildBorderXml(border) {
+        if (!border.border) {
+            return `<border/>`;
+        }
+        return `<border><left style="${border.border}"/><right style="${border.border}"/><top style="${border.border}"/><bottom style="${border.border}"/><diagonal/></border>`;
+    }
+    function mapNumberFormatId(numberFormat) {
+        switch (numberFormat) {
+            case "integer":
+                return 1;
+            case "decimal":
+                return 2;
+            case "date":
+                return 14;
+            case "datetime":
+                return 22;
+            case "percent":
+                return 10;
+            case "general":
+            default:
+                return 0;
+        }
+    }
+    function parseWorkbookEntries(entries) {
+        const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
+        const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
+        const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+        const workbookDocument = parseXmlDocument(workbookXml);
+        const relationshipsDocument = parseXmlDocument(workbookRelsXml);
+        const styleBook = parseStylesXml(stylesXml);
+        const relationshipMap = new Map();
+        const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/package/2006/relationships", "Relationship"));
+        for (const relationshipElement of relationshipElements) {
+            const id = relationshipElement.getAttribute("Id");
+            const target = relationshipElement.getAttribute("Target");
+            if (id && target) {
+                relationshipMap.set(id, normalizeWorkbookTarget(target));
+            }
+        }
+        const sheetElements = Array.from(workbookDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "sheet"));
+        return {
+            sheets: sheetElements.map((sheetElement) => {
+                const name = sheetElement.getAttribute("name") || "";
+                validateSheetName(name);
+                const relationshipId = sheetElement.getAttributeNS("http://schemas.openxmlformats.org/officeDocument/2006/relationships", "id") || sheetElement.getAttribute("r:id");
+                if (!relationshipId) {
+                    throw new Error(`Worksheet relationship id is missing for sheet: ${name}`);
+                }
+                const target = relationshipMap.get(relationshipId);
+                if (!target) {
+                    throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
+                }
+                const worksheetXml = decodeRequiredEntry(entries, target);
+                return parseWorksheetXml(name, worksheetXml, styleBook);
+            })
+        };
+    }
+    function normalizeWorkbookTarget(target) {
+        return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
+    }
+    function parseWorksheetXml(name, xmlText, styleBook) {
+        const document = parseXmlDocument(xmlText);
+        const rowElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "row"));
+        return {
+            name,
+            columns: parseWorksheetColumns(document),
+            mergedRanges: parseWorksheetMergedRanges(document),
+            rows: rowElements.map((rowElement) => ({
+                height: parseOptionalNumber(rowElement.getAttribute("ht")),
+                cells: parseWorksheetRowCells(rowElement, styleBook)
+            }))
+        };
+    }
+    function parseWorksheetColumns(document) {
+        const colElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "col"));
+        if (colElements.length === 0) {
+            return undefined;
+        }
+        const columns = [];
+        for (const colElement of colElements) {
+            const min = Number(colElement.getAttribute("min") || "0");
+            const max = Number(colElement.getAttribute("max") || "0");
+            const width = parseOptionalNumber(colElement.getAttribute("width"));
+            for (let index = min; index <= max; index += 1) {
+                columns[index - 1] = { width };
+            }
+        }
+        while (columns.length > 0 && !columns[columns.length - 1]) {
+            columns.pop();
+        }
+        return columns.length > 0 ? columns.map((column) => column || {}) : undefined;
+    }
+    function parseWorksheetMergedRanges(document) {
+        const mergeCellElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "mergeCell"));
+        if (mergeCellElements.length === 0) {
+            return undefined;
+        }
+        return mergeCellElements
+            .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
+            .filter(Boolean);
+    }
+    function parseWorksheetRowCells(rowElement, styleBook) {
+        const cells = [];
+        const cellElements = Array.from(rowElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c")).filter((element) => element.parentElement === rowElement);
+        for (const cellElement of cellElements) {
+            const reference = cellElement.getAttribute("r") || "";
+            const columnIndex = decodeColumnReference(reference);
+            while (cells.length < columnIndex) {
+                cells.push({});
+            }
+            cells.push(parseWorksheetCell(cellElement, styleBook));
+        }
+        return cells;
+    }
+    function parseWorksheetCell(cellElement, styleBook) {
+        const type = cellElement.getAttribute("t") || "";
+        const styleIndex = Number(cellElement.getAttribute("s") || "0");
+        const formulaElement = findDirectChild(cellElement, "f");
+        const valueElement = findDirectChild(cellElement, "v");
+        const inlineStringElement = findDirectChild(cellElement, "is");
+        let value;
+        if (type === "inlineStr") {
+            const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
+            value = textElement ? (textElement.textContent || "") : "";
+        }
+        else if (type === "b") {
+            value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) === "1";
+        }
+        else if (type === "str") {
+            value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) || "";
+        }
+        else if (valueElement) {
+            const rawValue = valueElement.textContent || "";
+            value = rawValue === "" ? "" : Number(rawValue);
+        }
+        const style = styleBook[styleIndex] || DEFAULT_STYLE;
+        const cell = {};
+        if (style.numberFormat !== "general") {
+            cell.numberFormat = style.numberFormat;
+        }
+        if (style.horizontalAlign) {
+            cell.horizontalAlign = style.horizontalAlign;
+        }
+        if (style.bold) {
+            cell.bold = true;
+        }
+        if (style.fillColor) {
+            cell.fillColor = denormalizeColor(style.fillColor);
+        }
+        if (style.border) {
+            cell.border = style.border;
+        }
+        if (formulaElement) {
+            cell.formula = formulaElement.textContent || "";
+        }
+        if (value !== undefined) {
+            cell.value = value;
+        }
+        return cell;
+    }
+    function parseStylesXml(xmlText) {
+        if (!xmlText) {
+            return [DEFAULT_STYLE];
+        }
+        const document = parseXmlDocument(xmlText);
+        const fonts = parseFonts(document);
+        const fills = parseFills(document);
+        const borders = parseBorders(document);
+        const xfElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "xf")).filter((element) => { var _a; return ((_a = element.parentElement) === null || _a === void 0 ? void 0 : _a.localName) === "cellXfs"; });
+        if (xfElements.length === 0) {
+            return [DEFAULT_STYLE];
+        }
+        return xfElements.map((xfElement) => {
+            var _a, _b, _c;
+            const numFmtId = Number(xfElement.getAttribute("numFmtId") || "0");
+            const fontId = Number(xfElement.getAttribute("fontId") || "0");
+            const fillId = Number(xfElement.getAttribute("fillId") || "0");
+            const borderId = Number(xfElement.getAttribute("borderId") || "0");
+            const alignmentElement = findDirectChild(xfElement, "alignment");
+            const horizontalAlign = alignmentElement === null || alignmentElement === void 0 ? void 0 : alignmentElement.getAttribute("horizontal");
+            return {
+                numberFormat: parseNumberFormatId(numFmtId),
+                horizontalAlign: horizontalAlign || undefined,
+                bold: ((_a = fonts[fontId]) === null || _a === void 0 ? void 0 : _a.bold) ? true : undefined,
+                fillColor: (_b = fills[fillId]) === null || _b === void 0 ? void 0 : _b.fillColor,
+                border: (_c = borders[borderId]) === null || _c === void 0 ? void 0 : _c.border
+            };
+        });
+    }
+    function parseFonts(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "font")).map((fontElement) => ({
+            bold: findDirectChild(fontElement, "b") ? true : undefined
+        }));
+    }
+    function parseFills(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "fill")).map((fillElement) => {
+            const patternFill = findDirectChild(fillElement, "patternFill");
+            const fgColor = patternFill ? findDirectChild(patternFill, "fgColor") : null;
+            return {
+                fillColor: (fgColor === null || fgColor === void 0 ? void 0 : fgColor.getAttribute("rgb")) || undefined
+            };
+        });
+    }
+    function parseBorders(document) {
+        return Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "border")).map((borderElement) => {
+            const left = findDirectChild(borderElement, "left");
+            const style = left === null || left === void 0 ? void 0 : left.getAttribute("style");
+            return {
+                border: style && BORDER_STYLES.includes(style) ? style : undefined
+            };
+        });
+    }
+    function parseNumberFormatId(numFmtId) {
+        switch (numFmtId) {
+            case 1:
+                return "integer";
+            case 2:
+                return "decimal";
+            case 10:
+                return "percent";
+            case 14:
+                return "date";
+            case 22:
+                return "datetime";
+            default:
+                return "general";
+        }
+    }
+    function parseOptionalNumber(value) {
+        if (!value) {
+            return undefined;
+        }
+        return Number(value);
+    }
+    function findDirectChild(element, localName) {
+        for (const childNode of Array.from(element.childNodes)) {
+            if (childNode.nodeType !== Node.ELEMENT_NODE) {
+                continue;
+            }
+            const childElement = childNode;
+            if (childElement.localName === localName) {
+                return childElement;
+            }
+        }
+        return null;
+    }
+    function parseXmlDocument(xmlText) {
+        const document = new DOMParser().parseFromString(xmlText, "application/xml");
+        if (document.querySelector("parsererror")) {
+            throw new Error("Failed to parse XML document");
+        }
+        return document;
+    }
+    function decodeRequiredEntry(entries, name) {
+        const bytes = entries[name];
+        if (!bytes) {
+            throw new Error(`Required ZIP entry is missing: ${name}`);
+        }
+        return decodeUtf8(bytes);
+    }
+    function encodeUtf8(value) {
+        return TEXT_ENCODER.encode(value);
+    }
+    function decodeUtf8(bytes) {
+        return TEXT_DECODER.decode(bytes);
+    }
+    function escapeXml(value) {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&apos;");
+    }
+    function encodeColumnName(columnIndex) {
+        let current = columnIndex + 1;
+        let result = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            result = String.fromCharCode(65 + remainder) + result;
+            current = Math.floor((current - 1) / 26);
+        }
+        return result;
+    }
+    function decodeColumnReference(reference) {
+        const match = /^([A-Z]+)\d+$/i.exec(reference);
+        if (!match) {
+            throw new Error(`Invalid cell reference: ${reference}`);
+        }
+        const letters = match[1].toUpperCase();
+        let value = 0;
+        for (const character of letters) {
+            value = (value * 26) + (character.charCodeAt(0) - 64);
+        }
+        return value - 1;
+    }
+    function packZip(entries) {
+        const localParts = [];
+        const centralParts = [];
+        let offset = 0;
+        for (const entry of entries) {
+            const nameBytes = encodeUtf8(entry.name);
+            const crc32 = computeCrc32(entry.data);
+            const localHeader = new Uint8Array(30 + nameBytes.length);
+            const localView = new DataView(localHeader.buffer);
+            localView.setUint32(0, 0x04034b50, true);
+            localView.setUint16(4, 20, true);
+            localView.setUint16(6, 0, true);
+            localView.setUint16(8, 0, true);
+            localView.setUint16(10, 0, true);
+            localView.setUint16(12, 0, true);
+            localView.setUint32(14, crc32, true);
+            localView.setUint32(18, entry.data.byteLength, true);
+            localView.setUint32(22, entry.data.byteLength, true);
+            localView.setUint16(26, nameBytes.length, true);
+            localView.setUint16(28, 0, true);
+            localHeader.set(nameBytes, 30);
+            const centralHeader = new Uint8Array(46 + nameBytes.length);
+            const centralView = new DataView(centralHeader.buffer);
+            centralView.setUint32(0, 0x02014b50, true);
+            centralView.setUint16(4, 20, true);
+            centralView.setUint16(6, 20, true);
+            centralView.setUint16(8, 0, true);
+            centralView.setUint16(10, 0, true);
+            centralView.setUint16(12, 0, true);
+            centralView.setUint16(14, 0, true);
+            centralView.setUint32(16, crc32, true);
+            centralView.setUint32(20, entry.data.byteLength, true);
+            centralView.setUint32(24, entry.data.byteLength, true);
+            centralView.setUint16(28, nameBytes.length, true);
+            centralView.setUint16(30, 0, true);
+            centralView.setUint16(32, 0, true);
+            centralView.setUint16(34, 0, true);
+            centralView.setUint16(36, 0, true);
+            centralView.setUint32(38, 0, true);
+            centralView.setUint32(42, offset, true);
+            centralHeader.set(nameBytes, 46);
+            localParts.push(localHeader, entry.data);
+            centralParts.push(centralHeader);
+            offset += localHeader.byteLength + entry.data.byteLength;
+        }
+        const centralDirectoryOffset = offset;
+        const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+        const endOfCentralDirectory = new Uint8Array(22);
+        const endView = new DataView(endOfCentralDirectory.buffer);
+        endView.setUint32(0, 0x06054b50, true);
+        endView.setUint16(4, 0, true);
+        endView.setUint16(6, 0, true);
+        endView.setUint16(8, entries.length, true);
+        endView.setUint16(10, entries.length, true);
+        endView.setUint32(12, centralDirectorySize, true);
+        endView.setUint32(16, centralDirectoryOffset, true);
+        endView.setUint16(20, 0, true);
+        return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+    }
+    function unpackZip(bytes) {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const endOffset = findEndOfCentralDirectoryOffset(bytes);
+        const totalEntries = view.getUint16(endOffset + 10, true);
+        const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+        const entries = {};
+        let pointer = centralDirectoryOffset;
+        for (let index = 0; index < totalEntries; index += 1) {
+            if (view.getUint32(pointer, true) !== 0x02014b50) {
+                throw new Error("Invalid ZIP central directory header");
+            }
+            const compressionMethod = view.getUint16(pointer + 10, true);
+            const compressedSize = view.getUint32(pointer + 20, true);
+            const uncompressedSize = view.getUint32(pointer + 24, true);
+            const fileNameLength = view.getUint16(pointer + 28, true);
+            const extraLength = view.getUint16(pointer + 30, true);
+            const commentLength = view.getUint16(pointer + 32, true);
+            const localHeaderOffset = view.getUint32(pointer + 42, true);
+            const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+            const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+            if (localView.getUint32(0, true) !== 0x04034b50) {
+                throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+            }
+            const localFileNameLength = localView.getUint16(26, true);
+            const localExtraLength = localView.getUint16(28, true);
+            const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+            const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+            if (compressionMethod !== 0) {
+                throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+            }
+            if (compressedSize !== uncompressedSize) {
+                throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+            }
+            entries[fileName] = data;
+            pointer += 46 + fileNameLength + extraLength + commentLength;
+        }
+        return entries;
+    }
+    function findEndOfCentralDirectoryOffset(bytes) {
+        for (let index = bytes.byteLength - 22; index >= 0; index -= 1) {
+            if (bytes[index] === 0x50 &&
+                bytes[index + 1] === 0x4b &&
+                bytes[index + 2] === 0x05 &&
+                bytes[index + 3] === 0x06) {
+                return index;
+            }
+        }
+        throw new Error("ZIP end of central directory not found");
+    }
+    function concatUint8Arrays(parts) {
+        const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+        const result = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const part of parts) {
+            result.set(part, offset);
+            offset += part.byteLength;
+        }
+        return result;
+    }
+    function computeCrc32(bytes) {
+        let crc = 0xffffffff;
+        for (const byte of bytes) {
+            crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+        }
+        return (crc ^ 0xffffffff) >>> 0;
+    }
+    function buildCrc32Table() {
+        const table = new Uint32Array(256);
+        for (let index = 0; index < 256; index += 1) {
+            let value = index;
+            for (let bit = 0; bit < 8; bit += 1) {
+                value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+            }
+            table[index] = value >>> 0;
+        }
+        return table;
+    }
+    globalThis.__mikuprojectExcelIo = {
+        XlsxWorkbookCodec
+    };
+})();

--- a/docs/project/src/mikuproject/js/main.js
+++ b/docs/project/src/mikuproject/js/main.js
@@ -3,10 +3,24 @@
     if (!mikuprojectXml) {
         throw new Error("mikuproject XML module is not loaded");
     }
+    const mikuprojectExcelIo = globalThis.__mikuprojectExcelIo;
+    if (!mikuprojectExcelIo) {
+        throw new Error("mikuproject Excel IO module is not loaded");
+    }
+    const mikuprojectProjectXlsx = globalThis.__mikuprojectProjectXlsx;
+    if (!mikuprojectProjectXlsx) {
+        throw new Error("mikuproject Project XLSX module is not loaded");
+    }
+    const mikuprojectWbsXlsx = globalThis.__mikuprojectWbsXlsx;
+    if (!mikuprojectWbsXlsx) {
+        throw new Error("mikuproject WBS XLSX module is not loaded");
+    }
     const mermaidApi = globalThis.mermaid;
     let currentModel = null;
     let currentMermaidSvg = "";
     let mermaidRenderCount = 0;
+    let lastSavedXmlText = "";
+    let lastSavedXmlStamp = "";
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -16,6 +30,31 @@
     }
     function getTextArea(id) {
         return getElement(id);
+    }
+    function parseWbsHolidayDates() {
+        const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+        if (!raw) {
+            return [];
+        }
+        const seen = new Set();
+        const holidays = [];
+        for (const token of raw.split(/[\s,、;]+/)) {
+            const value = token.trim();
+            if (!value) {
+                continue;
+            }
+            const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+            if (!match) {
+                continue;
+            }
+            const dateText = match[1];
+            if (seen.has(dateText)) {
+                continue;
+            }
+            seen.add(dateText);
+            holidays.push(dateText);
+        }
+        return holidays;
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -99,6 +138,35 @@
     }
     function setStatus(message) {
         getElement("statusMessage").textContent = message;
+    }
+    function formatSaveStamp(date) {
+        return [
+            date.getFullYear(),
+            String(date.getMonth() + 1).padStart(2, "0"),
+            String(date.getDate()).padStart(2, "0")
+        ].join("-") + " " + [
+            String(date.getHours()).padStart(2, "0"),
+            String(date.getMinutes()).padStart(2, "0")
+        ].join(":");
+    }
+    function updateXmlSaveState(isDirty) {
+        const node = getElement("xmlSaveState");
+        node.textContent = isDirty
+            ? "XML 保存状態: 未保存"
+            : `XML 保存状態: 保存済み (${lastSavedXmlStamp || "-"})`;
+        node.classList.toggle("md-save-state--dirty", isDirty);
+        node.classList.toggle("md-save-state--clean", !isDirty);
+    }
+    function markXmlDirty() {
+        updateXmlSaveState(true);
+    }
+    function markXmlSavedCurrent() {
+        lastSavedXmlText = getTextArea("xmlInput").value;
+        lastSavedXmlStamp = formatSaveStamp(new Date());
+        updateXmlSaveState(false);
+    }
+    function refreshXmlSaveState() {
+        updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
     }
     function renderPreviewList(containerId, items) {
         const container = getElement(containerId);
@@ -207,9 +275,12 @@
     }
     function renderValidationIssues(issues) {
         const container = getElement("validationIssues");
+        const label = container.previousElementSibling;
         if (issues.length === 0) {
             container.classList.add("md-hidden");
             container.innerHTML = "";
+            label === null || label === void 0 ? void 0 : label.classList.add("md-hidden");
+            updateFeedbackVisibility();
             return;
         }
         const sections = ["project", "tasks", "resources", "assignments", "calendars"];
@@ -221,6 +292,7 @@
             calendars: "Calendars"
         };
         container.classList.remove("md-hidden");
+        label === null || label === void 0 ? void 0 : label.classList.remove("md-hidden");
         container.innerHTML = `
       <div class="md-issues__title">検証メッセージ</div>
       ${sections
@@ -240,6 +312,115 @@
         })
             .join("")}
     `;
+        updateFeedbackVisibility();
+    }
+    function renderXlsxImportSummary(changes) {
+        const container = getElement("xlsxImportSummary");
+        const label = container.previousElementSibling;
+        if (changes.length === 0) {
+            container.classList.add("md-hidden");
+            container.innerHTML = "";
+            label === null || label === void 0 ? void 0 : label.classList.add("md-hidden");
+            updateFeedbackVisibility();
+            return;
+        }
+        const scopeLabel = {
+            project: "Project",
+            tasks: "Tasks",
+            resources: "Resources",
+            assignments: "Assignments",
+            calendars: "Calendars"
+        };
+        const scopeCounts = {
+            project: 0,
+            tasks: 0,
+            resources: 0,
+            assignments: 0,
+            calendars: 0
+        };
+        const groupedByScope = new Map();
+        const groupedChanges = new Map();
+        for (const change of changes) {
+            const groupKey = `${change.scope}:${change.uid}:${change.label}`;
+            const currentGroup = groupedChanges.get(groupKey);
+            if (currentGroup) {
+                currentGroup.items.push({
+                    field: change.field,
+                    before: change.before,
+                    after: change.after
+                });
+                continue;
+            }
+            groupedChanges.set(groupKey, {
+                scope: change.scope,
+                uid: change.uid,
+                label: change.label,
+                items: [{
+                        field: change.field,
+                        before: change.before,
+                        after: change.after
+                    }]
+            });
+            scopeCounts[change.scope] += 1;
+        }
+        for (const group of groupedChanges.values()) {
+            const scopedGroups = groupedByScope.get(group.scope) || [];
+            scopedGroups.push({
+                uid: group.uid,
+                label: group.label,
+                items: group.items
+            });
+            groupedByScope.set(group.scope, scopedGroups);
+        }
+        const changedScopes = ["project", "tasks", "resources", "assignments", "calendars"].filter((scope) => scopeCounts[scope] > 0);
+        const unchangedScopes = ["project", "tasks", "resources", "assignments", "calendars"].filter((scope) => scopeCounts[scope] === 0);
+        container.classList.remove("md-hidden");
+        label === null || label === void 0 ? void 0 : label.classList.remove("md-hidden");
+        container.innerHTML = `
+      <div class="md-xlsx-summary__title">XLSX Import 反映結果</div>
+      <div class="md-xlsx-summary__counts">
+        ${changedScopes.map((scope) => `<span class="md-xlsx-summary__count">${scopeLabel[scope]} ${scopeCounts[scope]}</span>`).join("")}
+      </div>
+      ${unchangedScopes.length > 0 ? `<div class="md-xlsx-summary__unchanged">変更なし: ${unchangedScopes.map((scope) => scopeLabel[scope]).join(", ")}</div>` : ""}
+      ${changedScopes.map((scope) => `
+        <div class="md-xlsx-summary__section">
+          <div class="md-xlsx-summary__section-title">${scopeLabel[scope]}</div>
+          <ul class="md-xlsx-summary__list">
+            ${(groupedByScope.get(scope) || []).map((group) => `
+              <li class="md-xlsx-summary__item">
+                <div class="md-xlsx-summary__item-title">UID=${group.uid} ${escapeHtml(group.label)}</div>
+                <div class="md-xlsx-summary__item-body">
+                  ${group.items.map((item) => `${escapeHtml(item.field)}: ${escapeHtml(formatChangeValue(item.before))} -> ${escapeHtml(formatChangeValue(item.after))}`).join(" / ")}
+                </div>
+              </li>
+            `).join("")}
+          </ul>
+        </div>
+      `).join("")}
+      <div class="md-xlsx-summary__hint">反映後の XML は更新済みです。必要なら XML Export で保存できます。</div>
+    `;
+        updateFeedbackVisibility();
+    }
+    function updateFeedbackVisibility() {
+        const stack = document.querySelector(".md-feedback-stack");
+        const validationIssues = getElement("validationIssues");
+        const xlsxImportSummary = getElement("xlsxImportSummary");
+        const shouldShow = !validationIssues.classList.contains("md-hidden") || !xlsxImportSummary.classList.contains("md-hidden");
+        stack === null || stack === void 0 ? void 0 : stack.classList.toggle("md-hidden", !shouldShow);
+    }
+    function formatChangeValue(value) {
+        if (value === undefined) {
+            return "(empty)";
+        }
+        return String(value);
+    }
+    function escapeHtml(value) {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
@@ -316,6 +497,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function loadSample() {
         getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+        markXmlDirty();
         setStatus("サンプル XML を読み込みました");
     }
     async function importXmlFromFile(file) {
@@ -324,12 +506,25 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         }
         const xmlText = await file.text();
         getTextArea("xmlInput").value = xmlText;
+        markXmlDirty();
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
         showToast("XML を読み込んで解析しました");
+    }
+    function ensureCurrentModel() {
+        if (currentModel) {
+            return currentModel;
+        }
+        const xmlText = getTextArea("xmlInput").value.trim();
+        if (!xmlText) {
+            throw new Error("内部モデルがありません");
+        }
+        currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        return currentModel;
     }
     function parseCurrentXml() {
         const xmlText = getTextArea("xmlInput").value.trim();
@@ -341,6 +536,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
         showToast("XML を解析しました");
     }
@@ -350,7 +546,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             return;
         }
         getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+        markXmlDirty();
         renderValidationIssues([]);
+        renderXlsxImportSummary([]);
         setStatus("内部モデルから XML を再生成しました");
         showToast("XML を再生成しました");
     }
@@ -374,6 +572,65 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus("内部モデルから CSV + ParentID を生成しました");
         showToast("CSV を生成しました");
     }
+    function exportCurrentXlsx() {
+        const model = ensureCurrentModel();
+        const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const bytes = codec.exportWorkbook(workbook);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-export-${stamp}.xlsx`);
+        setStatus("XLSX ファイルをエクスポートしました");
+        showToast("XLSX を保存しました");
+    }
+    function exportCurrentWbsXlsx() {
+        const model = ensureCurrentModel();
+        const holidayDates = parseWbsHolidayDates();
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const bytes = codec.exportWorkbook(workbook);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+        showToast("WBS XLSX を保存しました");
+    }
+    async function importXlsxFromFile(file) {
+        if (!file) {
+            return;
+        }
+        const baseModel = ensureCurrentModel();
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const workbook = codec.importWorkbook(bytes);
+        const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
+        currentModel = result.model;
+        const issues = mikuprojectXml.validateProjectModel(currentModel);
+        updateSummary(currentModel);
+        renderValidationIssues(issues);
+        renderXlsxImportSummary(result.changes);
+        if (result.changes.length > 0) {
+            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+            markXmlDirty();
+        }
+        const summaryText = result.changes.length > 0
+            ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+            : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+        setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
+        showToast("XLSX を反映しました");
+    }
     function parseCurrentCsv() {
         const csvText = getTextArea("csvInput").value.trim();
         if (!csvText) {
@@ -384,6 +641,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
+        renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
         showToast("CSV を解析しました");
     }
@@ -410,6 +668,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         link.click();
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+        markXmlSavedCurrent();
         setStatus("XML ファイルをエクスポートしました");
         showToast("XML を保存しました");
     }
@@ -486,6 +745,22 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "CSV 生成に失敗しました");
             }
         });
+        getElement("exportXlsxBtn").addEventListener("click", () => {
+            try {
+                exportCurrentXlsx();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "XLSX エクスポートに失敗しました");
+            }
+        });
+        getElement("exportWbsXlsxBtn").addEventListener("click", () => {
+            try {
+                exportCurrentWbsXlsx();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+            }
+        });
         getElement("parseCsvBtn").addEventListener("click", () => {
             try {
                 parseCurrentCsv();
@@ -493,6 +768,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
             }
+        });
+        getElement("importXlsxBtn").addEventListener("click", () => {
+            getElement("importXlsxInput").click();
         });
         getElement("downloadXmlBtn").addEventListener("click", () => {
             try {
@@ -525,11 +803,30 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 }
             }
         });
+        getElement("importXlsxInput").addEventListener("change", async (event) => {
+            const input = event.target;
+            const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            try {
+                await importXlsxFromFile(file);
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+            }
+            finally {
+                if (input) {
+                    input.value = "";
+                }
+            }
+        });
+        getTextArea("xmlInput").addEventListener("input", () => {
+            refreshXmlSaveState();
+        });
     }
     function initialize() {
         bindEvents();
         updateSummary(null);
         renderValidationIssues([]);
+        renderXlsxImportSummary([]);
         updateMermaidSvgButton();
         clearMermaidError();
         loadSample();

--- a/docs/project/src/mikuproject/js/project-xlsx.js
+++ b/docs/project/src/mikuproject/js/project-xlsx.js
@@ -1,0 +1,506 @@
+(() => {
+    const HEADER_FILL = "#D9EAF7";
+    function exportProjectWorkbook(model) {
+        return {
+            sheets: [
+                buildProjectSheet(model),
+                buildTasksSheet(model),
+                buildResourcesSheet(model),
+                buildAssignmentsSheet(model),
+                buildCalendarsSheet(model)
+            ]
+        };
+    }
+    function importProjectWorkbook(workbook, baseModel) {
+        return importProjectWorkbookDetailed(workbook, baseModel).model;
+    }
+    function importProjectWorkbookDetailed(workbook, baseModel) {
+        const nextModel = cloneProjectModel(baseModel);
+        const changes = [];
+        importProjectSheet(workbook, nextModel, changes);
+        importTasksSheet(workbook, nextModel, changes);
+        importResourcesSheet(workbook, nextModel, changes);
+        importAssignmentsSheet(workbook, nextModel, changes);
+        importCalendarsSheet(workbook, nextModel, changes);
+        return {
+            model: nextModel,
+            changes
+        };
+    }
+    function importProjectSheet(workbook, model, changes) {
+        const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+        if (!projectSheet) {
+            return;
+        }
+        const valueByField = new Map();
+        for (const row of projectSheet.rows.slice(3)) {
+            const field = readStringCell(row.cells[0]);
+            if (!field) {
+                continue;
+            }
+            valueByField.set(field, row.cells[1]);
+        }
+        const projectLabel = model.project.name;
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "name", "Name", readStringCell(valueByField.get("Name")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "title", "Title", readStringCell(valueByField.get("Title")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "author", "Author", readStringCell(valueByField.get("Author")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "company", "Company", readStringCell(valueByField.get("Company")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "startDate", "StartDate", readStringCell(valueByField.get("StartDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "finishDate", "FinishDate", readStringCell(valueByField.get("FinishDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "currentDate", "CurrentDate", readStringCell(valueByField.get("CurrentDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "statusDate", "StatusDate", readStringCell(valueByField.get("StatusDate")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "calendarUID", "CalendarUID", readStringCell(valueByField.get("CalendarUID")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerDay", "MinutesPerDay", readNumberCell(valueByField.get("MinutesPerDay")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
+        assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+    }
+    function buildProjectSheet(model) {
+        const project = model.project;
+        const rows = [
+            titleRow("Project"),
+            titleRow("Basic Info"),
+            headerRow(["Field", "Value"]),
+            keyValueRow("Name", project.name),
+            keyValueRow("Title", project.title),
+            keyValueRow("Author", project.author),
+            keyValueRow("Company", project.company),
+            keyValueRow("StartDate", project.startDate),
+            keyValueRow("FinishDate", project.finishDate),
+            keyValueRow("CurrentDate", project.currentDate),
+            keyValueRow("StatusDate", project.statusDate),
+            titleRow("Settings"),
+            keyValueRow("CalendarUID", project.calendarUID),
+            keyValueRow("MinutesPerDay", project.minutesPerDay),
+            keyValueRow("MinutesPerWeek", project.minutesPerWeek),
+            keyValueRow("DaysPerMonth", project.daysPerMonth),
+            keyValueRow("ScheduleFromStart", project.scheduleFromStart),
+            keyValueRow("OutlineCodes", project.outlineCodes.length),
+            keyValueRow("WBSMasks", project.wbsMasks.length),
+            keyValueRow("ExtendedAttributes", project.extendedAttributes.length)
+        ];
+        return {
+            name: "Project",
+            columns: [{ width: 24 }, { width: 32 }],
+            mergedRanges: ["A1:B1", "A2:B2", "A11:B11"],
+            rows
+        };
+    }
+    function buildTasksSheet(model) {
+        return {
+            name: "Tasks",
+            columns: [
+                { width: 10 }, { width: 8 }, { width: 28 }, { width: 12 },
+                { width: 14 }, { width: 12 }, { width: 20 }, { width: 20 },
+                { width: 14 }, { width: 16 }, { width: 18 }, { width: 12 },
+                { width: 12 }, { width: 12 }, { width: 12 }, { width: 18 }
+            ],
+            mergedRanges: ["A1:P1", "A2:P2"],
+            rows: [
+                sectionTitleRow("Tasks", 16),
+                sectionTitleRow("Task List", 16),
+                headerRow([
+                    "UID", "ID", "Name", "OutlineLevel", "OutlineNumber", "WBS",
+                    "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete",
+                    "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors"
+                ]),
+                ...model.tasks.map((task) => ({
+                    cells: [
+                        cell(task.uid),
+                        cell(task.id),
+                        cell(task.name),
+                        cell(task.outlineLevel),
+                        cell(task.outlineNumber),
+                        cell(task.wbs),
+                        cell(task.start),
+                        cell(task.finish),
+                        cell(task.duration),
+                        cell(task.percentComplete),
+                        cell(task.percentWorkComplete),
+                        cell(task.milestone),
+                        cell(task.summary),
+                        cell(task.critical),
+                        cell(task.calendarUID),
+                        cell(task.predecessors.map((item) => item.predecessorUid).join(", "))
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildResourcesSheet(model) {
+        return {
+            name: "Resources",
+            columns: [
+                { width: 10 }, { width: 8 }, { width: 24 }, { width: 10 },
+                { width: 12 }, { width: 18 }, { width: 12 }, { width: 12 },
+                { width: 14 }, { width: 14 }, { width: 12 }, { width: 14 },
+                { width: 14 }, { width: 14 }
+            ],
+            mergedRanges: ["A1:N1", "A2:N2"],
+            rows: [
+                sectionTitleRow("Resources", 14),
+                sectionTitleRow("Resource List", 14),
+                headerRow([
+                    "UID", "ID", "Name", "Type", "Initials", "Group", "MaxUnits",
+                    "CalendarUID", "StandardRate", "OvertimeRate", "CostPerUse",
+                    "Work", "ActualWork", "RemainingWork"
+                ]),
+                ...model.resources.map((resource) => ({
+                    cells: [
+                        cell(resource.uid),
+                        cell(resource.id),
+                        cell(resource.name),
+                        cell(resource.type),
+                        cell(resource.initials),
+                        cell(resource.group),
+                        cell(resource.maxUnits),
+                        cell(resource.calendarUID),
+                        cell(resource.standardRate),
+                        cell(resource.overtimeRate),
+                        cell(resource.costPerUse),
+                        cell(resource.work),
+                        cell(resource.actualWork),
+                        cell(resource.remainingWork)
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildAssignmentsSheet(model) {
+        const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+        const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        return {
+            name: "Assignments",
+            columns: [
+                { width: 10 }, { width: 10 }, { width: 24 }, { width: 12 },
+                { width: 24 }, { width: 20 }, { width: 20 }, { width: 10 },
+                { width: 14 }, { width: 14 }, { width: 14 }, { width: 18 }
+            ],
+            mergedRanges: ["A1:L1", "A2:L2"],
+            rows: [
+                sectionTitleRow("Assignments", 12),
+                sectionTitleRow("Assignment List", 12),
+                headerRow([
+                    "UID", "TaskUID", "TaskName", "ResourceUID", "ResourceName", "Start",
+                    "Finish", "Units", "Work", "ActualWork", "RemainingWork", "PercentWorkComplete"
+                ]),
+                ...model.assignments.map((assignment) => ({
+                    cells: [
+                        cell(assignment.uid),
+                        cell(assignment.taskUid),
+                        cell(taskNameByUid.get(assignment.taskUid)),
+                        cell(assignment.resourceUid),
+                        cell(resourceNameByUid.get(assignment.resourceUid)),
+                        cell(assignment.start),
+                        cell(assignment.finish),
+                        cell(assignment.units),
+                        cell(assignment.work),
+                        cell(assignment.actualWork),
+                        cell(assignment.remainingWork),
+                        cell(assignment.percentWorkComplete)
+                    ]
+                }))
+            ]
+        };
+    }
+    function buildCalendarsSheet(model) {
+        return {
+            name: "Calendars",
+            columns: [
+                { width: 10 }, { width: 24 }, { width: 14 }, { width: 16 },
+                { width: 10 }, { width: 12 }, { width: 10 }
+            ],
+            mergedRanges: ["A1:G1", "A2:G2"],
+            rows: [
+                sectionTitleRow("Calendars", 7),
+                sectionTitleRow("Calendar List", 7),
+                headerRow([
+                    "UID", "Name", "IsBaseCalendar", "BaseCalendarUID", "WeekDays", "Exceptions", "WorkWeeks"
+                ]),
+                ...model.calendars.map((calendar) => ({
+                    cells: [
+                        cell(calendar.uid),
+                        cell(calendar.name),
+                        cell(calendar.isBaseCalendar),
+                        cell(calendar.baseCalendarUID),
+                        cell(calendar.weekDays.length),
+                        cell(calendar.exceptions.length),
+                        cell(calendar.workWeeks.length)
+                    ]
+                }))
+            ]
+        };
+    }
+    function headerRow(labels) {
+        return {
+            height: 24,
+            cells: labels.map((label) => ({
+                value: label,
+                bold: true,
+                fillColor: HEADER_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            }))
+        };
+    }
+    function titleRow(title) {
+        return {
+            height: 28,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                {}
+            ]
+        };
+    }
+    function sectionTitleRow(title, columnCount) {
+        return {
+            height: 26,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function keyValueRow(label, value) {
+        return {
+            cells: [
+                {
+                    value: label,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin"
+                },
+                cell(value)
+            ]
+        };
+    }
+    function cell(value) {
+        if (value === undefined) {
+            return {};
+        }
+        return {
+            value,
+            border: "thin"
+        };
+    }
+    function cloneProjectModel(model) {
+        return JSON.parse(JSON.stringify(model));
+    }
+    function importTasksSheet(workbook, model, changes) {
+        const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+        if (!tasksSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(tasksSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const taskByUid = new Map(model.tasks.map((task) => [task.uid, task]));
+        for (const row of tasksSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const task = taskByUid.get(uid);
+            if (!task) {
+                continue;
+            }
+            const taskLabel = task.name;
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", readStringCellAt(row.cells, columnIndexByLabel.get("Start")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", readStringCellAt(row.cells, columnIndexByLabel.get("Finish")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+        }
+    }
+    function importResourcesSheet(workbook, model, changes) {
+        const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+        if (!resourcesSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(resourcesSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const resourceByUid = new Map(model.resources.map((resource) => [resource.uid, resource]));
+        for (const row of resourcesSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const resource = resourceByUid.get(uid);
+            if (!resource) {
+                continue;
+            }
+            const resourceLabel = resource.name;
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+        }
+    }
+    function importAssignmentsSheet(workbook, model, changes) {
+        const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+        if (!assignmentsSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(assignmentsSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const assignmentByUid = new Map(model.assignments.map((assignment) => [assignment.uid, assignment]));
+        for (const row of assignmentsSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const assignment = assignmentByUid.get(uid);
+            if (!assignment) {
+                continue;
+            }
+            const assignmentLabel = `TaskUID=${assignment.taskUid}`;
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "units", "Units", readNumberCellAt(row.cells, columnIndexByLabel.get("Units")));
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "work", "Work", readStringCellAt(row.cells, columnIndexByLabel.get("Work")));
+            assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+        }
+    }
+    function importCalendarsSheet(workbook, model, changes) {
+        const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+        if (!calendarsSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(calendarsSheet, 2);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return;
+        }
+        const calendarByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar]));
+        for (const row of calendarsSheet.rows.slice(3)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const calendar = calendarByUid.get(uid);
+            if (!calendar) {
+                continue;
+            }
+            const calendarLabel = calendar.name;
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
+            assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
+        }
+    }
+    function readHeaderMap(sheet, headerRowIndex) {
+        const headerRow = sheet.rows[headerRowIndex];
+        const columnIndexByLabel = new Map();
+        if (!headerRow) {
+            return columnIndexByLabel;
+        }
+        headerRow.cells.forEach((cell, index) => {
+            if (typeof cell.value === "string" && cell.value) {
+                columnIndexByLabel.set(cell.value, index);
+            }
+        });
+        return columnIndexByLabel;
+    }
+    function readStringCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readStringCell(cells[index]);
+    }
+    function readNumberCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readNumberCell(cells[index]);
+    }
+    function readBooleanCellAt(cells, index) {
+        if (index === undefined) {
+            return undefined;
+        }
+        return readBooleanCell(cells[index]);
+    }
+    function readStringCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "string") {
+            return cell.value;
+        }
+        if (typeof cell.value === "number" || typeof cell.value === "boolean") {
+            return String(cell.value);
+        }
+        return undefined;
+    }
+    function readNumberCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "number" && Number.isFinite(cell.value)) {
+            return cell.value;
+        }
+        if (typeof cell.value === "string" && cell.value.trim() !== "") {
+            const parsed = Number(cell.value);
+            return Number.isFinite(parsed) ? parsed : undefined;
+        }
+        return undefined;
+    }
+    function readBooleanCell(cell) {
+        if (!cell || cell.value === undefined) {
+            return undefined;
+        }
+        if (typeof cell.value === "boolean") {
+            return cell.value;
+        }
+        if (typeof cell.value === "number") {
+            return cell.value !== 0;
+        }
+        if (typeof cell.value === "string") {
+            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+                return true;
+            }
+            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+                return false;
+            }
+        }
+        return undefined;
+    }
+    function assignIfChanged(changes, scope, uid, label, target, key, field, value) {
+        if (value === undefined) {
+            return;
+        }
+        const before = target[key];
+        if (before === value) {
+            return;
+        }
+        target[key] = value;
+        changes.push({
+            scope,
+            uid,
+            label,
+            field,
+            before: before,
+            after: value
+        });
+    }
+    globalThis.__mikuprojectProjectXlsx = {
+        exportProjectWorkbook,
+        importProjectWorkbook,
+        importProjectWorkbookDetailed
+    };
+})();

--- a/docs/project/src/mikuproject/js/wbs-xlsx.js
+++ b/docs/project/src/mikuproject/js/wbs-xlsx.js
@@ -1,0 +1,342 @@
+(() => {
+    const HEADER_FILL = "#D9EAF7";
+    const PHASE_FILL = "#EEF7E8";
+    const MILESTONE_FILL = "#FFF4E0";
+    const BAND_FILL = "#F4F7FB";
+    const ACTIVE_BAND_FILL = "#9FD5C9";
+    const PROGRESS_BAND_FILL = "#5BAE9C";
+    const WEEKEND_BAND_FILL = "#F1F1F1";
+    const TODAY_BAND_FILL = "#FFE6A7";
+    const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
+    const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
+    const HOLIDAY_BAND_FILL = "#FCE4EC";
+    function exportWbsWorkbook(model, options = {}) {
+        const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        const predecessorNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+        const calendarNameByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar.name]));
+        const resourceNamesByTaskUid = new Map();
+        const holidaySet = new Set((options.holidayDates || []).map((day) => day.slice(0, 10)));
+        for (const assignment of model.assignments) {
+            const resourceName = resourceNameByUid.get(assignment.resourceUid);
+            if (!resourceName) {
+                continue;
+            }
+            const resourceNames = resourceNamesByTaskUid.get(assignment.taskUid) || [];
+            if (!resourceNames.includes(resourceName)) {
+                resourceNames.push(resourceName);
+            }
+            resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
+        }
+        const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+        const fixedHeaders = [
+            "UID",
+            "ID",
+            "WBS",
+            "Kind",
+            "OutlineLevel",
+            "Name",
+            "Start",
+            "Finish",
+            "Duration",
+            "PercentComplete",
+            "PercentWorkComplete",
+            "Milestone",
+            "Summary",
+            "Critical",
+            "Owner",
+            "Calendar",
+            "Resources",
+            "Predecessors"
+        ];
+        const totalColumns = fixedHeaders.length + dateBand.length;
+        const lastColumnRef = columnName(totalColumns);
+        return {
+            sheets: [
+                {
+                    name: "WBS",
+                    columns: [
+                        { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
+                        { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+                        { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
+                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+                        ...dateBand.map(() => ({ width: 6 }))
+                    ],
+                    mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+                    rows: [
+                        sectionTitleRow("WBS", totalColumns),
+                        sectionTitleRow(model.project.name || "Project", totalColumns),
+                        infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
+                        infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
+                        sectionTitleRow("Task View", totalColumns),
+                        todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+                        headerRow([
+                            ...fixedHeaders,
+                            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+                        ]),
+                        ...model.tasks.map((task) => ({
+                            cells: [
+                                taskCell(task, task.uid, "center"),
+                                taskCell(task, task.id, "center"),
+                                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                                taskCell(task, classifyTaskKind(task), "center"),
+                                taskCell(task, task.outlineLevel, "center"),
+                                taskCell(task, formatTaskLabel(task)),
+                                taskCell(task, task.start),
+                                taskCell(task, task.finish),
+                                taskCell(task, task.duration, "center"),
+                                taskCell(task, task.percentComplete, "center"),
+                                taskCell(task, task.percentWorkComplete, "center"),
+                                taskCell(task, task.milestone, "center"),
+                                taskCell(task, task.summary, "center"),
+                                taskCell(task, task.critical, "center"),
+                                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
+                            ]
+                        }))
+                    ]
+                }
+            ]
+        };
+    }
+    function formatTaskLabel(task) {
+        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+    }
+    function classifyTaskKind(task) {
+        if (task.summary) {
+            return "phase";
+        }
+        if (task.milestone) {
+            return "milestone";
+        }
+        return "task";
+    }
+    function firstResourceName(resourceNames) {
+        if (!resourceNames || resourceNames.length === 0) {
+            return "";
+        }
+        return resourceNames[0];
+    }
+    function formatCalendarLabel(calendarUID, calendarNameByUid) {
+        if (!calendarUID) {
+            return "-";
+        }
+        const calendarName = calendarNameByUid.get(calendarUID);
+        return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+    }
+    function sectionTitleRow(title, columnCount) {
+        return {
+            height: 28,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: HEADER_FILL,
+                    border: "thin",
+                    horizontalAlign: "center"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function infoRow(text, columnCount) {
+        return {
+            height: 24,
+            cells: [
+                {
+                    value: text,
+                    border: "thin",
+                    horizontalAlign: "left"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function headerRow(labels) {
+        return {
+            height: 24,
+            cells: labels.map((label) => {
+                if (typeof label === "string") {
+                    return {
+                        value: label,
+                        bold: true,
+                        fillColor: HEADER_FILL,
+                        border: "thin",
+                        horizontalAlign: "center"
+                    };
+                }
+                return {
+                    border: "thin",
+                    horizontalAlign: "center",
+                    ...label
+                };
+            })
+        };
+    }
+    function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
+        return {
+            height: 22,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
+                    ? {
+                        value: "Today",
+                        bold: true,
+                        border: "thin",
+                        horizontalAlign: "right"
+                    }
+                    : {})),
+                ...dateBand.map((day) => ({
+                    value: isSameDay(day, currentDate) ? "▼" : "",
+                    bold: true,
+                    border: "thin",
+                    horizontalAlign: "center",
+                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+                }))
+            ]
+        };
+    }
+    function cell(value) {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin"
+        };
+    }
+    function taskCell(task, value, horizontalAlign = "left") {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin",
+            horizontalAlign,
+            bold: task.summary || task.milestone || false,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
+    function dateHeaderCell(day, currentDate, holidaySet) {
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        return {
+            value: formatDateLabel(day),
+            bold: true,
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+        };
+    }
+    function dateBandCell(task, day, currentDate, holidaySet) {
+        const active = includesDay(task.start, task.finish, day);
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        const complete = active && isCompletedDay(task, day);
+        return {
+            value: active ? "■" : "",
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: active
+                ? (complete
+                    ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
+                    : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
+                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+        };
+    }
+    function buildDateBand(startDate, finishDate) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [];
+        }
+        const days = [];
+        const cursor = new Date(start.getTime());
+        while (cursor.getTime() <= finish.getTime()) {
+            days.push(formatDateOnly(cursor));
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        return days;
+    }
+    function includesDay(startDate, finishDate, day) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        const target = parseDateOnly(day);
+        if (!start || !finish || !target) {
+            return false;
+        }
+        return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
+    }
+    function isCompletedDay(task, day) {
+        const start = parseDateOnly(task.start);
+        const finish = parseDateOnly(task.finish);
+        const target = parseDateOnly(day);
+        if (!start || !finish || !target) {
+            return false;
+        }
+        const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
+        if (totalDays <= 0) {
+            return false;
+        }
+        const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+        const completedDays = Math.floor(totalDays * (percent / 100));
+        const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
+        return dayIndex >= 0 && dayIndex < completedDays;
+    }
+    function isSameDay(day, other) {
+        return day === (other || "").slice(0, 10);
+    }
+    function isWeekend(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        const weekday = target.getDay();
+        return weekday === 0 || weekday === 6;
+    }
+    function parseDateOnly(value) {
+        if (!value || value.length < 10) {
+            return null;
+        }
+        const dateOnly = value.slice(0, 10);
+        const [yearText, monthText, dayText] = dateOnly.split("-");
+        const year = Number(yearText);
+        const month = Number(monthText);
+        const day = Number(dayText);
+        if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+            return null;
+        }
+        return new Date(year, month - 1, day);
+    }
+    function formatDateOnly(value) {
+        return [
+            value.getFullYear(),
+            String(value.getMonth() + 1).padStart(2, "0"),
+            String(value.getDate()).padStart(2, "0")
+        ].join("-");
+    }
+    function formatDateLabel(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+        return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+    }
+    function columnName(index) {
+        let current = index;
+        let name = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            name = String.fromCharCode(65 + remainder) + name;
+            current = Math.floor((current - 1) / 26);
+        }
+        return name;
+    }
+    globalThis.__mikuprojectWbsXlsx = {
+        exportWbsWorkbook
+    };
+})();

--- a/docs/project/src/mikuproject/ts/excel-io.ts
+++ b/docs/project/src/mikuproject/ts/excel-io.ts
@@ -1,0 +1,1095 @@
+(() => {
+  type XlsxPrimitiveValue = string | number | boolean;
+  type XlsxNumberFormat = "general" | "integer" | "decimal" | "date" | "datetime" | "percent";
+  type XlsxHorizontalAlign = "left" | "center" | "right";
+  type XlsxBorderStyle = "thin";
+
+  type XlsxCellModel = {
+    value?: XlsxPrimitiveValue;
+    formula?: string;
+    numberFormat?: XlsxNumberFormat;
+    horizontalAlign?: XlsxHorizontalAlign;
+    bold?: boolean;
+    fillColor?: string;
+    border?: XlsxBorderStyle;
+  };
+
+  type XlsxRowModel = {
+    height?: number;
+    cells: XlsxCellModel[];
+  };
+
+  type XlsxColumnModel = {
+    width?: number;
+  };
+
+  type XlsxSheetModel = {
+    name: string;
+    columns?: XlsxColumnModel[];
+    mergedRanges?: string[];
+    rows: XlsxRowModel[];
+  };
+
+  type XlsxWorkbookModel = {
+    sheets: XlsxSheetModel[];
+  };
+
+  type ZipEntry = {
+    name: string;
+    data: Uint8Array;
+  };
+
+  type StyleDescriptor = {
+    numberFormat: XlsxNumberFormat;
+    horizontalAlign?: XlsxHorizontalAlign;
+    bold?: boolean;
+    fillColor?: string;
+    border?: XlsxBorderStyle;
+  };
+
+  type StyleBook = {
+    styles: StyleDescriptor[];
+    styleIndexByKey: Map<string, number>;
+  };
+
+  type FontDescriptor = {
+    bold?: boolean;
+  };
+
+  type FillDescriptor = {
+    fillColor?: string;
+  };
+
+  type BorderDescriptor = {
+    border?: XlsxBorderStyle;
+  };
+
+  const TEXT_ENCODER = new TextEncoder();
+  const TEXT_DECODER = new TextDecoder();
+  const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
+  const CRC32_TABLE = buildCrc32Table();
+  const NUMBER_FORMATS: XlsxNumberFormat[] = ["general", "integer", "decimal", "date", "datetime", "percent"];
+  const HORIZONTAL_ALIGNS: XlsxHorizontalAlign[] = ["left", "center", "right"];
+  const BORDER_STYLES: XlsxBorderStyle[] = ["thin"];
+  const STYLE_KEY_DELIMITER = "::";
+  const DEFAULT_STYLE: StyleDescriptor = { numberFormat: "general" };
+
+  class XlsxWorkbookCodec {
+    exportWorkbook(workbook: XlsxWorkbookModel): Uint8Array {
+      const normalizedWorkbook = normalizeWorkbook(workbook);
+      const entries = this.createWorkbookEntries(normalizedWorkbook);
+      return packZip(entries);
+    }
+
+    importWorkbook(bytes: Uint8Array): XlsxWorkbookModel {
+      const entries = this.unpackEntries(bytes);
+      return parseWorkbookEntries(entries);
+    }
+
+    listEntries(bytes: Uint8Array): string[] {
+      return Object.keys(this.unpackEntries(bytes)).sort();
+    }
+
+    unpackEntries(bytes: Uint8Array): Record<string, Uint8Array> {
+      return unpackZip(bytes);
+    }
+
+    private createWorkbookEntries(workbook: XlsxWorkbookModel): ZipEntry[] {
+      const styleBook = createStyleBook(workbook);
+      const worksheetRelationships = workbook.sheets.map((sheet, index) => ({
+        relationshipId: `rId${index + 1}`,
+        target: `worksheets/sheet${index + 1}.xml`,
+        name: sheet.name
+      }));
+      const worksheetEntries = workbook.sheets.map((sheet, index) => ({
+        name: `xl/worksheets/sheet${index + 1}.xml`,
+        data: encodeUtf8(buildWorksheetXml(sheet, styleBook))
+      }));
+
+      const entries: ZipEntry[] = [
+        {
+          name: "[Content_Types].xml",
+          data: encodeUtf8(buildContentTypesXml(workbook.sheets.length, styleBook.styles.length > 1))
+        },
+        {
+          name: "_rels/.rels",
+          data: encodeUtf8(buildRootRelationshipsXml())
+        },
+        {
+          name: "xl/_rels/workbook.xml.rels",
+          data: encodeUtf8(buildWorkbookRelationshipsXml(worksheetRelationships, styleBook.styles.length > 1))
+        },
+        {
+          name: "xl/workbook.xml",
+          data: encodeUtf8(buildWorkbookXml(worksheetRelationships))
+        }
+      ];
+
+      if (styleBook.styles.length > 1) {
+        entries.push({
+          name: "xl/styles.xml",
+          data: encodeUtf8(buildStylesXml(styleBook.styles))
+        });
+      }
+
+      entries.push(...worksheetEntries);
+      return entries;
+    }
+  }
+
+  function normalizeWorkbook(workbook: XlsxWorkbookModel): XlsxWorkbookModel {
+    if (!workbook || !Array.isArray(workbook.sheets) || workbook.sheets.length === 0) {
+      throw new Error("Workbook must contain at least one sheet");
+    }
+
+    const seenNames = new Set<string>();
+    return {
+      sheets: workbook.sheets.map((sheet) => {
+        if (!sheet || typeof sheet.name !== "string") {
+          throw new Error("Each sheet must have a valid sheet name");
+        }
+        validateSheetName(sheet.name);
+        const canonicalName = sheet.name.toLocaleLowerCase();
+        if (seenNames.has(canonicalName)) {
+          throw new Error(`Duplicate sheet name is not allowed: ${sheet.name}`);
+        }
+        seenNames.add(canonicalName);
+        return {
+          name: sheet.name,
+          columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+          mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+          rows: Array.isArray(sheet.rows)
+            ? sheet.rows.map((row) => ({
+              height: normalizeOptionalPositiveNumber(row?.height, "Row height"),
+              cells: Array.isArray(row?.cells)
+                ? row.cells.map((cell) => normalizeCell(cell))
+                : []
+            }))
+            : []
+        };
+      })
+    };
+  }
+
+  function normalizeColumn(column: XlsxColumnModel | undefined): XlsxColumnModel {
+    if (!column) {
+      return {};
+    }
+    return {
+      width: normalizeOptionalPositiveNumber(column.width, "Column width")
+    };
+  }
+
+  function normalizeCell(cell: XlsxCellModel | undefined): XlsxCellModel {
+    if (!cell) {
+      return {};
+    }
+    if (cell.value !== undefined && typeof cell.value !== "string" && typeof cell.value !== "number" && typeof cell.value !== "boolean") {
+      throw new Error("Cell value must be string, number, or boolean");
+    }
+    if (cell.formula !== undefined && typeof cell.formula !== "string") {
+      throw new Error("Cell formula must be a string");
+    }
+    if (cell.numberFormat !== undefined && !NUMBER_FORMATS.includes(cell.numberFormat)) {
+      throw new Error(`Unsupported cell number format: ${cell.numberFormat}`);
+    }
+    if (cell.horizontalAlign !== undefined && !HORIZONTAL_ALIGNS.includes(cell.horizontalAlign)) {
+      throw new Error(`Unsupported cell horizontal align: ${cell.horizontalAlign}`);
+    }
+    if (cell.border !== undefined && !BORDER_STYLES.includes(cell.border)) {
+      throw new Error(`Unsupported cell border: ${cell.border}`);
+    }
+    if (cell.fillColor !== undefined) {
+      assertColor(cell.fillColor);
+    }
+    return {
+      value: cell.value,
+      formula: cell.formula,
+      numberFormat: cell.numberFormat,
+      horizontalAlign: cell.horizontalAlign,
+      bold: cell.bold === true ? true : undefined,
+      fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
+      border: cell.border
+    };
+  }
+
+  function normalizeMergedRange(range: string): string {
+    if (typeof range !== "string") {
+      throw new Error("Merged range must be a string");
+    }
+    const trimmed = range.trim().toUpperCase();
+    if (!/^[A-Z]+\d+:[A-Z]+\d+$/.test(trimmed)) {
+      throw new Error(`Invalid merged range: ${range}`);
+    }
+    return trimmed;
+  }
+
+  function normalizeOptionalPositiveNumber(value: number | undefined, label: string): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error(`${label} must be a finite positive number`);
+    }
+    return value;
+  }
+
+  function validateSheetName(name: string): void {
+    if (!name || !name.trim()) {
+      throw new Error("Sheet name must not be empty");
+    }
+    if (name.length > 31) {
+      throw new Error(`Sheet name is too long: ${name}`);
+    }
+    if (INVALID_SHEET_NAME_PATTERN.test(name)) {
+      throw new Error(`Sheet name contains invalid characters: ${name}`);
+    }
+    if (name.startsWith("'") || name.endsWith("'")) {
+      throw new Error(`Sheet name must not start or end with apostrophe: ${name}`);
+    }
+  }
+
+  function assertColor(color: string): void {
+    if (!/^#?[0-9a-fA-F]{6}$/.test(color)) {
+      throw new Error(`Unsupported color format: ${color}`);
+    }
+  }
+
+  function normalizeColor(color: string): string {
+    const hex = color.startsWith("#") ? color.slice(1) : color;
+    return `FF${hex.toUpperCase()}`;
+  }
+
+  function denormalizeColor(color: string | undefined): string | undefined {
+    if (!color) {
+      return undefined;
+    }
+    const normalized = color.toUpperCase();
+    if (/^[0-9A-F]{8}$/.test(normalized)) {
+      return `#${normalized.slice(2)}`;
+    }
+    if (/^[0-9A-F]{6}$/.test(normalized)) {
+      return `#${normalized}`;
+    }
+    return undefined;
+  }
+
+  function buildContentTypesXml(sheetCount: number, includeStyles: boolean): string {
+    const worksheetOverrides = Array.from({ length: sheetCount }, (_unused, index) => (
+      `<Override PartName="/xl/worksheets/sheet${index + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`
+    )).join("");
+    const stylesOverride = includeStyles
+      ? `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>`
+      : "";
+
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  ${worksheetOverrides}
+  ${stylesOverride}
+</Types>`;
+  }
+
+  function buildRootRelationshipsXml(): string {
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`;
+  }
+
+  function buildWorkbookRelationshipsXml(
+    relationships: Array<{ relationshipId: string; target: string }>,
+    includeStyles: boolean
+  ): string {
+    const worksheetNodes = relationships.map((relationship) => (
+      `<Relationship Id="${escapeXml(relationship.relationshipId)}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="${escapeXml(relationship.target)}"/>`
+    )).join("");
+    const stylesNode = includeStyles
+      ? `<Relationship Id="rId${relationships.length + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`
+      : "";
+
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  ${worksheetNodes}
+  ${stylesNode}
+</Relationships>`;
+  }
+
+  function buildWorkbookXml(
+    relationships: Array<{ relationshipId: string; name: string }>
+  ): string {
+    const sheets = relationships.map((relationship, index) => (
+      `<sheet name="${escapeXml(relationship.name)}" sheetId="${index + 1}" r:id="${escapeXml(relationship.relationshipId)}"/>`
+    )).join("");
+
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>${sheets}</sheets>
+</workbook>`;
+  }
+
+  function buildWorksheetXml(sheet: XlsxSheetModel, styleBook: StyleBook): string {
+    const colsXml = buildColumnsXml(sheet.columns);
+    const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+    const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${colsXml}
+  <sheetData>${rows}</sheetData>
+  ${mergeCellsXml}
+</worksheet>`;
+  }
+
+  function buildColumnsXml(columns: XlsxColumnModel[] | undefined): string {
+    if (!columns || columns.length === 0 || columns.every((column) => column.width === undefined)) {
+      return "";
+    }
+    const cols = columns.map((column, index) => (
+      column.width !== undefined
+        ? `<col min="${index + 1}" max="${index + 1}" width="${formatNumber(column.width)}" customWidth="1"/>`
+        : ""
+    )).filter(Boolean).join("");
+    return cols ? `<cols>${cols}</cols>` : "";
+  }
+
+  function buildMergeCellsXml(mergedRanges: string[] | undefined): string {
+    if (!mergedRanges || mergedRanges.length === 0) {
+      return "";
+    }
+    const mergeCells = mergedRanges
+      .map((range) => `<mergeCell ref="${range}"/>`)
+      .join("");
+    return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+  }
+
+  function buildWorksheetRowXml(row: XlsxRowModel, rowIndex: number, styleBook: StyleBook): string {
+    const cells = row.cells
+      .map((cell, cellIndex) => buildWorksheetCellXml(cell, rowIndex, cellIndex, styleBook))
+      .filter(Boolean)
+      .join("");
+
+    if (!cells) {
+      return "";
+    }
+
+    const heightAttributes = row.height !== undefined
+      ? ` ht="${formatNumber(row.height)}" customHeight="1"`
+      : "";
+    return `<row r="${rowIndex + 1}"${heightAttributes}>${cells}</row>`;
+  }
+
+  function buildWorksheetCellXml(cell: XlsxCellModel, rowIndex: number, cellIndex: number, styleBook: StyleBook): string {
+    const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
+    const styleIndex = resolveStyleIndex(cell, styleBook);
+    const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+
+    if (cell.formula !== undefined) {
+      const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
+      const valueXml = buildFormulaValueXml(cell.value);
+      const typeAttribute = getCellTypeAttribute(cell.value, true);
+      return `<c r="${reference}"${styleAttribute}${typeAttribute}>${formulaXml}${valueXml}</c>`;
+    }
+
+    if (cell.value === undefined) {
+      return "";
+    }
+
+    if (typeof cell.value === "string") {
+      return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+    }
+    if (typeof cell.value === "number") {
+      return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
+    }
+    return `<c r="${reference}"${styleAttribute} t="b"><v>${cell.value ? "1" : "0"}</v></c>`;
+  }
+
+  function buildFormulaValueXml(value: XlsxPrimitiveValue | undefined): string {
+    if (value === undefined) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return `<v>${escapeXml(value)}</v>`;
+    }
+    if (typeof value === "number") {
+      return `<v>${formatNumber(value)}</v>`;
+    }
+    return `<v>${value ? "1" : "0"}</v>`;
+  }
+
+  function getCellTypeAttribute(value: XlsxPrimitiveValue | undefined, hasFormula: boolean): string {
+    if (!hasFormula) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return ` t="str"`;
+    }
+    if (typeof value === "boolean") {
+      return ` t="b"`;
+    }
+    return "";
+  }
+
+  function formatNumber(value: number): string {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Cell number must be finite: ${value}`);
+    }
+    return String(value);
+  }
+
+  function createStyleBook(workbook: XlsxWorkbookModel): StyleBook {
+    const styles: StyleDescriptor[] = [DEFAULT_STYLE];
+    const styleIndexByKey = new Map<string, number>([[styleKey(DEFAULT_STYLE), 0]]);
+
+    for (const sheet of workbook.sheets) {
+      for (const row of sheet.rows) {
+        for (const cell of row.cells) {
+          const descriptor = getStyleDescriptor(cell);
+          if (!descriptor) {
+            continue;
+          }
+          const key = styleKey(descriptor);
+          if (!styleIndexByKey.has(key)) {
+            styleIndexByKey.set(key, styles.length);
+            styles.push(descriptor);
+          }
+        }
+      }
+    }
+
+    return { styles, styleIndexByKey };
+  }
+
+  function getStyleDescriptor(cell: XlsxCellModel): StyleDescriptor | null {
+    if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+      return null;
+    }
+    return {
+      numberFormat: cell.numberFormat || "general",
+      horizontalAlign: cell.horizontalAlign,
+      bold: cell.bold === true ? true : undefined,
+      fillColor: cell.fillColor,
+      border: cell.border
+    };
+  }
+
+  function styleKey(style: StyleDescriptor): string {
+    return [
+      style.numberFormat,
+      style.horizontalAlign || "",
+      style.bold ? "bold" : "",
+      style.fillColor || "",
+      style.border || ""
+    ].join(STYLE_KEY_DELIMITER);
+  }
+
+  function resolveStyleIndex(cell: XlsxCellModel, styleBook: StyleBook): number {
+    const descriptor = getStyleDescriptor(cell);
+    if (!descriptor) {
+      return 0;
+    }
+    return styleBook.styleIndexByKey.get(styleKey(descriptor)) || 0;
+  }
+
+  function buildStylesXml(styles: StyleDescriptor[]): string {
+    const fonts = dedupeDescriptors(styles.map((style) => ({ bold: style.bold } as FontDescriptor)), fontKey, { bold: undefined });
+    const fills = dedupeDescriptors(styles.map((style) => ({ fillColor: style.fillColor } as FillDescriptor)), fillKey, { fillColor: undefined });
+    const borders = dedupeDescriptors(styles.map((style) => ({ border: style.border } as BorderDescriptor)), borderKey, { border: undefined });
+
+    const styleNodes = styles.map((style) => {
+      const numFmtId = mapNumberFormatId(style.numberFormat);
+      const fontId = fonts.indexByKey.get(fontKey({ bold: style.bold })) || 0;
+      const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
+      const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
+      const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
+      const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+      const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
+      const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
+      const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
+      const alignmentNode = style.horizontalAlign
+        ? `<alignment horizontal="${style.horizontalAlign}"/>`
+        : "";
+      return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
+    }).join("");
+
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <numFmts count="0"/>
+  <fonts count="${fonts.items.length}">
+    ${fonts.items.map(buildFontXml).join("")}
+  </fonts>
+  <fills count="${fills.items.length}">
+    ${fills.items.map(buildFillXml).join("")}
+  </fills>
+  <borders count="${borders.items.length}">
+    ${borders.items.map(buildBorderXml).join("")}
+  </borders>
+  <cellStyleXfs count="1">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+  </cellStyleXfs>
+  <cellXfs count="${styles.length}">
+    ${styleNodes}
+  </cellXfs>
+  <cellStyles count="1">
+    <cellStyle name="Normal" xfId="0" builtinId="0"/>
+  </cellStyles>
+</styleSheet>`;
+  }
+
+  function dedupeDescriptors<T>(items: T[], keyFn: (item: T) => string, defaultItem: T): { items: T[]; indexByKey: Map<string, number> } {
+    const uniqueItems: T[] = [defaultItem];
+    const indexByKey = new Map<string, number>([[keyFn(defaultItem), 0]]);
+    for (const item of items) {
+      const key = keyFn(item);
+      if (!indexByKey.has(key)) {
+        indexByKey.set(key, uniqueItems.length);
+        uniqueItems.push(item);
+      }
+    }
+    return { items: uniqueItems, indexByKey };
+  }
+
+  function fontKey(font: FontDescriptor): string {
+    return font.bold ? "bold" : "";
+  }
+
+  function fillKey(fill: FillDescriptor): string {
+    return fill.fillColor || "";
+  }
+
+  function borderKey(border: BorderDescriptor): string {
+    return border.border || "";
+  }
+
+  function buildFontXml(font: FontDescriptor): string {
+    return font.bold ? `<font><b/></font>` : `<font/>`;
+  }
+
+  function buildFillXml(fill: FillDescriptor): string {
+    if (!fill.fillColor) {
+      return `<fill><patternFill patternType="none"/></fill>`;
+    }
+    return `<fill><patternFill patternType="solid"><fgColor rgb="${fill.fillColor}"/><bgColor indexed="64"/></patternFill></fill>`;
+  }
+
+  function buildBorderXml(border: BorderDescriptor): string {
+    if (!border.border) {
+      return `<border/>`;
+    }
+    return `<border><left style="${border.border}"/><right style="${border.border}"/><top style="${border.border}"/><bottom style="${border.border}"/><diagonal/></border>`;
+  }
+
+  function mapNumberFormatId(numberFormat: XlsxNumberFormat): number {
+    switch (numberFormat) {
+      case "integer":
+        return 1;
+      case "decimal":
+        return 2;
+      case "date":
+        return 14;
+      case "datetime":
+        return 22;
+      case "percent":
+        return 10;
+      case "general":
+      default:
+        return 0;
+    }
+  }
+
+  function parseWorkbookEntries(entries: Record<string, Uint8Array>): XlsxWorkbookModel {
+    const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
+    const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
+    const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+    const workbookDocument = parseXmlDocument(workbookXml);
+    const relationshipsDocument = parseXmlDocument(workbookRelsXml);
+    const styleBook = parseStylesXml(stylesXml);
+    const relationshipMap = new Map<string, string>();
+    const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/package/2006/relationships",
+      "Relationship"
+    ));
+
+    for (const relationshipElement of relationshipElements) {
+      const id = relationshipElement.getAttribute("Id");
+      const target = relationshipElement.getAttribute("Target");
+      if (id && target) {
+        relationshipMap.set(id, normalizeWorkbookTarget(target));
+      }
+    }
+
+    const sheetElements = Array.from(workbookDocument.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "sheet"
+    ));
+
+    return {
+      sheets: sheetElements.map((sheetElement) => {
+        const name = sheetElement.getAttribute("name") || "";
+        validateSheetName(name);
+        const relationshipId = sheetElement.getAttributeNS(
+          "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+          "id"
+        ) || sheetElement.getAttribute("r:id");
+        if (!relationshipId) {
+          throw new Error(`Worksheet relationship id is missing for sheet: ${name}`);
+        }
+        const target = relationshipMap.get(relationshipId);
+        if (!target) {
+          throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
+        }
+        const worksheetXml = decodeRequiredEntry(entries, target);
+        return parseWorksheetXml(name, worksheetXml, styleBook);
+      })
+    };
+  }
+
+  function normalizeWorkbookTarget(target: string): string {
+    return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
+  }
+
+  function parseWorksheetXml(name: string, xmlText: string, styleBook: StyleDescriptor[]): XlsxSheetModel {
+    const document = parseXmlDocument(xmlText);
+    const rowElements = Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "row"
+    ));
+
+    return {
+      name,
+      columns: parseWorksheetColumns(document),
+      mergedRanges: parseWorksheetMergedRanges(document),
+      rows: rowElements.map((rowElement) => ({
+        height: parseOptionalNumber(rowElement.getAttribute("ht")),
+        cells: parseWorksheetRowCells(rowElement, styleBook)
+      }))
+    };
+  }
+
+  function parseWorksheetColumns(document: XMLDocument): XlsxColumnModel[] | undefined {
+    const colElements = Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "col"
+    ));
+    if (colElements.length === 0) {
+      return undefined;
+    }
+    const columns: XlsxColumnModel[] = [];
+    for (const colElement of colElements) {
+      const min = Number(colElement.getAttribute("min") || "0");
+      const max = Number(colElement.getAttribute("max") || "0");
+      const width = parseOptionalNumber(colElement.getAttribute("width"));
+      for (let index = min; index <= max; index += 1) {
+        columns[index - 1] = { width };
+      }
+    }
+    while (columns.length > 0 && !columns[columns.length - 1]) {
+      columns.pop();
+    }
+    return columns.length > 0 ? columns.map((column) => column || {}) : undefined;
+  }
+
+  function parseWorksheetMergedRanges(document: XMLDocument): string[] | undefined {
+    const mergeCellElements = Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "mergeCell"
+    ));
+    if (mergeCellElements.length === 0) {
+      return undefined;
+    }
+    return mergeCellElements
+      .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
+      .filter(Boolean);
+  }
+
+  function parseWorksheetRowCells(rowElement: Element, styleBook: StyleDescriptor[]): XlsxCellModel[] {
+    const cells: XlsxCellModel[] = [];
+    const cellElements = Array.from(rowElement.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "c"
+    )).filter((element) => element.parentElement === rowElement);
+
+    for (const cellElement of cellElements) {
+      const reference = cellElement.getAttribute("r") || "";
+      const columnIndex = decodeColumnReference(reference);
+      while (cells.length < columnIndex) {
+        cells.push({});
+      }
+      cells.push(parseWorksheetCell(cellElement, styleBook));
+    }
+
+    return cells;
+  }
+
+  function parseWorksheetCell(cellElement: Element, styleBook: StyleDescriptor[]): XlsxCellModel {
+    const type = cellElement.getAttribute("t") || "";
+    const styleIndex = Number(cellElement.getAttribute("s") || "0");
+    const formulaElement = findDirectChild(cellElement, "f");
+    const valueElement = findDirectChild(cellElement, "v");
+    const inlineStringElement = findDirectChild(cellElement, "is");
+    let value: XlsxPrimitiveValue | undefined;
+
+    if (type === "inlineStr") {
+      const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
+      value = textElement ? (textElement.textContent || "") : "";
+    } else if (type === "b") {
+      value = valueElement?.textContent === "1";
+    } else if (type === "str") {
+      value = valueElement?.textContent || "";
+    } else if (valueElement) {
+      const rawValue = valueElement.textContent || "";
+      value = rawValue === "" ? "" : Number(rawValue);
+    }
+
+    const style = styleBook[styleIndex] || DEFAULT_STYLE;
+    const cell: XlsxCellModel = {};
+    if (style.numberFormat !== "general") {
+      cell.numberFormat = style.numberFormat;
+    }
+    if (style.horizontalAlign) {
+      cell.horizontalAlign = style.horizontalAlign;
+    }
+    if (style.bold) {
+      cell.bold = true;
+    }
+    if (style.fillColor) {
+      cell.fillColor = denormalizeColor(style.fillColor);
+    }
+    if (style.border) {
+      cell.border = style.border;
+    }
+    if (formulaElement) {
+      cell.formula = formulaElement.textContent || "";
+    }
+    if (value !== undefined) {
+      cell.value = value;
+    }
+    return cell;
+  }
+
+  function parseStylesXml(xmlText: string | null): StyleDescriptor[] {
+    if (!xmlText) {
+      return [DEFAULT_STYLE];
+    }
+    const document = parseXmlDocument(xmlText);
+    const fonts = parseFonts(document);
+    const fills = parseFills(document);
+    const borders = parseBorders(document);
+    const xfElements = Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "xf"
+    )).filter((element) => element.parentElement?.localName === "cellXfs");
+
+    if (xfElements.length === 0) {
+      return [DEFAULT_STYLE];
+    }
+
+    return xfElements.map((xfElement) => {
+      const numFmtId = Number(xfElement.getAttribute("numFmtId") || "0");
+      const fontId = Number(xfElement.getAttribute("fontId") || "0");
+      const fillId = Number(xfElement.getAttribute("fillId") || "0");
+      const borderId = Number(xfElement.getAttribute("borderId") || "0");
+      const alignmentElement = findDirectChild(xfElement, "alignment");
+      const horizontalAlign = alignmentElement?.getAttribute("horizontal") as XlsxHorizontalAlign | null;
+      return {
+        numberFormat: parseNumberFormatId(numFmtId),
+        horizontalAlign: horizontalAlign || undefined,
+        bold: fonts[fontId]?.bold ? true : undefined,
+        fillColor: fills[fillId]?.fillColor,
+        border: borders[borderId]?.border
+      };
+    });
+  }
+
+  function parseFonts(document: XMLDocument): FontDescriptor[] {
+    return Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "font"
+    )).map((fontElement) => ({
+      bold: findDirectChild(fontElement, "b") ? true : undefined
+    }));
+  }
+
+  function parseFills(document: XMLDocument): FillDescriptor[] {
+    return Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "fill"
+    )).map((fillElement) => {
+      const patternFill = findDirectChild(fillElement, "patternFill");
+      const fgColor = patternFill ? findDirectChild(patternFill, "fgColor") : null;
+      return {
+        fillColor: fgColor?.getAttribute("rgb") || undefined
+      };
+    });
+  }
+
+  function parseBorders(document: XMLDocument): BorderDescriptor[] {
+    return Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "border"
+    )).map((borderElement) => {
+      const left = findDirectChild(borderElement, "left");
+      const style = left?.getAttribute("style") as XlsxBorderStyle | null;
+      return {
+        border: style && BORDER_STYLES.includes(style) ? style : undefined
+      };
+    });
+  }
+
+  function parseNumberFormatId(numFmtId: number): XlsxNumberFormat {
+    switch (numFmtId) {
+      case 1:
+        return "integer";
+      case 2:
+        return "decimal";
+      case 10:
+        return "percent";
+      case 14:
+        return "date";
+      case 22:
+        return "datetime";
+      default:
+        return "general";
+    }
+  }
+
+  function parseOptionalNumber(value: string | null): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+    return Number(value);
+  }
+
+  function findDirectChild(element: Element, localName: string): Element | null {
+    for (const childNode of Array.from(element.childNodes)) {
+      if (childNode.nodeType !== Node.ELEMENT_NODE) {
+        continue;
+      }
+      const childElement = childNode as Element;
+      if (childElement.localName === localName) {
+        return childElement;
+      }
+    }
+    return null;
+  }
+
+  function parseXmlDocument(xmlText: string): XMLDocument {
+    const document = new DOMParser().parseFromString(xmlText, "application/xml");
+    if (document.querySelector("parsererror")) {
+      throw new Error("Failed to parse XML document");
+    }
+    return document;
+  }
+
+  function decodeRequiredEntry(entries: Record<string, Uint8Array>, name: string): string {
+    const bytes = entries[name];
+    if (!bytes) {
+      throw new Error(`Required ZIP entry is missing: ${name}`);
+    }
+    return decodeUtf8(bytes);
+  }
+
+  function encodeUtf8(value: string): Uint8Array {
+    return TEXT_ENCODER.encode(value);
+  }
+
+  function decodeUtf8(bytes: Uint8Array): string {
+    return TEXT_DECODER.decode(bytes);
+  }
+
+  function escapeXml(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+  }
+
+  function encodeColumnName(columnIndex: number): string {
+    let current = columnIndex + 1;
+    let result = "";
+    while (current > 0) {
+      const remainder = (current - 1) % 26;
+      result = String.fromCharCode(65 + remainder) + result;
+      current = Math.floor((current - 1) / 26);
+    }
+    return result;
+  }
+
+  function decodeColumnReference(reference: string): number {
+    const match = /^([A-Z]+)\d+$/i.exec(reference);
+    if (!match) {
+      throw new Error(`Invalid cell reference: ${reference}`);
+    }
+    const letters = match[1].toUpperCase();
+    let value = 0;
+    for (const character of letters) {
+      value = (value * 26) + (character.charCodeAt(0) - 64);
+    }
+    return value - 1;
+  }
+
+  function packZip(entries: ZipEntry[]): Uint8Array {
+    const localParts: Uint8Array[] = [];
+    const centralParts: Uint8Array[] = [];
+    let offset = 0;
+
+    for (const entry of entries) {
+      const nameBytes = encodeUtf8(entry.name);
+      const crc32 = computeCrc32(entry.data);
+      const localHeader = new Uint8Array(30 + nameBytes.length);
+      const localView = new DataView(localHeader.buffer);
+      localView.setUint32(0, 0x04034b50, true);
+      localView.setUint16(4, 20, true);
+      localView.setUint16(6, 0, true);
+      localView.setUint16(8, 0, true);
+      localView.setUint16(10, 0, true);
+      localView.setUint16(12, 0, true);
+      localView.setUint32(14, crc32, true);
+      localView.setUint32(18, entry.data.byteLength, true);
+      localView.setUint32(22, entry.data.byteLength, true);
+      localView.setUint16(26, nameBytes.length, true);
+      localView.setUint16(28, 0, true);
+      localHeader.set(nameBytes, 30);
+
+      const centralHeader = new Uint8Array(46 + nameBytes.length);
+      const centralView = new DataView(centralHeader.buffer);
+      centralView.setUint32(0, 0x02014b50, true);
+      centralView.setUint16(4, 20, true);
+      centralView.setUint16(6, 20, true);
+      centralView.setUint16(8, 0, true);
+      centralView.setUint16(10, 0, true);
+      centralView.setUint16(12, 0, true);
+      centralView.setUint16(14, 0, true);
+      centralView.setUint32(16, crc32, true);
+      centralView.setUint32(20, entry.data.byteLength, true);
+      centralView.setUint32(24, entry.data.byteLength, true);
+      centralView.setUint16(28, nameBytes.length, true);
+      centralView.setUint16(30, 0, true);
+      centralView.setUint16(32, 0, true);
+      centralView.setUint16(34, 0, true);
+      centralView.setUint16(36, 0, true);
+      centralView.setUint32(38, 0, true);
+      centralView.setUint32(42, offset, true);
+      centralHeader.set(nameBytes, 46);
+
+      localParts.push(localHeader, entry.data);
+      centralParts.push(centralHeader);
+      offset += localHeader.byteLength + entry.data.byteLength;
+    }
+
+    const centralDirectoryOffset = offset;
+    const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+    const endOfCentralDirectory = new Uint8Array(22);
+    const endView = new DataView(endOfCentralDirectory.buffer);
+    endView.setUint32(0, 0x06054b50, true);
+    endView.setUint16(4, 0, true);
+    endView.setUint16(6, 0, true);
+    endView.setUint16(8, entries.length, true);
+    endView.setUint16(10, entries.length, true);
+    endView.setUint32(12, centralDirectorySize, true);
+    endView.setUint32(16, centralDirectoryOffset, true);
+    endView.setUint16(20, 0, true);
+
+    return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+  }
+
+  function unpackZip(bytes: Uint8Array): Record<string, Uint8Array> {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const endOffset = findEndOfCentralDirectoryOffset(bytes);
+    const totalEntries = view.getUint16(endOffset + 10, true);
+    const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+    const entries: Record<string, Uint8Array> = {};
+    let pointer = centralDirectoryOffset;
+
+    for (let index = 0; index < totalEntries; index += 1) {
+      if (view.getUint32(pointer, true) !== 0x02014b50) {
+        throw new Error("Invalid ZIP central directory header");
+      }
+
+      const compressionMethod = view.getUint16(pointer + 10, true);
+      const compressedSize = view.getUint32(pointer + 20, true);
+      const uncompressedSize = view.getUint32(pointer + 24, true);
+      const fileNameLength = view.getUint16(pointer + 28, true);
+      const extraLength = view.getUint16(pointer + 30, true);
+      const commentLength = view.getUint16(pointer + 32, true);
+      const localHeaderOffset = view.getUint32(pointer + 42, true);
+      const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+      const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+      if (localView.getUint32(0, true) !== 0x04034b50) {
+        throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+      }
+      const localFileNameLength = localView.getUint16(26, true);
+      const localExtraLength = localView.getUint16(28, true);
+      const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+      const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+
+      if (compressionMethod !== 0) {
+        throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+      }
+      if (compressedSize !== uncompressedSize) {
+        throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+      }
+
+      entries[fileName] = data;
+      pointer += 46 + fileNameLength + extraLength + commentLength;
+    }
+
+    return entries;
+  }
+
+  function findEndOfCentralDirectoryOffset(bytes: Uint8Array): number {
+    for (let index = bytes.byteLength - 22; index >= 0; index -= 1) {
+      if (
+        bytes[index] === 0x50 &&
+        bytes[index + 1] === 0x4b &&
+        bytes[index + 2] === 0x05 &&
+        bytes[index + 3] === 0x06
+      ) {
+        return index;
+      }
+    }
+    throw new Error("ZIP end of central directory not found");
+  }
+
+  function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
+    const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const part of parts) {
+      result.set(part, offset);
+      offset += part.byteLength;
+    }
+    return result;
+  }
+
+  function computeCrc32(bytes: Uint8Array): number {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+      crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xff];
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  function buildCrc32Table(): Uint32Array {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < 256; index += 1) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+      }
+      table[index] = value >>> 0;
+    }
+    return table;
+  }
+
+  (globalThis as typeof globalThis & {
+    __mikuprojectExcelIo?: {
+      XlsxWorkbookCodec: typeof XlsxWorkbookCodec;
+    };
+  }).__mikuprojectExcelIo = {
+    XlsxWorkbookCodec
+  };
+})();

--- a/docs/project/src/mikuproject/ts/main.ts
+++ b/docs/project/src/mikuproject/ts/main.ts
@@ -16,6 +16,51 @@
     throw new Error("mikuproject XML module is not loaded");
   }
 
+  const mikuprojectExcelIo = (globalThis as typeof globalThis & {
+    __mikuprojectExcelIo?: {
+      XlsxWorkbookCodec: new () => {
+        exportWorkbook: (workbook: unknown) => Uint8Array;
+        importWorkbook: (bytes: Uint8Array) => unknown;
+      };
+    };
+  }).__mikuprojectExcelIo;
+
+  if (!mikuprojectExcelIo) {
+    throw new Error("mikuproject Excel IO module is not loaded");
+  }
+
+  const mikuprojectProjectXlsx = (globalThis as typeof globalThis & {
+    __mikuprojectProjectXlsx?: {
+      exportProjectWorkbook: (model: ProjectModel) => unknown;
+      importProjectWorkbook: (workbook: unknown, baseModel: ProjectModel) => ProjectModel;
+      importProjectWorkbookDetailed: (workbook: unknown, baseModel: ProjectModel) => {
+        model: ProjectModel;
+        changes: Array<{
+          scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+          uid: string;
+          label: string;
+          field: string;
+          before: string | number | boolean | undefined;
+          after: string | number | boolean;
+        }>;
+      };
+    };
+  }).__mikuprojectProjectXlsx;
+
+  if (!mikuprojectProjectXlsx) {
+    throw new Error("mikuproject Project XLSX module is not loaded");
+  }
+
+  const mikuprojectWbsXlsx = (globalThis as typeof globalThis & {
+    __mikuprojectWbsXlsx?: {
+      exportWbsWorkbook: (model: ProjectModel, options?: { holidayDates?: string[] }) => unknown;
+    };
+  }).__mikuprojectWbsXlsx;
+
+  if (!mikuprojectWbsXlsx) {
+    throw new Error("mikuproject WBS XLSX module is not loaded");
+  }
+
   const mermaidApi = (globalThis as typeof globalThis & {
     mermaid?: {
       initialize: (config: Record<string, unknown>) => void;
@@ -26,6 +71,8 @@
   let currentModel: ProjectModel | null = null;
   let currentMermaidSvg = "";
   let mermaidRenderCount = 0;
+  let lastSavedXmlText = "";
+  let lastSavedXmlStamp = "";
 
   function getElement<T extends HTMLElement>(id: string): T {
     const element = document.getElementById(id);
@@ -37,6 +84,32 @@
 
   function getTextArea(id: string): HTMLTextAreaElement {
     return getElement<HTMLTextAreaElement>(id);
+  }
+
+  function parseWbsHolidayDates(): string[] {
+    const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+    if (!raw) {
+      return [];
+    }
+    const seen = new Set<string>();
+    const holidays: string[] = [];
+    for (const token of raw.split(/[\s,、;]+/)) {
+      const value = token.trim();
+      if (!value) {
+        continue;
+      }
+      const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+      if (!match) {
+        continue;
+      }
+      const dateText = match[1];
+      if (seen.has(dateText)) {
+        continue;
+      }
+      seen.add(dateText);
+      holidays.push(dateText);
+    }
+    return holidays;
   }
 
   function showToast(message: string): void {
@@ -131,6 +204,40 @@
 
   function setStatus(message: string): void {
     getElement<HTMLElement>("statusMessage").textContent = message;
+  }
+
+  function formatSaveStamp(date: Date): string {
+    return [
+      date.getFullYear(),
+      String(date.getMonth() + 1).padStart(2, "0"),
+      String(date.getDate()).padStart(2, "0")
+    ].join("-") + " " + [
+      String(date.getHours()).padStart(2, "0"),
+      String(date.getMinutes()).padStart(2, "0")
+    ].join(":");
+  }
+
+  function updateXmlSaveState(isDirty: boolean): void {
+    const node = getElement<HTMLElement>("xmlSaveState");
+    node.textContent = isDirty
+      ? "XML 保存状態: 未保存"
+      : `XML 保存状態: 保存済み (${lastSavedXmlStamp || "-"})`;
+    node.classList.toggle("md-save-state--dirty", isDirty);
+    node.classList.toggle("md-save-state--clean", !isDirty);
+  }
+
+  function markXmlDirty(): void {
+    updateXmlSaveState(true);
+  }
+
+  function markXmlSavedCurrent(): void {
+    lastSavedXmlText = getTextArea("xmlInput").value;
+    lastSavedXmlStamp = formatSaveStamp(new Date());
+    updateXmlSaveState(false);
+  }
+
+  function refreshXmlSaveState(): void {
+    updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
   }
 
   function renderPreviewList(containerId: string, items: string[]): void {
@@ -251,9 +358,12 @@
 
   function renderValidationIssues(issues: ValidationIssue[]): void {
     const container = getElement<HTMLElement>("validationIssues");
+    const label = container.previousElementSibling as HTMLElement | null;
     if (issues.length === 0) {
       container.classList.add("md-hidden");
       container.innerHTML = "";
+      label?.classList.add("md-hidden");
+      updateFeedbackVisibility();
       return;
     }
     const sections: ValidationIssue["scope"][] = ["project", "tasks", "resources", "assignments", "calendars"];
@@ -265,6 +375,7 @@
       calendars: "Calendars"
     };
     container.classList.remove("md-hidden");
+    label?.classList.remove("md-hidden");
     container.innerHTML = `
       <div class="md-issues__title">検証メッセージ</div>
       ${sections
@@ -284,6 +395,143 @@
         })
         .join("")}
     `;
+    updateFeedbackVisibility();
+  }
+
+  function renderXlsxImportSummary(changes: Array<{
+    scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+    uid: string;
+    label: string;
+    field: string;
+    before: string | number | boolean | undefined;
+    after: string | number | boolean;
+  }>): void {
+    const container = getElement<HTMLElement>("xlsxImportSummary");
+    const label = container.previousElementSibling as HTMLElement | null;
+    if (changes.length === 0) {
+      container.classList.add("md-hidden");
+      container.innerHTML = "";
+      label?.classList.add("md-hidden");
+      updateFeedbackVisibility();
+      return;
+    }
+    const scopeLabel: Record<"project" | "tasks" | "resources" | "assignments" | "calendars", string> = {
+      project: "Project",
+      tasks: "Tasks",
+      resources: "Resources",
+      assignments: "Assignments",
+      calendars: "Calendars"
+    };
+    const scopeCounts: Record<"project" | "tasks" | "resources" | "assignments" | "calendars", number> = {
+      project: 0,
+      tasks: 0,
+      resources: 0,
+      assignments: 0,
+      calendars: 0
+    };
+    const groupedByScope = new Map<"project" | "tasks" | "resources" | "assignments" | "calendars", Array<{
+      uid: string;
+      label: string;
+      items: Array<{
+        field: string;
+        before: string | number | boolean | undefined;
+        after: string | number | boolean;
+      }>;
+    }>>();
+    const groupedChanges = new Map<string, {
+      scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+      uid: string;
+      label: string;
+      items: Array<{
+        field: string;
+        before: string | number | boolean | undefined;
+        after: string | number | boolean;
+      }>;
+    }>();
+    for (const change of changes) {
+      const groupKey = `${change.scope}:${change.uid}:${change.label}`;
+      const currentGroup = groupedChanges.get(groupKey);
+      if (currentGroup) {
+        currentGroup.items.push({
+          field: change.field,
+          before: change.before,
+          after: change.after
+        });
+        continue;
+      }
+      groupedChanges.set(groupKey, {
+        scope: change.scope,
+        uid: change.uid,
+        label: change.label,
+        items: [{
+          field: change.field,
+          before: change.before,
+          after: change.after
+        }]
+      });
+      scopeCounts[change.scope] += 1;
+    }
+    for (const group of groupedChanges.values()) {
+      const scopedGroups = groupedByScope.get(group.scope) || [];
+      scopedGroups.push({
+        uid: group.uid,
+        label: group.label,
+        items: group.items
+      });
+      groupedByScope.set(group.scope, scopedGroups);
+    }
+    const changedScopes = (["project", "tasks", "resources", "assignments", "calendars"] as const).filter((scope) => scopeCounts[scope] > 0);
+    const unchangedScopes = (["project", "tasks", "resources", "assignments", "calendars"] as const).filter((scope) => scopeCounts[scope] === 0);
+    container.classList.remove("md-hidden");
+    label?.classList.remove("md-hidden");
+    container.innerHTML = `
+      <div class="md-xlsx-summary__title">XLSX Import 反映結果</div>
+      <div class="md-xlsx-summary__counts">
+        ${changedScopes.map((scope) => `<span class="md-xlsx-summary__count">${scopeLabel[scope]} ${scopeCounts[scope]}</span>`).join("")}
+      </div>
+      ${unchangedScopes.length > 0 ? `<div class="md-xlsx-summary__unchanged">変更なし: ${unchangedScopes.map((scope) => scopeLabel[scope]).join(", ")}</div>` : ""}
+      ${changedScopes.map((scope) => `
+        <div class="md-xlsx-summary__section">
+          <div class="md-xlsx-summary__section-title">${scopeLabel[scope]}</div>
+          <ul class="md-xlsx-summary__list">
+            ${(groupedByScope.get(scope) || []).map((group) => `
+              <li class="md-xlsx-summary__item">
+                <div class="md-xlsx-summary__item-title">UID=${group.uid} ${escapeHtml(group.label)}</div>
+                <div class="md-xlsx-summary__item-body">
+                  ${group.items.map((item) => `${escapeHtml(item.field)}: ${escapeHtml(formatChangeValue(item.before))} -> ${escapeHtml(formatChangeValue(item.after))}`).join(" / ")}
+                </div>
+              </li>
+            `).join("")}
+          </ul>
+        </div>
+      `).join("")}
+      <div class="md-xlsx-summary__hint">反映後の XML は更新済みです。必要なら XML Export で保存できます。</div>
+    `;
+    updateFeedbackVisibility();
+  }
+
+  function updateFeedbackVisibility(): void {
+    const stack = document.querySelector<HTMLElement>(".md-feedback-stack");
+    const validationIssues = getElement<HTMLElement>("validationIssues");
+    const xlsxImportSummary = getElement<HTMLElement>("xlsxImportSummary");
+    const shouldShow = !validationIssues.classList.contains("md-hidden") || !xlsxImportSummary.classList.contains("md-hidden");
+    stack?.classList.toggle("md-hidden", !shouldShow);
+  }
+
+  function formatChangeValue(value: string | number | boolean | undefined): string {
+    if (value === undefined) {
+      return "(empty)";
+    }
+    return String(value);
+  }
+
+  function escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
 
   function updateSummary(model: ProjectModel | null): void {
@@ -362,6 +610,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   function loadSample(): void {
     getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+    markXmlDirty();
     setStatus("サンプル XML を読み込みました");
   }
 
@@ -371,12 +620,26 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     const xmlText = await file.text();
     getTextArea("xmlInput").value = xmlText;
+    markXmlDirty();
     currentModel = mikuprojectXml.importMsProjectXml(xmlText);
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
+    renderXlsxImportSummary([]);
     setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
     showToast("XML を読み込んで解析しました");
+  }
+
+  function ensureCurrentModel(): ProjectModel {
+    if (currentModel) {
+      return currentModel;
+    }
+    const xmlText = getTextArea("xmlInput").value.trim();
+    if (!xmlText) {
+      throw new Error("内部モデルがありません");
+    }
+    currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+    return currentModel;
   }
 
   function parseCurrentXml(): void {
@@ -389,6 +652,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
+    renderXlsxImportSummary([]);
     setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
     showToast("XML を解析しました");
   }
@@ -399,7 +663,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       return;
     }
     getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+    markXmlDirty();
     renderValidationIssues([]);
+    renderXlsxImportSummary([]);
     setStatus("内部モデルから XML を再生成しました");
     showToast("XML を再生成しました");
   }
@@ -426,6 +692,74 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     showToast("CSV を生成しました");
   }
 
+  function exportCurrentXlsx(): void {
+    const model = ensureCurrentModel();
+    const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+    const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook(workbook);
+    const now = new Date();
+    const stamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0")
+    ].join("");
+    downloadBlob(
+      new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }),
+      `mikuproject-export-${stamp}.xlsx`
+    );
+    setStatus("XLSX ファイルをエクスポートしました");
+    showToast("XLSX を保存しました");
+  }
+
+  function exportCurrentWbsXlsx(): void {
+    const model = ensureCurrentModel();
+    const holidayDates = parseWbsHolidayDates();
+    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+    const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook(workbook);
+    const now = new Date();
+    const stamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0")
+    ].join("");
+    downloadBlob(
+      new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }),
+      `mikuproject-wbs-${stamp}.xlsx`
+    );
+    setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+    showToast("WBS XLSX を保存しました");
+  }
+
+  async function importXlsxFromFile(file: File | null | undefined): Promise<void> {
+    if (!file) {
+      return;
+    }
+    const baseModel = ensureCurrentModel();
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = codec.importWorkbook(bytes);
+    const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
+    currentModel = result.model;
+    const issues = mikuprojectXml.validateProjectModel(currentModel);
+    updateSummary(currentModel);
+    renderValidationIssues(issues);
+    renderXlsxImportSummary(result.changes);
+    if (result.changes.length > 0) {
+      getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+      markXmlDirty();
+    }
+    const summaryText = result.changes.length > 0
+      ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+      : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+    setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
+    showToast("XLSX を反映しました");
+  }
+
   function parseCurrentCsv(): void {
     const csvText = getTextArea("csvInput").value.trim();
     if (!csvText) {
@@ -436,6 +770,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
+    renderXlsxImportSummary([]);
     setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
     showToast("CSV を解析しました");
   }
@@ -463,6 +798,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     link.click();
     document.body.removeChild(link);
     window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    markXmlSavedCurrent();
     setStatus("XML ファイルをエクスポートしました");
     showToast("XML を保存しました");
   }
@@ -538,12 +874,29 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus(error instanceof Error ? error.message : "CSV 生成に失敗しました");
       }
     });
+    getElement<HTMLButtonElement>("exportXlsxBtn").addEventListener("click", () => {
+      try {
+        exportCurrentXlsx();
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "XLSX エクスポートに失敗しました");
+      }
+    });
+    getElement<HTMLButtonElement>("exportWbsXlsxBtn").addEventListener("click", () => {
+      try {
+        exportCurrentWbsXlsx();
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+      }
+    });
     getElement<HTMLButtonElement>("parseCsvBtn").addEventListener("click", () => {
       try {
         parseCurrentCsv();
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
       }
+    });
+    getElement<HTMLButtonElement>("importXlsxBtn").addEventListener("click", () => {
+      getElement<HTMLInputElement>("importXlsxInput").click();
     });
     getElement<HTMLButtonElement>("downloadXmlBtn").addEventListener("click", () => {
       try {
@@ -572,12 +925,29 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         }
       }
     });
+    getElement<HTMLInputElement>("importXlsxInput").addEventListener("change", async (event) => {
+      const input = event.target as HTMLInputElement | null;
+      const file = input?.files && input.files[0];
+      try {
+        await importXlsxFromFile(file);
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+      } finally {
+        if (input) {
+          input.value = "";
+        }
+      }
+    });
+    getTextArea("xmlInput").addEventListener("input", () => {
+      refreshXmlSaveState();
+    });
   }
 
   function initialize(): void {
     bindEvents();
     updateSummary(null);
     renderValidationIssues([]);
+    renderXlsxImportSummary([]);
     updateMermaidSvgButton();
     clearMermaidError();
     loadSample();

--- a/docs/project/src/mikuproject/ts/project-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/project-xlsx.ts
@@ -1,0 +1,587 @@
+(() => {
+  type XlsxCellLike = {
+    value?: string | number | boolean;
+    numberFormat?: "general" | "integer" | "decimal" | "date" | "datetime" | "percent";
+    horizontalAlign?: "left" | "center" | "right";
+    bold?: boolean;
+    fillColor?: string;
+    border?: "thin";
+  };
+
+  type XlsxWorkbookLike = {
+    sheets: Array<{
+      name: string;
+      columns?: Array<{ width?: number }>;
+      mergedRanges?: string[];
+      rows: Array<{
+        height?: number;
+        cells: XlsxCellLike[];
+      }>;
+    }>;
+  };
+
+  type ImportChange = {
+    scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+    uid: string;
+    label: string;
+    field: string;
+    before: string | number | boolean | undefined;
+    after: string | number | boolean;
+  };
+
+  const HEADER_FILL = "#D9EAF7";
+
+  function exportProjectWorkbook(model: ProjectModel): XlsxWorkbookLike {
+    return {
+      sheets: [
+        buildProjectSheet(model),
+        buildTasksSheet(model),
+        buildResourcesSheet(model),
+        buildAssignmentsSheet(model),
+        buildCalendarsSheet(model)
+      ]
+    };
+  }
+
+  function importProjectWorkbook(workbook: XlsxWorkbookLike, baseModel: ProjectModel): ProjectModel {
+    return importProjectWorkbookDetailed(workbook, baseModel).model;
+  }
+
+  function importProjectWorkbookDetailed(workbook: XlsxWorkbookLike, baseModel: ProjectModel): {
+    model: ProjectModel;
+    changes: ImportChange[];
+  } {
+    const nextModel = cloneProjectModel(baseModel);
+    const changes: ImportChange[] = [];
+    importProjectSheet(workbook, nextModel, changes);
+    importTasksSheet(workbook, nextModel, changes);
+    importResourcesSheet(workbook, nextModel, changes);
+    importAssignmentsSheet(workbook, nextModel, changes);
+    importCalendarsSheet(workbook, nextModel, changes);
+    return {
+      model: nextModel,
+      changes
+    };
+  }
+
+  function importProjectSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    if (!projectSheet) {
+      return;
+    }
+    const valueByField = new Map<string, XlsxCellLike | undefined>();
+    for (const row of projectSheet.rows.slice(3)) {
+      const field = readStringCell(row.cells[0]);
+      if (!field) {
+        continue;
+      }
+      valueByField.set(field, row.cells[1]);
+    }
+    const projectLabel = model.project.name;
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "name", "Name", readStringCell(valueByField.get("Name")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "title", "Title", readStringCell(valueByField.get("Title")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "author", "Author", readStringCell(valueByField.get("Author")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "company", "Company", readStringCell(valueByField.get("Company")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "startDate", "StartDate", readStringCell(valueByField.get("StartDate")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "finishDate", "FinishDate", readStringCell(valueByField.get("FinishDate")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "currentDate", "CurrentDate", readStringCell(valueByField.get("CurrentDate")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "statusDate", "StatusDate", readStringCell(valueByField.get("StatusDate")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "calendarUID", "CalendarUID", readStringCell(valueByField.get("CalendarUID")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerDay", "MinutesPerDay", readNumberCell(valueByField.get("MinutesPerDay")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
+    assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+  }
+
+  function buildProjectSheet(model: ProjectModel) {
+    const project = model.project;
+    const rows = [
+      titleRow("Project"),
+      titleRow("Basic Info"),
+      headerRow(["Field", "Value"]),
+      keyValueRow("Name", project.name),
+      keyValueRow("Title", project.title),
+      keyValueRow("Author", project.author),
+      keyValueRow("Company", project.company),
+      keyValueRow("StartDate", project.startDate),
+      keyValueRow("FinishDate", project.finishDate),
+      keyValueRow("CurrentDate", project.currentDate),
+      keyValueRow("StatusDate", project.statusDate),
+      titleRow("Settings"),
+      keyValueRow("CalendarUID", project.calendarUID),
+      keyValueRow("MinutesPerDay", project.minutesPerDay),
+      keyValueRow("MinutesPerWeek", project.minutesPerWeek),
+      keyValueRow("DaysPerMonth", project.daysPerMonth),
+      keyValueRow("ScheduleFromStart", project.scheduleFromStart),
+      keyValueRow("OutlineCodes", project.outlineCodes.length),
+      keyValueRow("WBSMasks", project.wbsMasks.length),
+      keyValueRow("ExtendedAttributes", project.extendedAttributes.length)
+    ];
+
+    return {
+      name: "Project",
+      columns: [{ width: 24 }, { width: 32 }],
+      mergedRanges: ["A1:B1", "A2:B2", "A11:B11"],
+      rows
+    };
+  }
+
+  function buildTasksSheet(model: ProjectModel) {
+    return {
+      name: "Tasks",
+      columns: [
+        { width: 10 }, { width: 8 }, { width: 28 }, { width: 12 },
+        { width: 14 }, { width: 12 }, { width: 20 }, { width: 20 },
+        { width: 14 }, { width: 16 }, { width: 18 }, { width: 12 },
+        { width: 12 }, { width: 12 }, { width: 12 }, { width: 18 }
+      ],
+      mergedRanges: ["A1:P1", "A2:P2"],
+      rows: [
+        sectionTitleRow("Tasks", 16),
+        sectionTitleRow("Task List", 16),
+        headerRow([
+          "UID", "ID", "Name", "OutlineLevel", "OutlineNumber", "WBS",
+          "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete",
+          "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors"
+        ]),
+        ...model.tasks.map((task) => ({
+          cells: [
+            cell(task.uid),
+            cell(task.id),
+            cell(task.name),
+            cell(task.outlineLevel),
+            cell(task.outlineNumber),
+            cell(task.wbs),
+            cell(task.start),
+            cell(task.finish),
+            cell(task.duration),
+            cell(task.percentComplete),
+            cell(task.percentWorkComplete),
+            cell(task.milestone),
+            cell(task.summary),
+            cell(task.critical),
+            cell(task.calendarUID),
+            cell(task.predecessors.map((item) => item.predecessorUid).join(", "))
+          ]
+        }))
+      ]
+    };
+  }
+
+  function buildResourcesSheet(model: ProjectModel) {
+    return {
+      name: "Resources",
+      columns: [
+        { width: 10 }, { width: 8 }, { width: 24 }, { width: 10 },
+        { width: 12 }, { width: 18 }, { width: 12 }, { width: 12 },
+        { width: 14 }, { width: 14 }, { width: 12 }, { width: 14 },
+        { width: 14 }, { width: 14 }
+      ],
+      mergedRanges: ["A1:N1", "A2:N2"],
+      rows: [
+        sectionTitleRow("Resources", 14),
+        sectionTitleRow("Resource List", 14),
+        headerRow([
+          "UID", "ID", "Name", "Type", "Initials", "Group", "MaxUnits",
+          "CalendarUID", "StandardRate", "OvertimeRate", "CostPerUse",
+          "Work", "ActualWork", "RemainingWork"
+        ]),
+        ...model.resources.map((resource) => ({
+          cells: [
+            cell(resource.uid),
+            cell(resource.id),
+            cell(resource.name),
+            cell(resource.type),
+            cell(resource.initials),
+            cell(resource.group),
+            cell(resource.maxUnits),
+            cell(resource.calendarUID),
+            cell(resource.standardRate),
+            cell(resource.overtimeRate),
+            cell(resource.costPerUse),
+            cell(resource.work),
+            cell(resource.actualWork),
+            cell(resource.remainingWork)
+          ]
+        }))
+      ]
+    };
+  }
+
+  function buildAssignmentsSheet(model: ProjectModel) {
+    const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+    const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+
+    return {
+      name: "Assignments",
+      columns: [
+        { width: 10 }, { width: 10 }, { width: 24 }, { width: 12 },
+        { width: 24 }, { width: 20 }, { width: 20 }, { width: 10 },
+        { width: 14 }, { width: 14 }, { width: 14 }, { width: 18 }
+      ],
+      mergedRanges: ["A1:L1", "A2:L2"],
+      rows: [
+        sectionTitleRow("Assignments", 12),
+        sectionTitleRow("Assignment List", 12),
+        headerRow([
+          "UID", "TaskUID", "TaskName", "ResourceUID", "ResourceName", "Start",
+          "Finish", "Units", "Work", "ActualWork", "RemainingWork", "PercentWorkComplete"
+        ]),
+        ...model.assignments.map((assignment) => ({
+          cells: [
+            cell(assignment.uid),
+            cell(assignment.taskUid),
+            cell(taskNameByUid.get(assignment.taskUid)),
+            cell(assignment.resourceUid),
+            cell(resourceNameByUid.get(assignment.resourceUid)),
+            cell(assignment.start),
+            cell(assignment.finish),
+            cell(assignment.units),
+            cell(assignment.work),
+            cell(assignment.actualWork),
+            cell(assignment.remainingWork),
+            cell(assignment.percentWorkComplete)
+          ]
+        }))
+      ]
+    };
+  }
+
+  function buildCalendarsSheet(model: ProjectModel) {
+    return {
+      name: "Calendars",
+      columns: [
+        { width: 10 }, { width: 24 }, { width: 14 }, { width: 16 },
+        { width: 10 }, { width: 12 }, { width: 10 }
+      ],
+      mergedRanges: ["A1:G1", "A2:G2"],
+      rows: [
+        sectionTitleRow("Calendars", 7),
+        sectionTitleRow("Calendar List", 7),
+        headerRow([
+          "UID", "Name", "IsBaseCalendar", "BaseCalendarUID", "WeekDays", "Exceptions", "WorkWeeks"
+        ]),
+        ...model.calendars.map((calendar) => ({
+          cells: [
+            cell(calendar.uid),
+            cell(calendar.name),
+            cell(calendar.isBaseCalendar),
+            cell(calendar.baseCalendarUID),
+            cell(calendar.weekDays.length),
+            cell(calendar.exceptions.length),
+            cell(calendar.workWeeks.length)
+          ]
+        }))
+      ]
+    };
+  }
+
+  function headerRow(labels: string[]) {
+    return {
+      height: 24,
+      cells: labels.map((label) => ({
+        value: label,
+        bold: true,
+        fillColor: HEADER_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      }))
+    };
+  }
+
+  function titleRow(title: string) {
+    return {
+      height: 28,
+      cells: [
+        {
+          value: title,
+          bold: true,
+          fillColor: HEADER_FILL,
+          border: "thin",
+          horizontalAlign: "center"
+        },
+        {}
+      ]
+    };
+  }
+
+  function sectionTitleRow(title: string, columnCount: number) {
+    return {
+      height: 26,
+      cells: [
+        {
+          value: title,
+          bold: true,
+          fillColor: HEADER_FILL,
+          border: "thin",
+          horizontalAlign: "center"
+        },
+        ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+      ]
+    };
+  }
+
+  function keyValueRow(label: string, value: string | number | boolean | undefined) {
+    return {
+      cells: [
+        {
+          value: label,
+          bold: true,
+          fillColor: HEADER_FILL,
+          border: "thin"
+        },
+        cell(value)
+      ]
+    };
+  }
+
+  function cell(value: string | number | boolean | undefined): XlsxCellLike {
+    if (value === undefined) {
+      return {};
+    }
+    return {
+      value,
+      border: "thin"
+    };
+  }
+
+  function cloneProjectModel(model: ProjectModel): ProjectModel {
+    return JSON.parse(JSON.stringify(model)) as ProjectModel;
+  }
+
+  function importTasksSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    if (!tasksSheet) {
+      return;
+    }
+    const columnIndexByLabel = readHeaderMap(tasksSheet, 2);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return;
+    }
+    const taskByUid = new Map(model.tasks.map((task) => [task.uid, task]));
+    for (const row of tasksSheet.rows.slice(3)) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      const task = taskByUid.get(uid);
+      if (!task) {
+        continue;
+      }
+      const taskLabel = task.name;
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", readStringCellAt(row.cells, columnIndexByLabel.get("Start")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", readStringCellAt(row.cells, columnIndexByLabel.get("Finish")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+    }
+  }
+
+  function importResourcesSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    if (!resourcesSheet) {
+      return;
+    }
+    const columnIndexByLabel = readHeaderMap(resourcesSheet, 2);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return;
+    }
+    const resourceByUid = new Map(model.resources.map((resource) => [resource.uid, resource]));
+    for (const row of resourcesSheet.rows.slice(3)) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      const resource = resourceByUid.get(uid);
+      if (!resource) {
+        continue;
+      }
+      const resourceLabel = resource.name;
+      assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+      assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
+      assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+    }
+  }
+
+  function importAssignmentsSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+    if (!assignmentsSheet) {
+      return;
+    }
+    const columnIndexByLabel = readHeaderMap(assignmentsSheet, 2);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return;
+    }
+    const assignmentByUid = new Map(model.assignments.map((assignment) => [assignment.uid, assignment]));
+    for (const row of assignmentsSheet.rows.slice(3)) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      const assignment = assignmentByUid.get(uid);
+      if (!assignment) {
+        continue;
+      }
+      const assignmentLabel = `TaskUID=${assignment.taskUid}`;
+      assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "units", "Units", readNumberCellAt(row.cells, columnIndexByLabel.get("Units")));
+      assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "work", "Work", readStringCellAt(row.cells, columnIndexByLabel.get("Work")));
+      assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+    }
+  }
+
+  function importCalendarsSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+    if (!calendarsSheet) {
+      return;
+    }
+    const columnIndexByLabel = readHeaderMap(calendarsSheet, 2);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return;
+    }
+    const calendarByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar]));
+    for (const row of calendarsSheet.rows.slice(3)) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      const calendar = calendarByUid.get(uid);
+      if (!calendar) {
+        continue;
+      }
+      const calendarLabel = calendar.name;
+      assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
+      assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
+      assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
+    }
+  }
+
+  function readHeaderMap(sheet: XlsxWorkbookLike["sheets"][number], headerRowIndex: number): Map<string, number> {
+    const headerRow = sheet.rows[headerRowIndex];
+    const columnIndexByLabel = new Map<string, number>();
+    if (!headerRow) {
+      return columnIndexByLabel;
+    }
+    headerRow.cells.forEach((cell, index) => {
+      if (typeof cell.value === "string" && cell.value) {
+        columnIndexByLabel.set(cell.value, index);
+      }
+    });
+    return columnIndexByLabel;
+  }
+
+  function readStringCellAt(cells: XlsxCellLike[], index: number | undefined): string | undefined {
+    if (index === undefined) {
+      return undefined;
+    }
+    return readStringCell(cells[index]);
+  }
+
+  function readNumberCellAt(cells: XlsxCellLike[], index: number | undefined): number | undefined {
+    if (index === undefined) {
+      return undefined;
+    }
+    return readNumberCell(cells[index]);
+  }
+
+  function readBooleanCellAt(cells: XlsxCellLike[], index: number | undefined): boolean | undefined {
+    if (index === undefined) {
+      return undefined;
+    }
+    return readBooleanCell(cells[index]);
+  }
+
+  function readStringCell(cell: XlsxCellLike | undefined): string | undefined {
+    if (!cell || cell.value === undefined) {
+      return undefined;
+    }
+    if (typeof cell.value === "string") {
+      return cell.value;
+    }
+    if (typeof cell.value === "number" || typeof cell.value === "boolean") {
+      return String(cell.value);
+    }
+    return undefined;
+  }
+
+  function readNumberCell(cell: XlsxCellLike | undefined): number | undefined {
+    if (!cell || cell.value === undefined) {
+      return undefined;
+    }
+    if (typeof cell.value === "number" && Number.isFinite(cell.value)) {
+      return cell.value;
+    }
+    if (typeof cell.value === "string" && cell.value.trim() !== "") {
+      const parsed = Number(cell.value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  }
+
+  function readBooleanCell(cell: XlsxCellLike | undefined): boolean | undefined {
+    if (!cell || cell.value === undefined) {
+      return undefined;
+    }
+    if (typeof cell.value === "boolean") {
+      return cell.value;
+    }
+    if (typeof cell.value === "number") {
+      return cell.value !== 0;
+    }
+    if (typeof cell.value === "string") {
+      if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+        return true;
+      }
+      if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+        return false;
+      }
+    }
+    return undefined;
+  }
+
+  function assignIfChanged<T extends object, K extends keyof T>(
+    changes: ImportChange[],
+    scope: ImportChange["scope"],
+    uid: string,
+    label: string,
+    target: T,
+    key: K,
+    field: string,
+    value: T[K] | undefined
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+    const before = target[key];
+    if (before === value) {
+      return;
+    }
+    target[key] = value;
+    changes.push({
+      scope,
+      uid,
+      label,
+      field,
+      before: before as string | number | boolean | undefined,
+      after: value as string | number | boolean
+    });
+  }
+
+  (globalThis as typeof globalThis & {
+    __mikuprojectProjectXlsx?: {
+      exportProjectWorkbook: (model: ProjectModel) => XlsxWorkbookLike;
+      importProjectWorkbook: (workbook: XlsxWorkbookLike, baseModel: ProjectModel) => ProjectModel;
+      importProjectWorkbookDetailed: (workbook: XlsxWorkbookLike, baseModel: ProjectModel) => {
+        model: ProjectModel;
+        changes: ImportChange[];
+      };
+    };
+  }).__mikuprojectProjectXlsx = {
+    exportProjectWorkbook,
+    importProjectWorkbook,
+    importProjectWorkbookDetailed
+  };
+})();

--- a/docs/project/src/mikuproject/ts/wbs-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/wbs-xlsx.ts
@@ -1,0 +1,409 @@
+(() => {
+  type WbsXlsxCellLike = {
+    value?: string | number | boolean;
+    numberFormat?: "general" | "integer" | "decimal" | "date" | "datetime" | "percent";
+    horizontalAlign?: "left" | "center" | "right";
+    bold?: boolean;
+    fillColor?: string;
+    border?: "thin";
+  };
+
+  type WbsXlsxWorkbookLike = {
+    sheets: Array<{
+      name: string;
+      columns?: Array<{ width?: number }>;
+      mergedRanges?: string[];
+      rows: Array<{
+        height?: number;
+        cells: WbsXlsxCellLike[];
+      }>;
+    }>;
+  };
+
+  type WbsExportOptions = {
+    holidayDates?: string[];
+  };
+
+  const HEADER_FILL = "#D9EAF7";
+  const PHASE_FILL = "#EEF7E8";
+  const MILESTONE_FILL = "#FFF4E0";
+  const BAND_FILL = "#F4F7FB";
+  const ACTIVE_BAND_FILL = "#9FD5C9";
+  const PROGRESS_BAND_FILL = "#5BAE9C";
+  const WEEKEND_BAND_FILL = "#F1F1F1";
+  const TODAY_BAND_FILL = "#FFE6A7";
+  const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
+  const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
+  const HOLIDAY_BAND_FILL = "#FCE4EC";
+
+  function exportWbsWorkbook(model: ProjectModel, options: WbsExportOptions = {}): WbsXlsxWorkbookLike {
+    const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+    const predecessorNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
+    const calendarNameByUid = new Map(model.calendars.map((calendar) => [calendar.uid, calendar.name]));
+    const resourceNamesByTaskUid = new Map<string, string[]>();
+    const holidaySet = new Set((options.holidayDates || []).map((day) => day.slice(0, 10)));
+
+    for (const assignment of model.assignments) {
+      const resourceName = resourceNameByUid.get(assignment.resourceUid);
+      if (!resourceName) {
+        continue;
+      }
+      const resourceNames = resourceNamesByTaskUid.get(assignment.taskUid) || [];
+      if (!resourceNames.includes(resourceName)) {
+        resourceNames.push(resourceName);
+      }
+      resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
+    }
+
+    const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+    const fixedHeaders = [
+      "UID",
+      "ID",
+      "WBS",
+      "Kind",
+      "OutlineLevel",
+      "Name",
+      "Start",
+      "Finish",
+      "Duration",
+      "PercentComplete",
+      "PercentWorkComplete",
+      "Milestone",
+      "Summary",
+      "Critical",
+      "Owner",
+      "Calendar",
+      "Resources",
+      "Predecessors"
+    ];
+    const totalColumns = fixedHeaders.length + dateBand.length;
+    const lastColumnRef = columnName(totalColumns);
+
+    return {
+      sheets: [
+        {
+          name: "WBS",
+          columns: [
+            { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
+            { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+            { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
+            { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+            ...dateBand.map(() => ({ width: 6 }))
+          ],
+          mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+          rows: [
+            sectionTitleRow("WBS", totalColumns),
+            sectionTitleRow(model.project.name || "Project", totalColumns),
+            infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
+            infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
+            sectionTitleRow("Task View", totalColumns),
+            todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+            headerRow([
+              ...fixedHeaders,
+              ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+            ]),
+            ...model.tasks.map((task) => ({
+              cells: [
+                taskCell(task, task.uid, "center"),
+                taskCell(task, task.id, "center"),
+                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                taskCell(task, classifyTaskKind(task), "center"),
+                taskCell(task, task.outlineLevel, "center"),
+                taskCell(task, formatTaskLabel(task)),
+                taskCell(task, task.start),
+                taskCell(task, task.finish),
+                taskCell(task, task.duration, "center"),
+                taskCell(task, task.percentComplete, "center"),
+                taskCell(task, task.percentWorkComplete, "center"),
+                taskCell(task, task.milestone, "center"),
+                taskCell(task, task.summary, "center"),
+                taskCell(task, task.critical, "center"),
+                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
+              ]
+            }))
+          ]
+        }
+      ]
+    };
+  }
+
+  function formatTaskLabel(task: TaskModel): string {
+    return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+  }
+
+  function classifyTaskKind(task: TaskModel): string {
+    if (task.summary) {
+      return "phase";
+    }
+    if (task.milestone) {
+      return "milestone";
+    }
+    return "task";
+  }
+
+  function firstResourceName(resourceNames: string[] | undefined): string {
+    if (!resourceNames || resourceNames.length === 0) {
+      return "";
+    }
+    return resourceNames[0];
+  }
+
+  function formatCalendarLabel(
+    calendarUID: string | undefined,
+    calendarNameByUid: Map<string, string>
+  ): string {
+    if (!calendarUID) {
+      return "-";
+    }
+    const calendarName = calendarNameByUid.get(calendarUID);
+    return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+  }
+
+  function sectionTitleRow(title: string, columnCount: number) {
+    return {
+      height: 28,
+      cells: [
+        {
+          value: title,
+          bold: true,
+          fillColor: HEADER_FILL,
+          border: "thin",
+          horizontalAlign: "center"
+        },
+        ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+      ]
+    };
+  }
+
+  function infoRow(text: string, columnCount: number) {
+    return {
+      height: 24,
+      cells: [
+        {
+          value: text,
+          border: "thin",
+          horizontalAlign: "left"
+        },
+        ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+      ]
+    };
+  }
+
+  function headerRow(labels: Array<string | WbsXlsxCellLike>) {
+    return {
+      height: 24,
+      cells: labels.map((label) => {
+        if (typeof label === "string") {
+          return {
+            value: label,
+            bold: true,
+            fillColor: HEADER_FILL,
+            border: "thin" as const,
+            horizontalAlign: "center" as const
+          };
+        }
+        return {
+          border: "thin" as const,
+          horizontalAlign: "center" as const,
+          ...label
+        };
+      })
+    };
+  }
+
+  function todayGuideRow(
+    fixedColumnCount: number,
+    dateBand: string[],
+    currentDate: string | undefined,
+    holidaySet: Set<string>
+  ) {
+    return {
+      height: 22,
+      cells: [
+        ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
+          ? {
+              value: "Today",
+              bold: true,
+              border: "thin" as const,
+              horizontalAlign: "right" as const
+            }
+          : {})),
+        ...dateBand.map((day) => ({
+          value: isSameDay(day, currentDate) ? "▼" : "",
+          bold: true,
+          border: "thin" as const,
+          horizontalAlign: "center" as const,
+          fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+        }))
+      ]
+    };
+  }
+
+  function cell(value: string | number | boolean | undefined): WbsXlsxCellLike {
+    if (value === undefined || value === "") {
+      return {};
+    }
+    return {
+      value,
+      border: "thin"
+    };
+  }
+
+  function taskCell(
+    task: TaskModel,
+    value: string | number | boolean | undefined,
+    horizontalAlign: "left" | "center" | "right" = "left"
+  ): WbsXlsxCellLike {
+    if (value === undefined || value === "") {
+      return {};
+    }
+    return {
+      value,
+      border: "thin",
+      horizontalAlign,
+      bold: task.summary || task.milestone || false,
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+    };
+  }
+
+  function dateHeaderCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
+    const isToday = isSameDay(day, currentDate);
+    const isWeekendDay = isWeekend(day);
+    const isHoliday = holidaySet.has(day);
+    return {
+      value: formatDateLabel(day),
+      bold: true,
+      border: "thin",
+      horizontalAlign: "center",
+      fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+    };
+  }
+
+  function dateBandCell(task: TaskModel, day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
+    const active = includesDay(task.start, task.finish, day);
+    const isToday = isSameDay(day, currentDate);
+    const isWeekendDay = isWeekend(day);
+    const isHoliday = holidaySet.has(day);
+    const complete = active && isCompletedDay(task, day);
+    return {
+      value: active ? "■" : "",
+      border: "thin",
+      horizontalAlign: "center",
+      fillColor: active
+        ? (complete
+          ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
+          : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
+        : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+    };
+  }
+
+  function buildDateBand(startDate: string | undefined, finishDate: string | undefined): string[] {
+    const start = parseDateOnly(startDate);
+    const finish = parseDateOnly(finishDate);
+    if (!start || !finish || start.getTime() > finish.getTime()) {
+      return [];
+    }
+    const days: string[] = [];
+    const cursor = new Date(start.getTime());
+    while (cursor.getTime() <= finish.getTime()) {
+      days.push(formatDateOnly(cursor));
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return days;
+  }
+
+  function includesDay(startDate: string | undefined, finishDate: string | undefined, day: string): boolean {
+    const start = parseDateOnly(startDate);
+    const finish = parseDateOnly(finishDate);
+    const target = parseDateOnly(day);
+    if (!start || !finish || !target) {
+      return false;
+    }
+    return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
+  }
+
+  function isCompletedDay(task: TaskModel, day: string): boolean {
+    const start = parseDateOnly(task.start);
+    const finish = parseDateOnly(task.finish);
+    const target = parseDateOnly(day);
+    if (!start || !finish || !target) {
+      return false;
+    }
+    const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
+    if (totalDays <= 0) {
+      return false;
+    }
+    const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+    const completedDays = Math.floor(totalDays * (percent / 100));
+    const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
+    return dayIndex >= 0 && dayIndex < completedDays;
+  }
+
+  function isSameDay(day: string, other: string | undefined): boolean {
+    return day === (other || "").slice(0, 10);
+  }
+
+  function isWeekend(day: string): boolean {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return false;
+    }
+    const weekday = target.getDay();
+    return weekday === 0 || weekday === 6;
+  }
+
+  function parseDateOnly(value: string | undefined): Date | null {
+    if (!value || value.length < 10) {
+      return null;
+    }
+    const dateOnly = value.slice(0, 10);
+    const [yearText, monthText, dayText] = dateOnly.split("-");
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const day = Number(dayText);
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+      return null;
+    }
+    return new Date(year, month - 1, day);
+  }
+
+  function formatDateOnly(value: Date): string {
+    return [
+      value.getFullYear(),
+      String(value.getMonth() + 1).padStart(2, "0"),
+      String(value.getDate()).padStart(2, "0")
+    ].join("-");
+  }
+
+  function formatDateLabel(day: string): string {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return day;
+    }
+    const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+  }
+
+  function columnName(index: number): string {
+    let current = index;
+    let name = "";
+    while (current > 0) {
+      const remainder = (current - 1) % 26;
+      name = String.fromCharCode(65 + remainder) + name;
+      current = Math.floor((current - 1) / 26);
+    }
+    return name;
+  }
+
+  (globalThis as typeof globalThis & {
+    __mikuprojectWbsXlsx?: {
+      exportWbsWorkbook: typeof exportWbsWorkbook;
+    };
+  }).__mikuprojectWbsXlsx = {
+    exportWbsWorkbook
+  };
+})();

--- a/docs/project/tests/mikuproject-excel-io.test.js
+++ b/docs/project/tests/mikuproject-excel-io.test.js
@@ -1,0 +1,381 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const typesCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/types.js"),
+  "utf8"
+);
+const excelIoCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/excel-io.js"),
+  "utf8"
+);
+
+function bootExcelIoModule() {
+  new Function(`${typesCode}\n${excelIoCode}`)();
+  return globalThis.__mikuprojectExcelIo;
+}
+
+function decodeUtf8(bytes) {
+  return new TextDecoder().decode(bytes);
+}
+
+describe("mikuproject excel io", () => {
+  it("exports a minimal xlsx package with required workbook entries", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Project",
+          rows: [
+            {
+              cells: [
+                { value: "Name" },
+                { value: "Miku Project" }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const entryNames = codec.listEntries(bytes);
+
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    expect(entryNames).toEqual([
+      "[Content_Types].xml",
+      "_rels/.rels",
+      "xl/_rels/workbook.xml.rels",
+      "xl/workbook.xml",
+      "xl/worksheets/sheet1.xml"
+    ]);
+  });
+
+  it("round-trips sheet names, sparse cells, formulas, and primitive cell values", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Project",
+          rows: [
+            {
+              cells: [
+                { value: "Task" },
+                { value: "Days" },
+                { value: "Done" },
+                { value: "Formula" }
+              ]
+            },
+            {
+              cells: [
+                { value: "Design" },
+                { value: 2 },
+                { value: true },
+                { formula: "B2*2", value: 4 }
+              ]
+            },
+            {
+              cells: [
+                { value: "Build" },
+                {},
+                { value: false },
+                { value: "" }
+              ]
+            }
+          ]
+        },
+        {
+          name: "Resources",
+          rows: [
+            {
+              cells: [
+                { value: "Name" },
+                { value: "Role" }
+              ]
+            },
+            {
+              cells: [
+                { value: "Miku" },
+                { value: "Engineer" }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(imported).toEqual(workbook);
+  });
+
+  it("round-trips column widths, row heights, and basic cell formatting", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Schedule",
+          columns: [
+            { width: 24 },
+            { width: 12 },
+            { width: 14 }
+          ],
+          rows: [
+            {
+              height: 28,
+              cells: [
+                { value: "Task", horizontalAlign: "center" },
+                { value: "Start", horizontalAlign: "center" },
+                { value: "Progress", horizontalAlign: "center" }
+              ]
+            },
+            {
+              cells: [
+                { value: "Design" },
+                { value: 45367, numberFormat: "date" },
+                { value: 0.5, numberFormat: "percent" }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(imported).toEqual(workbook);
+  });
+
+  it("round-trips bold, fill color, and border styles", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Styled",
+          rows: [
+            {
+              cells: [
+                {
+                  value: "Header",
+                  bold: true,
+                  fillColor: "#D9EAF7",
+                  border: "thin"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(imported).toEqual(workbook);
+  });
+
+  it("round-trips merged cell ranges", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Merged",
+          mergedRanges: ["A1:B1", "A3:A4"],
+          rows: [
+            {
+              cells: [
+                { value: "Header", bold: true },
+                {}
+              ]
+            },
+            {
+              cells: [
+                { value: "Row1" },
+                { value: "Value1" }
+              ]
+            },
+            {
+              cells: [
+                { value: "Group" },
+                { value: "Value2" }
+              ]
+            },
+            {
+              cells: [
+                {},
+                { value: "Value3" }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(imported.sheets[0].name).toBe("Merged");
+    expect(imported.sheets[0].mergedRanges).toEqual(["A1:B1", "A3:A4"]);
+    expect(imported.sheets[0].rows[0].cells[0].value).toBe("Header");
+    expect(imported.sheets[0].rows[2].cells[0].value).toBe("Group");
+    expect(imported.sheets[0].rows[3].cells[1].value).toBe("Value3");
+  });
+
+  it("rejects duplicate or invalid sheet names", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+
+    expect(() => codec.exportWorkbook({
+      sheets: [
+        { name: "Same", rows: [] },
+        { name: "Same", rows: [] }
+      ]
+    })).toThrow(/sheet name/i);
+
+    expect(() => codec.exportWorkbook({
+      sheets: [
+        { name: "Bad/Name", rows: [] }
+      ]
+    })).toThrow(/sheet name/i);
+  });
+
+  it("exposes workbook xml for inspection after unzip", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook({
+      sheets: [
+        {
+          name: "One",
+          rows: [
+            {
+              cells: [
+                { value: "hello" },
+                { value: 1 }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const entries = codec.unpackEntries(bytes);
+
+    expect(decodeUtf8(entries["xl/workbook.xml"])).toContain("<sheet");
+    expect(decodeUtf8(entries["xl/workbook.xml"])).toContain('name="One"');
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain('r="A1"');
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("inlineStr");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("<v>1</v>");
+  });
+
+  it("writes styles and sheet layout xml when formatting is present", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook({
+      sheets: [
+        {
+          name: "Styled",
+          columns: [
+            { width: 18 }
+          ],
+          rows: [
+            {
+              height: 32,
+              cells: [
+                { value: 45367, numberFormat: "date", horizontalAlign: "center" }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const entries = codec.unpackEntries(bytes);
+
+    expect(Object.keys(entries).sort()).toContain("xl/styles.xml");
+    expect(decodeUtf8(entries["[Content_Types].xml"])).toContain("/xl/styles.xml");
+    expect(decodeUtf8(entries["xl/_rels/workbook.xml.rels"])).toContain("styles.xml");
+    expect(decodeUtf8(entries["xl/styles.xml"])).toContain("numFmtId=\"14\"");
+    expect(decodeUtf8(entries["xl/styles.xml"])).toContain("horizontal=\"center\"");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("<cols>");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("width=\"18\"");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("ht=\"32\"");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("customHeight=\"1\"");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain(" s=\"1\"");
+  });
+
+  it("writes font, fill, and border definitions when style options are present", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook({
+      sheets: [
+        {
+          name: "Styled",
+          rows: [
+            {
+              cells: [
+                {
+                  value: "Header",
+                  bold: true,
+                  fillColor: "#D9EAF7",
+                  border: "thin"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const stylesXml = decodeUtf8(codec.unpackEntries(bytes)["xl/styles.xml"]);
+
+    expect(stylesXml).toContain("<b/>");
+    expect(stylesXml).toContain('patternType="solid"');
+    expect(stylesXml).toContain("FFD9EAF7");
+    expect(stylesXml).toContain("<left style=\"thin\"/>");
+    expect(stylesXml).toContain("applyFill=\"1\"");
+    expect(stylesXml).toContain("applyBorder=\"1\"");
+    expect(stylesXml).toContain("applyFont=\"1\"");
+  });
+
+  it("writes mergeCells xml when merged ranges are present", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const bytes = codec.exportWorkbook({
+      sheets: [
+        {
+          name: "Merged",
+          mergedRanges: ["A1:B1"],
+          rows: [
+            {
+              cells: [
+                { value: "Header" },
+                {}
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const worksheetXml = decodeUtf8(codec.unpackEntries(bytes)["xl/worksheets/sheet1.xml"]);
+
+    expect(worksheetXml).toContain("<mergeCells");
+    expect(worksheetXml).toContain('ref="A1:B1"');
+  });
+});

--- a/docs/project/tests/mikuproject-main.test.js
+++ b/docs/project/tests/mikuproject-main.test.js
@@ -13,8 +13,20 @@ const typesCode = readFileSync(
   path.resolve(__dirname, "../src/mikuproject/js/types.js"),
   "utf8"
 );
+const excelIoCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/excel-io.js"),
+  "utf8"
+);
 const msProjectXmlCode = readFileSync(
   path.resolve(__dirname, "../src/mikuproject/js/msproject-xml.js"),
+  "utf8"
+);
+const projectXlsxCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/project-xlsx.js"),
+  "utf8"
+);
+const wbsXlsxCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/wbs-xlsx.js"),
   "utf8"
 );
 const mainCode = readFileSync(
@@ -43,12 +55,48 @@ function mountDom() {
     <button id="exportMermaidBtn" type="button">Mermaid を生成</button>
     <button id="downloadMermaidSvgBtn" type="button" disabled>SVG保存</button>
     <button id="exportCsvBtn" type="button">CSV を生成</button>
+    <button id="exportXlsxBtn" type="button">XLSX Export</button>
+    <button id="exportWbsXlsxBtn" type="button">WBS XLSX Export</button>
     <button id="parseCsvBtn" type="button">CSV を解析</button>
+    <button id="importXlsxBtn" type="button">XLSX Import</button>
     <button id="downloadXmlBtn" type="button">XML Export</button>
     <button id="roundTripBtn" type="button">再読込テスト</button>
     <input id="importXmlInput" type="file" />
+    <input id="importXlsxInput" type="file" />
     <div id="statusMessage"></div>
-    <div id="validationIssues" class="md-hidden"></div>
+    <div id="xmlSaveState" class="md-save-state md-save-state--dirty">XML 保存状態: 未保存</div>
+    <div class="md-feedback-stack md-hidden">
+      <div class="md-feedback-stack__title">取込結果</div>
+      <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+      <div class="md-feedback-stack__label md-hidden">検証メッセージ</div>
+      <div id="validationIssues" class="md-hidden"></div>
+      <div class="md-feedback-stack__label md-hidden">差分要約</div>
+      <div id="xlsxImportSummary" class="md-hidden"></div>
+    </div>
+    <section class="md-note-card">
+      <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+      <p class="md-note-card__text">XLSX は MS Project XML の代替正本ではなく、確認と限定編集のための周辺表現として扱います。</p>
+      <p class="md-note-card__text">現在の XLSX Import で反映するのは限定列のみです。</p>
+      <p class="md-note-card__text">反映結果は、Project / Tasks / Resources / Assignments / Calendars ごとの件数と、UID 単位の差分要約として画面上に表示します。</p>
+      <p class="md-note-card__text"><strong>反映対象</strong></p>
+      <ul class="md-note-list">
+        <li>Project: Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart</li>
+        <li>Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete</li>
+        <li>Resources: Name / Group / MaxUnits</li>
+        <li>Assignments: Units / Work / PercentWorkComplete</li>
+        <li>Calendars: Name / IsBaseCalendar / BaseCalendarUID</li>
+      </ul>
+      <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+      <ul class="md-note-list">
+        <li>対象外の列や未対応シートの編集</li>
+        <li>Calendars の WeekDays / Exceptions / WorkWeeks と、Baseline / TimephasedData / ExtendedAttributes</li>
+      </ul>
+    </section>
+    <section class="md-note-card">
+      <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+      <p class="md-note-card__text">WBS XLSX Export では、YYYY-MM-DD 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。</p>
+    </section>
+    <textarea id="wbsHolidayDatesInput"></textarea>
     <textarea id="xmlInput"></textarea>
     <div id="summaryProjectName"></div>
     <div id="summaryTaskCount"></div>
@@ -80,7 +128,7 @@ function bootPage() {
       svg: `<svg data-source="${String(source).includes("gantt") ? "gantt" : "other"}"></svg>`
     }))
   };
-  new Function(`${typesCode}\n${msProjectXmlCode}\n${mainCode}`)();
+  new Function(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectXlsxCode}\n${wbsXlsxCode}\n${mainCode}`)();
   document.dispatchEvent(new Event("DOMContentLoaded"));
 }
 
@@ -116,6 +164,22 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("xmlInput").value).toContain("<Project");
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル XML");
+    expect(document.body.textContent).toContain("XLSX 編集の扱い");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
+    expect(document.body.textContent).toContain("現在の XLSX Import で反映するのは限定列のみです");
+    expect(document.body.textContent).toContain("UID 単位の差分要約として画面上に表示します");
+    expect(document.body.textContent).toContain("反映対象");
+    expect(document.body.textContent).toContain("現在は反映しないもの");
+    expect(document.body.textContent).toContain("取込結果");
+    expect(document.body.textContent).toContain("検証メッセージ");
+    expect(document.body.textContent).toContain("差分要約");
+    expect(document.body.textContent).toContain("差分反映と検証結果を確認します");
+    expect(document.body.textContent).toContain("Project: Name / Title / Author / Company");
+    expect(document.body.textContent).toContain("Calendars: Name / IsBaseCalendar / BaseCalendarUID");
+    expect(document.body.textContent).toContain("Calendars の WeekDays / Exceptions / WorkWeeks");
+    expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
+    expect(document.body.textContent).toContain("YYYY-MM-DD 形式の祝日");
+    expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(true);
   });
 
   it("parses xml into internal model summary", () => {
@@ -604,6 +668,945 @@ describe("mikuproject main", () => {
     expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルを読み込んで解析しました");
   });
 
+  it("downloads current xlsx", () => {
+    bootPage();
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("exportXlsxBtn").click();
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+    const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+    expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xlsx");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX ファイルをエクスポートしました");
+  });
+
+  it("downloads current wbs xlsx", () => {
+    bootPage();
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("exportWbsXlsxBtn").click();
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+    const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+    expect(clickedAnchor.download).toBe("mikuproject-wbs-202603162312.xlsx");
+    expect(document.getElementById("statusMessage").textContent).toContain("WBS XLSX ファイルをエクスポートしました");
+  });
+
+  it("downloads current wbs xlsx with configured holidays", async () => {
+    bootPage();
+    const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("wbsHolidayDatesInput").value = "2026-03-20, 2026-03-20\n2026-03-21";
+    document.getElementById("exportWbsXlsxBtn").click();
+
+    expect(exportSpy).toHaveBeenCalled();
+    expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
+      holidayDates: ["2026-03-20", "2026-03-21"]
+    });
+    const workbook = exportSpy.mock.results.at(-1)?.value;
+    const sheet = workbook.sheets[0];
+    expect(sheet.rows[3].cells[0].value).toContain("Holidays=2");
+    expect(sheet.rows[6].cells[22].fillColor).toBe("#FCE4EC");
+    expect(document.getElementById("statusMessage").textContent).toContain("祝日 2 件");
+  });
+
+  it("imports xlsx edits back into the current model and xml", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("downloadXmlBtn").click();
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    tasksSheet.rows[4].cells[2].value = "Design Imported From XLSX";
+    tasksSheet.rows[4].cells[9].value = 77;
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "sample.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Design Imported From XLSX\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 77");
+    expect(document.getElementById("xmlInput").value).toContain("<Name>Design Imported From XLSX</Name>");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("XML Export で保存できます");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Design -> Design Imported From XLSX");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 100 -> 77");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("反映後の XML は更新済みです");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("imports project sheet edits back into the current model and xml", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    projectSheet.rows[3].cells[1].value = "Project From XLSX";
+    projectSheet.rows[13].cells[1].value = 420;
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "project-sheet.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Project From XLSX\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"minutesPerDay\": 420");
+    expect(document.getElementById("xmlInput").value).toContain("<Name>Project From XLSX</Name>");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Sample Project -> Project From XLSX");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerDay: 480 -> 420");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows project calendar and schedule mode changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    projectSheet.rows[12].cells[1].value = "2";
+    projectSheet.rows[16].cells[1].value = false;
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "project-settings.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"scheduleFromStart\": false");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("CalendarUID: 1 -> 2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("ScheduleFromStart: true -> false");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows project metadata and date changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    projectSheet.rows[4].cells[1].value = "Title From XLSX";
+    projectSheet.rows[6].cells[1].value = "Company From XLSX";
+    projectSheet.rows[7].cells[1].value = "2026-03-15T09:00:00";
+    projectSheet.rows[8].cells[1].value = "2026-03-28T18:00:00";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "project-metadata.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"title\": \"Title From XLSX\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"company\": \"Company From XLSX\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"startDate\": \"2026-03-15T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finishDate\": \"2026-03-28T18:00:00\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Title: Sample Project Title -> Title From XLSX");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Company: Local HTML Tools -> Company From XLSX");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("StartDate: 2026-03-16T09:00:00 -> 2026-03-15T09:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("FinishDate: 2026-03-20T18:00:00 -> 2026-03-28T18:00:00");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows project author change in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    projectSheet.rows[5].cells[1].value = "Author From XLSX";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "project-author.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"author\": \"Author From XLSX\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Author: Toshiki Iga -> Author From XLSX");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows project current and status dates plus weekly settings changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    projectSheet.rows[9].cells[1].value = "2026-03-18T09:00:00";
+    projectSheet.rows[10].cells[1].value = "2026-03-22T09:00:00";
+    projectSheet.rows[14].cells[1].value = 2100;
+    projectSheet.rows[15].cells[1].value = 18;
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "project-dates-settings.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"currentDate\": \"2026-03-18T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"statusDate\": \"2026-03-22T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"minutesPerWeek\": 2100");
+    expect(document.getElementById("modelOutput").value).toContain("\"daysPerMonth\": 18");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("CurrentDate: 2026-03-16T09:00:00 -> 2026-03-18T09:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("StatusDate: 2026-03-19T09:00:00 -> 2026-03-22T09:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerWeek: 2400 -> 2100");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("DaysPerMonth: 20 -> 18");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("reports when xlsx import has no applicable changes", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const originalXml = document.getElementById("xmlInput").value;
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(originalXml)
+    );
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "no-change.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
+    expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
+    expect(document.getElementById("xmlInput").value).toBe(originalXml);
+    expect(document.getElementById("xlsxImportSummary").textContent).toBe("");
+    expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
+  });
+
+  it("ignores edits in unsupported xlsx columns and sheets", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const originalXml = document.getElementById("xmlInput").value;
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(originalXml)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    tasksSheet.rows[4].cells[8].value = "PT99H0M0S";
+    calendarsSheet.rows[3].cells[4].value = 99;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "unsupported-columns.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
+    expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"duration\": \"PT99H0M0S\"");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"weekDays\": 99");
+    expect(document.getElementById("xmlInput").value).toBe(originalXml);
+    expect(document.getElementById("xlsxImportSummary").textContent).toBe("");
+    expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
+  });
+
+  it("ignores calendar WeekDays, Exceptions, and WorkWeeks edits in xlsx import", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const originalXml = document.getElementById("xmlInput").value;
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(originalXml)
+    );
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[4].value = 77;
+    calendarsSheet.rows[3].cells[5].value = 88;
+    calendarsSheet.rows[3].cells[6].value = 99;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "ignored-calendar-structure.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
+    expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"weekDays\": 77");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"exceptions\": 88");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"workWeeks\": 99");
+    expect(document.getElementById("xmlInput").value).toBe(originalXml);
+    expect(document.getElementById("xlsxImportSummary").textContent).toBe("");
+    expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
+  });
+
+  it("shows calendar changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+    calendarsSheet.rows[3].cells[1].value = "Standard Updated";
+    calendarsSheet.rows[3].cells[3].value = "2";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "calendar-sheet.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard Updated\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"2\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Assignments");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Standard");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Standard -> Standard Updated");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 2");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows calendar isBaseCalendar change in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+    calendarsSheet.rows[4].cells[2].value = true;
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "calendar-base-flag.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"isBaseCalendar\": true");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Assignments");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Development");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("IsBaseCalendar: false -> true");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("groups xlsx import summary by sheet when multiple sheets change", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+
+    tasksSheet.rows[4].cells[2].value = "Design Multi Sheet";
+    resourcesSheet.rows[3].cells[2].value = "Miku Multi Sheet";
+    assignmentsSheet.rows[3].cells[11].value = 55;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "multi-sheet.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 3 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Design Multi Sheet\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Miku Multi Sheet\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 55");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Design -> Design Multi Sheet");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Miku -> Miku Multi Sheet");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 50 -> 55");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(3);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(3);
+  });
+
+  it("shows non-name resource and assignment field changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+
+    resourcesSheet.rows[3].cells[5].value = "Platform";
+    resourcesSheet.rows[3].cells[6].value = 0.8;
+    assignmentsSheet.rows[3].cells[7].value = 0.75;
+    assignmentsSheet.rows[3].cells[8].value = "PT12H0M0S";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "resource-assignment-fields.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 4 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"group\": \"Platform\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"maxUnits\": 0.8");
+    expect(document.getElementById("modelOutput").value).toContain("\"units\": 0.75");
+    expect(document.getElementById("modelOutput").value).toContain("\"work\": \"PT12H0M0S\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Group: Engineering -> Platform");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MaxUnits: 1 -> 0.8");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Units: 1 -> 0.75");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Work: PT16H0M0S -> PT12H0M0S");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(2);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(2);
+  });
+
+  it("shows task date field changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[6].value = "2026-03-17T09:00:00";
+    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "task-dates.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-17T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-03-18T18:00:00\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Start: 2026-03-16T09:00:00 -> 2026-03-17T09:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Finish: 2026-03-17T18:00:00 -> 2026-03-18T18:00:00");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows task percent work complete changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[10].value = 65;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "task-percent-work-complete.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 65");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 100 -> 65");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows resource name changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+
+    resourcesSheet.rows[3].cells[2].value = "Miku Renamed";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "resource-name.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Miku Renamed\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Miku -> Miku Renamed");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows assignment percent work complete changes in xlsx import summary", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+
+    assignmentsSheet.rows[3].cells[11].value = 85;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "assignment-percent-work-complete.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 85");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 50 -> 85");
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("shows validation issues after xlsx import when edited values are invalid", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[9].value = 120;
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "invalid-percent-complete.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 120");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 100 -> 120");
+    expect(document.getElementById("validationIssues").textContent).toContain("PercentComplete");
+    expect(document.getElementById("validationIssues").textContent).toContain("0..100");
+    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
+    expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(false);
+  });
+
+  it("shows validation issues after xlsx import when task start is after finish", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
+    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "invalid-task-dates.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
+    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-19T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-03-18T18:00:00\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Start: 2026-03-16T09:00:00 -> 2026-03-19T09:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Finish: 2026-03-17T18:00:00 -> 2026-03-18T18:00:00");
+    expect(document.getElementById("validationIssues").textContent).toContain("Start");
+    expect(document.getElementById("validationIssues").textContent).toContain("Finish");
+    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
+  });
+
+  it("shows validation issues after xlsx import when calendar baseCalendarUID is missing", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[3].value = "99";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "invalid-calendar-base.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
+    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"99\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 99");
+    expect(document.getElementById("validationIssues").textContent).toContain("Calendar BaseCalendarUID");
+    expect(document.getElementById("validationIssues").textContent).toContain("Standard");
+    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
+  });
+
+  it("shows validation issues after xlsx import when calendar baseCalendarUID points to itself", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[3].value = "1";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "invalid-calendar-self-base.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
+    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"1\"");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 1");
+    expect(document.getElementById("validationIssues").textContent).toContain("Calendar BaseCalendarUID");
+    expect(document.getElementById("validationIssues").textContent).toContain("自身を指しています");
+    expect(document.getElementById("validationIssues").textContent).toContain("Standard");
+    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
+  });
+
   it("downloads current xml", () => {
     bootPage();
 
@@ -614,6 +1617,151 @@ describe("mikuproject main", () => {
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
     expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xml");
     expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルをエクスポートしました");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
+    expect(document.getElementById("xmlSaveState").classList.contains("md-save-state--clean")).toBe(true);
+  });
+
+  it("returns xml save state to unsaved after manual xml edit", async () => {
+    bootPage();
+
+    document.getElementById("downloadXmlBtn").click();
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
+
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
+    await flushAsyncWork();
+
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
+    expect(document.getElementById("xmlSaveState").classList.contains("md-save-state--dirty")).toBe(true);
+  });
+
+  it("exports edited xml after xlsx import", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    tasksSheet.rows[4].cells[2].value = "Design Saved From XLSX";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "saved-after-import.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    const OriginalBlob = Blob;
+    class InspectableBlob extends OriginalBlob {
+      __parts;
+
+      constructor(parts, options) {
+        super(parts, options);
+        this.__parts = parts;
+      }
+
+      text() {
+        return Promise.resolve(this.__parts.join(""));
+      }
+    }
+    globalThis.Blob = InspectableBlob;
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
+
+    try {
+      document.getElementById("downloadXmlBtn").click();
+
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+      const exportedBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+      expect(exportedBlob).toBeInstanceOf(InspectableBlob);
+      await expect(exportedBlob.text()).resolves.toContain("<Name>Design Saved From XLSX</Name>");
+      const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+      expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xml");
+      expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルをエクスポートしました");
+    } finally {
+      globalThis.Blob = OriginalBlob;
+    }
+  });
+
+  it("exports current xml after xlsx import even when validation issues remain", async () => {
+    bootPage();
+    document.getElementById("parseXmlBtn").click();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
+    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importXlsxInput");
+    const file = new File([bytes], "saved-invalid-after-import.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
+
+    const OriginalBlob = Blob;
+    class InspectableBlob extends OriginalBlob {
+      __parts;
+
+      constructor(parts, options) {
+        super(parts, options);
+        this.__parts = parts;
+      }
+
+      text() {
+        return Promise.resolve(this.__parts.join(""));
+      }
+    }
+    globalThis.Blob = InspectableBlob;
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
+
+    try {
+      document.getElementById("downloadXmlBtn").click();
+
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+      const exportedBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+      expect(exportedBlob).toBeInstanceOf(InspectableBlob);
+      await expect(exportedBlob.text()).resolves.toContain("<Start>2026-03-19T09:00:00</Start>");
+      await expect(exportedBlob.text()).resolves.toContain("<Finish>2026-03-18T18:00:00</Finish>");
+      const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+      expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xml");
+      expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルをエクスポートしました");
+    } finally {
+      globalThis.Blob = OriginalBlob;
+    }
   });
 
   it("downloads rendered mermaid svg", async () => {

--- a/docs/project/tests/mikuproject-project-xlsx.test.js
+++ b/docs/project/tests/mikuproject-project-xlsx.test.js
@@ -1,0 +1,436 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const typesCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/types.js"),
+  "utf8"
+);
+const excelIoCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/excel-io.js"),
+  "utf8"
+);
+const msProjectXmlCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/msproject-xml.js"),
+  "utf8"
+);
+const projectXlsxCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/project-xlsx.js"),
+  "utf8"
+);
+
+function bootModules() {
+  new Function(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectXlsxCode}`)();
+  return {
+    excelIo: globalThis.__mikuprojectExcelIo,
+    xml: globalThis.__mikuprojectXml,
+    projectXlsx: globalThis.__mikuprojectProjectXlsx
+  };
+}
+
+describe("mikuproject project xlsx", () => {
+  it("converts ProjectModel into workbook sheets", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+
+    expect(workbook.sheets.map((sheet) => sheet.name)).toEqual([
+      "Project",
+      "Tasks",
+      "Resources",
+      "Assignments",
+      "Calendars"
+    ]);
+    expect(workbook.sheets[0].mergedRanges).toEqual(["A1:B1", "A2:B2", "A11:B11"]);
+    expect(workbook.sheets[0].rows[0].cells[0].value).toBe("Project");
+    expect(workbook.sheets[0].rows[0].cells[0].bold).toBe(true);
+    expect(workbook.sheets[0].rows[1].cells[0].value).toBe("Basic Info");
+    expect(workbook.sheets[0].rows[2].cells[0].value).toBe("Field");
+    expect(workbook.sheets[0].rows[3].cells[0].value).toBe("Name");
+    expect(workbook.sheets[0].rows[3].cells[1].value).toBe("Sample Project");
+    expect(workbook.sheets[0].rows[11].cells[0].value).toBe("Settings");
+  });
+
+  it("maps tasks, resources, assignments, and calendars to tabular rows", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    expect(tasksSheet.mergedRanges).toEqual(["A1:P1", "A2:P2"]);
+    expect(tasksSheet.rows[0].cells[0].value).toBe("Tasks");
+    expect(tasksSheet.rows[1].cells[0].value).toBe("Task List");
+    expect(tasksSheet.rows[2].cells.map((cell) => cell.value)).toEqual([
+      "UID",
+      "ID",
+      "Name",
+      "OutlineLevel",
+      "OutlineNumber",
+      "WBS",
+      "Start",
+      "Finish",
+      "Duration",
+      "PercentComplete",
+      "PercentWorkComplete",
+      "Milestone",
+      "Summary",
+      "Critical",
+      "CalendarUID",
+      "Predecessors"
+    ]);
+    expect(tasksSheet.rows[3].cells[2].value).toBe("Project Summary");
+    expect(tasksSheet.rows[5].cells[2].value).toBe("Implementation");
+    expect(tasksSheet.rows[5].cells[15].value).toBe("2");
+
+    expect(resourcesSheet.mergedRanges).toEqual(["A1:N1", "A2:N2"]);
+    expect(resourcesSheet.rows[0].cells[0].value).toBe("Resources");
+    expect(resourcesSheet.rows[1].cells[0].value).toBe("Resource List");
+    expect(resourcesSheet.rows[2].cells.map((cell) => cell.value)).toEqual([
+      "UID",
+      "ID",
+      "Name",
+      "Type",
+      "Initials",
+      "Group",
+      "MaxUnits",
+      "CalendarUID",
+      "StandardRate",
+      "OvertimeRate",
+      "CostPerUse",
+      "Work",
+      "ActualWork",
+      "RemainingWork"
+    ]);
+    expect(resourcesSheet.rows[3].cells[2].value).toBe("Miku");
+
+    expect(assignmentsSheet.mergedRanges).toEqual(["A1:L1", "A2:L2"]);
+    expect(assignmentsSheet.rows[0].cells[0].value).toBe("Assignments");
+    expect(assignmentsSheet.rows[1].cells[0].value).toBe("Assignment List");
+    expect(assignmentsSheet.rows[2].cells.map((cell) => cell.value)).toEqual([
+      "UID",
+      "TaskUID",
+      "TaskName",
+      "ResourceUID",
+      "ResourceName",
+      "Start",
+      "Finish",
+      "Units",
+      "Work",
+      "ActualWork",
+      "RemainingWork",
+      "PercentWorkComplete"
+    ]);
+    expect(assignmentsSheet.rows[3].cells[2].value).toBe("Design");
+    expect(assignmentsSheet.rows[3].cells[4].value).toBe("Miku");
+
+    expect(calendarsSheet.mergedRanges).toEqual(["A1:G1", "A2:G2"]);
+    expect(calendarsSheet.rows[0].cells[0].value).toBe("Calendars");
+    expect(calendarsSheet.rows[1].cells[0].value).toBe("Calendar List");
+    expect(calendarsSheet.rows[2].cells.map((cell) => cell.value)).toEqual([
+      "UID",
+      "Name",
+      "IsBaseCalendar",
+      "BaseCalendarUID",
+      "WeekDays",
+      "Exceptions",
+      "WorkWeeks"
+    ]);
+    expect(calendarsSheet.rows[3].cells[1].value).toBe("Standard");
+  });
+
+  it("can generate a real xlsx from ProjectModel through the workbook adapter", () => {
+    const { excelIo, xml, projectXlsx } = bootModules();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const bytes = codec.exportWorkbook(workbook);
+    const entries = codec.listEntries(bytes);
+    const projectSheetXml = new TextDecoder().decode(codec.unpackEntries(bytes)["xl/worksheets/sheet1.xml"]);
+
+    expect(entries).toContain("xl/workbook.xml");
+    expect(entries).toContain("xl/worksheets/sheet1.xml");
+    expect(entries).toContain("xl/styles.xml");
+    expect(projectSheetXml).toContain('ref="A1:B1"');
+  });
+
+  it("imports limited task fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[2].value = "Design Updated";
+    tasksSheet.rows[4].cells[6].value = "2026-03-17T09:00:00";
+    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+    tasksSheet.rows[4].cells[9].value = 80;
+    tasksSheet.rows[4].cells[10].value = 90;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const designTask = importedModel.tasks.find((task) => task.uid === "2");
+    const implementationTask = importedModel.tasks.find((task) => task.uid === "3");
+
+    expect(designTask.name).toBe("Design Updated");
+    expect(designTask.start).toBe("2026-03-17T09:00:00");
+    expect(designTask.finish).toBe("2026-03-18T18:00:00");
+    expect(designTask.percentComplete).toBe(80);
+    expect(designTask.percentWorkComplete).toBe(90);
+    expect(implementationTask.name).toBe("Implementation");
+  });
+
+  it("imports limited resource and assignment fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+
+    resourcesSheet.rows[3].cells[2].value = "Miku Updated";
+    resourcesSheet.rows[3].cells[5].value = "Platform";
+    resourcesSheet.rows[3].cells[6].value = 0.8;
+
+    assignmentsSheet.rows[3].cells[7].value = 0.75;
+    assignmentsSheet.rows[3].cells[8].value = "PT12H0M0S";
+    assignmentsSheet.rows[3].cells[11].value = 70;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const resource = importedModel.resources.find((item) => item.uid === "1");
+    const assignment = importedModel.assignments.find((item) => item.uid === "1");
+
+    expect(resource.name).toBe("Miku Updated");
+    expect(resource.group).toBe("Platform");
+    expect(resource.maxUnits).toBe(0.8);
+    expect(assignment.units).toBe(0.75);
+    expect(assignment.work).toBe("PT12H0M0S");
+    expect(assignment.percentWorkComplete).toBe(70);
+  });
+
+  it("imports limited project fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[3].cells[1].value = "Renamed Project";
+    projectSheet.rows[7].cells[1].value = "2026-03-15T09:00:00";
+    projectSheet.rows[12].cells[1].value = "2";
+    projectSheet.rows[13].cells[1].value = 420;
+    projectSheet.rows[16].cells[1].value = false;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.project.name).toBe("Renamed Project");
+    expect(importedModel.project.startDate).toBe("2026-03-15T09:00:00");
+    expect(importedModel.project.calendarUID).toBe("2");
+    expect(importedModel.project.minutesPerDay).toBe(420);
+    expect(importedModel.project.scheduleFromStart).toBe(false);
+  });
+
+  it("imports project calendar and schedule mode fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[12].cells[1].value = "2";
+    projectSheet.rows[16].cells[1].value = false;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.project.calendarUID).toBe("2");
+    expect(importedModel.project.scheduleFromStart).toBe(false);
+  });
+
+  it("imports project metadata and date fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[4].cells[1].value = "Updated Title";
+    projectSheet.rows[6].cells[1].value = "Updated Company";
+    projectSheet.rows[7].cells[1].value = "2026-03-15T09:00:00";
+    projectSheet.rows[8].cells[1].value = "2026-03-28T18:00:00";
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.project.title).toBe("Updated Title");
+    expect(importedModel.project.company).toBe("Updated Company");
+    expect(importedModel.project.startDate).toBe("2026-03-15T09:00:00");
+    expect(importedModel.project.finishDate).toBe("2026-03-28T18:00:00");
+  });
+
+  it("imports project author field from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[5].cells[1].value = "Author From XLSX";
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.project.author).toBe("Author From XLSX");
+  });
+
+  it("imports project current and status dates plus weekly settings from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[9].cells[1].value = "2026-03-18T09:00:00";
+    projectSheet.rows[10].cells[1].value = "2026-03-22T09:00:00";
+    projectSheet.rows[14].cells[1].value = 2100;
+    projectSheet.rows[15].cells[1].value = 18;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.project.currentDate).toBe("2026-03-18T09:00:00");
+    expect(importedModel.project.statusDate).toBe("2026-03-22T09:00:00");
+    expect(importedModel.project.minutesPerWeek).toBe(2100);
+    expect(importedModel.project.daysPerMonth).toBe(18);
+  });
+
+  it("reports field-level import changes", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+
+    tasksSheet.rows[4].cells[2].value = "Design Updated";
+    tasksSheet.rows[4].cells[9].value = 80;
+
+    const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
+
+    expect(result.changes).toEqual([
+      { scope: "tasks", uid: "2", label: "Design", field: "Name", before: "Design", after: "Design Updated" },
+      { scope: "tasks", uid: "2", label: "Design", field: "PercentComplete", before: 100, after: 80 }
+    ]);
+  });
+
+  it("reports project-level import changes", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+
+    projectSheet.rows[3].cells[1].value = "Renamed Project";
+    projectSheet.rows[13].cells[1].value = 420;
+
+    const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
+
+    expect(result.changes).toEqual([
+      { scope: "project", uid: "project", label: "Sample Project", field: "Name", before: "Sample Project", after: "Renamed Project" },
+      { scope: "project", uid: "project", label: "Sample Project", field: "MinutesPerDay", before: 480, after: 420 }
+    ]);
+  });
+
+  it("imports limited calendar fields from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[1].value = "Standard Updated";
+    calendarsSheet.rows[3].cells[3].value = "2";
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "1").name).toBe("Standard Updated");
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "1").baseCalendarUID).toBe("2");
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "2").name).toBe("Development");
+  });
+
+  it("reports calendar-level import changes", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[1].value = "Standard Updated";
+    calendarsSheet.rows[3].cells[3].value = "2";
+
+    const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
+
+    expect(result.changes).toEqual([
+      { scope: "calendars", uid: "1", label: "Standard", field: "Name", before: "Standard", after: "Standard Updated" },
+      { scope: "calendars", uid: "1", label: "Standard", field: "BaseCalendarUID", before: undefined, after: "2" }
+    ]);
+  });
+
+  it("imports calendar isBaseCalendar field from workbook rows back into ProjectModel", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[4].cells[2].value = true;
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "2").isBaseCalendar).toBe(true);
+  });
+
+  it("ignores calendar WeekDays, Exceptions, and WorkWeeks workbook edits", () => {
+    const { xml, projectXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    calendarsSheet.rows[3].cells[4].value = 77;
+    calendarsSheet.rows[3].cells[5].value = 88;
+    calendarsSheet.rows[3].cells[6].value = 99;
+
+    const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
+
+    expect(result.model.calendars.find((calendar) => calendar.uid === "1").weekDays).toHaveLength(1);
+    expect(result.model.calendars.find((calendar) => calendar.uid === "1").exceptions).toHaveLength(1);
+    expect(result.model.calendars.find((calendar) => calendar.uid === "1").workWeeks).toHaveLength(0);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("round-trips editable fields through workbook and xlsx bytes", () => {
+    const { excelIo, xml, projectXlsx } = bootModules();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const workbook = projectXlsx.exportProjectWorkbook(model);
+
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+
+    tasksSheet.rows[4].cells[2].value = "Design via XLSX";
+    tasksSheet.rows[4].cells[9].value = 60;
+    resourcesSheet.rows[3].cells[2].value = "Miku via XLSX";
+    assignmentsSheet.rows[3].cells[11].value = 55;
+    calendarsSheet.rows[4].cells[1].value = "Development via XLSX";
+    calendarsSheet.rows[4].cells[2].value = true;
+    calendarsSheet.rows[4].cells[3].value = "1";
+
+    const bytes = codec.exportWorkbook(workbook);
+    const importedWorkbook = codec.importWorkbook(bytes);
+    const importedModel = projectXlsx.importProjectWorkbook(importedWorkbook, model);
+
+    expect(importedModel.tasks.find((task) => task.uid === "2").name).toBe("Design via XLSX");
+    expect(importedModel.tasks.find((task) => task.uid === "2").percentComplete).toBe(60);
+    expect(importedModel.resources.find((resource) => resource.uid === "1").name).toBe("Miku via XLSX");
+    expect(importedModel.assignments.find((assignment) => assignment.uid === "1").percentWorkComplete).toBe(55);
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "2").name).toBe("Development via XLSX");
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "2").isBaseCalendar).toBe(true);
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "2").baseCalendarUID).toBe("1");
+  });
+});

--- a/docs/project/tests/mikuproject-wbs-xlsx.test.js
+++ b/docs/project/tests/mikuproject-wbs-xlsx.test.js
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const typesCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/types.js"),
+  "utf8"
+);
+const excelIoCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/excel-io.js"),
+  "utf8"
+);
+const msProjectXmlCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/msproject-xml.js"),
+  "utf8"
+);
+const wbsXlsxCode = readFileSync(
+  path.resolve(__dirname, "../src/mikuproject/js/wbs-xlsx.js"),
+  "utf8"
+);
+
+function bootModules() {
+  new Function(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${wbsXlsxCode}`)();
+  return {
+    excelIo: globalThis.__mikuprojectExcelIo,
+    xml: globalThis.__mikuprojectXml,
+    wbsXlsx: globalThis.__mikuprojectWbsXlsx
+  };
+}
+
+describe("mikuproject wbs xlsx", () => {
+  it("exports a dedicated WBS workbook from ProjectModel", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(workbook.sheets.map((item) => item.name)).toEqual(["WBS"]);
+    expect(sheet.mergedRanges).toEqual(["A1:W1", "A2:W2", "A3:W3", "A4:W4"]);
+    expect(sheet.rows[0].cells[0].value).toBe("WBS");
+    expect(sheet.rows[1].cells[0].value).toBe("Sample Project");
+    expect(String(sheet.rows[2].cells[0].value)).toContain("Title=Sample Project Title");
+    expect(String(sheet.rows[3].cells[0].value)).toContain("Start=2026-03-16T09:00:00");
+    expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=0");
+    expect(sheet.rows[4].cells[0].value).toBe("Task View");
+    expect(sheet.rows[5].cells[5].value).toBe("Today");
+    expect(sheet.rows[5].cells[18].value).toBe("▼");
+    expect(sheet.rows[6].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
+      "UID",
+      "ID",
+      "WBS",
+      "Kind",
+      "OutlineLevel",
+      "Name",
+      "Start",
+      "Finish",
+      "Duration",
+      "PercentComplete",
+      "PercentWorkComplete",
+      "Milestone",
+      "Summary",
+      "Critical",
+      "Owner",
+      "Calendar",
+      "Resources",
+      "Predecessors"
+    ]);
+    expect(sheet.rows[6].cells.slice(18).map((cell) => cell.value)).toEqual([
+      "03/16 Mon",
+      "03/17 Tue",
+      "03/18 Wed",
+      "03/19 Thu",
+      "03/20 Fri"
+    ]);
+    expect(sheet.rows[6].cells[18].fillColor).toBe("#FFE6A7");
+    expect(sheet.rows[7].cells[3].value).toBe("phase");
+    expect(sheet.rows[7].cells[0].fillColor).toBe("#EEF7E8");
+    expect(sheet.rows[7].cells[5].bold).toBe(true);
+    expect(sheet.rows[8].cells[3].value).toBe("task");
+    expect(sheet.rows[8].cells[4].value).toBe(2);
+    expect(sheet.rows[8].cells[5].value).toBe("  Design");
+    expect(sheet.rows[8].cells[14].value).toBe("Miku");
+    expect(sheet.rows[8].cells[15].value).toBe("1 Standard");
+    expect(sheet.rows[8].cells[16].value).toBe("Miku");
+    expect(sheet.rows[9].cells[17].value).toBe("Design");
+    expect(sheet.rows[8].cells[5].bold).toBe(false);
+    expect(sheet.rows[8].cells[18].value).toBe("■");
+    expect(sheet.rows[8].cells[18].fillColor).toBe("#D89A2B");
+    expect(sheet.rows[8].cells[19].value).toBe("■");
+    expect(sheet.rows[8].cells[19].fillColor).toBe("#5BAE9C");
+    expect(sheet.rows[8].cells[20].value).toBe("");
+    expect(sheet.rows[8].cells[21].value).toBe("");
+  });
+
+  it("can generate a real xlsx from the dedicated WBS workbook", () => {
+    const { excelIo, xml, wbsXlsx } = bootModules();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const bytes = codec.exportWorkbook(workbook);
+    const entries = codec.listEntries(bytes);
+    const sheetXml = new TextDecoder().decode(codec.unpackEntries(bytes)["xl/worksheets/sheet1.xml"]);
+
+    expect(entries).toContain("xl/workbook.xml");
+    expect(entries).toContain("xl/worksheets/sheet1.xml");
+    expect(sheetXml).toContain('ref="A1:W1"');
+    expect(sheetXml).toContain('ref="A4:W4"');
+    expect(sheetXml).toContain("Task View");
+    expect(sheetXml).toContain("Sample Project");
+    expect(sheetXml).toContain("OutlineLevel");
+    expect(sheetXml).toContain("03/16 Mon");
+  });
+
+  it("marks weekend date-band cells with weekend fill", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-20T09:00:00";
+    model.project.finishDate = "2026-03-23T18:00:00";
+    model.project.currentDate = "2026-03-21T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.rows[6].cells.slice(18).map((cell) => cell.value)).toEqual([
+      "03/20 Fri",
+      "03/21 Sat",
+      "03/22 Sun",
+      "03/23 Mon"
+    ]);
+    expect(sheet.rows[5].cells[19].value).toBe("▼");
+    expect(sheet.rows[6].cells[19].fillColor).toBe("#FFE6A7");
+    expect(sheet.rows[6].cells[20].fillColor).toBe("#F1F1F1");
+  });
+
+  it("marks configured holidays in the date band", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model, {
+      holidayDates: ["2026-03-20"]
+    });
+    const sheet = workbook.sheets[0];
+
+    expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=1");
+    expect(sheet.rows[6].cells[22].value).toBe("03/20 Fri");
+    expect(sheet.rows[6].cells[22].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[8].cells[22].value).toBe("");
+    expect(sheet.rows[8].cells[22].fillColor).toBe("#FCE4EC");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "build:life": "node scripts/build-life.mjs",
     "build:link": "node scripts/build-link.mjs",
     "build:project": "node scripts/build-project.mjs",
+    "build:project:xlsx-sample": "npm run build:project && node scripts/build-project-xlsx-sample.mjs",
     "build:prompt": "node scripts/build-prompt.mjs",
     "build:text": "node scripts/build-text.mjs",
     "build:img": "node scripts/build-img.mjs",
     "build:docs": "node scripts/build-docs-index.mjs",
-    "build:all": "npm run build:music && npm run build:git && npm run build:knowledge-timeline && npm run build:grep && npm run build:password && npm run build:diagram && npm run build:ffmpeg && npm run build:life && npm run build:link && npm run build:project && npm run build:prompt && npm run build:text && npm run build:img && npm run build:docs && npm test"
+    "build:all": "npm run build:music && npm run build:git && npm run build:knowledge-timeline && npm run build:grep && npm run build:password && npm run build:diagram && npm run build:ffmpeg && npm run build:life && npm run build:link && npm run build:project:xlsx-sample && npm run build:prompt && npm run build:text && npm run build:img && npm run build:docs && npm test"
   },
   "devDependencies": {
     "@material/web": "^2.4.1",

--- a/scripts/build-project-xlsx-sample.mjs
+++ b/scripts/build-project-xlsx-sample.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { JSDOM } from "jsdom";
+
+const ROOT = process.cwd();
+const typesCode = fs.readFileSync(path.resolve(ROOT, "docs/project/src/mikuproject/js/types.js"), "utf8");
+const excelIoCode = fs.readFileSync(path.resolve(ROOT, "docs/project/src/mikuproject/js/excel-io.js"), "utf8");
+const msProjectXmlCode = fs.readFileSync(path.resolve(ROOT, "docs/project/src/mikuproject/js/msproject-xml.js"), "utf8");
+const projectXlsxCode = fs.readFileSync(path.resolve(ROOT, "docs/project/src/mikuproject/js/project-xlsx.js"), "utf8");
+const wbsXlsxCode = fs.readFileSync(path.resolve(ROOT, "docs/project/src/mikuproject/js/wbs-xlsx.js"), "utf8");
+
+const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
+globalThis.window = dom.window;
+globalThis.document = dom.window.document;
+globalThis.DOMParser = dom.window.DOMParser;
+globalThis.XMLSerializer = dom.window.XMLSerializer;
+globalThis.Node = dom.window.Node;
+
+globalThis.eval(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectXlsxCode}\n${wbsXlsxCode}`);
+
+const excelIo = globalThis.__mikuprojectExcelIo;
+const xml = globalThis.__mikuprojectXml;
+const projectXlsx = globalThis.__mikuprojectProjectXlsx;
+const wbsXlsx = globalThis.__mikuprojectWbsXlsx;
+if (!excelIo?.XlsxWorkbookCodec) {
+  throw new Error("mikuproject excel io module is not loaded");
+}
+if (!xml?.SAMPLE_XML || typeof xml.importMsProjectXml !== "function") {
+  throw new Error("mikuproject xml module is not loaded");
+}
+if (typeof projectXlsx?.exportProjectWorkbook !== "function") {
+  throw new Error("mikuproject project xlsx module is not loaded");
+}
+if (typeof wbsXlsx?.exportWbsWorkbook !== "function") {
+  throw new Error("mikuproject wbs xlsx module is not loaded");
+}
+
+const codec = new excelIo.XlsxWorkbookCodec();
+const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+const workbook = projectXlsx.exportProjectWorkbook(model);
+const holidayDates = Array.from(new Set(
+  model.calendars.flatMap((calendar) => calendar.exceptions || [])
+    .filter((exception) => (exception.workingTimes || []).length === 0)
+    .flatMap((exception) => {
+      const from = (exception.fromDate || "").slice(0, 10);
+      const to = (exception.toDate || "").slice(0, 10);
+      if (!from) {
+        return [];
+      }
+      if (!to || to === from) {
+        return [from];
+      }
+      const days = [];
+      const start = new Date(`${from}T00:00:00`);
+      const finish = new Date(`${to}T00:00:00`);
+      for (const cursor = new Date(start.getTime()); cursor.getTime() <= finish.getTime(); cursor.setDate(cursor.getDate() + 1)) {
+        const year = cursor.getFullYear();
+        const month = String(cursor.getMonth() + 1).padStart(2, "0");
+        const day = String(cursor.getDate()).padStart(2, "0");
+        days.push(`${year}-${month}-${day}`);
+      }
+      return days;
+    })
+));
+const wbsWorkbook = wbsXlsx.exportWbsWorkbook(model, { holidayDates });
+
+const bytes = codec.exportWorkbook(workbook);
+const wbsBytes = codec.exportWorkbook(wbsWorkbook);
+const outputPath = path.resolve(ROOT, "docs/project/local-data/mikuproject-sample.xlsx");
+const wbsOutputPath = path.resolve(ROOT, "docs/project/local-data/mikuproject-wbs-sample.xlsx");
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, Buffer.from(bytes));
+fs.writeFileSync(wbsOutputPath, Buffer.from(wbsBytes));
+console.log(`[build:project:xlsx-sample] generated ${path.relative(ROOT, outputPath)}`);
+console.log(`[build:project:xlsx-sample] generated ${path.relative(ROOT, wbsOutputPath)}`);

--- a/scripts/build-project.mjs
+++ b/scripts/build-project.mjs
@@ -11,7 +11,10 @@ const TARGETS = [
     outHtml: "docs/project/mikuproject.html",
     tsOrder: [
       "src/mikuproject/ts/types.ts",
+      "src/mikuproject/ts/excel-io.ts",
       "src/mikuproject/ts/msproject-xml.ts",
+      "src/mikuproject/ts/project-xlsx.ts",
+      "src/mikuproject/ts/wbs-xlsx.ts",
       "src/mikuproject/ts/main.ts"
     ]
   }


### PR DESCRIPTION
## 概要

`mikuproject` に対して、`MS Project XML` を基軸とした `.xlsx` 対応を追加します。 あわせて、WBS 表示専用の workbook export、UI 上の import/export 導線、仕様・TODO・サンプル生成・テストをまとめて整備します。

## 変更内容

### `.xlsx` 入出力基盤の追加
- `excel-io.ts/js` を追加
- `.xlsx` workbook の export/import を扱う基盤を追加
- スタイル、列幅、行高、結合セルなど workbook 表現を実装

### `ProjectModel` と `.xlsx` の変換追加
- `project-xlsx.ts/js` を追加
- `Project / Tasks / Resources / Assignments / Calendars` を対象に、構造忠実な workbook export を追加
- 限定列のみを対象にした workbook import を追加
- `ProjectModel -> workbook -> .xlsx -> workbook -> ProjectModel` の経路を扱える構成を追加

### WBS 向け `.xlsx` export の追加
- `wbs-xlsx.ts/js` を追加
- `Tasks` 中心の表示専用 `WBS` workbook export を追加
- `Kind / OutlineLevel / Owner / Calendar / Resources / Predecessors` を含む WBS 向け表現を追加
- 日付帯、進捗帯、週末、today、祝日色分けを持つ WBS 表示を追加
- `WBS XLSX Export` 向けの祝日指定を追加

### UI の拡張
- `mikuproject-src.html` と `main.ts/js` を更新
- `XLSX Export` / `XLSX Import` / `WBS XLSX Export` を追加
- `XML 保存状態` 表示を追加
- `XLSX Import` 後の差分要約と検証メッセージ表示を追加
- `.xlsx` の位置づけ、反映対象、非対応範囲、WBS 祝日指定の説明を追加

### ビルドとサンプル生成の追加
- `build-project-xlsx-sample.mjs` を追加
- `mikuproject-sample.xlsx` と `mikuproject-wbs-sample.xlsx` の生成を追加
- `build:project:xlsx-sample` を追加
- `build:all` に sample 生成を含めるよう更新
- WBS sample 生成時に `Calendar.Exceptions` の非稼働日例外を祝日候補として反映

### 仕様書・TODO の更新
- `mikuproject-spec.md` を更新
- `.xlsx` の位置づけ、editable 範囲、WBS export、祝日指定を追記
- `TODO.md` を新規追加
- `.xlsx` 方針と今後の整理事項を明文化

### テスト追加
- `mikuproject-excel-io.test.js` を追加
- `mikuproject-project-xlsx.test.js` を追加
- `mikuproject-wbs-xlsx.test.js` を追加
- `mikuproject-main.test.js` を拡張
- `.xlsx` export/import、WBS export、UI 表示、差分要約、validation 連携を確認するテストを追加

## 影響範囲

- `mikuproject` の UI
- `mikuproject` の build
- `docs/project` 配下の仕様・sample・テスト

## 補足

- `.xlsx` は正本ではなく、`MS Project XML` を基軸とした周辺表現として扱います
- `WBS` workbook は表示専用 export であり、import は対象外です
- `Calendars` では `WeekDays / Exceptions / WorkWeeks` の import は引き続き非対応です