### PR TITLE
Git 作業一覧 / Git pseudo-squash の導線改善と mikuproject の WBS XLSX 出力強化

### DIFF
--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -75,6 +75,33 @@ limitations under the License.
 
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">
+        <div id="repoDisplayCard" class="md-repo-display-card md-hidden" aria-live="polite">
+          <p id="repoDisplayName" class="md-repo-display-name"></p>
+          <span class="md-repo-display-actions">
+            <button id="copyGitCurrentDirBackupBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                <rect x="13" y="3" width="8" height="8" rx="2"></rect>
+                <path d="M15.5 7h3"></path>
+                <path d="M17 5.5v3"></path>
+              </svg>
+            </button>
+            <button id="openRepoUrlBackupBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="リポジトリ URL を開く" aria-label="リポジトリ URL を開く">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M14 5h5v5"></path>
+                <path d="M10 14 19 5"></path>
+                <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
+              </svg>
+            </button>
+            <button id="saveToWorkBranchListInlineBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="Git 作業一覧へ保存" aria-label="Git 作業一覧へ保存">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M4 7h16"></path>
+                <path d="M4 12h16"></path>
+                <path d="M4 17h16"></path>
+              </svg>
+            </button>
+          </span>
+        </div>
         <div class="md-form-row md-form-row--nowrap">
           <lht-text-field-help field-id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" value="devel" help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></lht-text-field-help>
           <md-menu id="baseBranchMenu" anchor="squashBaseBranch" positioning="popover" quick no-navigation-wrap></md-menu>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -1136,8 +1136,48 @@ lht-index-card-link {
       margin-top: 28px;
     }
 
+    lht-page-hero {
+      margin-bottom: 0.35rem;
+    }
+
+    #baseBlock {
+      margin-top: 2px;
+    }
+
     .md-section-title {
       font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-repo-display-card {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      max-width: 100%;
+      padding: 0.28rem 0.78rem;
+      border: 1px solid #e3dcef;
+      border-radius: 999px;
+      background: #fbf9ff;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+      margin-top: 0.32rem;
+      margin-bottom: 0.52rem;
+    }
+
+    .md-repo-display-name {
+      margin: 0;
+      font-size: 1.02rem;
+      line-height: 1.35;
+      font-weight: 700;
+      letter-spacing: 0;
+      color: var(--md-sys-color-on-surface);
+      word-break: break-word;
+    }
+
+    .md-repo-display-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      flex: 0 0 auto;
+      margin-left: 0.15rem;
     }
 
     .md-grid {
@@ -2544,6 +2584,33 @@ lht-index-card-link {
 
     <section id="baseBlock" class="md-section md-stack-md">
       <div class="md-stack-md">
+        <div id="repoDisplayCard" class="md-repo-display-card md-hidden" aria-live="polite">
+          <p id="repoDisplayName" class="md-repo-display-name"></p>
+          <span class="md-repo-display-actions">
+            <button id="copyGitCurrentDirBackupBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                <rect x="13" y="3" width="8" height="8" rx="2"></rect>
+                <path d="M15.5 7h3"></path>
+                <path d="M17 5.5v3"></path>
+              </svg>
+            </button>
+            <button id="openRepoUrlBackupBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="リポジトリ URL を開く" aria-label="リポジトリ URL を開く">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M14 5h5v5"></path>
+                <path d="M10 14 19 5"></path>
+                <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
+              </svg>
+            </button>
+            <button id="saveToWorkBranchListInlineBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="Git 作業一覧へ保存" aria-label="Git 作業一覧へ保存">
+              <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M4 7h16"></path>
+                <path d="M4 12h16"></path>
+                <path d="M4 17h16"></path>
+              </svg>
+            </button>
+          </span>
+        </div>
         <div class="md-form-row md-form-row--nowrap">
           <lht-text-field-help field-id="squashBaseBranch" label="基点ブランチ" required autocomplete="on" placeholder="例: devel" value="devel" help-text="基点は git 作業の差分の起点として利用されます。git 作業をどこが基点なのか確認しましょう。基点が違うと差分がずれるため要確認です。設定の順番を揃えると意図した差分になりやすいです。"></lht-text-field-help>
           <md-menu id="baseBranchMenu" anchor="squashBaseBranch" positioning="popover" quick no-navigation-wrap></md-menu>
@@ -4972,6 +5039,14 @@ if (!customElements.get("lht-page-menu")) {
       return trimmed.replace(/\/+$/, "");
     }
 
+    function extractRepoName(repoUrl) {
+      const trimmed = String(repoUrl || "").trim().replace(/\/+$/, "");
+      if (!trimmed) return "";
+      const normalized = trimmed.replace(/\.git$/i, "");
+      const parts = normalized.split(/[/:]/).filter(Boolean);
+      return parts[parts.length - 1] || normalized;
+    }
+
     function isOpenableExternalUrl(url) {
       return /^https?:\/\//i.test(String(url || "").trim());
     }
@@ -5046,6 +5121,21 @@ if (!customElements.get("lht-page-menu")) {
       repoUrlField.readOnly = !!locked;
       repoUrlField.classList.toggle("md-disabled", !!locked);
       repoUrlField.setAttribute("aria-readonly", locked ? "true" : "false");
+    }
+
+    function updateRepoDisplay() {
+      const card = document.getElementById("repoDisplayCard");
+      const nameNode = document.getElementById("repoDisplayName");
+      if (!card || !nameNode) return;
+      const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
+      const repoName = extractRepoName(repoUrl);
+      if (!repoName) {
+        nameNode.textContent = "";
+        card.classList.add("md-hidden");
+        return;
+      }
+      nameNode.textContent = repoName;
+      card.classList.remove("md-hidden");
     }
 
     function updateBaseScope() {
@@ -5298,9 +5388,11 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function setupWorkBranchListButton() {
-      const button = document.getElementById("saveToWorkBranchListBtn");
-      if (!button) return;
-      button.addEventListener("click", saveToWorkBranchListAndOpen);
+      ["saveToWorkBranchListBtn", "saveToWorkBranchListInlineBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", saveToWorkBranchListAndOpen);
+      });
     }
 
     function setupBranchDiffButton() {
@@ -5766,18 +5858,25 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function updateGitCurrentDirectoryAction() {
-      const button = document.getElementById("copyGitCurrentDirBtn");
-      if (!button) return;
+      const buttons = [
+        document.getElementById("copyGitCurrentDirBtn"),
+        document.getElementById("copyGitCurrentDirBackupBtn")
+      ].filter(Boolean);
+      if (buttons.length === 0) return;
       const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
       if (gitCurrentDir) {
-        button.dataset.gitCurrentDir = gitCurrentDir;
-        button.title = gitCurrentDir;
-        button.classList.remove("md-hidden");
+        buttons.forEach((button) => {
+          button.dataset.gitCurrentDir = gitCurrentDir;
+          button.title = gitCurrentDir;
+          button.classList.remove("md-hidden");
+        });
         return;
       }
-      delete button.dataset.gitCurrentDir;
-      button.title = "git カレントディレクトリをコピー";
-      button.classList.add("md-hidden");
+      buttons.forEach((button) => {
+        delete button.dataset.gitCurrentDir;
+        button.title = "git カレントディレクトリをコピー";
+        button.classList.add("md-hidden");
+      });
     }
 
     function applyQueryParams() {
@@ -5838,6 +5937,7 @@ if (!customElements.get("lht-page-menu")) {
         }
       }
       updateGitCurrentDirectoryAction();
+      updateRepoDisplay();
     }
 
     function createWorkBranchListEntryId() {
@@ -6570,15 +6670,19 @@ if (!customElements.get("lht-page-menu")) {
     }
 
     function setupOpenRepoUrlButton() {
-      const button = document.getElementById("openRepoUrlBtn");
-      if (!button) return;
-      button.addEventListener("click", openRepoUrl);
+      ["openRepoUrlBtn", "openRepoUrlBackupBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", openRepoUrl);
+      });
     }
 
     function setupCopyGitCurrentDirectoryButton() {
-      const button = document.getElementById("copyGitCurrentDirBtn");
-      if (!button) return;
-      button.addEventListener("click", copyGitCurrentDirectory);
+      ["copyGitCurrentDirBtn", "copyGitCurrentDirBackupBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", copyGitCurrentDirectory);
+      });
       const sync = () => updateGitCurrentDirectoryAction();
       ["repoUrl", "squashBaseBranch"].forEach((id) => {
         const element = document.getElementById(id);
@@ -6587,6 +6691,15 @@ if (!customElements.get("lht-page-menu")) {
         element.addEventListener("change", sync);
       });
       updateGitCurrentDirectoryAction();
+    }
+
+    function setupRepoDisplay() {
+      const repoUrlField = document.getElementById("repoUrl");
+      if (!repoUrlField) return;
+      const sync = () => updateRepoDisplay();
+      repoUrlField.addEventListener("input", sync);
+      repoUrlField.addEventListener("change", sync);
+      updateRepoDisplay();
     }
 
     applyQueryParams();
@@ -6609,6 +6722,7 @@ if (!customElements.get("lht-page-menu")) {
     setupBranchDiffButton();
     setupOpenRepoUrlButton();
     setupCopyGitCurrentDirectoryButton();
+    setupRepoDisplay();
     setupCodeSelectAll();
   </script>
 </body>

--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -33,8 +33,7 @@ limitations under the License.
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      リポジトリ URL、基準ブランチ、作業ブランチ、ローカル/リモートの扱いをまとめて保存し、一覧で管理します。<br><br>
-      複数リポジトリ・複数作業を並行で扱うときの「今どの組み合わせを見ていたか」を忘れにくくするためのローカル専用メモ兼一覧ツールです。
+      複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
@@ -145,7 +144,7 @@ limitations under the License.
             <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
           </div>
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="gitCurrentDirectory" label="git カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
           </div>
         </div>
 

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1742,8 +1742,7 @@ lht-index-card-link {
       help-wide
       menu-home-href="../index.html"
       menu-home-label="トップへ戻る">
-      リポジトリ URL、基準ブランチ、作業ブランチ、ローカル/リモートの扱いをまとめて保存し、一覧で管理します。<br><br>
-      複数リポジトリ・複数作業を並行で扱うときの「今どの組み合わせを見ていたか」を忘れにくくするためのローカル専用メモ兼一覧ツールです。
+      複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。
     </lht-page-hero>
 
     <section class="md-section md-stack-md">
@@ -1854,7 +1853,7 @@ lht-index-card-link {
             <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
           </div>
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="gitCurrentDirectory" label="git カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
           </div>
         </div>
 
@@ -4542,11 +4541,14 @@ if (!customElements.get("lht-page-menu")) {
         baseScope: readSelectValue("baseScope", "remote"),
         compareBranch: entryType === "git" ? readText("compareBranch") : "",
         compareScope: readSelectValue("compareScope", "local"),
-        compareUseHead: false,
+        compareUseHead: entryType === "git"
+          ? (existingEntry ? existingEntry.compareUseHead === true : true)
+          : false,
         locked: existingEntry?.locked === true,
         remoteName: entryType === "git" ? (readText("remoteName") || "origin") : "",
         createdAt: existingEntry?.createdAt || Date.now(),
-        updatedAt: Date.now()
+        updatedAt: Date.now(),
+        lastOpenedAt: existingEntry ? Number(existingEntry.lastOpenedAt || 0) : Date.now()
       });
     }
 

--- a/docs/git/src/git-pseudo-squash/css/app.css
+++ b/docs/git/src/git-pseudo-squash/css/app.css
@@ -59,8 +59,48 @@
       margin-top: 28px;
     }
 
+    lht-page-hero {
+      margin-bottom: 0.35rem;
+    }
+
+    #baseBlock {
+      margin-top: 2px;
+    }
+
     .md-section-title {
       font-size: 1.1rem; font-weight: 700; margin-bottom: 0.75rem;
+    }
+
+    .md-repo-display-card {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      max-width: 100%;
+      padding: 0.28rem 0.78rem;
+      border: 1px solid #e3dcef;
+      border-radius: 999px;
+      background: #fbf9ff;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+      margin-top: 0.32rem;
+      margin-bottom: 0.52rem;
+    }
+
+    .md-repo-display-name {
+      margin: 0;
+      font-size: 1.02rem;
+      line-height: 1.35;
+      font-weight: 700;
+      letter-spacing: 0;
+      color: var(--md-sys-color-on-surface);
+      word-break: break-word;
+    }
+
+    .md-repo-display-actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      flex: 0 0 auto;
+      margin-left: 0.15rem;
     }
 
     .md-grid {

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -28,6 +28,14 @@
       return trimmed.replace(/\/+$/, "");
     }
 
+    function extractRepoName(repoUrl) {
+      const trimmed = String(repoUrl || "").trim().replace(/\/+$/, "");
+      if (!trimmed) return "";
+      const normalized = trimmed.replace(/\.git$/i, "");
+      const parts = normalized.split(/[/:]/).filter(Boolean);
+      return parts[parts.length - 1] || normalized;
+    }
+
     function isOpenableExternalUrl(url) {
       return /^https?:\/\//i.test(String(url || "").trim());
     }
