### PR TITLE
mikuproject の WBS XLSX 表示改善と freeze pane 対応、git 補助画面の UI 整理

### DIFF
--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -161,6 +161,7 @@ limitations under the License.
       <div id="squashRemoteRow">
         <lht-text-field-help field-id="squashRemote" label="squashリモート" placeholder="例: origin" value="origin" help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></lht-text-field-help>
       </div>
+      <input id="repoUrl" type="hidden" value="" />
     </div>
 
     <section id="commonFields" class="md-section md-stack-md">
@@ -190,7 +191,7 @@ limitations under the License.
       </div>
       <lht-command-block command-id="createBranchCmd"></lht-command-block>
 
-      <div class="md-flow-divider">
+      <div class="md-flow-divider md-flow-divider--after-create">
         <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
@@ -247,11 +248,11 @@ limitations under the License.
           <lht-switch-help switch-id="useCurrentBranch" label="現在ブランチで作業" help-label="現在ブランチで作業の説明" checked on-change="toggleCurrentBranch">
             現在チェックアウト中のブランチを作業ブランチとして扱います。チェックを外すと、作業ブランチ名で switch するコマンドが含まれます。
           </lht-switch-help>
-          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで整理" aria-label="生成AIで整理">
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで作文" aria-label="生成AIで作文">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
             </svg>
-            <span>生成AIで整理</span>
+            <span>生成AIで作文</span>
           </a>
         </span>
       </div>
@@ -292,62 +293,6 @@ limitations under the License.
       </span>
     </div>
     <lht-command-block command-id="pushCmd"></lht-command-block>
-
-    <div class="md-flow-row md-footer-flow">
-      <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
-        <path d="M18 46h28" stroke="#93C5FD" stroke-width="3.5" stroke-linecap="round"/>
-        <path d="M32 18v20" stroke="#A78BFA" stroke-width="3.5" stroke-linecap="round"/>
-        <path d="M24 26l8-8 8 8" stroke="#A78BFA" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
-        <circle cx="46" cy="24" r="5" fill="#86EFAC"/>
-        <rect x="18" y="42" width="28" height="8" rx="4" fill="#BFDBFE"/>
-      </svg>
-      <span class="md-title-info-row">
-        <p class="md-section-title">一覧連携</p>
-        <lht-help-tooltip label="一覧連携の説明">
-          ここでは、この作業内容を `Git 作業一覧` に保存したり、比較専用の画面へ移動したりできます。
-          squash の実行手順そのものではなく、作業管理と画面遷移のための補助エリアです。
-        </lht-help-tooltip>
-      </span>
-    </div>
-
-    <div class="md-bottom-actions">
-      <button id="saveToWorkBranchListBtn" type="button" class="md-button md-button--primary md-button--with-icon">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M4 7h16"></path>
-          <path d="M4 12h16"></path>
-          <path d="M4 17h16"></path>
-        </svg>
-        <span>一覧</span>
-      </button>
-      <button id="openBranchDiffBtn" type="button" class="md-button md-button--surface md-button--with-icon">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M7 7h8"></path>
-          <path d="M11 3l4 4-4 4"></path>
-          <path d="M17 17H9"></path>
-          <path d="M13 13l-4 4 4 4"></path>
-        </svg>
-        <span>比較</span>
-      </button>
-      <div class="md-bottom-actions__field">
-        <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" placeholder="例: https://github.com/igapyon/local-html-tools" help-text="Git 作業一覧へ戻すときの保存先識別に使います。"></lht-text-field-help>
-      </div>
-      <button id="openRepoUrlBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="URL を開く" aria-label="URL を開く">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M14 5h5v5"></path>
-          <path d="M10 14 19 5"></path>
-          <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
-        </svg>
-      </button>
-      <button id="copyGitCurrentDirBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="7" width="14" height="12" rx="2"></rect>
-          <rect x="13" y="3" width="8" height="8" rx="2"></rect>
-          <path d="M15.5 7h3"></path>
-          <path d="M17 5.5v3"></path>
-        </svg>
-      </button>
-    </div>
 
     <lht-toast id="toast"></lht-toast>
 

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -2026,7 +2026,7 @@ lht-index-card-link {
     }
     .md-headline__icon { margin-right: 0.5rem; }
 
-    .md-section { margin-bottom: 1rem; }
+    .md-section { margin-bottom: 0.7rem; }
     .md-stack-md > * + * { margin-top: 0.75rem; }
     .md-stack-sm > * + * { margin-top: 0.5rem; }
 
@@ -2047,13 +2047,14 @@ lht-index-card-link {
 
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
 
-    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.12rem 0; }
     .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
     .md-title-info-row .md-section-title { margin: 0; }
     .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-title-action-btn { margin-left: 0.35rem; }
     .md-title-action-icon { margin-left: 0.25rem; }