@@ -102,6 +110,21 @@
       repoUrlField.readOnly = !!locked;
       repoUrlField.classList.toggle("md-disabled", !!locked);
       repoUrlField.setAttribute("aria-readonly", locked ? "true" : "false");
+    }
+
+    function updateRepoDisplay() {
+      const card = document.getElementById("repoDisplayCard");
+      const nameNode = document.getElementById("repoDisplayName");
+      if (!card || !nameNode) return;
+      const repoUrl = document.getElementById("repoUrl")?.value.trim() || "";
+      const repoName = extractRepoName(repoUrl);
+      if (!repoName) {
+        nameNode.textContent = "";
+        card.classList.add("md-hidden");
+        return;
+      }
+      nameNode.textContent = repoName;
+      card.classList.remove("md-hidden");
     }
 
     function updateBaseScope() {
@@ -354,9 +377,11 @@
     }
 
     function setupWorkBranchListButton() {
-      const button = document.getElementById("saveToWorkBranchListBtn");
-      if (!button) return;
-      button.addEventListener("click", saveToWorkBranchListAndOpen);
+      ["saveToWorkBranchListBtn", "saveToWorkBranchListInlineBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", saveToWorkBranchListAndOpen);
+      });
     }
 
     function setupBranchDiffButton() {
@@ -822,18 +847,25 @@
     }
 
     function updateGitCurrentDirectoryAction() {
-      const button = document.getElementById("copyGitCurrentDirBtn");
-      if (!button) return;
+      const buttons = [
+        document.getElementById("copyGitCurrentDirBtn"),
+        document.getElementById("copyGitCurrentDirBackupBtn")
+      ].filter(Boolean);
+      if (buttons.length === 0) return;
       const gitCurrentDir = getGitCurrentDirectoryForCurrentContext();
       if (gitCurrentDir) {
-        button.dataset.gitCurrentDir = gitCurrentDir;
-        button.title = gitCurrentDir;
-        button.classList.remove("md-hidden");
+        buttons.forEach((button) => {
+          button.dataset.gitCurrentDir = gitCurrentDir;
+          button.title = gitCurrentDir;
+          button.classList.remove("md-hidden");
+        });
         return;
       }
-      delete button.dataset.gitCurrentDir;
-      button.title = "git カレントディレクトリをコピー";
-      button.classList.add("md-hidden");
+      buttons.forEach((button) => {
+        delete button.dataset.gitCurrentDir;
+        button.title = "git カレントディレクトリをコピー";
+        button.classList.add("md-hidden");
+      });
     }
 
     function applyQueryParams() {
@@ -894,6 +926,7 @@
         }
       }
       updateGitCurrentDirectoryAction();
+      updateRepoDisplay();
     }
 
     function createWorkBranchListEntryId() {
@@ -1626,15 +1659,19 @@
     }
 
     function setupOpenRepoUrlButton() {
-      const button = document.getElementById("openRepoUrlBtn");
-      if (!button) return;
-      button.addEventListener("click", openRepoUrl);
+      ["openRepoUrlBtn", "openRepoUrlBackupBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", openRepoUrl);
+      });
     }
 
     function setupCopyGitCurrentDirectoryButton() {
-      const button = document.getElementById("copyGitCurrentDirBtn");
-      if (!button) return;
-      button.addEventListener("click", copyGitCurrentDirectory);
+      ["copyGitCurrentDirBtn", "copyGitCurrentDirBackupBtn"].forEach((id) => {
+        const button = document.getElementById(id);
+        if (!button) return;
+        button.addEventListener("click", copyGitCurrentDirectory);
+      });
       const sync = () => updateGitCurrentDirectoryAction();
       ["repoUrl", "squashBaseBranch"].forEach((id) => {
         const element = document.getElementById(id);
@@ -1643,6 +1680,15 @@
         element.addEventListener("change", sync);
       });
       updateGitCurrentDirectoryAction();
+    }
+
+    function setupRepoDisplay() {
+      const repoUrlField = document.getElementById("repoUrl");
+      if (!repoUrlField) return;
+      const sync = () => updateRepoDisplay();
+      repoUrlField.addEventListener("input", sync);
+      repoUrlField.addEventListener("change", sync);
+      updateRepoDisplay();
     }
 
     applyQueryParams();
@@ -1665,4 +1711,5 @@
     setupBranchDiffButton();
     setupOpenRepoUrlButton();
     setupCopyGitCurrentDirectoryButton();
+    setupRepoDisplay();
     setupCodeSelectAll();

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -546,11 +546,14 @@
         baseScope: readSelectValue("baseScope", "remote"),
         compareBranch: entryType === "git" ? readText("compareBranch") : "",
         compareScope: readSelectValue("compareScope", "local"),
-        compareUseHead: false,
+        compareUseHead: entryType === "git"
+          ? (existingEntry ? existingEntry.compareUseHead === true : true)
+          : false,
         locked: existingEntry?.locked === true,
         remoteName: entryType === "git" ? (readText("remoteName") || "origin") : "",
         createdAt: existingEntry?.createdAt || Date.now(),
-        updatedAt: Date.now()
+        updatedAt: Date.now(),
+        lastOpenedAt: existingEntry ? Number(existingEntry.lastOpenedAt || 0) : Date.now()
       });
     }
 

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -37,8 +37,12 @@ function mountGitPseudoSquashDom() {
     <div id="pushCmd"></div>
     <button id="openBranchDiffBtn" type="button">compare</button>
     <button id="saveToWorkBranchListBtn" type="button">save</button>
+    <button id="saveToWorkBranchListInlineBtn" type="button">save inline</button>
     <button id="openRepoUrlBtn" type="button">open</button>
+    <button id="openRepoUrlBackupBtn" type="button">open backup</button>
     <button id="copyGitCurrentDirBtn" type="button" class="md-hidden">copy dir</button>
+    <button id="copyGitCurrentDirBackupBtn" type="button" class="md-hidden">copy dir backup</button>
+    <div id="repoDisplayCard" class="md-hidden"><p id="repoDisplayName"></p></div>
     <div id="toast"></div>
     <dialog id="normalizeDiffDialog"></dialog>
     <div id="normalizeDiffBefore"></div>
@@ -654,6 +658,38 @@ window.__gitPseudoSquashTest = {
     expect(window.open).toHaveBeenCalledWith("https://example.com/repo-a", "_blank", "noopener,noreferrer");
   });
 
+  it("shows repository display name above base branch when repoUrl exists", () => {
+    bootGitPseudoSquashPage();
+
+    document.getElementById("repoUrl").value = "https://github.com/igapyon/local-html-tools";
+    document.getElementById("repoUrl").dispatchEvent(new Event("input"));
+
+    expect(document.getElementById("repoDisplayCard").classList.contains("md-hidden")).toBe(false);
+    expect(document.getElementById("repoDisplayName").textContent).toBe("local-html-tools");
+  });
+
+  it("hides repository display name when repoUrl is empty", () => {
+    bootGitPseudoSquashPage();
+
+    const repoUrl = document.getElementById("repoUrl");
+    repoUrl.value = "https://github.com/igapyon/local-html-tools";
+    repoUrl.dispatchEvent(new Event("input"));
+    repoUrl.value = "";
+    repoUrl.dispatchEvent(new Event("input"));
+
+    expect(document.getElementById("repoDisplayCard").classList.contains("md-hidden")).toBe(true);
+    expect(document.getElementById("repoDisplayName").textContent).toBe("");
+  });
+
+  it("opens repoUrl in a new tab from the backup row action button", () => {
+    bootGitPseudoSquashPage();
+
+    document.getElementById("repoUrl").value = "https://example.com/repo-a";
+    document.getElementById("openRepoUrlBackupBtn").click();
+
+    expect(window.open).toHaveBeenCalledWith("https://example.com/repo-a", "_blank", "noopener,noreferrer");
+  });
+
   it("shows git current directory copy button when saved in git-work-list memos", () => {
     installLocalStorageMock();
     localStorage.setItem("gitWorkList.memos", JSON.stringify({
@@ -682,8 +718,11 @@ window.__gitPseudoSquashTest = {
     new Function(instrumentedCode)();
 
     const copyButton = document.getElementById("copyGitCurrentDirBtn");
+    const backupCopyButton = document.getElementById("copyGitCurrentDirBackupBtn");
     expect(copyButton.classList.contains("md-hidden")).toBe(false);
     expect(copyButton.title).toBe("/tmp/repo-a");
+    expect(backupCopyButton.classList.contains("md-hidden")).toBe(false);
+    expect(backupCopyButton.title).toBe("/tmp/repo-a");
   });
 
   it("copies git current directory from the URL row action button", () => {
@@ -719,6 +758,39 @@ window.__gitPseudoSquashTest = {
     expect(document.getElementById("toast").show).toHaveBeenCalledWith("git カレントディレクトリをコピーしました", 2200);
   });
 
+  it("copies git current directory from the backup row action button", () => {
+    installLocalStorageMock();
+    localStorage.setItem("gitWorkList.memos", JSON.stringify({
+      "https://example.com/repo-a::devel": {
+        memo: "memo",
+        gitCurrentDir: "/tmp/repo-a"
+      }
+    }));
+    mountGitPseudoSquashDom();
+    window.history.replaceState(
+      {},
+      "",
+      "/docs/git/git-pseudo-squash.html?repoUrl=https%3A%2F%2Fexample.com%2Frepo-a&baseBranch=devel&workBranch=feature-a"
+    );
+    const instrumentedCode = `${mainCode}
+window.__gitPseudoSquashTest = {
+  normalizeCommitMessageForPr,
+  regenerateAllCommands,
+  getUseCurrentBranchSelected,
+  toggleOriginLock,
+  clearUiPreferences,
+  saveToWorkBranchListAndOpen,
+  applyQueryParams,
+  buildBranchDiffUrlFromPlannedDiff
+};`;
+    new Function(instrumentedCode)();
+
+    document.getElementById("copyGitCurrentDirBackupBtn").click();
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(document.getElementById("toast").show).toHaveBeenCalledWith("git カレントディレクトリをコピーしました", 2200);
+  });
+
   it("keeps git current directory copy button hidden when no saved path exists", () => {
     bootGitPseudoSquashPage();
 
@@ -727,5 +799,6 @@ window.__gitPseudoSquashTest = {
     document.getElementById("repoUrl").dispatchEvent(new Event("input"));
 
     expect(document.getElementById("copyGitCurrentDirBtn").classList.contains("md-hidden")).toBe(true);
+    expect(document.getElementById("copyGitCurrentDirBackupBtn").classList.contains("md-hidden")).toBe(true);
   });
 });

--- a/docs/git/tests/git-work-list-main.test.js
+++ b/docs/git/tests/git-work-list-main.test.js
@@ -182,6 +182,19 @@ describe("git-work-list main", () => {
     expect(squashButton.classList.contains("md-button--surface")).toBe(true);
   });
 
+  it("defaults new git entries to current-branch mode on", () => {
+    bootPage();
+
+    document.getElementById("repoUrl").value = "https://example.com/repo-a";
+    document.getElementById("baseBranch").value = "main";
+    document.getElementById("compareBranch").value = "feature-a";
+    window.__gitWorkListTest.saveCurrentEntry();
+
+    const savedEntries = getSavedJsonByKey("gitWorkList.entries");
+    expect(savedEntries).toHaveLength(1);
+    expect(savedEntries[0].compareUseHead).toBe(true);
+  });
+
   it("locks repoUrl in edit dialog when an existing URL is loaded", () => {
     bootPage();
 
@@ -432,6 +445,32 @@ describe("git-work-list main", () => {
         compareScope: "remote",
         remoteName: "origin",
         createdAt: 1
+      }
+    ]));
+
+    bootPage();
+
+    document.getElementById("repoUrl").value = "https://example.com/repo-b";
+    document.getElementById("baseBranch").value = "devel";
+    document.getElementById("compareBranch").value = "feature-b";
+    window.__gitWorkListTest.saveCurrentEntry();
+
+    const entriesHtml = document.getElementById("entriesList").textContent;
+    expect(entriesHtml.indexOf("repo-b")).toBeLessThan(entriesHtml.indexOf("repo-a"));
+  });
+
+  it("shows a newly added entry above entries with recent open history", () => {
+    localStorage.setItem("gitWorkList.entries", JSON.stringify([
+      {
+        id: "a",
+        repoUrl: "https://example.com/repo-a",
+        baseBranch: "main",
+        baseScope: "remote",
+        compareBranch: "feature-a",
+        compareScope: "remote",
+        remoteName: "origin",
+        createdAt: 1,
+        lastOpenedAt: 999999
       }
     ]));
 

--- a/docs/index-src.html
+++ b/docs/index-src.html
@@ -1086,7 +1086,7 @@
       </h2>
       <p class="md-section-subtitle">よく使うツールへのショートカット</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。"></lht-index-card-link>
         <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="生成AIプロンプト作成" desc="生成AIに引き渡す定型プロンプトの作成を支援します。"></lht-index-card-link>
         <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
         <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
@@ -1103,7 +1103,7 @@
       </h3>
       <p class="md-section-subtitle">Git操作の補助ツール</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。URL、基準ブランチ、作業ブランチ、ローカル/リモートの扱いを保存し、比較や squash への導線もまとめて扱えます。"></lht-index-card-link>
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。"></lht-index-card-link>
         <lht-index-card-link href="git/git-pseudo-squash.html" icon="🧩" title="Git pseudo-squash" desc="reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。"></lht-index-card-link>
         <lht-index-card-link href="git/git-branch-diff.html" icon="🧰" title="Git ブランチ比較" desc="2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。"></lht-index-card-link>
         <lht-index-card-link href="git/git-config-setup.html" icon="⚙️" title="Git ユーザー設定" desc="グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。"></lht-index-card-link>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2137,7 +2137,7 @@ lht-index-card-link {
       </h2>
       <p class="md-section-subtitle">よく使うツールへのショートカット</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。"></lht-index-card-link>
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。"></lht-index-card-link>
         <lht-index-card-link href="prompt/prompt-gen.html" icon="📝" title="生成AIプロンプト作成" desc="生成AIに引き渡す定型プロンプトの作成を支援します。"></lht-index-card-link>
         <lht-index-card-link href="link/url-memo.html" icon="🗂️" title="URLメモ" desc="URL とメモをローカルで一覧管理し、検索起点で再利用しやすくします。"></lht-index-card-link>
         <lht-index-card-link href="grep/find-gen.html" icon="🔎" title="find 検索" desc="findでファイル/ディレクトリを検索するコマンドを生成します。"></lht-index-card-link>
@@ -2154,7 +2154,7 @@ lht-index-card-link {
       </h3>
       <p class="md-section-subtitle">Git操作の補助ツール</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数リポジトリの作業状況を一覧管理します。URL、基準ブランチ、作業ブランチ、ローカル/リモートの扱いを保存し、比較や squash への導線もまとめて扱えます。"></lht-index-card-link>
+        <lht-index-card-link href="git/git-work-list.html" icon="🗂️" title="Git 作業一覧" desc="複数 Git リポジトリの作業状況を一覧管理し、ここから個別のリポジトリ作業をおこないます。"></lht-index-card-link>
         <lht-index-card-link href="git/git-pseudo-squash.html" icon="🧩" title="Git pseudo-squash" desc="reset --soft と再コミットで履歴を整え、内容を1コミットにまとめるコマンドを生成します。運用の流れ（作成 → まとめ → 必要なら push）が先に可視化され、段階ごとに必要なコマンドが並ぶのがこのツールの価値です。"></lht-index-card-link>
         <lht-index-card-link href="git/git-branch-diff.html" icon="🧰" title="Git ブランチ比較" desc="2つのブランチ差分を表示する `git diff` コマンドを生成します。ローカル/リモートを選べ、表示形式（内容/統計/ファイル一覧）や `..` / `...` を切り替えできます。"></lht-index-card-link>
         <lht-index-card-link href="git/git-config-setup.html" icon="⚙️" title="Git ユーザー設定" desc="グローバル設定でGitユーザー名とメールアドレスを設定するためのコマンドを生成します。"></lht-index-card-link>

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -34,7 +34,7 @@
 - 上記シート粒度が `MS Project XML` / `ProjectModel` の構造に由来することを明記する
 - Excel 側の独自都合ではなく、まずは `MS Project XML` の構造に忠実な workbook 構成を優先する
 - WBS 帳票的な見せ方は、別ビュー・別 workbook として export を継続改善する
-- `WBS XLSX Export` では、必要に応じて `YYYY-MM-DD` 形式の祝日を UI から指定できるように保つ
+- `WBS XLSX Export` では、`ProjectModel` 由来の既定祝日と、UI から入力した追加祝日を分けて扱えるように保つ
 - WBS sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として日付帯へ反映する
 - `build-project-xlsx-sample.mjs` を静的 workbook 直書きから `project-xlsx.ts` 利用へ切り替える
 - `MS Project XML -> ProjectModel -> XlsxWorkbookModel -> .xlsx` のサンプル生成経路へ寄せる

--- a/docs/project/mikuproject-spec.md
+++ b/docs/project/mikuproject-spec.md
@@ -64,9 +64,9 @@ STEP 1 の目的は、`MS Project XML` を意味的に往復できる状態を�
 - 表示専用の `WBS` workbook export
   - `Tasks` 中心の別 workbook として `.xlsx` 出力できる
   - 現時点では export 専用であり、import は扱わない
-  - `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を UI から指定できる
+  - `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、UI で指定した追加祝日を合成して扱う
   - 指定した祝日は WBS 日付帯で祝日色として表示する
-  - sample 生成では、`Calendar.Exceptions` のうち `WorkingTimes` を持たない日付例外を祝日候補として WBS workbook へ反映する
+  - sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として WBS workbook へ反映する
 
 現時点で `XLSX Import` の反映対象としている列は次のとおり。
 

--- a/docs/project/mikuproject-src.html
+++ b/docs/project/mikuproject-src.html
@@ -82,15 +82,30 @@
       <section class="md-note-card" aria-label="WBS xlsx export options">
         <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
         <p class="md-note-card__text">
-          `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。
+          `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
+        </p>
+        <p class="md-note-card__text">
+          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。
         </p>
         <div class="md-form-grid">
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"
-            label="WBS 祝日"
+            label="WBS 既定祝日"
             rows="3"
-            placeholder="2026-03-20&#10;2026-03-21"
+            placeholder="2026-03-20"
+            readonly
+            help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
+        </div>
+        <div class="md-form-grid">
+          <lht-text-field-help
+            field-id="wbsExtraHolidayDatesInput"
+            label="WBS 追加祝日"
+            rows="3"
+            placeholder="2026-03-21&#10;2026-03-22"
             help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+        </div>
+        <div class="md-panel-actions">
+          <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
         </div>
       </section>
 

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -1556,15 +1556,30 @@ lht-index-card-link {
       <section class="md-note-card" aria-label="WBS xlsx export options">
         <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
         <p class="md-note-card__text">
-          `WBS XLSX Export` では、`YYYY-MM-DD` 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。
+          `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
+        </p>
+        <p class="md-note-card__text">
+          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。
         </p>
         <div class="md-form-grid">
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"
-            label="WBS 祝日"
+            label="WBS 既定祝日"
             rows="3"
-            placeholder="2026-03-20&#10;2026-03-21"
+            placeholder="2026-03-20"
+            readonly
+            help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
+        </div>
+        <div class="md-form-grid">
+          <lht-text-field-help
+            field-id="wbsExtraHolidayDatesInput"
+            label="WBS 追加祝日"
+            rows="3"
+            placeholder="2026-03-21&#10;2026-03-22"
             help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+        </div>
+        <div class="md-panel-actions">
+          <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
         </div>
       </section>
 
@@ -9430,16 +9445,41 @@ if (!customElements.get("lht-page-menu")) {
   <script>
 (() => {
     const HEADER_FILL = "#D9EAF7";
+    const HEADER_ID_FILL = "#D7E7F6";
+    const HEADER_STRUCTURE_FILL = "#E6F0DF";
+    const HEADER_SCHEDULE_FILL = "#FDE7D3";
+    const HEADER_STATUS_FILL = "#FBE4EC";
+    const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
     const PHASE_FILL = "#EEF7E8";
+    const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
+    const PLACEHOLDER_FILL = "#F5F7FA";
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
     const PROGRESS_BAND_FILL = "#5BAE9C";
     const WEEKEND_BAND_FILL = "#F1F1F1";
+    const WEEK_START_BAND_FILL = "#E3EEF9";
+    const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
+    const MONTH_START_HEADER_FILL = "#DCEAF7";
     const TODAY_BAND_FILL = "#FFE6A7";
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
+    const DIVIDER_FILL = "#C5D1DB";
+    function collectWbsHolidayDates(model) {
+        const holidaySet = new Set();
+        for (const calendar of model.calendars) {
+            for (const exception of calendar.exceptions || []) {
+                if (exception.dayWorking !== false && (exception.workingTimes || []).length > 0) {
+                    continue;
+                }
+                for (const day of expandExceptionDays(exception)) {
+                    holidaySet.add(day);
+                }
+            }
+        }
+        return Array.from(holidaySet).sort();
+    }
     function exportWbsWorkbook(model, options = {}) {
         const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
         const predecessorNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
@@ -9478,8 +9518,11 @@ if (!customElements.get("lht-page-menu")) {
             "Resources",
             "Predecessors"
         ];
-        const totalColumns = fixedHeaders.length + dateBand.length;
+        const dividerColumnIndex = fixedHeaders.length + 1;
+        const dateBandStartColumnIndex = dividerColumnIndex + 1;
+        const totalColumns = fixedHeaders.length + 1 + dateBand.length;
         const lastColumnRef = columnName(totalColumns);
+        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
         return {
             sheets: [
                 {
@@ -9488,19 +9531,29 @@ if (!customElements.get("lht-page-menu")) {
                         { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
                         { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
-                    mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+                    mergedRanges: [
+                        `A1:${lastColumnRef}1`,
+                        `A2:${lastColumnRef}2`,
+                        `A3:${lastColumnRef}3`,
+                        `A4:${lastColumnRef}4`,
+                        ...weekBandRanges.map((item) => item.range)
+                    ],
                     rows: [
                         sectionTitleRow("WBS", totalColumns),
                         sectionTitleRow(model.project.name || "Project", totalColumns),
                         infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
                         infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-                        sectionTitleRow("Task View", totalColumns),
-                        todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+                        displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
+                        legendRow(totalColumns),
+                        sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+                        weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
+                        todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
                         headerRow([
                             ...fixedHeaders,
+                            dividerCell(),
                             ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
                         ]),
                         ...model.tasks.map((task) => ({
@@ -9508,7 +9561,7 @@ if (!customElements.get("lht-page-menu")) {
                                 taskCell(task, task.uid, "center"),
                                 taskCell(task, task.id, "center"),
                                 taskCell(task, task.wbs || task.outlineNumber, "center"),
-                                taskCell(task, classifyTaskKind(task), "center"),
+                                kindCell(task),
                                 taskCell(task, task.outlineLevel, "center"),
                                 taskCell(task, formatTaskLabel(task)),
                                 taskCell(task, task.start),
@@ -9516,13 +9569,14 @@ if (!customElements.get("lht-page-menu")) {
                                 taskCell(task, task.duration, "center"),
                                 taskCell(task, task.percentComplete, "center"),
                                 taskCell(task, task.percentWorkComplete, "center"),
-                                taskCell(task, task.milestone, "center"),
-                                taskCell(task, task.summary, "center"),
-                                taskCell(task, task.critical, "center"),
-                                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                flagCell(task, task.milestone, "M"),
+                                flagCell(task, task.summary, "S"),
+                                flagCell(task, task.critical, "!"),
+                                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                dividerCell(),
                                 ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
                             ]
                         }))
@@ -9556,6 +9610,20 @@ if (!customElements.get("lht-page-menu")) {
         const calendarName = calendarNameByUid.get(calendarUID);
         return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
     }
+    function displayReferenceValue(value) {
+        return value && value.trim() ? value : "-";
+    }
+    function referenceCell(task, value, horizontalAlign = "left") {
+        const displayValue = displayReferenceValue(value);
+        const placeholder = displayValue === "-";
+        return {
+            value: displayValue,
+            border: "thin",
+            horizontalAlign,
+            bold: task.summary || task.milestone || false,
+            fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+        };
+    }
     function sectionTitleRow(title, columnCount) {
         return {
             height: 28,
@@ -9584,6 +9652,155 @@ if (!customElements.get("lht-page-menu")) {
             ]
         };
     }
+    function legendRow(columnCount) {
+        const items = [
+            {
+                value: "Legend",
+                bold: true,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "進捗済み",
+                fillColor: PROGRESS_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "予定帯",
+                fillColor: ACTIVE_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "Today",
+                fillColor: TODAY_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "週頭",
+                fillColor: WEEK_START_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "週末",
+                fillColor: WEEKEND_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "祝日",
+                fillColor: HOLIDAY_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "━:phase",
+                fillColor: PHASE_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "■:task",
+                fillColor: ACTIVE_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "◆:milestone",
+                fillColor: MILESTONE_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "M:Milestone",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "S:Summary",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "!:Critical",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "-:未設定",
+                fillColor: PLACEHOLDER_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            }
+        ];
+        return {
+            height: 22,
+            cells: [
+                ...items,
+                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            ]
+        };
+    }
+    function weekBandRow(fixedColumnCount, weekBandRanges, dateBandLength) {
+        const bandCells = Array.from({ length: dateBandLength }, () => ({}));
+        weekBandRanges.forEach((item, index) => {
+            bandCells[item.startIndex] = {
+                value: item.label,
+                bold: true,
+                border: "thin",
+                horizontalAlign: "center",
+                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+            };
+        });
+        return {
+            height: 22,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...bandCells
+            ]
+        };
+    }
+    function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
+        const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
+        const items = [
+            summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
+            summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
+            summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
+            summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
+            summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
+            summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+        ];
+        return {
+            height: 22,
+            cells: [
+                ...items,
+                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            ]
+        };
+    }
+    function summaryStatCell(value, fillColor) {
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: true,
+            fillColor
+        };
+    }
     function headerRow(labels) {
         return {
             height: 24,
@@ -9592,7 +9809,7 @@ if (!customElements.get("lht-page-menu")) {
                     return {
                         value: label,
                         bold: true,
-                        fillColor: HEADER_FILL,
+                        fillColor: headerFillForLabel(label),
                         border: "thin",
                         horizontalAlign: "center"
                     };
@@ -9604,6 +9821,32 @@ if (!customElements.get("lht-page-menu")) {
                 };
             })
         };
+    }
+    function dividerCell() {
+        return {
+            value: "",
+            fillColor: DIVIDER_FILL,
+            border: "thin",
+            horizontalAlign: "center"
+        };
+    }
+    function headerFillForLabel(label) {
+        if (label === "UID" || label === "ID") {
+            return HEADER_ID_FILL;
+        }
+        if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+            return HEADER_STRUCTURE_FILL;
+        }
+        if (label === "Start" || label === "Finish" || label === "Duration") {
+            return HEADER_SCHEDULE_FILL;
+        }
+        if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+            return HEADER_STATUS_FILL;
+        }
+        if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+            return HEADER_ASSIGNMENT_FILL;
+        }
+        return HEADER_FILL;
     }
     function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
         return {
@@ -9618,11 +9861,11 @@ if (!customElements.get("lht-page-menu")) {
                     }
                     : {})),
                 ...dateBand.map((day) => ({
-                    value: isSameDay(day, currentDate) ? "▼" : "",
+                    value: isSameDay(day, currentDate) ? "TODAY" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
-                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
                 }))
             ]
         };
@@ -9648,16 +9891,36 @@ if (!customElements.get("lht-page-menu")) {
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
         };
     }
+    function kindCell(task) {
+        return {
+            value: classifyTaskKind(task),
+            border: "thin",
+            horizontalAlign: "center",
+            bold: true,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : TASK_KIND_FILL)
+        };
+    }
+    function flagCell(task, enabled, marker) {
+        return {
+            value: enabled ? marker : "",
+            border: "thin",
+            horizontalAlign: "center",
+            bold: !!enabled,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
     function dateHeaderCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
+        const monthStart = isMonthStart(day);
         return {
-            value: formatDateLabel(day),
+            value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
-            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
     function dateBandCell(task, day, currentDate, holidaySet) {
@@ -9665,17 +9928,27 @@ if (!customElements.get("lht-page-menu")) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
         const complete = active && isCompletedDay(task, day);
         return {
-            value: active ? "■" : "",
+            value: active ? activeBandMarker(task) : "",
             border: "thin",
             horizontalAlign: "center",
             fillColor: active
                 ? (complete
                     ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
                     : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
-                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (weekStart ? WEEK_START_BAND_FILL : BAND_FILL))))
         };
+    }
+    function activeBandMarker(task) {
+        if (task.summary) {
+            return "━";
+        }
+        if (task.milestone) {
+            return "◆";
+        }
+        return "■";
     }
     function buildDateBand(startDate, finishDate) {
         const start = parseDateOnly(startDate);
@@ -9690,6 +9963,31 @@ if (!customElements.get("lht-page-menu")) {
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildWeekBandRanges(dateBand, startColumnIndex, rowNumber) {
+        const ranges = [];
+        if (dateBand.length === 0) {
+            return ranges;
+        }
+        let chunkStart = 0;
+        while (chunkStart < dateBand.length) {
+            const weekStart = formatWeekKey(dateBand[chunkStart]);
+            let chunkEnd = chunkStart;
+            while (chunkEnd + 1 < dateBand.length && formatWeekKey(dateBand[chunkEnd + 1]) === weekStart) {
+                chunkEnd += 1;
+            }
+            const startColumn = columnName(startColumnIndex + chunkStart);
+            const endColumn = columnName(startColumnIndex + chunkEnd);
+            const chunkDays = dateBand.slice(chunkStart, chunkEnd + 1);
+            ranges.push({
+                range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
+                startIndex: chunkStart,
+                label: formatWeekLabel(chunkDays),
+                hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
+            });
+            chunkStart = chunkEnd + 1;
+        }
+        return ranges;
     }
     function includesDay(startDate, finishDate, day) {
         const start = parseDateOnly(startDate);
@@ -9727,6 +10025,20 @@ if (!customElements.get("lht-page-menu")) {
         const weekday = target.getDay();
         return weekday === 0 || weekday === 6;
     }
+    function isWeekStart(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        return target.getDay() === 1;
+    }
+    function isMonthStart(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        return target.getDate() === 1;
+    }
     function parseDateOnly(value) {
         if (!value || value.length < 10) {
             return null;
@@ -9740,6 +10052,28 @@ if (!customElements.get("lht-page-menu")) {
             return null;
         }
         return new Date(year, month - 1, day);
+    }
+    function expandExceptionDays(exception) {
+        const from = (exception.fromDate || "").slice(0, 10);
+        const to = (exception.toDate || "").slice(0, 10);
+        if (!from) {
+            return [];
+        }
+        if (!to || to === from) {
+            return [from];
+        }
+        const start = parseDateOnly(from);
+        const finish = parseDateOnly(to);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [from];
+        }
+        const days = [];
+        const cursor = new Date(start.getTime());
+        while (cursor.getTime() <= finish.getTime()) {
+            days.push(formatDateOnly(cursor));
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        return days;
     }
     function formatDateOnly(value) {
         return [
@@ -9756,6 +10090,38 @@ if (!customElements.get("lht-page-menu")) {
         const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
     }
+    function formatWeekKey(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        const monday = new Date(target.getTime());
+        const offset = (monday.getDay() + 6) % 7;
+        monday.setDate(monday.getDate() - offset);
+        return formatDateOnly(monday);
+    }
+    function formatWeekLabel(days) {
+        if (days.length === 0) {
+            return "Week";
+        }
+        const start = parseDateOnly(days[0]);
+        if (!start) {
+            return days[0];
+        }
+        const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+        const monthSet = new Set(days.map((day) => {
+            const target = parseDateOnly(day);
+            return target ? target.getMonth() : -1;
+        }));
+        const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+        if (monthSet.size <= 1) {
+            return `Week of ${startLabel}`;
+        }
+        const tailMonths = Array.from(monthSet)
+            .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
+            .map((monthIndex) => monthNames[monthIndex]);
+        return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+    }
     function columnName(index) {
         let current = index;
         let name = "";
@@ -9767,6 +10133,7 @@ if (!customElements.get("lht-page-menu")) {
         return name;
     }
     globalThis.__mikuprojectWbsXlsx = {
+        collectWbsHolidayDates,
         exportWbsWorkbook
     };
 })();
@@ -9806,8 +10173,7 @@ if (!customElements.get("lht-page-menu")) {
     function getTextArea(id) {
         return getElement(id);
     }
-    function parseWbsHolidayDates() {
-        const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+    function parseHolidayDateList(raw) {
         if (!raw) {
             return [];
         }
@@ -9830,6 +10196,29 @@ if (!customElements.get("lht-page-menu")) {
             holidays.push(dateText);
         }
         return holidays;
+    }
+    function parseWbsDefaultHolidayDates() {
+        return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
+    }
+    function parseWbsAdditionalHolidayDates() {
+        return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+    }
+    function syncWbsHolidayDatesInput(model) {
+        const input = getTextArea("wbsHolidayDatesInput");
+        if (!model) {
+            input.value = "";
+            getTextArea("wbsExtraHolidayDatesInput").value = "";
+            return;
+        }
+        input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+    }
+    function resetWbsHolidayDatesInput() {
+        const model = ensureCurrentModel();
+        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+        getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
+        getTextArea("wbsExtraHolidayDatesInput").value = "";
+        setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
+        showToast("WBS 祝日を既定値へ戻しました");
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -10198,6 +10587,7 @@ if (!customElements.get("lht-page-menu")) {
             .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
+        syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
         getElement("summaryResourceCount").textContent = String((model === null || model === void 0 ? void 0 : model.resources.length) || 0);
@@ -10366,8 +10756,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
-        const holidayDates = parseWbsHolidayDates();
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+        const defaultHolidayDates = parseWbsDefaultHolidayDates();
+        const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+        const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+        if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
+            getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
+        }
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
         const now = new Date();
@@ -10379,7 +10774,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
         showToast("WBS XLSX を保存しました");
     }
     async function importXlsxFromFile(file) {
@@ -10534,6 +10929,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+            }
+        });
+        getElement("resetWbsHolidayDatesBtn").addEventListener("click", () => {
+            try {
+                resetWbsHolidayDatesInput();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
             }
         });
         getElement("parseCsvBtn").addEventListener("click", () => {

--- a/docs/project/src/mikuproject/js/main.js
+++ b/docs/project/src/mikuproject/js/main.js
@@ -31,8 +31,7 @@
     function getTextArea(id) {
         return getElement(id);
     }
-    function parseWbsHolidayDates() {
-        const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+    function parseHolidayDateList(raw) {
         if (!raw) {
             return [];
         }
@@ -55,6 +54,29 @@
             holidays.push(dateText);
         }
         return holidays;
+    }
+    function parseWbsDefaultHolidayDates() {
+        return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
+    }
+    function parseWbsAdditionalHolidayDates() {
+        return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+    }
+    function syncWbsHolidayDatesInput(model) {
+        const input = getTextArea("wbsHolidayDatesInput");
+        if (!model) {
+            input.value = "";
+            getTextArea("wbsExtraHolidayDatesInput").value = "";
+            return;
+        }
+        input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+    }
+    function resetWbsHolidayDatesInput() {
+        const model = ensureCurrentModel();
+        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+        getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
+        getTextArea("wbsExtraHolidayDatesInput").value = "";
+        setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
+        showToast("WBS 祝日を既定値へ戻しました");
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -423,6 +445,7 @@
             .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
+        syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
         getElement("summaryResourceCount").textContent = String((model === null || model === void 0 ? void 0 : model.resources.length) || 0);
@@ -591,8 +614,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
-        const holidayDates = parseWbsHolidayDates();
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+        const defaultHolidayDates = parseWbsDefaultHolidayDates();
+        const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+        const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+        if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
+            getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
+        }
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
         const now = new Date();
@@ -604,7 +632,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
         showToast("WBS XLSX を保存しました");
     }
     async function importXlsxFromFile(file) {
@@ -759,6 +787,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+            }
+        });
+        getElement("resetWbsHolidayDatesBtn").addEventListener("click", () => {
+            try {
+                resetWbsHolidayDatesInput();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
             }
         });
         getElement("parseCsvBtn").addEventListener("click", () => {

--- a/docs/project/src/mikuproject/js/wbs-xlsx.js
+++ b/docs/project/src/mikuproject/js/wbs-xlsx.js
@@ -1,15 +1,40 @@
 (() => {
     const HEADER_FILL = "#D9EAF7";
+    const HEADER_ID_FILL = "#D7E7F6";
+    const HEADER_STRUCTURE_FILL = "#E6F0DF";
+    const HEADER_SCHEDULE_FILL = "#FDE7D3";
+    const HEADER_STATUS_FILL = "#FBE4EC";
+    const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
     const PHASE_FILL = "#EEF7E8";
+    const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
+    const PLACEHOLDER_FILL = "#F5F7FA";
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
     const PROGRESS_BAND_FILL = "#5BAE9C";
     const WEEKEND_BAND_FILL = "#F1F1F1";
+    const WEEK_START_BAND_FILL = "#E3EEF9";
+    const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
+    const MONTH_START_HEADER_FILL = "#DCEAF7";
     const TODAY_BAND_FILL = "#FFE6A7";
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
+    const DIVIDER_FILL = "#C5D1DB";
+    function collectWbsHolidayDates(model) {
+        const holidaySet = new Set();
+        for (const calendar of model.calendars) {
+            for (const exception of calendar.exceptions || []) {
+                if (exception.dayWorking !== false && (exception.workingTimes || []).length > 0) {
+                    continue;
+                }
+                for (const day of expandExceptionDays(exception)) {
+                    holidaySet.add(day);
+                }
+            }
+        }
+        return Array.from(holidaySet).sort();
+    }
     function exportWbsWorkbook(model, options = {}) {
         const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
         const predecessorNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
@@ -48,8 +73,11 @@
             "Resources",
             "Predecessors"
         ];
-        const totalColumns = fixedHeaders.length + dateBand.length;
+        const dividerColumnIndex = fixedHeaders.length + 1;
+        const dateBandStartColumnIndex = dividerColumnIndex + 1;
+        const totalColumns = fixedHeaders.length + 1 + dateBand.length;
         const lastColumnRef = columnName(totalColumns);
+        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
         return {
             sheets: [
                 {
@@ -58,19 +86,29 @@
                         { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
                         { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
-                    mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+                    mergedRanges: [
+                        `A1:${lastColumnRef}1`,
+                        `A2:${lastColumnRef}2`,
+                        `A3:${lastColumnRef}3`,
+                        `A4:${lastColumnRef}4`,
+                        ...weekBandRanges.map((item) => item.range)
+                    ],
                     rows: [
                         sectionTitleRow("WBS", totalColumns),
                         sectionTitleRow(model.project.name || "Project", totalColumns),
                         infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
                         infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-                        sectionTitleRow("Task View", totalColumns),
-                        todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+                        displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
+                        legendRow(totalColumns),
+                        sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+                        weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
+                        todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
                         headerRow([
                             ...fixedHeaders,
+                            dividerCell(),
                             ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
                         ]),
                         ...model.tasks.map((task) => ({
@@ -78,7 +116,7 @@
                                 taskCell(task, task.uid, "center"),
                                 taskCell(task, task.id, "center"),
                                 taskCell(task, task.wbs || task.outlineNumber, "center"),
-                                taskCell(task, classifyTaskKind(task), "center"),
+                                kindCell(task),
                                 taskCell(task, task.outlineLevel, "center"),
                                 taskCell(task, formatTaskLabel(task)),
                                 taskCell(task, task.start),
@@ -86,13 +124,14 @@
                                 taskCell(task, task.duration, "center"),
                                 taskCell(task, task.percentComplete, "center"),
                                 taskCell(task, task.percentWorkComplete, "center"),
-                                taskCell(task, task.milestone, "center"),
-                                taskCell(task, task.summary, "center"),
-                                taskCell(task, task.critical, "center"),
-                                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                flagCell(task, task.milestone, "M"),
+                                flagCell(task, task.summary, "S"),
+                                flagCell(task, task.critical, "!"),
+                                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                                dividerCell(),
                                 ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
                             ]
                         }))
@@ -126,6 +165,20 @@
         const calendarName = calendarNameByUid.get(calendarUID);
         return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
     }
+    function displayReferenceValue(value) {
+        return value && value.trim() ? value : "-";
+    }
+    function referenceCell(task, value, horizontalAlign = "left") {
+        const displayValue = displayReferenceValue(value);
+        const placeholder = displayValue === "-";
+        return {
+            value: displayValue,
+            border: "thin",
+            horizontalAlign,
+            bold: task.summary || task.milestone || false,
+            fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+        };
+    }
     function sectionTitleRow(title, columnCount) {
         return {
             height: 28,
@@ -154,6 +207,155 @@
             ]
         };
     }
+    function legendRow(columnCount) {
+        const items = [
+            {
+                value: "Legend",
+                bold: true,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "進捗済み",
+                fillColor: PROGRESS_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "予定帯",
+                fillColor: ACTIVE_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "Today",
+                fillColor: TODAY_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "週頭",
+                fillColor: WEEK_START_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "週末",
+                fillColor: WEEKEND_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "祝日",
+                fillColor: HOLIDAY_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "━:phase",
+                fillColor: PHASE_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "■:task",
+                fillColor: ACTIVE_BAND_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "◆:milestone",
+                fillColor: MILESTONE_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "M:Milestone",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "S:Summary",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "!:Critical",
+                fillColor: HEADER_STATUS_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            },
+            {
+                value: "-:未設定",
+                fillColor: PLACEHOLDER_FILL,
+                border: "thin",
+                horizontalAlign: "center"
+            }
+        ];
+        return {
+            height: 22,
+            cells: [
+                ...items,
+                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            ]
+        };
+    }
+    function weekBandRow(fixedColumnCount, weekBandRanges, dateBandLength) {
+        const bandCells = Array.from({ length: dateBandLength }, () => ({}));
+        weekBandRanges.forEach((item, index) => {
+            bandCells[item.startIndex] = {
+                value: item.label,
+                bold: true,
+                border: "thin",
+                horizontalAlign: "center",
+                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+            };
+        });
+        return {
+            height: 22,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...bandCells
+            ]
+        };
+    }
+    function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
+        const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
+        const items = [
+            summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
+            summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
+            summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
+            summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
+            summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
+            summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
+            summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
+            summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+        ];
+        return {
+            height: 22,
+            cells: [
+                ...items,
+                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            ]
+        };
+    }
+    function summaryStatCell(value, fillColor) {
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: true,
+            fillColor
+        };
+    }
     function headerRow(labels) {
         return {
             height: 24,
@@ -162,7 +364,7 @@
                     return {
                         value: label,
                         bold: true,
-                        fillColor: HEADER_FILL,
+                        fillColor: headerFillForLabel(label),
                         border: "thin",
                         horizontalAlign: "center"
                     };
@@ -174,6 +376,32 @@
                 };
             })
         };
+    }
+    function dividerCell() {
+        return {
+            value: "",
+            fillColor: DIVIDER_FILL,
+            border: "thin",
+            horizontalAlign: "center"
+        };
+    }
+    function headerFillForLabel(label) {
+        if (label === "UID" || label === "ID") {
+            return HEADER_ID_FILL;
+        }
+        if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+            return HEADER_STRUCTURE_FILL;
+        }
+        if (label === "Start" || label === "Finish" || label === "Duration") {
+            return HEADER_SCHEDULE_FILL;
+        }
+        if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+            return HEADER_STATUS_FILL;
+        }
+        if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+            return HEADER_ASSIGNMENT_FILL;
+        }
+        return HEADER_FILL;
     }
     function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
         return {
@@ -188,11 +416,11 @@
                     }
                     : {})),
                 ...dateBand.map((day) => ({
-                    value: isSameDay(day, currentDate) ? "▼" : "",
+                    value: isSameDay(day, currentDate) ? "TODAY" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
-                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
                 }))
             ]
         };
@@ -218,16 +446,36 @@
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
         };
     }
+    function kindCell(task) {
+        return {
+            value: classifyTaskKind(task),
+            border: "thin",
+            horizontalAlign: "center",
+            bold: true,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : TASK_KIND_FILL)
+        };
+    }
+    function flagCell(task, enabled, marker) {
+        return {
+            value: enabled ? marker : "",
+            border: "thin",
+            horizontalAlign: "center",
+            bold: !!enabled,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
     function dateHeaderCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
+        const monthStart = isMonthStart(day);
         return {
-            value: formatDateLabel(day),
+            value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
-            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
     function dateBandCell(task, day, currentDate, holidaySet) {
@@ -235,17 +483,27 @@
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
         const complete = active && isCompletedDay(task, day);
         return {
-            value: active ? "■" : "",
+            value: active ? activeBandMarker(task) : "",
             border: "thin",
             horizontalAlign: "center",
             fillColor: active
                 ? (complete
                     ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
                     : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
-                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+                : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (weekStart ? WEEK_START_BAND_FILL : BAND_FILL))))
         };
+    }
+    function activeBandMarker(task) {
+        if (task.summary) {
+            return "━";
+        }
+        if (task.milestone) {
+            return "◆";
+        }
+        return "■";
     }
     function buildDateBand(startDate, finishDate) {
         const start = parseDateOnly(startDate);
@@ -260,6 +518,31 @@
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildWeekBandRanges(dateBand, startColumnIndex, rowNumber) {
+        const ranges = [];
+        if (dateBand.length === 0) {
+            return ranges;
+        }
+        let chunkStart = 0;
+        while (chunkStart < dateBand.length) {
+            const weekStart = formatWeekKey(dateBand[chunkStart]);
+            let chunkEnd = chunkStart;
+            while (chunkEnd + 1 < dateBand.length && formatWeekKey(dateBand[chunkEnd + 1]) === weekStart) {
+                chunkEnd += 1;
+            }
+            const startColumn = columnName(startColumnIndex + chunkStart);
+            const endColumn = columnName(startColumnIndex + chunkEnd);
+            const chunkDays = dateBand.slice(chunkStart, chunkEnd + 1);
+            ranges.push({
+                range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
+                startIndex: chunkStart,
+                label: formatWeekLabel(chunkDays),
+                hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
+            });
+            chunkStart = chunkEnd + 1;
+        }
+        return ranges;
     }
     function includesDay(startDate, finishDate, day) {
         const start = parseDateOnly(startDate);
@@ -297,6 +580,20 @@
         const weekday = target.getDay();
         return weekday === 0 || weekday === 6;
     }
+    function isWeekStart(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        return target.getDay() === 1;
+    }
+    function isMonthStart(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return false;
+        }
+        return target.getDate() === 1;
+    }
     function parseDateOnly(value) {
         if (!value || value.length < 10) {
             return null;
@@ -310,6 +607,28 @@
             return null;
         }
         return new Date(year, month - 1, day);
+    }
+    function expandExceptionDays(exception) {
+        const from = (exception.fromDate || "").slice(0, 10);
+        const to = (exception.toDate || "").slice(0, 10);
+        if (!from) {
+            return [];
+        }
+        if (!to || to === from) {
+            return [from];
+        }
+        const start = parseDateOnly(from);
+        const finish = parseDateOnly(to);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [from];
+        }
+        const days = [];
+        const cursor = new Date(start.getTime());
+        while (cursor.getTime() <= finish.getTime()) {
+            days.push(formatDateOnly(cursor));
+            cursor.setDate(cursor.getDate() + 1);
+        }
+        return days;
     }
     function formatDateOnly(value) {
         return [
@@ -326,6 +645,38 @@
         const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
     }
+    function formatWeekKey(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        const monday = new Date(target.getTime());
+        const offset = (monday.getDay() + 6) % 7;
+        monday.setDate(monday.getDate() - offset);
+        return formatDateOnly(monday);
+    }
+    function formatWeekLabel(days) {
+        if (days.length === 0) {
+            return "Week";
+        }
+        const start = parseDateOnly(days[0]);
+        if (!start) {
+            return days[0];
+        }
+        const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+        const monthSet = new Set(days.map((day) => {
+            const target = parseDateOnly(day);
+            return target ? target.getMonth() : -1;
+        }));
+        const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+        if (monthSet.size <= 1) {
+            return `Week of ${startLabel}`;
+        }
+        const tailMonths = Array.from(monthSet)
+            .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
+            .map((monthIndex) => monthNames[monthIndex]);
+        return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+    }
     function columnName(index) {
         let current = index;
         let name = "";
@@ -337,6 +688,7 @@
         return name;
     }
     globalThis.__mikuprojectWbsXlsx = {
+        collectWbsHolidayDates,
         exportWbsWorkbook
     };
 })();

--- a/docs/project/src/mikuproject/ts/main.ts
+++ b/docs/project/src/mikuproject/ts/main.ts
@@ -53,6 +53,7 @@
 
   const mikuprojectWbsXlsx = (globalThis as typeof globalThis & {
     __mikuprojectWbsXlsx?: {
+      collectWbsHolidayDates: (model: ProjectModel) => string[];
       exportWbsWorkbook: (model: ProjectModel, options?: { holidayDates?: string[] }) => unknown;
     };
   }).__mikuprojectWbsXlsx;
@@ -86,8 +87,7 @@
     return getElement<HTMLTextAreaElement>(id);
   }
 
-  function parseWbsHolidayDates(): string[] {
-    const raw = getTextArea("wbsHolidayDatesInput").value.trim();
+  function parseHolidayDateList(raw: string): string[] {
     if (!raw) {
       return [];
     }
@@ -110,6 +110,33 @@
       holidays.push(dateText);
     }
     return holidays;
+  }
+
+  function parseWbsDefaultHolidayDates(): string[] {
+    return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
+  }
+
+  function parseWbsAdditionalHolidayDates(): string[] {
+    return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+  }
+
+  function syncWbsHolidayDatesInput(model: ProjectModel | null): void {
+    const input = getTextArea("wbsHolidayDatesInput");
+    if (!model) {
+      input.value = "";
+      getTextArea("wbsExtraHolidayDatesInput").value = "";
+      return;
+    }
+    input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+  }
+
+  function resetWbsHolidayDatesInput(): void {
+    const model = ensureCurrentModel();
+    const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+    getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
+    getTextArea("wbsExtraHolidayDatesInput").value = "";
+    setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
+    showToast("WBS 祝日を既定値へ戻しました");
   }
 
   function showToast(message: string): void {
@@ -535,6 +562,7 @@
   }
 
   function updateSummary(model: ProjectModel | null): void {
+    syncWbsHolidayDatesInput(model);
     getElement<HTMLElement>("summaryProjectName").textContent = model?.project.name || "-";
     getElement<HTMLElement>("summaryTaskCount").textContent = String(model?.tasks.length || 0);
     getElement<HTMLElement>("summaryResourceCount").textContent = String(model?.resources.length || 0);
@@ -715,8 +743,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   function exportCurrentWbsXlsx(): void {
     const model = ensureCurrentModel();
-    const holidayDates = parseWbsHolidayDates();
-    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates });
+    const defaultHolidayDates = parseWbsDefaultHolidayDates();
+    const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+    const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
+    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+    if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
+      getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
+    }
     const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
     const bytes = codec.exportWorkbook(workbook);
     const now = new Date();
@@ -731,7 +764,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }),
       `mikuproject-wbs-${stamp}.xlsx`
     );
-    setStatus(`WBS XLSX ファイルをエクスポートしました${holidayDates.length > 0 ? ` (祝日 ${holidayDates.length} 件)` : ""}`);
+    setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
     showToast("WBS XLSX を保存しました");
   }
 
@@ -886,6 +919,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         exportCurrentWbsXlsx();
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "WBS XLSX エクスポートに失敗しました");
+      }
+    });
+    getElement<HTMLButtonElement>("resetWbsHolidayDatesBtn").addEventListener("click", () => {
+      try {
+        resetWbsHolidayDatesInput();
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
       }
     });
     getElement<HTMLButtonElement>("parseCsvBtn").addEventListener("click", () => {

--- a/docs/project/src/mikuproject/ts/wbs-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/wbs-xlsx.ts
@@ -25,16 +25,42 @@
   };
 
   const HEADER_FILL = "#D9EAF7";
+  const HEADER_ID_FILL = "#D7E7F6";
+  const HEADER_STRUCTURE_FILL = "#E6F0DF";
+  const HEADER_SCHEDULE_FILL = "#FDE7D3";
+  const HEADER_STATUS_FILL = "#FBE4EC";
+  const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
   const PHASE_FILL = "#EEF7E8";
+  const TASK_KIND_FILL = "#EEF2F6";
   const MILESTONE_FILL = "#FFF4E0";
+  const PLACEHOLDER_FILL = "#F5F7FA";
   const BAND_FILL = "#F4F7FB";
   const ACTIVE_BAND_FILL = "#9FD5C9";
   const PROGRESS_BAND_FILL = "#5BAE9C";
   const WEEKEND_BAND_FILL = "#F1F1F1";
+  const WEEK_START_BAND_FILL = "#E3EEF9";
+  const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
+  const MONTH_START_HEADER_FILL = "#DCEAF7";
   const TODAY_BAND_FILL = "#FFE6A7";
   const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
   const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
   const HOLIDAY_BAND_FILL = "#FCE4EC";
+  const DIVIDER_FILL = "#C5D1DB";
+
+  function collectWbsHolidayDates(model: ProjectModel): string[] {
+    const holidaySet = new Set<string>();
+    for (const calendar of model.calendars) {
+      for (const exception of calendar.exceptions || []) {
+        if (exception.dayWorking !== false && (exception.workingTimes || []).length > 0) {
+          continue;
+        }
+        for (const day of expandExceptionDays(exception)) {
+          holidaySet.add(day);
+        }
+      }
+    }
+    return Array.from(holidaySet).sort();
+  }
 
   function exportWbsWorkbook(model: ProjectModel, options: WbsExportOptions = {}): WbsXlsxWorkbookLike {
     const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
@@ -76,8 +102,11 @@
       "Resources",
       "Predecessors"
     ];
-    const totalColumns = fixedHeaders.length + dateBand.length;
+    const dividerColumnIndex = fixedHeaders.length + 1;
+    const dateBandStartColumnIndex = dividerColumnIndex + 1;
+    const totalColumns = fixedHeaders.length + 1 + dateBand.length;
     const lastColumnRef = columnName(totalColumns);
+    const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
 
     return {
       sheets: [
@@ -87,19 +116,29 @@
             { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
             { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
             { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-            { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 },
+            { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
             ...dateBand.map(() => ({ width: 6 }))
           ],
-          mergedRanges: [`A1:${lastColumnRef}1`, `A2:${lastColumnRef}2`, `A3:${lastColumnRef}3`, `A4:${lastColumnRef}4`],
+          mergedRanges: [
+            `A1:${lastColumnRef}1`,
+            `A2:${lastColumnRef}2`,
+            `A3:${lastColumnRef}3`,
+            `A4:${lastColumnRef}4`,
+            ...weekBandRanges.map((item) => item.range)
+          ],
           rows: [
             sectionTitleRow("WBS", totalColumns),
             sectionTitleRow(model.project.name || "Project", totalColumns),
             infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
             infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-            sectionTitleRow("Task View", totalColumns),
-            todayGuideRow(fixedHeaders.length, dateBand, model.project.currentDate, holidaySet),
+            displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
+            legendRow(totalColumns),
+            sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+            weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
+            todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
             headerRow([
               ...fixedHeaders,
+              dividerCell(),
               ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
             ]),
             ...model.tasks.map((task) => ({
@@ -107,7 +146,7 @@
                 taskCell(task, task.uid, "center"),
                 taskCell(task, task.id, "center"),
                 taskCell(task, task.wbs || task.outlineNumber, "center"),
-                taskCell(task, classifyTaskKind(task), "center"),
+                kindCell(task),
                 taskCell(task, task.outlineLevel, "center"),
                 taskCell(task, formatTaskLabel(task)),
                 taskCell(task, task.start),
@@ -115,13 +154,14 @@
                 taskCell(task, task.duration, "center"),
                 taskCell(task, task.percentComplete, "center"),
                 taskCell(task, task.percentWorkComplete, "center"),
-                taskCell(task, task.milestone, "center"),
-                taskCell(task, task.summary, "center"),
-                taskCell(task, task.critical, "center"),
-                taskCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                taskCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                taskCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                taskCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                flagCell(task, task.milestone, "M"),
+                flagCell(task, task.summary, "S"),
+                flagCell(task, task.critical, "!"),
+                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
+                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
+                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
+                dividerCell(),
                 ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
               ]
             }))
@@ -163,6 +203,26 @@
     return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
   }
 
+  function displayReferenceValue(value: string | undefined): string {
+    return value && value.trim() ? value : "-";
+  }
+
+  function referenceCell(
+    task: TaskModel,
+    value: string | undefined,
+    horizontalAlign: "left" | "center" | "right" = "left"
+  ): WbsXlsxCellLike {
+    const displayValue = displayReferenceValue(value);
+    const placeholder = displayValue === "-";
+    return {
+      value: displayValue,
+      border: "thin",
+      horizontalAlign,
+      bold: task.summary || task.milestone || false,
+      fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+    };
+  }
+
   function sectionTitleRow(title: string, columnCount: number) {
     return {
       height: 28,
@@ -193,6 +253,171 @@
     };
   }
 
+  function legendRow(columnCount: number) {
+    const items: WbsXlsxCellLike[] = [
+      {
+        value: "Legend",
+        bold: true,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "進捗済み",
+        fillColor: PROGRESS_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "予定帯",
+        fillColor: ACTIVE_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "Today",
+        fillColor: TODAY_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "週頭",
+        fillColor: WEEK_START_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "週末",
+        fillColor: WEEKEND_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "祝日",
+        fillColor: HOLIDAY_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "━:phase",
+        fillColor: PHASE_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "■:task",
+        fillColor: ACTIVE_BAND_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "◆:milestone",
+        fillColor: MILESTONE_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "M:Milestone",
+        fillColor: HEADER_STATUS_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "S:Summary",
+        fillColor: HEADER_STATUS_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "!:Critical",
+        fillColor: HEADER_STATUS_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      },
+      {
+        value: "-:未設定",
+        fillColor: PLACEHOLDER_FILL,
+        border: "thin",
+        horizontalAlign: "center"
+      }
+    ];
+    return {
+      height: 22,
+      cells: [
+        ...items,
+        ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+      ]
+    };
+  }
+
+  function weekBandRow(
+    fixedColumnCount: number,
+    weekBandRanges: Array<{ startIndex: number; label: string; hasMonthBoundary: boolean }>,
+    dateBandLength: number
+  ) {
+    const bandCells = Array.from({ length: dateBandLength }, () => ({} as WbsXlsxCellLike));
+    weekBandRanges.forEach((item, index) => {
+      bandCells[item.startIndex] = {
+        value: item.label,
+        bold: true,
+        border: "thin" as const,
+        horizontalAlign: "center" as const,
+        fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+      };
+    });
+    return {
+      height: 22,
+      cells: [
+        ...Array.from({ length: fixedColumnCount }, () => ({})),
+        ...bandCells
+      ]
+    };
+  }
+
+  function displaySummaryRow(
+    displayDays: number,
+    baseDate: string | undefined,
+    taskCount: number,
+    resourceCount: number,
+    assignmentCount: number,
+    calendarCount: number,
+    columnCount: number
+  ) {
+    const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
+    const items: WbsXlsxCellLike[] = [
+      summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
+      summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
+      summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
+      summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
+      summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
+      summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
+      summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
+      summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
+      summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
+      summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
+      summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
+      summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
+      summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
+      summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+    ];
+    return {
+      height: 22,
+      cells: [
+        ...items,
+        ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+      ]
+    };
+  }
+
+  function summaryStatCell(value: string | number, fillColor: string): WbsXlsxCellLike {
+    return {
+      value,
+      border: "thin",
+      horizontalAlign: "center",
+      bold: true,
+      fillColor
+    };
+  }
+
   function headerRow(labels: Array<string | WbsXlsxCellLike>) {
     return {
       height: 24,
@@ -201,7 +426,7 @@
           return {
             value: label,
             bold: true,
-            fillColor: HEADER_FILL,
+            fillColor: headerFillForLabel(label),
             border: "thin" as const,
             horizontalAlign: "center" as const
           };
@@ -213,6 +438,34 @@
         };
       })
     };
+  }
+
+  function dividerCell(): WbsXlsxCellLike {
+    return {
+      value: "",
+      fillColor: DIVIDER_FILL,
+      border: "thin",
+      horizontalAlign: "center"
+    };
+  }
+
+  function headerFillForLabel(label: string): string {
+    if (label === "UID" || label === "ID") {
+      return HEADER_ID_FILL;
+    }
+    if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+      return HEADER_STRUCTURE_FILL;
+    }
+    if (label === "Start" || label === "Finish" || label === "Duration") {
+      return HEADER_SCHEDULE_FILL;
+    }
+    if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+      return HEADER_STATUS_FILL;
+    }
+    if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+      return HEADER_ASSIGNMENT_FILL;
+    }
+    return HEADER_FILL;
   }
 
   function todayGuideRow(
@@ -233,11 +486,11 @@
             }
           : {})),
         ...dateBand.map((day) => ({
-          value: isSameDay(day, currentDate) ? "▼" : "",
+          value: isSameDay(day, currentDate) ? "TODAY" : "",
           bold: true,
           border: "thin" as const,
           horizontalAlign: "center" as const,
-          fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : BAND_FILL)
+          fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
         }))
       ]
     };
@@ -270,16 +523,38 @@
     };
   }
 
+  function kindCell(task: TaskModel): WbsXlsxCellLike {
+    return {
+      value: classifyTaskKind(task),
+      border: "thin",
+      horizontalAlign: "center",
+      bold: true,
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : TASK_KIND_FILL)
+    };
+  }
+
+  function flagCell(task: TaskModel, enabled: boolean | undefined, marker: string): WbsXlsxCellLike {
+    return {
+      value: enabled ? marker : "",
+      border: "thin",
+      horizontalAlign: "center",
+      bold: !!enabled,
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+    };
+  }
+
   function dateHeaderCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
     const isToday = isSameDay(day, currentDate);
     const isWeekendDay = isWeekend(day);
     const isHoliday = holidaySet.has(day);
+    const weekStart = isWeekStart(day);
+    const monthStart = isMonthStart(day);
     return {
-      value: formatDateLabel(day),
+      value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
       bold: true,
       border: "thin",
       horizontalAlign: "center",
-      fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : HEADER_FILL))
+      fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
     };
   }
 
@@ -288,17 +563,28 @@
     const isToday = isSameDay(day, currentDate);
     const isWeekendDay = isWeekend(day);
     const isHoliday = holidaySet.has(day);
+    const weekStart = isWeekStart(day);
     const complete = active && isCompletedDay(task, day);
     return {
-      value: active ? "■" : "",
+      value: active ? activeBandMarker(task) : "",
       border: "thin",
       horizontalAlign: "center",
       fillColor: active
         ? (complete
           ? (isToday ? TODAY_PROGRESS_BAND_FILL : PROGRESS_BAND_FILL)
           : (isToday ? TODAY_ACTIVE_BAND_FILL : ACTIVE_BAND_FILL))
-        : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : BAND_FILL)))
+        : (isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (weekStart ? WEEK_START_BAND_FILL : BAND_FILL))))
     };
+  }
+
+  function activeBandMarker(task: TaskModel): string {
+    if (task.summary) {
+      return "━";
+    }
+    if (task.milestone) {
+      return "◆";
+    }
+    return "■";
   }
 
   function buildDateBand(startDate: string | undefined, finishDate: string | undefined): string[] {
@@ -314,6 +600,32 @@
       cursor.setDate(cursor.getDate() + 1);
     }
     return days;
+  }
+
+  function buildWeekBandRanges(dateBand: string[], startColumnIndex: number, rowNumber: number) {
+    const ranges: Array<{ range: string; startIndex: number; label: string; hasMonthBoundary: boolean }> = [];
+    if (dateBand.length === 0) {
+      return ranges;
+    }
+    let chunkStart = 0;
+    while (chunkStart < dateBand.length) {
+      const weekStart = formatWeekKey(dateBand[chunkStart]);
+      let chunkEnd = chunkStart;
+      while (chunkEnd + 1 < dateBand.length && formatWeekKey(dateBand[chunkEnd + 1]) === weekStart) {
+        chunkEnd += 1;
+      }
+      const startColumn = columnName(startColumnIndex + chunkStart);
+      const endColumn = columnName(startColumnIndex + chunkEnd);
+      const chunkDays = dateBand.slice(chunkStart, chunkEnd + 1);
+      ranges.push({
+        range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
+        startIndex: chunkStart,
+        label: formatWeekLabel(chunkDays),
+        hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
+      });
+      chunkStart = chunkEnd + 1;
+    }
+    return ranges;
   }
 
   function includesDay(startDate: string | undefined, finishDate: string | undefined, day: string): boolean {
@@ -356,6 +668,22 @@
     return weekday === 0 || weekday === 6;
   }
 
+  function isWeekStart(day: string): boolean {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return false;
+    }
+    return target.getDay() === 1;
+  }
+
+  function isMonthStart(day: string): boolean {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return false;
+    }
+    return target.getDate() === 1;
+  }
+
   function parseDateOnly(value: string | undefined): Date | null {
     if (!value || value.length < 10) {
       return null;
@@ -369,6 +697,29 @@
       return null;
     }
     return new Date(year, month - 1, day);
+  }
+
+  function expandExceptionDays(exception: CalendarExceptionModel): string[] {
+    const from = (exception.fromDate || "").slice(0, 10);
+    const to = (exception.toDate || "").slice(0, 10);
+    if (!from) {
+      return [];
+    }
+    if (!to || to === from) {
+      return [from];
+    }
+    const start = parseDateOnly(from);
+    const finish = parseDateOnly(to);
+    if (!start || !finish || start.getTime() > finish.getTime()) {
+      return [from];
+    }
+    const days: string[] = [];
+    const cursor = new Date(start.getTime());
+    while (cursor.getTime() <= finish.getTime()) {
+      days.push(formatDateOnly(cursor));
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return days;
   }
 
   function formatDateOnly(value: Date): string {
@@ -388,6 +739,40 @@
     return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
   }
 
+  function formatWeekKey(day: string): string {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return day;
+    }
+    const monday = new Date(target.getTime());
+    const offset = (monday.getDay() + 6) % 7;
+    monday.setDate(monday.getDate() - offset);
+    return formatDateOnly(monday);
+  }
+
+  function formatWeekLabel(days: string[]): string {
+    if (days.length === 0) {
+      return "Week";
+    }
+    const start = parseDateOnly(days[0]);
+    if (!start) {
+      return days[0];
+    }
+    const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    const monthSet = new Set(days.map((day) => {
+      const target = parseDateOnly(day);
+      return target ? target.getMonth() : -1;
+    }));
+    const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+    if (monthSet.size <= 1) {
+      return `Week of ${startLabel}`;
+    }
+    const tailMonths = Array.from(monthSet)
+      .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
+      .map((monthIndex) => monthNames[monthIndex]);
+    return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+  }
+
   function columnName(index: number): string {
     let current = index;
     let name = "";
@@ -401,9 +786,11 @@
 
   (globalThis as typeof globalThis & {
     __mikuprojectWbsXlsx?: {
+      collectWbsHolidayDates: typeof collectWbsHolidayDates;
       exportWbsWorkbook: typeof exportWbsWorkbook;
     };
   }).__mikuprojectWbsXlsx = {
+    collectWbsHolidayDates,
     exportWbsWorkbook
   };
 })();

--- a/docs/project/tests/mikuproject-main.test.js
+++ b/docs/project/tests/mikuproject-main.test.js
@@ -57,6 +57,7 @@ function mountDom() {
     <button id="exportCsvBtn" type="button">CSV を生成</button>
     <button id="exportXlsxBtn" type="button">XLSX Export</button>
     <button id="exportWbsXlsxBtn" type="button">WBS XLSX Export</button>
+    <button id="resetWbsHolidayDatesBtn" type="button">WBS 祝日を既定値へ戻す</button>
     <button id="parseCsvBtn" type="button">CSV を解析</button>
     <button id="importXlsxBtn" type="button">XLSX Import</button>
     <button id="downloadXmlBtn" type="button">XML Export</button>
@@ -94,9 +95,11 @@ function mountDom() {
     </section>
     <section class="md-note-card">
       <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
-      <p class="md-note-card__text">WBS XLSX Export では、YYYY-MM-DD 形式の祝日を改行またはカンマ区切りで指定できます。指定した日付は WBS 日付帯で祝日色として表示します。</p>
+      <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日と、YYYY-MM-DD 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。</p>
+      <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。</p>
     </section>
     <textarea id="wbsHolidayDatesInput"></textarea>
+    <textarea id="wbsExtraHolidayDatesInput"></textarea>
     <textarea id="xmlInput"></textarea>
     <div id="summaryProjectName"></div>
     <div id="summaryTaskCount"></div>
@@ -178,7 +181,11 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).toContain("Calendars: Name / IsBaseCalendar / BaseCalendarUID");
     expect(document.body.textContent).toContain("Calendars の WeekDays / Exceptions / WorkWeeks");
     expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
-    expect(document.body.textContent).toContain("YYYY-MM-DD 形式の祝日");
+    expect(document.body.textContent).toContain("既定祝日と");
+    expect(document.body.textContent).toContain("追加祝日を合成");
+    expect(document.body.textContent).toContain("非稼働日例外から補完");
+    expect(document.getElementById("wbsHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
     expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(true);
   });
 
@@ -683,6 +690,7 @@ describe("mikuproject main", () => {
 
   it("downloads current wbs xlsx", () => {
     bootPage();
+    const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
     document.getElementById("parseXmlBtn").click();
     document.getElementById("exportWbsXlsxBtn").click();
@@ -691,7 +699,13 @@ describe("mikuproject main", () => {
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
     expect(clickedAnchor.download).toBe("mikuproject-wbs-202603162312.xlsx");
+    expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
+    expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
+      holidayDates: ["2026-03-20"]
+    });
     expect(document.getElementById("statusMessage").textContent).toContain("WBS XLSX ファイルをエクスポートしました");
+    expect(document.getElementById("statusMessage").textContent).toContain("祝日 1 件");
   });
 
   it("downloads current wbs xlsx with configured holidays", async () => {
@@ -699,7 +713,7 @@ describe("mikuproject main", () => {
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
     document.getElementById("parseXmlBtn").click();
-    document.getElementById("wbsHolidayDatesInput").value = "2026-03-20, 2026-03-20\n2026-03-21";
+    document.getElementById("wbsExtraHolidayDatesInput").value = "2026-03-20, 2026-03-20\n2026-03-21";
     document.getElementById("exportWbsXlsxBtn").click();
 
     expect(exportSpy).toHaveBeenCalled();
@@ -709,8 +723,30 @@ describe("mikuproject main", () => {
     const workbook = exportSpy.mock.results.at(-1)?.value;
     const sheet = workbook.sheets[0];
     expect(sheet.rows[3].cells[0].value).toContain("Holidays=2");
-    expect(sheet.rows[6].cells[22].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[9].cells[23].fillColor).toBe("#FCE4EC");
     expect(document.getElementById("statusMessage").textContent).toContain("祝日 2 件");
+  });
+
+  it("fills wbs holiday input from model defaults when xml is parsed", () => {
+    bootPage();
+
+    document.getElementById("parseXmlBtn").click();
+
+    expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
+    expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+  });
+
+  it("resets wbs holiday input back to model defaults", () => {
+    bootPage();
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("wbsExtraHolidayDatesInput").value = "2026-03-25\n2026-03-26";
+    document.getElementById("resetWbsHolidayDatesBtn").click();
+
+    expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
+    expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("statusMessage").textContent).toContain("WBS 祝日入力を既定値へ戻しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("1 件");
   });
 
   it("imports xlsx edits back into the current model and xml", async () => {

--- a/docs/project/tests/mikuproject-wbs-xlsx.test.js
+++ b/docs/project/tests/mikuproject-wbs-xlsx.test.js
@@ -36,6 +36,13 @@ function bootModules() {
 }
 
 describe("mikuproject wbs xlsx", () => {
+  it("collects holiday dates from calendar exceptions", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    expect(wbsXlsx.collectWbsHolidayDates(model)).toEqual(["2026-03-20"]);
+  });
+
   it("exports a dedicated WBS workbook from ProjectModel", () => {
     const { xml, wbsXlsx } = bootModules();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
@@ -44,16 +51,66 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     expect(workbook.sheets.map((item) => item.name)).toEqual(["WBS"]);
-    expect(sheet.mergedRanges).toEqual(["A1:W1", "A2:W2", "A3:W3", "A4:W4"]);
+    expect(sheet.mergedRanges).toEqual(["A1:X1", "A2:X2", "A3:X3", "A4:X4", "T8:X8"]);
     expect(sheet.rows[0].cells[0].value).toBe("WBS");
     expect(sheet.rows[1].cells[0].value).toBe("Sample Project");
     expect(String(sheet.rows[2].cells[0].value)).toContain("Title=Sample Project Title");
     expect(String(sheet.rows[3].cells[0].value)).toContain("Start=2026-03-16T09:00:00");
     expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=0");
-    expect(sheet.rows[4].cells[0].value).toBe("Task View");
-    expect(sheet.rows[5].cells[5].value).toBe("Today");
-    expect(sheet.rows[5].cells[18].value).toBe("▼");
-    expect(sheet.rows[6].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
+    expect(sheet.rows[4].cells[0].value).toBe("DisplayDays");
+    expect(sheet.rows[4].cells[1].value).toBe(5);
+    expect(sheet.rows[4].cells[0].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[1].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[2].value).toBe("DisplayWeeks");
+    expect(sheet.rows[4].cells[3].value).toBe(1);
+    expect(sheet.rows[4].cells[2].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[3].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[4].value).toBe("Tasks");
+    expect(sheet.rows[4].cells[5].value).toBe(3);
+    expect(sheet.rows[4].cells[4].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[5].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[6].value).toBe("Resources");
+    expect(sheet.rows[4].cells[7].value).toBe(1);
+    expect(sheet.rows[4].cells[6].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[7].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[8].value).toBe("Assignments");
+    expect(sheet.rows[4].cells[9].value).toBe(2);
+    expect(sheet.rows[4].cells[8].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[9].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[10].value).toBe("Calendars");
+    expect(sheet.rows[4].cells[11].value).toBe(2);
+    expect(sheet.rows[4].cells[10].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[11].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[12].value).toBe("BaseDate");
+    expect(sheet.rows[4].cells[13].value).toBe("2026-03-16");
+    expect(sheet.rows[4].cells[12].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[13].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[5].cells[0].value).toBe("Legend");
+    expect(sheet.rows[5].cells[1].value).toBe("進捗済み");
+    expect(sheet.rows[5].cells[1].fillColor).toBe("#5BAE9C");
+    expect(sheet.rows[5].cells[4].value).toBe("週頭");
+    expect(sheet.rows[5].cells[4].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[5].cells[6].value).toBe("祝日");
+    expect(sheet.rows[5].cells[6].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[5].cells[7].value).toBe("━:phase");
+    expect(sheet.rows[5].cells[7].fillColor).toBe("#EEF7E8");
+    expect(sheet.rows[5].cells[8].value).toBe("■:task");
+    expect(sheet.rows[5].cells[8].fillColor).toBe("#9FD5C9");
+    expect(sheet.rows[5].cells[9].value).toBe("◆:milestone");
+    expect(sheet.rows[5].cells[9].fillColor).toBe("#FFF4E0");
+    expect(sheet.rows[5].cells[10].value).toBe("M:Milestone");
+    expect(sheet.rows[5].cells[10].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[5].cells[11].value).toBe("S:Summary");
+    expect(sheet.rows[5].cells[11].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[5].cells[12].value).toBe("!:Critical");
+    expect(sheet.rows[5].cells[12].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[5].cells[13].value).toBe("-:未設定");
+    expect(sheet.rows[5].cells[13].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[6].cells[0].value).toBe("Task View / BaseDate=2026-03-16");
+    expect(sheet.rows[7].cells[19].value).toBe("Week of Mar 16");
+    expect(sheet.rows[8].cells[5].value).toBe("Today");
+    expect(sheet.rows[8].cells[19].value).toBe("TODAY");
+    expect(sheet.rows[9].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
       "UID",
       "ID",
       "WBS",
@@ -73,31 +130,56 @@ describe("mikuproject wbs xlsx", () => {
       "Resources",
       "Predecessors"
     ]);
-    expect(sheet.rows[6].cells.slice(18).map((cell) => cell.value)).toEqual([
-      "03/16 Mon",
+    expect(sheet.rows[9].cells[18].fillColor).toBe("#C5D1DB");
+    expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
+      "03/16 Mon *",
       "03/17 Tue",
       "03/18 Wed",
       "03/19 Thu",
       "03/20 Fri"
     ]);
-    expect(sheet.rows[6].cells[18].fillColor).toBe("#FFE6A7");
-    expect(sheet.rows[7].cells[3].value).toBe("phase");
-    expect(sheet.rows[7].cells[0].fillColor).toBe("#EEF7E8");
-    expect(sheet.rows[7].cells[5].bold).toBe(true);
-    expect(sheet.rows[8].cells[3].value).toBe("task");
-    expect(sheet.rows[8].cells[4].value).toBe(2);
-    expect(sheet.rows[8].cells[5].value).toBe("  Design");
-    expect(sheet.rows[8].cells[14].value).toBe("Miku");
-    expect(sheet.rows[8].cells[15].value).toBe("1 Standard");
-    expect(sheet.rows[8].cells[16].value).toBe("Miku");
-    expect(sheet.rows[9].cells[17].value).toBe("Design");
-    expect(sheet.rows[8].cells[5].bold).toBe(false);
-    expect(sheet.rows[8].cells[18].value).toBe("■");
-    expect(sheet.rows[8].cells[18].fillColor).toBe("#D89A2B");
-    expect(sheet.rows[8].cells[19].value).toBe("■");
-    expect(sheet.rows[8].cells[19].fillColor).toBe("#5BAE9C");
-    expect(sheet.rows[8].cells[20].value).toBe("");
-    expect(sheet.rows[8].cells[21].value).toBe("");
+    expect(sheet.rows[9].cells[0].fillColor).toBe("#D7E7F6");
+    expect(sheet.rows[9].cells[2].fillColor).toBe("#E6F0DF");
+    expect(sheet.rows[9].cells[6].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[9].cells[9].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[9].cells[14].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[9].cells[19].fillColor).toBe("#FFE6A7");
+    expect(sheet.rows[11].cells[23].fillColor).toBe("#F4F7FB");
+    expect(sheet.rows[10].cells[3].value).toBe("phase");
+    expect(sheet.rows[10].cells[3].fillColor).toBe("#EEF7E8");
+    expect(sheet.rows[10].cells[0].fillColor).toBe("#EEF7E8");
+    expect(sheet.rows[10].cells[5].bold).toBe(true);
+    expect(sheet.rows[10].cells[14].value).toBe("-");
+    expect(sheet.rows[10].cells[14].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[16].value).toBe("-");
+    expect(sheet.rows[10].cells[16].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[17].value).toBe("-");
+    expect(sheet.rows[10].cells[17].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[11].value).toBe("");
+    expect(sheet.rows[10].cells[12].value).toBe("S");
+    expect(sheet.rows[10].cells[13].value).toBe("");
+    expect(sheet.rows[10].cells[19].value).toBe("━");
+    expect(sheet.rows[10].cells[20].value).toBe("━");
+    expect(sheet.rows[11].cells[3].value).toBe("task");
+    expect(sheet.rows[11].cells[3].fillColor).toBe("#EEF2F6");
+    expect(sheet.rows[11].cells[4].value).toBe(2);
+    expect(sheet.rows[11].cells[5].value).toBe("  Design");
+    expect(sheet.rows[11].cells[14].value).toBe("Miku");
+    expect(sheet.rows[11].cells[15].value).toBe("1 Standard");
+    expect(sheet.rows[11].cells[16].value).toBe("Miku");
+    expect(sheet.rows[11].cells[11].value).toBe("");
+    expect(sheet.rows[11].cells[12].value).toBe("");
+    expect(sheet.rows[11].cells[13].value).toBe("");
+    expect(sheet.rows[12].cells[17].value).toBe("Design");
+    expect(sheet.rows[11].cells[5].bold).toBe(false);
+    expect(sheet.rows[11].cells[18].fillColor).toBe("#C5D1DB");
+    expect(sheet.rows[11].cells[19].value).toBe("■");
+    expect(sheet.rows[11].cells[19].fillColor).toBe("#D89A2B");
+    expect(sheet.rows[11].cells[20].value).toBe("■");
+    expect(sheet.rows[11].cells[20].fillColor).toBe("#5BAE9C");
+    expect(sheet.rows[11].cells[21].value).toBe("");
+    expect(sheet.rows[11].cells[22].value).toBe("");
+    expect(sheet.rows[12].cells[23].value).toBe("■");
   });
 
   it("can generate a real xlsx from the dedicated WBS workbook", () => {
@@ -112,12 +194,15 @@ describe("mikuproject wbs xlsx", () => {
 
     expect(entries).toContain("xl/workbook.xml");
     expect(entries).toContain("xl/worksheets/sheet1.xml");
-    expect(sheetXml).toContain('ref="A1:W1"');
-    expect(sheetXml).toContain('ref="A4:W4"');
-    expect(sheetXml).toContain("Task View");
+    expect(sheetXml).toContain('ref="A1:X1"');
+    expect(sheetXml).toContain('ref="A4:X4"');
+    expect(sheetXml).toContain('ref="T8:X8"');
+    expect(sheetXml).toContain("Legend");
+    expect(sheetXml).toContain("Week of Mar 16");
+    expect(sheetXml).toContain("Task View / BaseDate=2026-03-16");
     expect(sheetXml).toContain("Sample Project");
     expect(sheetXml).toContain("OutlineLevel");
-    expect(sheetXml).toContain("03/16 Mon");
+    expect(sheetXml).toContain("03/16 Mon *");
   });
 
   it("marks weekend date-band cells with weekend fill", () => {
@@ -131,15 +216,90 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[6].cells.slice(18).map((cell) => cell.value)).toEqual([
+    expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
       "03/20 Fri",
-      "03/21 Sat",
+      "03/21 Sat *",
       "03/22 Sun",
       "03/23 Mon"
     ]);
-    expect(sheet.rows[5].cells[19].value).toBe("▼");
-    expect(sheet.rows[6].cells[19].fillColor).toBe("#FFE6A7");
-    expect(sheet.rows[6].cells[20].fillColor).toBe("#F1F1F1");
+    expect(sheet.rows[8].cells[20].value).toBe("TODAY");
+    expect(sheet.rows[9].cells[20].fillColor).toBe("#FFE6A7");
+    expect(sheet.rows[9].cells[21].fillColor).toBe("#F1F1F1");
+  });
+
+  it("marks week-start date-band cells with week-start fill", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-16T09:00:00";
+    model.project.finishDate = "2026-03-23T18:00:00";
+    model.project.currentDate = "2026-03-18T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.rows[9].cells[26].value).toBe("03/23 Mon");
+    expect(sheet.rows[9].cells[26].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[11].cells[26].fillColor).toBe("#E3EEF9");
+  });
+
+  it("emphasizes week labels that contain a month boundary", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-30T09:00:00";
+    model.project.finishDate = "2026-04-03T18:00:00";
+    model.project.currentDate = "2026-04-01T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.mergedRanges).toContain("T8:X8");
+    expect(sheet.rows[7].cells[19].value).toBe("Week of Mar 30 / Apr");
+    expect(sheet.rows[7].cells[19].fillColor).toBe("#D6E7F8");
+  });
+
+  it("emphasizes month-start date headers", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-30T09:00:00";
+    model.project.finishDate = "2026-04-03T18:00:00";
+    model.project.currentDate = "2026-03-31T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.rows[9].cells[21].value).toBe("04/01 Wed");
+    expect(sheet.rows[9].cells[21].fillColor).toBe("#DCEAF7");
+  });
+
+  it("renders milestone bands with a diamond marker", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.tasks[2].milestone = true;
+    model.tasks[2].finish = model.tasks[2].start;
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.rows[12].cells[3].value).toBe("milestone");
+    expect(sheet.rows[12].cells[3].fillColor).toBe("#FFF4E0");
+    expect(sheet.rows[12].cells[11].value).toBe("M");
+    expect(sheet.rows[12].cells[21].value).toBe("◆");
+  });
+
+  it("renders critical flags with an exclamation marker", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.tasks[1].critical = true;
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+
+    expect(sheet.rows[11].cells[13].value).toBe("!");
   });
 
   it("marks configured holidays in the date band", () => {
@@ -152,9 +312,9 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=1");
-    expect(sheet.rows[6].cells[22].value).toBe("03/20 Fri");
-    expect(sheet.rows[6].cells[22].fillColor).toBe("#FCE4EC");
-    expect(sheet.rows[8].cells[22].value).toBe("");
-    expect(sheet.rows[8].cells[22].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[9].cells[23].value).toBe("03/20 Fri");
+    expect(sheet.rows[9].cells[23].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[11].cells[23].value).toBe("");
+    expect(sheet.rows[11].cells[23].fillColor).toBe("#FCE4EC");
   });
 });

--- a/scripts/build-project-xlsx-sample.mjs
+++ b/scripts/build-project-xlsx-sample.mjs
@@ -38,30 +38,7 @@ if (typeof wbsXlsx?.exportWbsWorkbook !== "function") {
 const codec = new excelIo.XlsxWorkbookCodec();
 const model = xml.importMsProjectXml(xml.SAMPLE_XML);
 const workbook = projectXlsx.exportProjectWorkbook(model);
-const holidayDates = Array.from(new Set(
-  model.calendars.flatMap((calendar) => calendar.exceptions || [])
-    .filter((exception) => (exception.workingTimes || []).length === 0)
-    .flatMap((exception) => {
-      const from = (exception.fromDate || "").slice(0, 10);
-      const to = (exception.toDate || "").slice(0, 10);
-      if (!from) {
-        return [];
-      }
-      if (!to || to === from) {
-        return [from];
-      }
-      const days = [];
-      const start = new Date(`${from}T00:00:00`);
-      const finish = new Date(`${to}T00:00:00`);
-      for (const cursor = new Date(start.getTime()); cursor.getTime() <= finish.getTime(); cursor.setDate(cursor.getDate() + 1)) {
-        const year = cursor.getFullYear();
-        const month = String(cursor.getMonth() + 1).padStart(2, "0");
-        const day = String(cursor.getDate()).padStart(2, "0");
-        days.push(`${year}-${month}-${day}`);
-      }
-      return days;
-    })
-));
+const holidayDates = wbsXlsx.collectWbsHolidayDates(model);
 const wbsWorkbook = wbsXlsx.exportWbsWorkbook(model, { holidayDates });
 
 const bytes = codec.exportWorkbook(workbook);


### PR DESCRIPTION
## 概要

Git 系ツールの一覧管理と pseudo-squash 画面の導線・表示を改善しました。あわせて、mikuproject の WBS XLSX 出力まわりを拡張し、祝日扱いと日付帯表現を強化しています。

## 変更内容

### Git 作業一覧 / Git pseudo-squash

- `Git 作業一覧` の説明文を更新
  - 複数 Git リポジトリの作業状況を一覧管理し、個別のリポジトリ作業へ進む説明に変更
- `Git 作業一覧` のメモ編集ダイアログで、`git カレントディレクトリ` のラベルを `カレントディレクトリ` に変更
- `Git 作業一覧` で新規追加した Git エントリを、既定で `現在ブランチで作業` 相当の設定に変更
- `Git 作業一覧` で新規追加した項目が一覧の先頭に来るように調整
- `Git pseudo-squash` に、リポジトリ名表示ピルを追加
  - `repoUrl` からリポジトリ名を抽出して表示
  - 表示位置や余白、ピル装飾を調整
- `Git pseudo-squash` のリポジトリ名ピル右側に、以下の操作を配置
  - カレントディレクトリのコピー
  - リポジトリ URL を開く
  - Git 作業一覧へ保存
- `Git pseudo-squash` で、カレントディレクトリコピーとリポジトリ URL オープンの処理を複数ボタンから使えるように整理

### mikuproject / WBS XLSX

- `WBS XLSX Export` の祝日扱いを変更
  - `ProjectModel` 由来の既定祝日と、UI で入力した追加祝日を分けて扱うように変更
  - 既定祝日のリセット処理を追加
- `collectWbsHolidayDates` を追加し、カレンダー例外から非稼働日を収集する処理を共通化
- `build-project-xlsx-sample.mjs` で、祝日抽出処理を共通関数利用に変更
- WBS workbook の表現を拡張
  - 表示日数・週数・件数のサマリ行を追加
  - 凡例行を追加
  - 週ラベル行を追加
  - 固定列と日付帯の間に区切り列を追加
  - ヘッダ列の意味ごとに色分け
  - 週頭、月初、月跨ぎ週、祝日、Today の表示強調を追加
  - phase / task / milestone に応じた帯表現を追加
  - Milestone / Summary / Critical のフラグ表示を追加
  - 未設定値のプレースホルダ表示を追加
- 仕様書・TODO の記述を、既定祝日と追加祝日の扱いに合わせて更新

## テスト

- `git-pseudo-squash` の画面導線・表示まわりのテストを追加/更新
- `git-work-list` の既定値と並び順のテストを追加/更新
- `mikuproject-main` / `mikuproject-wbs-xlsx` のテストを追加/更新
- コミット差分上、テストファイルの更新は確認済みです