-    .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
+    .md-flow-divider { display: flex; justify-content: center; padding: 0.08rem 0; margin-top: 0.42rem; }
+    .md-flow-divider--after-create { padding-top: 0.24rem; }
 
     .md-diff-dialog {
       width: min(780px, calc(100vw - 2rem));
@@ -2146,12 +2147,12 @@ lht-index-card-link {
     .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
     .md-copy-button--bottom-right { top: auto; right: 0.5rem; bottom: 0.5rem; }
     md-icon-button.md-copy-button {
-      width: 32px;
-      height: 32px;
-      border-radius: 16px;
-      --md-icon-button-icon-size: 16px;
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      --md-icon-button-icon-size: 20px;
       --md-icon-button-icon-color: #3f3b46;
-      --md-icon-button-state-layer-shape: 16px;
+      --md-icon-button-state-layer-shape: 20px;
       --md-icon-button-hover-state-layer-color: #3f3b46;
       --md-icon-button-hover-state-layer-opacity: 0.08;
       --md-icon-button-pressed-state-layer-color: #3f3b46;
@@ -2422,6 +2423,27 @@ lht-index-card-link {
       flex: 0 0 auto;
     }
 
+    .md-input-action--inline.md-icon-btn--small {
+      width: 38px;
+      height: 38px;
+      border-radius: 19px;
+    }
+
+    .md-input-action--inline .md-icon-small {
+      width: 20px;
+      height: 20px;
+    }
+
+    lht-command-block .md-copy-button--fallback {
+      width: 2.4rem;
+      height: 2.4rem;
+    }
+
+    lht-command-block .md-copy-button--fallback .md-icon-small {
+      width: 18px;
+      height: 18px;
+    }
+
     md-outlined-text-field.md-disabled {
       opacity: 0.68;
     }
@@ -2670,6 +2692,7 @@ lht-index-card-link {
       <div id="squashRemoteRow">
         <lht-text-field-help field-id="squashRemote" label="squashリモート" placeholder="例: origin" value="origin" help-text="squash 作業で使う fetch / push のリモート名です。通常は origin です。「作業をまとめる（squash）」のコマンドに反映されます。基点のリモートと同じにしておくと混乱しにくいです。"></lht-text-field-help>
       </div>
+      <input id="repoUrl" type="hidden" value="" />
     </div>
 
     <section id="commonFields" class="md-section md-stack-md">
@@ -2699,7 +2722,7 @@ lht-index-card-link {
       </div>
       <lht-command-block command-id="createBranchCmd"></lht-command-block>
 
-      <div class="md-flow-divider">
+      <div class="md-flow-divider md-flow-divider--after-create">
         <svg aria-hidden="true" viewBox="0 0 420 64" class="md-flow-strip" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="8" width="412" height="48" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
           <rect x="18" y="18" width="70" height="28" rx="8" fill="#DDEBFF" />
@@ -2756,11 +2779,11 @@ lht-index-card-link {
           <lht-switch-help switch-id="useCurrentBranch" label="現在ブランチで作業" help-label="現在ブランチで作業の説明" checked on-change="toggleCurrentBranch">
             現在チェックアウト中のブランチを作業ブランチとして扱います。チェックを外すと、作業ブランチ名で switch するコマンドが含まれます。
           </lht-switch-help>
-          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで整理" aria-label="生成AIで整理">
+          <a class="md-button md-button--surface md-button--compact md-button--with-icon md-title-action-btn" href="../prompt/prompt-gen.html?q=A501&id=A501" title="生成AIで作文" aria-label="生成AIで作文">
             <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
               <use href="#md-icon-auto-fix" xlink:href="#md-icon-auto-fix"></use>
             </svg>
-            <span>生成AIで整理</span>
+            <span>生成AIで作文</span>
           </a>
         </span>
       </div>
@@ -2801,62 +2824,6 @@ lht-index-card-link {
       </span>
     </div>
     <lht-command-block command-id="pushCmd"></lht-command-block>
-
-    <div class="md-flow-row md-footer-flow">
-      <svg aria-hidden="true" viewBox="0 0 64 64" class="md-step-icon" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="4" y="4" width="56" height="56" rx="12" fill="#F8FAFC" stroke="#E2E8F0" />
-        <path d="M18 46h28" stroke="#93C5FD" stroke-width="3.5" stroke-linecap="round"/>
-        <path d="M32 18v20" stroke="#A78BFA" stroke-width="3.5" stroke-linecap="round"/>
-        <path d="M24 26l8-8 8 8" stroke="#A78BFA" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
-        <circle cx="46" cy="24" r="5" fill="#86EFAC"/>
-        <rect x="18" y="42" width="28" height="8" rx="4" fill="#BFDBFE"/>
-      </svg>
-      <span class="md-title-info-row">
-        <p class="md-section-title">一覧連携</p>
-        <lht-help-tooltip label="一覧連携の説明">
-          ここでは、この作業内容を `Git 作業一覧` に保存したり、比較専用の画面へ移動したりできます。
-          squash の実行手順そのものではなく、作業管理と画面遷移のための補助エリアです。
-        </lht-help-tooltip>
-      </span>
-    </div>
-
-    <div class="md-bottom-actions">
-      <button id="saveToWorkBranchListBtn" type="button" class="md-button md-button--primary md-button--with-icon">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M4 7h16"></path>
-          <path d="M4 12h16"></path>
-          <path d="M4 17h16"></path>
-        </svg>
-        <span>一覧</span>
-      </button>
-      <button id="openBranchDiffBtn" type="button" class="md-button md-button--surface md-button--with-icon">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M7 7h8"></path>
-          <path d="M11 3l4 4-4 4"></path>
-          <path d="M17 17H9"></path>
-          <path d="M13 13l-4 4 4 4"></path>
-        </svg>
-        <span>比較</span>
-      </button>
-      <div class="md-bottom-actions__field">
-        <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" placeholder="例: https://github.com/igapyon/local-html-tools" help-text="Git 作業一覧へ戻すときの保存先識別に使います。"></lht-text-field-help>
-      </div>
-      <button id="openRepoUrlBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface" title="URL を開く" aria-label="URL を開く">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M14 5h5v5"></path>
-          <path d="M10 14 19 5"></path>
-          <path d="M19 14v4a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h4"></path>
-        </svg>
-      </button>
-      <button id="copyGitCurrentDirBtn" type="button" class="md-icon-btn md-icon-btn--small md-icon-btn--surface md-hidden" title="git カレントディレクトリをコピー" aria-label="git カレントディレクトリをコピー">
-        <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="3" y="7" width="14" height="12" rx="2"></rect>
-          <rect x="13" y="3" width="8" height="8" rx="2"></rect>
-          <path d="M15.5 7h3"></path>
-          <path d="M17 5.5v3"></path>
-        </svg>
-      </button>
-    </div>
 
     <lht-toast id="toast"></lht-toast>
 

--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -149,7 +149,6 @@ limitations under the License.
         </div>
 
         <div class="md-dialog__footer">
-          <button id="copyGitStatusCommandBtn" type="button" class="md-button md-button--secondary">cd + git status</button>
           <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
         </div>
       </form>

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1858,7 +1858,6 @@ lht-index-card-link {
         </div>
 
         <div class="md-dialog__footer">
-          <button id="copyGitStatusCommandBtn" type="button" class="md-button md-button--secondary">cd + git status</button>
           <button id="saveMemoBtn" type="button" class="md-button md-button--primary">保存</button>
         </div>
       </form>
@@ -4769,26 +4768,6 @@ if (!customElements.get("lht-page-menu")) {
       showToast("メモを保存しました");
     }
 
-    function quoteShellPath(value) {
-      const text = String(value || "");
-      if (!text) return "''";
-      return `'${text.replace(/'/g, `'\"'\"'`)}'`;
-    }
-
-    async function copyGitStatusCommand() {
-      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
-      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
-      if (!gitCurrentDir) {
-        showToast("git カレントディレクトリを入力してください");
-        return;
-      }
-      const commandText = `cd ${quoteShellPath(gitCurrentDir)}\ngit status -sb`;
-      const copied = await copyTextToClipboard(commandText);
-      if (copied) {
-        showToast("cd + git status をコピーしました");
-      }
-    }
-
     async function copyTextToClipboard(text) {
       const normalizedText = String(text || "");
       if (!normalizedText) return false;
@@ -5041,12 +5020,6 @@ if (!customElements.get("lht-page-menu")) {
       const saveMemoButton = document.getElementById("saveMemoBtn");
       if (saveMemoButton) {
         saveMemoButton.addEventListener("click", saveMemo);
-      }
-      const copyGitStatusCommandButton = document.getElementById("copyGitStatusCommandBtn");
-      if (copyGitStatusCommandButton) {
-        copyGitStatusCommandButton.addEventListener("click", () => {
-          copyGitStatusCommand();
-        });
       }
       const memoDialog = getMemoDialog();
       if (memoDialog && !memoDialog.dataset.boundOutsideClose) {

--- a/docs/git/src/git-pseudo-squash/css/app.css
+++ b/docs/git/src/git-pseudo-squash/css/app.css
@@ -949,7 +949,7 @@
     }
     .md-headline__icon { margin-right: 0.5rem; }
 
-    .md-section { margin-bottom: 1rem; }
+    .md-section { margin-bottom: 0.7rem; }
     .md-stack-md > * + * { margin-top: 0.75rem; }
     .md-stack-sm > * + * { margin-top: 0.5rem; }
 
@@ -970,13 +970,14 @@
 
     .md-section-title { font-size: 1rem; font-weight: 600; color: #3f3b46; }
 
-    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.5rem 0; }
+    .md-flow-row { display: flex; align-items: center; gap: 0.75rem; padding: 0.12rem 0; }
     .md-title-info-row { display: inline-flex; align-items: center; gap: 0.08rem; }
     .md-title-info-row .md-section-title { margin: 0; }
     .md-title-info-row .md-info-chip { margin-left: 0; }
     .md-title-action-btn { margin-left: 0.35rem; }
     .md-title-action-icon { margin-left: 0.25rem; }
-    .md-flow-divider { display: flex; justify-content: center; padding: 0.5rem 0; }
+    .md-flow-divider { display: flex; justify-content: center; padding: 0.08rem 0; margin-top: 0.42rem; }
+    .md-flow-divider--after-create { padding-top: 0.24rem; }
 
     .md-diff-dialog {
       width: min(780px, calc(100vw - 2rem));
@@ -1069,12 +1070,12 @@
     .md-copy-button { position: absolute; top: 0.5rem; right: 0.5rem; }
     .md-copy-button--bottom-right { top: auto; right: 0.5rem; bottom: 0.5rem; }
     md-icon-button.md-copy-button {
-      width: 32px;
-      height: 32px;
-      border-radius: 16px;
-      --md-icon-button-icon-size: 16px;
+      width: 40px;
+      height: 40px;
+      border-radius: 20px;
+      --md-icon-button-icon-size: 20px;
       --md-icon-button-icon-color: #3f3b46;
-      --md-icon-button-state-layer-shape: 16px;
+      --md-icon-button-state-layer-shape: 20px;
       --md-icon-button-hover-state-layer-color: #3f3b46;
       --md-icon-button-hover-state-layer-opacity: 0.08;
       --md-icon-button-pressed-state-layer-color: #3f3b46;
@@ -1343,6 +1344,27 @@
 
     .md-input-action--inline {
       flex: 0 0 auto;
+    }
+
+    .md-input-action--inline.md-icon-btn--small {
+      width: 38px;
+      height: 38px;
+      border-radius: 19px;
+    }
+
+    .md-input-action--inline .md-icon-small {
+      width: 20px;
+      height: 20px;
+    }
+
+    lht-command-block .md-copy-button--fallback {
+      width: 2.4rem;
+      height: 2.4rem;
+    }
+
+    lht-command-block .md-copy-button--fallback .md-icon-small {
+      width: 18px;
+      height: 18px;
     }
 
     md-outlined-text-field.md-disabled {

--- a/docs/git/src/git-work-list/js/main.js
+++ b/docs/git/src/git-work-list/js/main.js
@@ -774,26 +774,6 @@
       showToast("メモを保存しました");
     }
 
-    function quoteShellPath(value) {
-      const text = String(value || "");
-      if (!text) return "''";
-      return `'${text.replace(/'/g, `'\"'\"'`)}'`;
-    }
-
-    async function copyGitStatusCommand() {
-      const gitCurrentDirectoryField = document.getElementById("gitCurrentDirectory");
-      const gitCurrentDir = gitCurrentDirectoryField ? String(gitCurrentDirectoryField.value || "").trim() : "";
-      if (!gitCurrentDir) {
-        showToast("git カレントディレクトリを入力してください");
-        return;
-      }
-      const commandText = `cd ${quoteShellPath(gitCurrentDir)}\ngit status -sb`;
-      const copied = await copyTextToClipboard(commandText);
-      if (copied) {
-        showToast("cd + git status をコピーしました");
-      }
-    }
-
     async function copyTextToClipboard(text) {
       const normalizedText = String(text || "");
       if (!normalizedText) return false;
@@ -1046,12 +1026,6 @@
       const saveMemoButton = document.getElementById("saveMemoBtn");
       if (saveMemoButton) {
         saveMemoButton.addEventListener("click", saveMemo);
-      }
-      const copyGitStatusCommandButton = document.getElementById("copyGitStatusCommandBtn");
-      if (copyGitStatusCommandButton) {
-        copyGitStatusCommandButton.addEventListener("click", () => {
-          copyGitStatusCommand();
-        });
       }
       const memoDialog = getMemoDialog();
       if (memoDialog && !memoDialog.dataset.boundOutsideClose) {

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -34,6 +34,7 @@
 - 上記シート粒度が `MS Project XML` / `ProjectModel` の構造に由来することを明記する
 - Excel 側の独自都合ではなく、まずは `MS Project XML` の構造に忠実な workbook 構成を優先する
 - WBS 帳票的な見せ方は、別ビュー・別 workbook として export を継続改善する
+- `WBS XLSX Export` は表示専用 workbook として、上部サマリ、凡例、Week/BaseDate ガイド、日付帯の視認性改善を継続する
 - `WBS XLSX Export` では、`ProjectModel` 由来の既定祝日と、UI から入力した追加祝日を分けて扱えるように保つ
 - WBS sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として日付帯へ反映する
 - `build-project-xlsx-sample.mjs` を静的 workbook 直書きから `project-xlsx.ts` 利用へ切り替える

--- a/docs/project/mikuproject-spec.md
+++ b/docs/project/mikuproject-spec.md
@@ -67,6 +67,7 @@ STEP 1 の目的は、`MS Project XML` を意味的に往復できる状態を�
   - `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、UI で指定した追加祝日を合成して扱う
   - 指定した祝日は WBS 日付帯で祝日色として表示する
   - sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として WBS workbook へ反映する
+  - レイアウトは表示専用として継続改善し、上部サマリ、凡例、Week/BaseDate ガイド、日付帯の視認性を段階的に整える
 
 現時点で `XLSX Import` の反映対象としている列は次のとおり。
 

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -5917,6 +5917,7 @@ if (!customElements.get("lht-page-menu")) {
                 return {
                     name: sheet.name,
                     columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+                    freezePane: normalizeFreezePane(sheet.freezePane),
                     mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
                     rows: Array.isArray(sheet.rows)
                         ? sheet.rows.map((row) => ({
@@ -5936,6 +5937,20 @@ if (!customElements.get("lht-page-menu")) {
         }
         return {
             width: normalizeOptionalPositiveNumber(column.width, "Column width")
+        };
+    }
+    function normalizeFreezePane(freezePane) {
+        if (!freezePane) {
+            return undefined;
+        }
+        const rowSplit = normalizeOptionalPositiveInteger(freezePane.rowSplit, "Freeze pane rowSplit");
+        const colSplit = normalizeOptionalPositiveInteger(freezePane.colSplit, "Freeze pane colSplit");
+        if (rowSplit === undefined && colSplit === undefined) {
+            return undefined;
+        }
+        return {
+            rowSplit,
+            colSplit
         };
     }
     function normalizeCell(cell) {
@@ -5986,6 +6001,15 @@ if (!customElements.get("lht-page-menu")) {
         }
         if (!Number.isFinite(value) || value <= 0) {
             throw new Error(`${label} must be a finite positive number`);
+        }
+        return value;
+    }
+    function normalizeOptionalPositiveInteger(value, label) {
+        if (value === undefined) {
+            return undefined;
+        }
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new Error(`${label} must be a positive integer`);
         }
         return value;
     }
@@ -6064,15 +6088,28 @@ if (!customElements.get("lht-page-menu")) {
 </workbook>`;
     }
     function buildWorksheetXml(sheet, styleBook) {
+        const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
         const colsXml = buildColumnsXml(sheet.columns);
         const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
         const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
         return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${sheetViewsXml}
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
 </worksheet>`;
+    }
+    function buildSheetViewsXml(freezePane) {
+        if (!freezePane || (!freezePane.rowSplit && !freezePane.colSplit)) {
+            return "";
+        }
+        const xSplit = freezePane.colSplit ? ` xSplit="${freezePane.colSplit}"` : "";
+        const ySplit = freezePane.rowSplit ? ` ySplit="${freezePane.rowSplit}"` : "";
+        const topLeftCell = encodeCellReference(freezePane.rowSplit || 0, freezePane.colSplit || 0);
+        const topLeftCellAttribute = topLeftCell ? ` topLeftCell="${topLeftCell}"` : "";
+        const activePane = resolveActivePane(freezePane);
+        return `<sheetViews><sheetView workbookViewId="0"><pane${xSplit}${ySplit}${topLeftCellAttribute} activePane="${activePane}" state="frozen"/></sheetView></sheetViews>`;
     }
     function buildColumnsXml(columns) {
         if (!columns || columns.length === 0 || columns.every((column) => column.width === undefined)) {
@@ -6342,6 +6379,7 @@ if (!customElements.get("lht-page-menu")) {
         return {
             name,
             columns: parseWorksheetColumns(document),
+            freezePane: parseWorksheetFreezePane(document),
             mergedRanges: parseWorksheetMergedRanges(document),
             rows: rowElements.map((rowElement) => ({
                 height: parseOptionalNumber(rowElement.getAttribute("ht")),
@@ -6376,6 +6414,21 @@ if (!customElements.get("lht-page-menu")) {
         return mergeCellElements
             .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
             .filter(Boolean);
+    }
+    function parseWorksheetFreezePane(document) {
+        const paneElement = document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "pane")[0];
+        if (!paneElement || paneElement.getAttribute("state") !== "frozen") {
+            return undefined;
+        }
+        const rowSplit = parseOptionalNumber(paneElement.getAttribute("ySplit"));
+        const colSplit = parseOptionalNumber(paneElement.getAttribute("xSplit"));
+        if (rowSplit === undefined && colSplit === undefined) {
+            return undefined;
+        }
+        return {
+            rowSplit,
+            colSplit
+        };
     }
     function parseWorksheetRowCells(rowElement, styleBook) {
         const cells = [];
@@ -6559,6 +6612,21 @@ if (!customElements.get("lht-page-menu")) {
             current = Math.floor((current - 1) / 26);
         }
         return result;
+    }
+    function encodeCellReference(rowIndex, columnIndex) {
+        if (rowIndex <= 0 && columnIndex <= 0) {
+            return "";
+        }
+        return `${encodeColumnName(columnIndex)}${rowIndex + 1}`;
+    }
+    function resolveActivePane(freezePane) {
+        if (freezePane.rowSplit && freezePane.colSplit) {
+            return "bottomRight";
+        }
+        if (freezePane.rowSplit) {
+            return "bottomLeft";
+        }
+        return "topRight";
     }
     function decodeColumnReference(reference) {
         const match = /^([A-Z]+)\d+$/i.exec(reference);
@@ -9453,6 +9521,7 @@ if (!customElements.get("lht-page-menu")) {
     const PHASE_FILL = "#EEF7E8";
     const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
+    const IDENTIFIER_FILL = "#F7F9FC";
     const PLACEHOLDER_FILL = "#F5F7FA";
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
@@ -9466,6 +9535,7 @@ if (!customElements.get("lht-page-menu")) {
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
     const DIVIDER_FILL = "#C5D1DB";
+    const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -9527,11 +9597,15 @@ if (!customElements.get("lht-page-menu")) {
             sheets: [
                 {
                     name: "WBS",
+                    freezePane: {
+                        rowSplit: 10,
+                        colSplit: 19
+                    },
                     columns: [
-                        { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
-                        { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+                        { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
+                        { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
+                        { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
                     mergedRanges: [
@@ -9548,27 +9622,35 @@ if (!customElements.get("lht-page-menu")) {
                         infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
                         displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
                         legendRow(totalColumns),
-                        sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+                        taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
                         weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
                         todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
                         headerRow([
-                            ...fixedHeaders,
+                            ...fixedHeaders.map((label) => label === "Name"
+                                ? {
+                                    value: label,
+                                    bold: true,
+                                    fillColor: headerFillForLabel(label),
+                                    border: "thin",
+                                    horizontalAlign: "left"
+                                }
+                                : label),
                             dividerCell(),
                             ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
                         ]),
                         ...model.tasks.map((task) => ({
                             cells: [
-                                taskCell(task, task.uid, "center"),
-                                taskCell(task, task.id, "center"),
-                                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                                identifierCell(task, task.uid),
+                                identifierCell(task, task.id),
+                                identifierCell(task, task.wbs || task.outlineNumber),
                                 kindCell(task),
-                                taskCell(task, task.outlineLevel, "center"),
+                                identifierCell(task, task.outlineLevel),
                                 taskCell(task, formatTaskLabel(task)),
-                                taskCell(task, task.start),
-                                taskCell(task, task.finish),
+                                taskCell(task, task.start, "center"),
+                                taskCell(task, task.finish, "center"),
                                 taskCell(task, task.duration, "center"),
-                                taskCell(task, task.percentComplete, "center"),
-                                taskCell(task, task.percentWorkComplete, "center"),
+                                progressCell(task, task.percentComplete),
+                                progressCell(task, task.percentWorkComplete),
                                 flagCell(task, task.milestone, "M"),
                                 flagCell(task, task.summary, "S"),
                                 flagCell(task, task.critical, "!"),
@@ -9619,7 +9701,7 @@ if (!customElements.get("lht-page-menu")) {
         return {
             value: displayValue,
             border: "thin",
-            horizontalAlign,
+            horizontalAlign: placeholder ? "center" : horizontalAlign,
             bold: task.summary || task.milestone || false,
             fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
         };
@@ -9639,6 +9721,30 @@ if (!customElements.get("lht-page-menu")) {
             ]
         };
     }
+    function taskViewRow(baseDate, columnCount) {
+        return {
+            height: 26,
+            cells: Array.from({ length: columnCount }, (_, index) => {
+                if (index === 0) {
+                    return {
+                        value: `Task View | BaseDate=${baseDate}`,
+                        bold: true,
+                        fillColor: "#EAF3FB",
+                        border: "thin",
+                        horizontalAlign: "left"
+                    };
+                }
+                if (index < 12) {
+                    return {
+                        value: "",
+                        fillColor: "#EAF3FB",
+                        border: "thin"
+                    };
+                }
+                return {};
+            })
+        };
+    }
     function infoRow(text, columnCount) {
         return {
             height: 24,
@@ -9655,7 +9761,7 @@ if (!customElements.get("lht-page-menu")) {
     function legendRow(columnCount) {
         const items = [
             {
-                value: "Legend",
+                value: "Legend / 記号",
                 bold: true,
                 border: "thin",
                 horizontalAlign: "center"
@@ -9755,13 +9861,38 @@ if (!customElements.get("lht-page-menu")) {
                 bold: true,
                 border: "thin",
                 horizontalAlign: "center",
-                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#EAF1F9")
             };
         });
         return {
             height: 22,
             cells: [
-                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...Array.from({ length: fixedColumnCount }, (_, index) => {
+                    if (index === 5) {
+                        return {
+                            value: "Week",
+                            bold: true,
+                            border: "thin",
+                            horizontalAlign: "right",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index > 5 && index < 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index === 5 || index === 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    return {};
+                }),
                 ...bandCells
             ]
         };
@@ -9769,6 +9900,8 @@ if (!customElements.get("lht-page-menu")) {
     function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
         const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
         const items = [
+            summaryStatCell("Summary", HEADER_ID_FILL),
+            summaryStatCell("", HEADER_FILL),
             summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
             summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
             summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
@@ -9852,20 +9985,44 @@ if (!customElements.get("lht-page-menu")) {
         return {
             height: 22,
             cells: [
-                ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
-                    ? {
-                        value: "Today",
-                        bold: true,
-                        border: "thin",
-                        horizontalAlign: "right"
+                ...Array.from({ length: fixedColumnCount }, (_, index) => {
+                    if (index === 5) {
+                        return {
+                            value: "BaseDate",
+                            bold: true,
+                            border: "thin",
+                            horizontalAlign: "right",
+                            fillColor: "#FFEFC2"
+                        };
                     }
-                    : {})),
-                ...dateBand.map((day) => ({
-                    value: isSameDay(day, currentDate) ? "TODAY" : "",
+                    if (index > 5 && index < 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    if (index === 5 || index === 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    return {};
+                }),
+                ...dateBand.map((day, index) => ({
+                    value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
-                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
+                    fillColor: isSameDay(day, currentDate)
+                        ? TODAY_BAND_FILL
+                        : (holidaySet.has(day)
+                            ? HOLIDAY_BAND_FILL
+                            : (isWeekStart(day)
+                                ? WEEK_START_BAND_FILL
+                                : (index < 3 ? BASEDATE_GUIDE_TAIL_FILL : BAND_FILL)))
                 }))
             ]
         };
@@ -9900,12 +10057,33 @@ if (!customElements.get("lht-page-menu")) {
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : TASK_KIND_FILL)
         };
     }
+    function identifierCell(task, value) {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: task.summary || task.milestone || false,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : IDENTIFIER_FILL)
+        };
+    }
     function flagCell(task, enabled, marker) {
         return {
             value: enabled ? marker : "",
             border: "thin",
             horizontalAlign: "center",
             bold: !!enabled,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
+    function progressCell(task, value) {
+        return {
+            value: value === undefined || value === null ? "" : `${value}%`,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: task.summary || task.milestone || false,
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
         };
     }
@@ -9916,7 +10094,7 @@ if (!customElements.get("lht-page-menu")) {
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
         return {
-            value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
+            value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",

--- a/docs/project/src/mikuproject/js/excel-io.js
+++ b/docs/project/src/mikuproject/js/excel-io.js
@@ -82,6 +82,7 @@
                 return {
                     name: sheet.name,
                     columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+                    freezePane: normalizeFreezePane(sheet.freezePane),
                     mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
                     rows: Array.isArray(sheet.rows)
                         ? sheet.rows.map((row) => ({
@@ -101,6 +102,20 @@
         }
         return {
             width: normalizeOptionalPositiveNumber(column.width, "Column width")
+        };
+    }
+    function normalizeFreezePane(freezePane) {
+        if (!freezePane) {
+            return undefined;
+        }
+        const rowSplit = normalizeOptionalPositiveInteger(freezePane.rowSplit, "Freeze pane rowSplit");
+        const colSplit = normalizeOptionalPositiveInteger(freezePane.colSplit, "Freeze pane colSplit");
+        if (rowSplit === undefined && colSplit === undefined) {
+            return undefined;
+        }
+        return {
+            rowSplit,
+            colSplit
         };
     }
     function normalizeCell(cell) {
@@ -151,6 +166,15 @@
         }
         if (!Number.isFinite(value) || value <= 0) {
             throw new Error(`${label} must be a finite positive number`);
+        }
+        return value;
+    }
+    function normalizeOptionalPositiveInteger(value, label) {
+        if (value === undefined) {
+            return undefined;
+        }
+        if (!Number.isInteger(value) || value <= 0) {
+            throw new Error(`${label} must be a positive integer`);
         }
         return value;
     }
@@ -229,15 +253,28 @@
 </workbook>`;
     }
     function buildWorksheetXml(sheet, styleBook) {
+        const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
         const colsXml = buildColumnsXml(sheet.columns);
         const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
         const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
         return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${sheetViewsXml}
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
 </worksheet>`;
+    }
+    function buildSheetViewsXml(freezePane) {
+        if (!freezePane || (!freezePane.rowSplit && !freezePane.colSplit)) {
+            return "";
+        }
+        const xSplit = freezePane.colSplit ? ` xSplit="${freezePane.colSplit}"` : "";
+        const ySplit = freezePane.rowSplit ? ` ySplit="${freezePane.rowSplit}"` : "";
+        const topLeftCell = encodeCellReference(freezePane.rowSplit || 0, freezePane.colSplit || 0);
+        const topLeftCellAttribute = topLeftCell ? ` topLeftCell="${topLeftCell}"` : "";
+        const activePane = resolveActivePane(freezePane);
+        return `<sheetViews><sheetView workbookViewId="0"><pane${xSplit}${ySplit}${topLeftCellAttribute} activePane="${activePane}" state="frozen"/></sheetView></sheetViews>`;
     }
     function buildColumnsXml(columns) {
         if (!columns || columns.length === 0 || columns.every((column) => column.width === undefined)) {
@@ -507,6 +544,7 @@
         return {
             name,
             columns: parseWorksheetColumns(document),
+            freezePane: parseWorksheetFreezePane(document),
             mergedRanges: parseWorksheetMergedRanges(document),
             rows: rowElements.map((rowElement) => ({
                 height: parseOptionalNumber(rowElement.getAttribute("ht")),
@@ -541,6 +579,21 @@
         return mergeCellElements
             .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
             .filter(Boolean);
+    }
+    function parseWorksheetFreezePane(document) {
+        const paneElement = document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "pane")[0];
+        if (!paneElement || paneElement.getAttribute("state") !== "frozen") {
+            return undefined;
+        }
+        const rowSplit = parseOptionalNumber(paneElement.getAttribute("ySplit"));
+        const colSplit = parseOptionalNumber(paneElement.getAttribute("xSplit"));
+        if (rowSplit === undefined && colSplit === undefined) {
+            return undefined;
+        }
+        return {
+            rowSplit,
+            colSplit
+        };
     }
     function parseWorksheetRowCells(rowElement, styleBook) {
         const cells = [];
@@ -724,6 +777,21 @@
             current = Math.floor((current - 1) / 26);
         }
         return result;
+    }
+    function encodeCellReference(rowIndex, columnIndex) {
+        if (rowIndex <= 0 && columnIndex <= 0) {
+            return "";
+        }
+        return `${encodeColumnName(columnIndex)}${rowIndex + 1}`;
+    }
+    function resolveActivePane(freezePane) {
+        if (freezePane.rowSplit && freezePane.colSplit) {
+            return "bottomRight";
+        }
+        if (freezePane.rowSplit) {
+            return "bottomLeft";
+        }
+        return "topRight";
     }
     function decodeColumnReference(reference) {
         const match = /^([A-Z]+)\d+$/i.exec(reference);

--- a/docs/project/src/mikuproject/js/wbs-xlsx.js
+++ b/docs/project/src/mikuproject/js/wbs-xlsx.js
@@ -8,6 +8,7 @@
     const PHASE_FILL = "#EEF7E8";
     const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
+    const IDENTIFIER_FILL = "#F7F9FC";
     const PLACEHOLDER_FILL = "#F5F7FA";
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
@@ -21,6 +22,7 @@
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
     const DIVIDER_FILL = "#C5D1DB";
+    const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -82,11 +84,15 @@
             sheets: [
                 {
                     name: "WBS",
+                    freezePane: {
+                        rowSplit: 10,
+                        colSplit: 19
+                    },
                     columns: [
-                        { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
-                        { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+                        { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
+                        { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-                        { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
+                        { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
                     mergedRanges: [
@@ -103,27 +109,35 @@
                         infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
                         displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
                         legendRow(totalColumns),
-                        sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+                        taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
                         weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
                         todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
                         headerRow([
-                            ...fixedHeaders,
+                            ...fixedHeaders.map((label) => label === "Name"
+                                ? {
+                                    value: label,
+                                    bold: true,
+                                    fillColor: headerFillForLabel(label),
+                                    border: "thin",
+                                    horizontalAlign: "left"
+                                }
+                                : label),
                             dividerCell(),
                             ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
                         ]),
                         ...model.tasks.map((task) => ({
                             cells: [
-                                taskCell(task, task.uid, "center"),
-                                taskCell(task, task.id, "center"),
-                                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                                identifierCell(task, task.uid),
+                                identifierCell(task, task.id),
+                                identifierCell(task, task.wbs || task.outlineNumber),
                                 kindCell(task),
-                                taskCell(task, task.outlineLevel, "center"),
+                                identifierCell(task, task.outlineLevel),
                                 taskCell(task, formatTaskLabel(task)),
-                                taskCell(task, task.start),
-                                taskCell(task, task.finish),
+                                taskCell(task, task.start, "center"),
+                                taskCell(task, task.finish, "center"),
                                 taskCell(task, task.duration, "center"),
-                                taskCell(task, task.percentComplete, "center"),
-                                taskCell(task, task.percentWorkComplete, "center"),
+                                progressCell(task, task.percentComplete),
+                                progressCell(task, task.percentWorkComplete),
                                 flagCell(task, task.milestone, "M"),
                                 flagCell(task, task.summary, "S"),
                                 flagCell(task, task.critical, "!"),
@@ -174,7 +188,7 @@
         return {
             value: displayValue,
             border: "thin",
-            horizontalAlign,
+            horizontalAlign: placeholder ? "center" : horizontalAlign,
             bold: task.summary || task.milestone || false,
             fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
         };
@@ -194,6 +208,30 @@
             ]
         };
     }
+    function taskViewRow(baseDate, columnCount) {
+        return {
+            height: 26,
+            cells: Array.from({ length: columnCount }, (_, index) => {
+                if (index === 0) {
+                    return {
+                        value: `Task View | BaseDate=${baseDate}`,
+                        bold: true,
+                        fillColor: "#EAF3FB",
+                        border: "thin",
+                        horizontalAlign: "left"
+                    };
+                }
+                if (index < 12) {
+                    return {
+                        value: "",
+                        fillColor: "#EAF3FB",
+                        border: "thin"
+                    };
+                }
+                return {};
+            })
+        };
+    }
     function infoRow(text, columnCount) {
         return {
             height: 24,
@@ -210,7 +248,7 @@
     function legendRow(columnCount) {
         const items = [
             {
-                value: "Legend",
+                value: "Legend / 記号",
                 bold: true,
                 border: "thin",
                 horizontalAlign: "center"
@@ -310,13 +348,38 @@
                 bold: true,
                 border: "thin",
                 horizontalAlign: "center",
-                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+                fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#EAF1F9")
             };
         });
         return {
             height: 22,
             cells: [
-                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...Array.from({ length: fixedColumnCount }, (_, index) => {
+                    if (index === 5) {
+                        return {
+                            value: "Week",
+                            bold: true,
+                            border: "thin",
+                            horizontalAlign: "right",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index > 5 && index < 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index === 5 || index === 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    return {};
+                }),
                 ...bandCells
             ]
         };
@@ -324,6 +387,8 @@
     function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
         const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
         const items = [
+            summaryStatCell("Summary", HEADER_ID_FILL),
+            summaryStatCell("", HEADER_FILL),
             summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
             summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
             summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
@@ -407,20 +472,44 @@
         return {
             height: 22,
             cells: [
-                ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
-                    ? {
-                        value: "Today",
-                        bold: true,
-                        border: "thin",
-                        horizontalAlign: "right"
+                ...Array.from({ length: fixedColumnCount }, (_, index) => {
+                    if (index === 5) {
+                        return {
+                            value: "BaseDate",
+                            bold: true,
+                            border: "thin",
+                            horizontalAlign: "right",
+                            fillColor: "#FFEFC2"
+                        };
                     }
-                    : {})),
-                ...dateBand.map((day) => ({
-                    value: isSameDay(day, currentDate) ? "TODAY" : "",
+                    if (index > 5 && index < 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    if (index === 5 || index === 9) {
+                        return {
+                            value: "",
+                            border: "thin",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    return {};
+                }),
+                ...dateBand.map((day, index) => ({
+                    value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
-                    fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
+                    fillColor: isSameDay(day, currentDate)
+                        ? TODAY_BAND_FILL
+                        : (holidaySet.has(day)
+                            ? HOLIDAY_BAND_FILL
+                            : (isWeekStart(day)
+                                ? WEEK_START_BAND_FILL
+                                : (index < 3 ? BASEDATE_GUIDE_TAIL_FILL : BAND_FILL)))
                 }))
             ]
         };
@@ -455,12 +544,33 @@
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : TASK_KIND_FILL)
         };
     }
+    function identifierCell(task, value) {
+        if (value === undefined || value === "") {
+            return {};
+        }
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: task.summary || task.milestone || false,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : IDENTIFIER_FILL)
+        };
+    }
     function flagCell(task, enabled, marker) {
         return {
             value: enabled ? marker : "",
             border: "thin",
             horizontalAlign: "center",
             bold: !!enabled,
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+        };
+    }
+    function progressCell(task, value) {
+        return {
+            value: value === undefined || value === null ? "" : `${value}%`,
+            border: "thin",
+            horizontalAlign: "center",
+            bold: task.summary || task.milestone || false,
             fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
         };
     }
@@ -471,7 +581,7 @@
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
         return {
-            value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
+            value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",

--- a/docs/project/src/mikuproject/ts/excel-io.ts
+++ b/docs/project/src/mikuproject/ts/excel-io.ts
@@ -23,9 +23,15 @@
     width?: number;
   };
 
+  type XlsxFreezePaneModel = {
+    rowSplit?: number;
+    colSplit?: number;
+  };
+
   type XlsxSheetModel = {
     name: string;
     columns?: XlsxColumnModel[];
+    freezePane?: XlsxFreezePaneModel;
     mergedRanges?: string[];
     rows: XlsxRowModel[];
   };
@@ -157,6 +163,7 @@
         return {
           name: sheet.name,
           columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
+          freezePane: normalizeFreezePane(sheet.freezePane),
           mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
           rows: Array.isArray(sheet.rows)
             ? sheet.rows.map((row) => ({
@@ -177,6 +184,21 @@
     }
     return {
       width: normalizeOptionalPositiveNumber(column.width, "Column width")
+    };
+  }
+
+  function normalizeFreezePane(freezePane: XlsxFreezePaneModel | undefined): XlsxFreezePaneModel | undefined {
+    if (!freezePane) {
+      return undefined;
+    }
+    const rowSplit = normalizeOptionalPositiveInteger(freezePane.rowSplit, "Freeze pane rowSplit");
+    const colSplit = normalizeOptionalPositiveInteger(freezePane.colSplit, "Freeze pane colSplit");
+    if (rowSplit === undefined && colSplit === undefined) {
+      return undefined;
+    }
+    return {
+      rowSplit,
+      colSplit
     };
   }
 
@@ -230,6 +252,16 @@
     }
     if (!Number.isFinite(value) || value <= 0) {
       throw new Error(`${label} must be a finite positive number`);
+    }
+    return value;
+  }
+
+  function normalizeOptionalPositiveInteger(value: number | undefined, label: string): number | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (!Number.isInteger(value) || value <= 0) {
+      throw new Error(`${label} must be a positive integer`);
     }
     return value;
   }
@@ -331,15 +363,29 @@
   }
 
   function buildWorksheetXml(sheet: XlsxSheetModel, styleBook: StyleBook): string {
+    const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
     const colsXml = buildColumnsXml(sheet.columns);
     const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
     const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
     return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  ${sheetViewsXml}
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
 </worksheet>`;
+  }
+
+  function buildSheetViewsXml(freezePane: XlsxFreezePaneModel | undefined): string {
+    if (!freezePane || (!freezePane.rowSplit && !freezePane.colSplit)) {
+      return "";
+    }
+    const xSplit = freezePane.colSplit ? ` xSplit="${freezePane.colSplit}"` : "";
+    const ySplit = freezePane.rowSplit ? ` ySplit="${freezePane.rowSplit}"` : "";
+    const topLeftCell = encodeCellReference(freezePane.rowSplit || 0, freezePane.colSplit || 0);
+    const topLeftCellAttribute = topLeftCell ? ` topLeftCell="${topLeftCell}"` : "";
+    const activePane = resolveActivePane(freezePane);
+    return `<sheetViews><sheetView workbookViewId="0"><pane${xSplit}${ySplit}${topLeftCellAttribute} activePane="${activePane}" state="frozen"/></sheetView></sheetViews>`;
   }
 
   function buildColumnsXml(columns: XlsxColumnModel[] | undefined): string {
@@ -659,6 +705,7 @@
     return {
       name,
       columns: parseWorksheetColumns(document),
+      freezePane: parseWorksheetFreezePane(document),
       mergedRanges: parseWorksheetMergedRanges(document),
       rows: rowElements.map((rowElement) => ({
         height: parseOptionalNumber(rowElement.getAttribute("ht")),
@@ -701,6 +748,25 @@
     return mergeCellElements
       .map((element) => normalizeMergedRange(element.getAttribute("ref") || ""))
       .filter(Boolean);
+  }
+
+  function parseWorksheetFreezePane(document: XMLDocument): XlsxFreezePaneModel | undefined {
+    const paneElement = document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "pane"
+    )[0];
+    if (!paneElement || paneElement.getAttribute("state") !== "frozen") {
+      return undefined;
+    }
+    const rowSplit = parseOptionalNumber(paneElement.getAttribute("ySplit"));
+    const colSplit = parseOptionalNumber(paneElement.getAttribute("xSplit"));
+    if (rowSplit === undefined && colSplit === undefined) {
+      return undefined;
+    }
+    return {
+      rowSplit,
+      colSplit
+    };
   }
 
   function parseWorksheetRowCells(rowElement: Element, styleBook: StyleDescriptor[]): XlsxCellModel[] {
@@ -916,6 +982,23 @@
       current = Math.floor((current - 1) / 26);
     }
     return result;
+  }
+
+  function encodeCellReference(rowIndex: number, columnIndex: number): string {
+    if (rowIndex <= 0 && columnIndex <= 0) {
+      return "";
+    }
+    return `${encodeColumnName(columnIndex)}${rowIndex + 1}`;
+  }
+
+  function resolveActivePane(freezePane: XlsxFreezePaneModel): string {
+    if (freezePane.rowSplit && freezePane.colSplit) {
+      return "bottomRight";
+    }
+    if (freezePane.rowSplit) {
+      return "bottomLeft";
+    }
+    return "topRight";
   }
 
   function decodeColumnReference(reference: string): number {

--- a/docs/project/src/mikuproject/ts/wbs-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/wbs-xlsx.ts
@@ -12,6 +12,10 @@
     sheets: Array<{
       name: string;
       columns?: Array<{ width?: number }>;
+      freezePane?: {
+        rowSplit?: number;
+        colSplit?: number;
+      };
       mergedRanges?: string[];
       rows: Array<{
         height?: number;
@@ -33,6 +37,7 @@
   const PHASE_FILL = "#EEF7E8";
   const TASK_KIND_FILL = "#EEF2F6";
   const MILESTONE_FILL = "#FFF4E0";
+  const IDENTIFIER_FILL = "#F7F9FC";
   const PLACEHOLDER_FILL = "#F5F7FA";
   const BAND_FILL = "#F4F7FB";
   const ACTIVE_BAND_FILL = "#9FD5C9";
@@ -46,6 +51,7 @@
   const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
   const HOLIDAY_BAND_FILL = "#FCE4EC";
   const DIVIDER_FILL = "#C5D1DB";
+  const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
 
   function collectWbsHolidayDates(model: ProjectModel): string[] {
     const holidaySet = new Set<string>();
@@ -112,11 +118,15 @@
       sheets: [
         {
           name: "WBS",
+          freezePane: {
+            rowSplit: 10,
+            colSplit: 19
+          },
           columns: [
-            { width: 8 }, { width: 8 }, { width: 14 }, { width: 12 }, { width: 12 }, { width: 34 },
-            { width: 20 }, { width: 20 }, { width: 14 }, { width: 14 },
+            { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
+            { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
             { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
-            { width: 20 }, { width: 14 }, { width: 24 }, { width: 22 }, { width: 3 },
+            { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
             ...dateBand.map(() => ({ width: 6 }))
           ],
           mergedRanges: [
@@ -133,27 +143,35 @@
             infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
             displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
             legendRow(totalColumns),
-            sectionTitleRow(`Task View / BaseDate=${(model.project.currentDate || "-").slice(0, 10) || "-"}`, totalColumns),
+            taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
             weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
             todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
             headerRow([
-              ...fixedHeaders,
+              ...fixedHeaders.map((label) => label === "Name"
+                ? {
+                    value: label,
+                    bold: true,
+                    fillColor: headerFillForLabel(label),
+                    border: "thin" as const,
+                    horizontalAlign: "left" as const
+                  }
+                : label),
               dividerCell(),
               ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
             ]),
             ...model.tasks.map((task) => ({
               cells: [
-                taskCell(task, task.uid, "center"),
-                taskCell(task, task.id, "center"),
-                taskCell(task, task.wbs || task.outlineNumber, "center"),
+                identifierCell(task, task.uid),
+                identifierCell(task, task.id),
+                identifierCell(task, task.wbs || task.outlineNumber),
                 kindCell(task),
-                taskCell(task, task.outlineLevel, "center"),
+                identifierCell(task, task.outlineLevel),
                 taskCell(task, formatTaskLabel(task)),
-                taskCell(task, task.start),
-                taskCell(task, task.finish),
+                taskCell(task, task.start, "center"),
+                taskCell(task, task.finish, "center"),
                 taskCell(task, task.duration, "center"),
-                taskCell(task, task.percentComplete, "center"),
-                taskCell(task, task.percentWorkComplete, "center"),
+                progressCell(task, task.percentComplete),
+                progressCell(task, task.percentWorkComplete),
                 flagCell(task, task.milestone, "M"),
                 flagCell(task, task.summary, "S"),
                 flagCell(task, task.critical, "!"),
@@ -217,7 +235,7 @@
     return {
       value: displayValue,
       border: "thin",
-      horizontalAlign,
+      horizontalAlign: placeholder ? "center" : horizontalAlign,
       bold: task.summary || task.milestone || false,
       fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
     };
@@ -239,6 +257,31 @@
     };
   }
 
+  function taskViewRow(baseDate: string, columnCount: number) {
+    return {
+      height: 26,
+      cells: Array.from({ length: columnCount }, (_, index) => {
+        if (index === 0) {
+          return {
+            value: `Task View | BaseDate=${baseDate}`,
+            bold: true,
+            fillColor: "#EAF3FB",
+            border: "thin" as const,
+            horizontalAlign: "left" as const
+          };
+        }
+        if (index < 12) {
+          return {
+            value: "",
+            fillColor: "#EAF3FB",
+            border: "thin" as const
+          };
+        }
+        return {};
+      })
+    };
+  }
+
   function infoRow(text: string, columnCount: number) {
     return {
       height: 24,
@@ -256,7 +299,7 @@
   function legendRow(columnCount: number) {
     const items: WbsXlsxCellLike[] = [
       {
-        value: "Legend",
+        value: "Legend / 記号",
         bold: true,
         border: "thin",
         horizontalAlign: "center"
@@ -361,13 +404,38 @@
         bold: true,
         border: "thin" as const,
         horizontalAlign: "center" as const,
-        fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#E4EEF8")
+        fillColor: item.hasMonthBoundary ? MONTH_BOUNDARY_WEEK_FILL : (index % 2 === 0 ? "#EDF4FB" : "#EAF1F9")
       };
     });
     return {
       height: 22,
       cells: [
-        ...Array.from({ length: fixedColumnCount }, () => ({})),
+        ...Array.from({ length: fixedColumnCount }, (_, index) => {
+          if (index === 5) {
+            return {
+              value: "Week",
+              bold: true,
+              border: "thin" as const,
+              horizontalAlign: "right" as const,
+              fillColor: "#E3EEF9"
+            };
+          }
+          if (index > 5 && index < 9) {
+            return {
+              value: "",
+              border: "thin" as const,
+              fillColor: "#E3EEF9"
+            };
+          }
+          if (index === 5 || index === 9) {
+            return {
+              value: "",
+              border: "thin" as const,
+              fillColor: "#E3EEF9"
+            };
+          }
+          return {};
+        }),
         ...bandCells
       ]
     };
@@ -384,6 +452,8 @@
   ) {
     const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
     const items: WbsXlsxCellLike[] = [
+      summaryStatCell("Summary", HEADER_ID_FILL),
+      summaryStatCell("", HEADER_FILL),
       summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
       summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
       summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
@@ -477,20 +547,44 @@
     return {
       height: 22,
       cells: [
-        ...Array.from({ length: fixedColumnCount }, (_, index) => (index === 5
-          ? {
-              value: "Today",
+        ...Array.from({ length: fixedColumnCount }, (_, index) => {
+          if (index === 5) {
+            return {
+              value: "BaseDate",
               bold: true,
               border: "thin" as const,
-              horizontalAlign: "right" as const
-            }
-          : {})),
-        ...dateBand.map((day) => ({
-          value: isSameDay(day, currentDate) ? "TODAY" : "",
+              horizontalAlign: "right" as const,
+              fillColor: "#FFEFC2"
+            };
+          }
+          if (index > 5 && index < 9) {
+            return {
+              value: "",
+              border: "thin" as const,
+              fillColor: "#FFEFC2"
+            };
+          }
+          if (index === 5 || index === 9) {
+            return {
+              value: "",
+              border: "thin" as const,
+              fillColor: "#FFEFC2"
+            };
+          }
+          return {};
+        }),
+        ...dateBand.map((day, index) => ({
+          value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
           bold: true,
           border: "thin" as const,
           horizontalAlign: "center" as const,
-          fillColor: isSameDay(day, currentDate) ? TODAY_BAND_FILL : (holidaySet.has(day) ? HOLIDAY_BAND_FILL : (isWeekStart(day) ? WEEK_START_BAND_FILL : BAND_FILL))
+          fillColor: isSameDay(day, currentDate)
+            ? TODAY_BAND_FILL
+            : (holidaySet.has(day)
+              ? HOLIDAY_BAND_FILL
+              : (isWeekStart(day)
+                ? WEEK_START_BAND_FILL
+                : (index < 3 ? BASEDATE_GUIDE_TAIL_FILL : BAND_FILL)))
         }))
       ]
     };
@@ -533,12 +627,35 @@
     };
   }
 
+  function identifierCell(task: TaskModel, value: string | number | boolean | undefined): WbsXlsxCellLike {
+    if (value === undefined || value === "") {
+      return {};
+    }
+    return {
+      value,
+      border: "thin",
+      horizontalAlign: "center",
+      bold: task.summary || task.milestone || false,
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : IDENTIFIER_FILL)
+    };
+  }
+
   function flagCell(task: TaskModel, enabled: boolean | undefined, marker: string): WbsXlsxCellLike {
     return {
       value: enabled ? marker : "",
       border: "thin",
       horizontalAlign: "center",
       bold: !!enabled,
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+    };
+  }
+
+  function progressCell(task: TaskModel, value: number | undefined): WbsXlsxCellLike {
+    return {
+      value: value === undefined || value === null ? "" : `${value}%`,
+      border: "thin",
+      horizontalAlign: "center",
+      bold: task.summary || task.milestone || false,
       fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
     };
   }
@@ -550,7 +667,7 @@
     const weekStart = isWeekStart(day);
     const monthStart = isMonthStart(day);
     return {
-      value: isToday ? `${formatDateLabel(day)} *` : formatDateLabel(day),
+      value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
       bold: true,
       border: "thin",
       horizontalAlign: "center",

--- a/docs/project/tests/mikuproject-excel-io.test.js
+++ b/docs/project/tests/mikuproject-excel-io.test.js
@@ -237,6 +237,51 @@ describe("mikuproject excel io", () => {
     expect(imported.sheets[0].rows[3].cells[1].value).toBe("Value3");
   });
 
+  it("round-trips frozen pane settings", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Frozen",
+          freezePane: {
+            rowSplit: 2,
+            colSplit: 3
+          },
+          rows: [
+            {
+              cells: [
+                { value: "A" },
+                { value: "B" },
+                { value: "C" },
+                { value: "D" }
+              ]
+            },
+            {
+              cells: [
+                { value: 1 },
+                { value: 2 },
+                { value: 3 },
+                { value: 4 }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+    const sheetXml = decodeUtf8(codec.unpackEntries(bytes)["xl/worksheets/sheet1.xml"]);
+
+    expect(imported).toEqual(workbook);
+    expect(sheetXml).toContain("<sheetViews>");
+    expect(sheetXml).toContain('xSplit="3"');
+    expect(sheetXml).toContain('ySplit="2"');
+    expect(sheetXml).toContain('topLeftCell="D3"');
+    expect(sheetXml).toContain('state="frozen"');
+  });
+
   it("rejects duplicate or invalid sheet names", () => {
     const excelIo = bootExcelIoModule();
     const codec = new excelIo.XlsxWorkbookCodec();

--- a/docs/project/tests/mikuproject-wbs-xlsx.test.js
+++ b/docs/project/tests/mikuproject-wbs-xlsx.test.js
@@ -51,41 +51,57 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     expect(workbook.sheets.map((item) => item.name)).toEqual(["WBS"]);
+    expect(sheet.columns[2].width).toBe(12);
+    expect(sheet.columns[3].width).toBe(10);
+    expect(sheet.columns[4].width).toBe(10);
+    expect(sheet.columns[5].width).toBe(42);
+    expect(sheet.columns[6].width).toBe(18);
+    expect(sheet.columns[7].width).toBe(18);
+    expect(sheet.columns[8].width).toBe(12);
+    expect(sheet.columns[14].width).toBe(16);
+    expect(sheet.columns[15].width).toBe(12);
+    expect(sheet.columns[16].width).toBe(20);
+    expect(sheet.columns[17].width).toBe(18);
+    expect(sheet.freezePane).toEqual({ rowSplit: 10, colSplit: 19 });
     expect(sheet.mergedRanges).toEqual(["A1:X1", "A2:X2", "A3:X3", "A4:X4", "T8:X8"]);
     expect(sheet.rows[0].cells[0].value).toBe("WBS");
     expect(sheet.rows[1].cells[0].value).toBe("Sample Project");
     expect(String(sheet.rows[2].cells[0].value)).toContain("Title=Sample Project Title");
     expect(String(sheet.rows[3].cells[0].value)).toContain("Start=2026-03-16T09:00:00");
     expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=0");
-    expect(sheet.rows[4].cells[0].value).toBe("DisplayDays");
-    expect(sheet.rows[4].cells[1].value).toBe(5);
-    expect(sheet.rows[4].cells[0].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[1].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[2].value).toBe("DisplayWeeks");
-    expect(sheet.rows[4].cells[3].value).toBe(1);
+    expect(sheet.rows[4].cells[0].value).toBe("Summary");
+    expect(sheet.rows[4].cells[1].value).toBe("");
+    expect(sheet.rows[4].cells[0].fillColor).toBe("#D7E7F6");
+    expect(sheet.rows[4].cells[1].fillColor).toBe("#D9EAF7");
+    expect(sheet.rows[4].cells[2].value).toBe("DisplayDays");
+    expect(sheet.rows[4].cells[3].value).toBe(5);
     expect(sheet.rows[4].cells[2].fillColor).toBe("#FDE7D3");
     expect(sheet.rows[4].cells[3].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[4].value).toBe("Tasks");
-    expect(sheet.rows[4].cells[5].value).toBe(3);
-    expect(sheet.rows[4].cells[4].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[5].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[6].value).toBe("Resources");
-    expect(sheet.rows[4].cells[7].value).toBe(1);
+    expect(sheet.rows[4].cells[4].value).toBe("DisplayWeeks");
+    expect(sheet.rows[4].cells[5].value).toBe(1);
+    expect(sheet.rows[4].cells[4].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[5].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[6].value).toBe("Tasks");
+    expect(sheet.rows[4].cells[7].value).toBe(3);
     expect(sheet.rows[4].cells[6].fillColor).toBe("#E2F1EF");
     expect(sheet.rows[4].cells[7].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[8].value).toBe("Assignments");
-    expect(sheet.rows[4].cells[9].value).toBe(2);
+    expect(sheet.rows[4].cells[8].value).toBe("Resources");
+    expect(sheet.rows[4].cells[9].value).toBe(1);
     expect(sheet.rows[4].cells[8].fillColor).toBe("#E2F1EF");
     expect(sheet.rows[4].cells[9].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[10].value).toBe("Calendars");
+    expect(sheet.rows[4].cells[10].value).toBe("Assignments");
     expect(sheet.rows[4].cells[11].value).toBe(2);
     expect(sheet.rows[4].cells[10].fillColor).toBe("#E2F1EF");
     expect(sheet.rows[4].cells[11].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[12].value).toBe("BaseDate");
-    expect(sheet.rows[4].cells[13].value).toBe("2026-03-16");
-    expect(sheet.rows[4].cells[12].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[13].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[5].cells[0].value).toBe("Legend");
+    expect(sheet.rows[4].cells[12].value).toBe("Calendars");
+    expect(sheet.rows[4].cells[13].value).toBe(2);
+    expect(sheet.rows[4].cells[12].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[13].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[4].cells[14].value).toBe("BaseDate");
+    expect(sheet.rows[4].cells[15].value).toBe("2026-03-16");
+    expect(sheet.rows[4].cells[14].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[4].cells[15].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[5].cells[0].value).toBe("Legend / 記号");
     expect(sheet.rows[5].cells[1].value).toBe("進捗済み");
     expect(sheet.rows[5].cells[1].fillColor).toBe("#5BAE9C");
     expect(sheet.rows[5].cells[4].value).toBe("週頭");
@@ -106,10 +122,27 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[5].cells[12].fillColor).toBe("#FBE4EC");
     expect(sheet.rows[5].cells[13].value).toBe("-:未設定");
     expect(sheet.rows[5].cells[13].fillColor).toBe("#F5F7FA");
-    expect(sheet.rows[6].cells[0].value).toBe("Task View / BaseDate=2026-03-16");
+    expect(sheet.rows[6].cells[0].value).toBe("Task View | BaseDate=2026-03-16");
+    expect(sheet.rows[6].cells[0].fillColor).toBe("#EAF3FB");
+    expect(sheet.rows[6].cells[1].fillColor).toBe("#EAF3FB");
+    expect(sheet.rows[6].cells[8].fillColor).toBe("#EAF3FB");
+    expect(sheet.rows[6].cells[11].fillColor).toBe("#EAF3FB");
+    expect(sheet.rows[7].cells[5].value).toBe("Week");
+    expect(sheet.rows[7].cells[5].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[7].cells[6].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[7].cells[7].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[7].cells[8].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[7].cells[9].fillColor).toBe("#E3EEF9");
     expect(sheet.rows[7].cells[19].value).toBe("Week of Mar 16");
-    expect(sheet.rows[8].cells[5].value).toBe("Today");
-    expect(sheet.rows[8].cells[19].value).toBe("TODAY");
+    expect(sheet.rows[8].cells[5].value).toBe("BaseDate");
+    expect(sheet.rows[8].cells[5].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[8].cells[6].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[8].cells[7].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[8].cells[8].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[8].cells[9].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[8].cells[19].value).toBe("▼BaseDate");
+    expect(sheet.rows[8].cells[20].fillColor).toBe("#FFF8E1");
+    expect(sheet.rows[8].cells[21].fillColor).toBe("#FFF8E1");
     expect(sheet.rows[9].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
       "UID",
       "ID",
@@ -132,7 +165,7 @@ describe("mikuproject wbs xlsx", () => {
     ]);
     expect(sheet.rows[9].cells[18].fillColor).toBe("#C5D1DB");
     expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
-      "03/16 Mon *",
+      "[03/16 Mon *]",
       "03/17 Tue",
       "03/18 Wed",
       "03/19 Thu",
@@ -140,7 +173,11 @@ describe("mikuproject wbs xlsx", () => {
     ]);
     expect(sheet.rows[9].cells[0].fillColor).toBe("#D7E7F6");
     expect(sheet.rows[9].cells[2].fillColor).toBe("#E6F0DF");
+    expect(sheet.rows[9].cells[5].horizontalAlign).toBe("left");
     expect(sheet.rows[9].cells[6].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[10].cells[6].horizontalAlign).toBe("center");
+    expect(sheet.rows[10].cells[7].horizontalAlign).toBe("center");
+    expect(sheet.rows[10].cells[8].horizontalAlign).toBe("center");
     expect(sheet.rows[9].cells[9].fillColor).toBe("#FBE4EC");
     expect(sheet.rows[9].cells[14].fillColor).toBe("#E2F1EF");
     expect(sheet.rows[9].cells[19].fillColor).toBe("#FFE6A7");
@@ -151,10 +188,15 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[10].cells[5].bold).toBe(true);
     expect(sheet.rows[10].cells[14].value).toBe("-");
     expect(sheet.rows[10].cells[14].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[14].horizontalAlign).toBe("center");
     expect(sheet.rows[10].cells[16].value).toBe("-");
     expect(sheet.rows[10].cells[16].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[16].horizontalAlign).toBe("center");
     expect(sheet.rows[10].cells[17].value).toBe("-");
     expect(sheet.rows[10].cells[17].fillColor).toBe("#F5F7FA");
+    expect(sheet.rows[10].cells[17].horizontalAlign).toBe("center");
+    expect(sheet.rows[10].cells[9].value).toBe("50%");
+    expect(sheet.rows[10].cells[10].value).toBe("50%");
     expect(sheet.rows[10].cells[11].value).toBe("");
     expect(sheet.rows[10].cells[12].value).toBe("S");
     expect(sheet.rows[10].cells[13].value).toBe("");
@@ -162,15 +204,23 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[10].cells[20].value).toBe("━");
     expect(sheet.rows[11].cells[3].value).toBe("task");
     expect(sheet.rows[11].cells[3].fillColor).toBe("#EEF2F6");
+    expect(sheet.rows[11].cells[0].fillColor).toBe("#F7F9FC");
+    expect(sheet.rows[11].cells[1].fillColor).toBe("#F7F9FC");
+    expect(sheet.rows[11].cells[2].fillColor).toBe("#F7F9FC");
+    expect(sheet.rows[11].cells[4].fillColor).toBe("#F7F9FC");
     expect(sheet.rows[11].cells[4].value).toBe(2);
     expect(sheet.rows[11].cells[5].value).toBe("  Design");
     expect(sheet.rows[11].cells[14].value).toBe("Miku");
     expect(sheet.rows[11].cells[15].value).toBe("1 Standard");
     expect(sheet.rows[11].cells[16].value).toBe("Miku");
+    expect(sheet.rows[11].cells[9].value).toBe("100%");
+    expect(sheet.rows[11].cells[10].value).toBe("100%");
     expect(sheet.rows[11].cells[11].value).toBe("");
     expect(sheet.rows[11].cells[12].value).toBe("");
     expect(sheet.rows[11].cells[13].value).toBe("");
     expect(sheet.rows[12].cells[17].value).toBe("Design");
+    expect(sheet.rows[12].cells[9].value).toBe("0%");
+    expect(sheet.rows[12].cells[10].value).toBe("0%");
     expect(sheet.rows[11].cells[5].bold).toBe(false);
     expect(sheet.rows[11].cells[18].fillColor).toBe("#C5D1DB");
     expect(sheet.rows[11].cells[19].value).toBe("■");
@@ -197,12 +247,16 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheetXml).toContain('ref="A1:X1"');
     expect(sheetXml).toContain('ref="A4:X4"');
     expect(sheetXml).toContain('ref="T8:X8"');
-    expect(sheetXml).toContain("Legend");
+    expect(sheetXml).toContain("<pane");
+    expect(sheetXml).toContain('xSplit="19"');
+    expect(sheetXml).toContain('ySplit="10"');
+    expect(sheetXml).toContain('topLeftCell="T11"');
+    expect(sheetXml).toContain("Legend / 記号");
     expect(sheetXml).toContain("Week of Mar 16");
-    expect(sheetXml).toContain("Task View / BaseDate=2026-03-16");
+    expect(sheetXml).toContain("Task View | BaseDate=2026-03-16");
     expect(sheetXml).toContain("Sample Project");
     expect(sheetXml).toContain("OutlineLevel");
-    expect(sheetXml).toContain("03/16 Mon *");
+    expect(sheetXml).toContain("[03/16 Mon *]");
   });
 
   it("marks weekend date-band cells with weekend fill", () => {
@@ -218,11 +272,11 @@ describe("mikuproject wbs xlsx", () => {
 
     expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
       "03/20 Fri",
-      "03/21 Sat *",
+      "[03/21 Sat *]",
       "03/22 Sun",
       "03/23 Mon"
     ]);
-    expect(sheet.rows[8].cells[20].value).toBe("TODAY");
+    expect(sheet.rows[8].cells[20].value).toBe("▼BaseDate");
     expect(sheet.rows[9].cells[20].fillColor).toBe("#FFE6A7");
     expect(sheet.rows[9].cells[21].fillColor).toBe("#F1F1F1");
   });


### PR DESCRIPTION
## 概要

`mikuproject` の WBS 向け `.xlsx` 出力を改善し、固定表示のための `freezePane` 対応を追加します。 あわせて、`docs/git` 配下の補助画面について不要な一覧連携 UI や補助コマンドを整理し、レイアウトを調整します。

## 変更内容

### `mikuproject` の `.xlsx` / WBS 改善
- `excel-io.ts` / `excel-io.js` に `freezePane` モデルを追加
- worksheet の `sheetViews/pane` 出力と import を追加
- freeze pane の正規化と parse を追加
- `mikuproject-excel-io.test.js` に freeze pane の round-trip と XML 確認を追加

### WBS workbook の表示改善
- `wbs-xlsx.ts` / `wbs-xlsx.js` の WBS シートに `freezePane` を設定
- WBS の上部サマリ、凡例、`Task View | BaseDate=...`、`Week` / `BaseDate` ガイドを整理
- 列幅、ヘッダ配色、識別列の見た目、プレースホルダ表示を調整
- 進捗列を `%` 付き表示に変更
- 日付ヘッダの today 表示を強調
- WBS の帯記号と凡例を整理
- `mikuproject-wbs-xlsx.test.js` を更新し、freeze pane を含む表示仕様を確認するテストを追加

### 文書更新
- `mikuproject-spec.md` に、WBS workbook のレイアウト改善を継続する方針を追記
- `TODO.md` に、`WBS XLSX Export` の視認性改善を継続する項目を追記

### `docs/git` 配下の整理
- `git-pseudo-squash` のレイアウト余白やコピー UI サイズを調整
- `生成AIで整理` を `生成AIで作文` に変更
- `repoUrl` を hidden input に変更
- `一覧連携` セクションと関連ボタンを削除
- `git-work-list` から `cd + git status` コピー機能を削除
- 生成済み HTML / CSS / JS を更新

## 影響範囲

- `docs/project` の WBS 向け `.xlsx` 出力
- `.xlsx` workbook 基盤の worksheet 表示設定
- `docs/git` 配下の補助 UI

## 補足

- `WBS XLSX Export` は表示専用 workbook の改善です
- `WBS` の import 対応はこの変更には含みません
- `docs/git` 側は UI 整理が中心です