### PR TITLE
mikuproject の WBS XLSX 出力を縦レイアウトへ再設計し、表示期間・営業日オプションを追加

### DIFF
--- a/docs/project/mikuproject-src.html
+++ b/docs/project/mikuproject-src.html
@@ -85,8 +85,34 @@
           `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
         </p>
         <p class="md-note-card__text">
-          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。
+          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
         </p>
+        <div class="md-form-grid md-form-grid--two">
+          <lht-text-field-help
+            field-id="wbsDisplayDaysBeforeInput"
+            label="表示期間: 基準日前"
+            rows="1"
+            placeholder="3"
+            help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+          <lht-text-field-help
+            field-id="wbsDisplayDaysAfterInput"
+            label="表示期間: 基準日後"
+            rows="1"
+            placeholder="7"
+            help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+        </div>
+        <div class="md-form-grid">
+          <label class="md-checkbox-row">
+            <input id="wbsBusinessDayRangeInput" type="checkbox" />
+            <span>表示期間を営業日ベースで数える</span>
+          </label>
+        </div>
+        <div class="md-form-grid">
+          <label class="md-checkbox-row">
+            <input id="wbsBusinessDayProgressInput" type="checkbox" />
+            <span>進捗帯を営業日ベースで計算する</span>
+          </label>
+        </div>
         <div class="md-form-grid">
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -1559,8 +1559,34 @@ lht-index-card-link {
           `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
         </p>
         <p class="md-note-card__text">
-          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。
+          既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
         </p>
+        <div class="md-form-grid md-form-grid--two">
+          <lht-text-field-help
+            field-id="wbsDisplayDaysBeforeInput"
+            label="表示期間: 基準日前"
+            rows="1"
+            placeholder="3"
+            help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+          <lht-text-field-help
+            field-id="wbsDisplayDaysAfterInput"
+            label="表示期間: 基準日後"
+            rows="1"
+            placeholder="7"
+            help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+        </div>
+        <div class="md-form-grid">
+          <label class="md-checkbox-row">
+            <input id="wbsBusinessDayRangeInput" type="checkbox" />
+            <span>表示期間を営業日ベースで数える</span>
+          </label>
+        </div>
+        <div class="md-form-grid">
+          <label class="md-checkbox-row">
+            <input id="wbsBusinessDayProgressInput" type="checkbox" />
+            <span>進捗帯を営業日ベースで計算する</span>
+          </label>
+        </div>
         <div class="md-form-grid">
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"
@@ -6795,7 +6821,7 @@ if (!customElements.get("lht-page-menu")) {
   <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
-  <FinishDate>2026-03-20T18:00:00</FinishDate>
+  <FinishDate>2026-03-31T18:00:00</FinishDate>
   <ScheduleFromStart>1</ScheduleFromStart>
   <DefaultStartTime>09:00:00</DefaultStartTime>
   <DefaultFinishTime>18:00:00</DefaultFinishTime>
@@ -9513,11 +9539,13 @@ if (!customElements.get("lht-page-menu")) {
   <script>
 (() => {
     const HEADER_FILL = "#D9EAF7";
-    const HEADER_ID_FILL = "#D7E7F6";
+    const HEADER_ID_FILL = "#E1EDF8";
     const HEADER_STRUCTURE_FILL = "#E6F0DF";
     const HEADER_SCHEDULE_FILL = "#FDE7D3";
     const HEADER_STATUS_FILL = "#FBE4EC";
     const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
+    const SUMMARY_SCHEDULE_FILL = "#FDF1E4";
+    const SUMMARY_ASSIGNMENT_FILL = "#E8F4F1";
     const PHASE_FILL = "#EEF7E8";
     const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
@@ -9534,8 +9562,12 @@ if (!customElements.get("lht-page-menu")) {
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
-    const DIVIDER_FILL = "#C5D1DB";
+    const DIVIDER_FILL = "#D9E2EA";
     const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
+    const NAME_COLUMN_FILL = "#FBFCFE";
+    const SCHEDULE_COLUMN_FILL = "#FCFAF7";
+    const PROGRESS_COLUMN_FILL = "#FCF8FB";
+    const REFERENCE_COLUMN_FILL = "#F8FBFB";
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -9567,117 +9599,126 @@ if (!customElements.get("lht-page-menu")) {
             }
             resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
         }
-        const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+        const dateBand = buildDisplayDateBand(model.project.startDate, model.project.finishDate, model.project.currentDate, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, holidaySet, options.useBusinessDaysForDisplayRange);
         const fixedHeaders = [
             "UID",
             "ID",
             "WBS",
-            "Kind",
-            "OutlineLevel",
-            "Name",
-            "Start",
-            "Finish",
-            "Duration",
-            "PercentComplete",
-            "PercentWorkComplete",
-            "Milestone",
-            "Summary",
-            "Critical",
-            "Owner",
-            "Calendar",
-            "Resources",
-            "Predecessors"
+            "種別",
+            "階層",
+            "名称",
+            "開始",
+            "終了",
+            "期間",
+            "進捗",
+            "作業進捗",
+            "マイル",
+            "サマリ",
+            "クリティカル",
+            "担当",
+            "カレンダ",
+            "リソース",
+            "先行"
         ];
         const dividerColumnIndex = fixedHeaders.length + 1;
         const dateBandStartColumnIndex = dividerColumnIndex + 1;
         const totalColumns = fixedHeaders.length + 1 + dateBand.length;
         const lastColumnRef = columnName(totalColumns);
-        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
+        const rows = [
+            sheetTitleRow("WBS", totalColumns),
+            sheetSubtitleRow(model.project.name || "Project", totalColumns)
+        ];
+        const mergedRanges = [
+            `A1:${lastColumnRef}1`,
+            `A2:${lastColumnRef}2`
+        ];
+        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 5, rows.length + 1);
+        rows.push(...projectInfoBlock.rows);
+        mergedRanges.push(...projectInfoBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        rows.push(...summaryBlock.rows);
+        mergedRanges.push(...summaryBlock.mergedRanges);
+        rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
+        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
+        rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
+        rows.push(todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
+        rows.push(headerRow([
+            ...fixedHeaders.map((label) => label === "名称"
+                ? {
+                    value: label,
+                    bold: true,
+                    fillColor: headerFillForLabel(label),
+                    border: "thin",
+                    horizontalAlign: "left"
+                }
+                : label),
+            dividerCell(),
+            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+        ]));
+        rows.push(...model.tasks.map((task) => ({
+            cells: [
+                identifierCell(task, task.uid),
+                identifierCell(task, task.id),
+                identifierCell(task, task.wbs || task.outlineNumber),
+                kindCell(task),
+                identifierCell(task, task.outlineLevel),
+                taskCell(task, formatTaskLabel(task)),
+                taskCell(task, formatWbsDate(task.start), "center"),
+                taskCell(task, formatWbsDate(task.finish), "center"),
+                taskCell(task, formatDurationLabel(task, holidaySet, options.useBusinessDaysForProgressBand), "center"),
+                progressCell(task, task.percentComplete),
+                progressCell(task, task.percentWorkComplete),
+                flagCell(task, task.milestone, "Mil"),
+                flagCell(task, task.summary, "Sum"),
+                flagCell(task, task.critical, "Crit"),
+                referenceCell(task, truncateWbsReference(firstResourceName(resourceNamesByTaskUid.get(task.uid)), 14), "center"),
+                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                referenceCell(task, truncateWbsReference((resourceNamesByTaskUid.get(task.uid) || []).join(", "), 18)),
+                referenceCell(task, truncateWbsReference(task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", "), 18)),
+                dividerCell(),
+                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet, options.useBusinessDaysForProgressBand))
+            ]
+        })));
+        rows.push(emptyRow(totalColumns, 28));
+        const legendBlock = legendRows(totalColumns, rows.length + 1);
+        rows.push(...legendBlock.rows);
+        mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
         return {
             sheets: [
                 {
                     name: "WBS",
-                    freezePane: {
-                        rowSplit: 10,
-                        colSplit: 19
-                    },
                     columns: [
                         { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-                        { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
+                        { width: 20 }, { width: 18 }, { width: 12 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
                         { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
-                    mergedRanges: [
-                        `A1:${lastColumnRef}1`,
-                        `A2:${lastColumnRef}2`,
-                        `A3:${lastColumnRef}3`,
-                        `A4:${lastColumnRef}4`,
-                        ...weekBandRanges.map((item) => item.range)
-                    ],
-                    rows: [
-                        sectionTitleRow("WBS", totalColumns),
-                        sectionTitleRow(model.project.name || "Project", totalColumns),
-                        infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
-                        infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-                        displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
-                        legendRow(totalColumns),
-                        taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
-                        weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
-                        todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
-                        headerRow([
-                            ...fixedHeaders.map((label) => label === "Name"
-                                ? {
-                                    value: label,
-                                    bold: true,
-                                    fillColor: headerFillForLabel(label),
-                                    border: "thin",
-                                    horizontalAlign: "left"
-                                }
-                                : label),
-                            dividerCell(),
-                            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
-                        ]),
-                        ...model.tasks.map((task) => ({
-                            cells: [
-                                identifierCell(task, task.uid),
-                                identifierCell(task, task.id),
-                                identifierCell(task, task.wbs || task.outlineNumber),
-                                kindCell(task),
-                                identifierCell(task, task.outlineLevel),
-                                taskCell(task, formatTaskLabel(task)),
-                                taskCell(task, task.start, "center"),
-                                taskCell(task, task.finish, "center"),
-                                taskCell(task, task.duration, "center"),
-                                progressCell(task, task.percentComplete),
-                                progressCell(task, task.percentWorkComplete),
-                                flagCell(task, task.milestone, "M"),
-                                flagCell(task, task.summary, "S"),
-                                flagCell(task, task.critical, "!"),
-                                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
-                                dividerCell(),
-                                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
-                            ]
-                        }))
-                    ]
+                    mergedRanges,
+                    rows
                 }
             ]
         };
     }
+    function emptyRow(columnCount, height = 22) {
+        return {
+            height,
+            cells: Array.from({ length: columnCount }, () => ({}))
+        };
+    }
     function formatTaskLabel(task) {
-        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+        const prefix = task.summary ? "> " : (task.milestone ? "* " : "- ");
+        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${prefix}${task.name}`;
     }
     function classifyTaskKind(task) {
         if (task.summary) {
-            return "phase";
+            return "フェーズ";
         }
         if (task.milestone) {
-            return "milestone";
+            return "マイル";
         }
-        return "task";
+        return "タスク";
     }
     function firstResourceName(resourceNames) {
         if (!resourceNames || resourceNames.length === 0) {
@@ -9690,10 +9731,20 @@ if (!customElements.get("lht-page-menu")) {
             return "-";
         }
         const calendarName = calendarNameByUid.get(calendarUID);
-        return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+        return calendarName ? `${calendarUID} ${truncateWbsReference(calendarName, 9)}` : calendarUID;
     }
     function displayReferenceValue(value) {
         return value && value.trim() ? value : "-";
+    }
+    function truncateWbsReference(value, maxLength) {
+        const normalized = (value === null || value === void 0 ? void 0 : value.trim()) || "";
+        if (!normalized) {
+            return "";
+        }
+        if (normalized.length <= maxLength) {
+            return normalized;
+        }
+        return `${normalized.slice(0, Math.max(1, maxLength - 3))}...`;
     }
     function referenceCell(task, value, horizontalAlign = "left") {
         const displayValue = displayReferenceValue(value);
@@ -9703,19 +9754,38 @@ if (!customElements.get("lht-page-menu")) {
             border: "thin",
             horizontalAlign: placeholder ? "center" : horizontalAlign,
             bold: task.summary || task.milestone || false,
-            fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+            fillColor: placeholder
+                ? PLACEHOLDER_FILL
+                : (task.summary
+                    ? PHASE_FILL
+                    : (task.milestone ? MILESTONE_FILL : REFERENCE_COLUMN_FILL))
         };
     }
-    function sectionTitleRow(title, columnCount) {
+    function sheetTitleRow(title, columnCount) {
         return {
-            height: 28,
+            height: 24,
             cells: [
                 {
                     value: title,
                     bold: true,
-                    fillColor: HEADER_FILL,
+                    fillColor: "#EEF4FA",
                     border: "thin",
-                    horizontalAlign: "center"
+                    horizontalAlign: "left"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function sheetSubtitleRow(title, columnCount) {
+        return {
+            height: 22,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: "#F6F9FC",
+                    border: "thin",
+                    horizontalAlign: "left"
                 },
                 ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
             ]
@@ -9725,19 +9795,28 @@ if (!customElements.get("lht-page-menu")) {
         return {
             height: 26,
             cells: Array.from({ length: columnCount }, (_, index) => {
-                if (index === 0) {
+                if (index === 5) {
                     return {
-                        value: `Task View | BaseDate=${baseDate}`,
+                        value: "タスク表",
                         bold: true,
-                        fillColor: "#EAF3FB",
+                        fillColor: "#E6F1FB",
                         border: "thin",
-                        horizontalAlign: "left"
+                        horizontalAlign: "center"
                     };
                 }
-                if (index < 12) {
+                if (index === 6) {
+                    return {
+                        value: `基準日 ${baseDate}`,
+                        bold: true,
+                        fillColor: "#E6F1FB",
+                        border: "thin",
+                        horizontalAlign: "center"
+                    };
+                }
+                if (index > 5 && index < 12) {
                     return {
                         value: "",
-                        fillColor: "#EAF3FB",
+                        fillColor: "#E6F1FB",
                         border: "thin"
                     };
                 }
@@ -9758,98 +9837,51 @@ if (!customElements.get("lht-page-menu")) {
             ]
         };
     }
-    function legendRow(columnCount) {
+    function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
+        const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
-            {
-                value: "Legend / 記号",
-                bold: true,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "進捗済み",
-                fillColor: PROGRESS_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "予定帯",
-                fillColor: ACTIVE_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "Today",
-                fillColor: TODAY_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "週頭",
-                fillColor: WEEK_START_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "週末",
-                fillColor: WEEKEND_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "祝日",
-                fillColor: HOLIDAY_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "━:phase",
-                fillColor: PHASE_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "■:task",
-                fillColor: ACTIVE_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "◆:milestone",
-                fillColor: MILESTONE_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "M:Milestone",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "S:Summary",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "!:Critical",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "-:未設定",
-                fillColor: PLACEHOLDER_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            }
+            { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            height: 22,
-            cells: [
-                ...items,
-                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            rows: [
+                blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+            ]
+        };
+    }
+    function legendRows(columnCount, startRowNumber) {
+        const items = [
+            { value: "進捗済み", fillColor: PROGRESS_BAND_FILL },
+            { value: "予定帯", fillColor: ACTIVE_BAND_FILL },
+            { value: "当日", fillColor: TODAY_BAND_FILL },
+            { value: "週頭", fillColor: WEEK_START_BAND_FILL },
+            { value: "週末", fillColor: WEEKEND_BAND_FILL },
+            { value: "祝日", fillColor: HOLIDAY_BAND_FILL },
+            { value: "━:フェーズ", fillColor: PHASE_FILL },
+            { value: "■:タスク", fillColor: ACTIVE_BAND_FILL },
+            { value: "◆:マイルストーン", fillColor: MILESTONE_FILL },
+            { value: "Mil:マイルストーン", fillColor: "#FBE4EC" },
+            { value: "Sum:サマリ", fillColor: "#F7EAF0" },
+            { value: "Crit:クリティカル", fillColor: "#F3E1E9" },
+            { value: "-:未設定", fillColor: PLACEHOLDER_FILL }
+        ];
+        const startColumnRef = columnName(6);
+        const endColumnRef = columnName(7);
+        return {
+            mergedRanges: [
+                `${startColumnRef}${startRowNumber}:${endColumnRef}${startRowNumber}`,
+                ...items.map((_, index) => `${startColumnRef}${startRowNumber + index + 1}:${endColumnRef}${startRowNumber + index + 1}`)
+            ],
+            rows: [
+                blockHeaderRow(columnCount, 5, "凡例"),
+                ...items.map((item) => mergedLabelRow(columnCount, 5, item.value, item.fillColor))
             ]
         };
     }
@@ -9865,15 +9897,22 @@ if (!customElements.get("lht-page-menu")) {
             };
         });
         return {
-            height: 22,
+            height: 24,
             cells: [
                 ...Array.from({ length: fixedColumnCount }, (_, index) => {
                     if (index === 5) {
                         return {
-                            value: "Week",
+                            value: "週",
                             bold: true,
                             border: "thin",
                             horizontalAlign: "right",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index === 6) {
+                        return {
+                            value: "",
+                            border: "thin",
                             fillColor: "#E3EEF9"
                         };
                     }
@@ -9897,39 +9936,74 @@ if (!customElements.get("lht-page-menu")) {
             ]
         };
     }
-    function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
+    function displaySummaryRows(displayDays, businessDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount, startColumnIndex = 5, startRowNumber = 5, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, useBusinessDaysForDisplayRange, useBusinessDaysForProgressBand) {
         const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
         const items = [
-            summaryStatCell("Summary", HEADER_ID_FILL),
-            summaryStatCell("", HEADER_FILL),
-            summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
-            summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
-            summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
-            summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
-            summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
-            summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+            { label: "表示日", value: displayDays, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "表示週", value: displayWeeks, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "営業日", value: businessDays, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "前日数", value: displayDaysBeforeBaseDate !== null && displayDaysBeforeBaseDate !== void 0 ? displayDaysBeforeBaseDate : "-", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "後日数", value: displayDaysAfterBaseDate !== null && displayDaysAfterBaseDate !== void 0 ? displayDaysAfterBaseDate : "-", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "表示", value: useBusinessDaysForDisplayRange ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "進捗", value: useBusinessDaysForProgressBand ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "タスク", value: taskCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "リソース", value: resourceCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "割当", value: assignmentCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "カレンダ", value: calendarCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "基準日", value: (baseDate || "-").slice(0, 10), fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            height: 22,
-            cells: [
-                ...items,
-                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            rows: [
+                blockHeaderRow(columnCount, startColumnIndex, "サマリ"),
+                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
     }
-    function summaryStatCell(value, fillColor) {
-        return {
+    function blockHeaderRow(columnCount, startColumnIndex, title) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: title,
+            border: "thin",
+            horizontalAlign: "left",
+            bold: true,
+            fillColor: HEADER_ID_FILL
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor: HEADER_ID_FILL
+        };
+        return { height: 24, cells };
+    }
+    function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
+        cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+        return { height: 22, cells };
+    }
+    function mergedLabelRow(columnCount, startColumnIndex, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
             value,
             border: "thin",
             horizontalAlign: "center",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        return { height: 24, cells };
+    }
+    function summaryStatCell(value, fillColor, isValueCell) {
+        const valueAlign = typeof value === "number" ? "center" : "left";
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: isValueCell ? valueAlign : "right",
             bold: true,
             fillColor
         };
@@ -9967,31 +10041,38 @@ if (!customElements.get("lht-page-menu")) {
         if (label === "UID" || label === "ID") {
             return HEADER_ID_FILL;
         }
-        if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+        if (label === "WBS" || label === "種別" || label === "階層" || label === "名称") {
             return HEADER_STRUCTURE_FILL;
         }
-        if (label === "Start" || label === "Finish" || label === "Duration") {
+        if (label === "開始" || label === "終了" || label === "期間") {
             return HEADER_SCHEDULE_FILL;
         }
-        if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+        if (label === "進捗" || label === "作業進捗" || label === "マイル" || label === "サマリ" || label === "クリティカル") {
             return HEADER_STATUS_FILL;
         }
-        if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+        if (label === "担当" || label === "カレンダ" || label === "リソース" || label === "先行") {
             return HEADER_ASSIGNMENT_FILL;
         }
         return HEADER_FILL;
     }
     function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
         return {
-            height: 22,
+            height: 24,
             cells: [
                 ...Array.from({ length: fixedColumnCount }, (_, index) => {
                     if (index === 5) {
                         return {
-                            value: "BaseDate",
+                            value: "基準日",
                             bold: true,
                             border: "thin",
                             horizontalAlign: "right",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    if (index === 6) {
+                        return {
+                            value: "",
+                            border: "thin",
                             fillColor: "#FFEFC2"
                         };
                     }
@@ -10012,7 +10093,7 @@ if (!customElements.get("lht-page-menu")) {
                     return {};
                 }),
                 ...dateBand.map((day, index) => ({
-                    value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
+                    value: isSameDay(day, currentDate) ? "▼基準日" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
@@ -10045,7 +10126,13 @@ if (!customElements.get("lht-page-menu")) {
             border: "thin",
             horizontalAlign,
             bold: task.summary || task.milestone || false,
-            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+            fillColor: task.summary
+                ? PHASE_FILL
+                : (task.milestone
+                    ? MILESTONE_FILL
+                    : (horizontalAlign === "left"
+                        ? NAME_COLUMN_FILL
+                        : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
         };
     }
     function kindCell(task) {
@@ -10079,13 +10166,34 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function progressCell(task, value) {
+        const progressValue = formatProgressLabel(value);
         return {
-            value: value === undefined || value === null ? "" : `${value}%`,
+            value: progressValue,
             border: "thin",
             horizontalAlign: "center",
             bold: task.summary || task.milestone || false,
-            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : PROGRESS_COLUMN_FILL)
         };
+    }
+    function formatProgressLabel(value) {
+        if (value === undefined || value === null || !Number.isFinite(value)) {
+            return "";
+        }
+        const clamped = Math.max(0, Math.min(100, Math.round(value)));
+        const filled = Math.round(clamped / 10);
+        const bar = `${"#".repeat(filled)}${"-".repeat(10 - filled)}`;
+        return `${String(clamped).padStart(3, " ")}% [${bar}]`;
+    }
+    function formatDurationLabel(task, holidaySet, useBusinessDaysForProgressBand) {
+        if (useBusinessDaysForProgressBand) {
+            const businessDays = enumerateBusinessDays(task.start, task.finish, holidaySet).length;
+            return businessDays > 0 ? `${businessDays}営業日` : "-";
+        }
+        const calendarDays = buildDateBand(task.start, task.finish).length;
+        return calendarDays > 0 ? `${calendarDays}日` : "-";
+    }
+    function formatWbsDate(value) {
+        return value ? value.slice(0, 10) : "-";
     }
     function dateHeaderCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
@@ -10101,13 +10209,13 @@ if (!customElements.get("lht-page-menu")) {
             fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
-    function dateBandCell(task, day, currentDate, holidaySet) {
+    function dateBandCell(task, day, currentDate, holidaySet, useBusinessDaysForProgressBand) {
         const active = includesDay(task.start, task.finish, day);
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
-        const complete = active && isCompletedDay(task, day);
+        const complete = active && isCompletedDay(task, day, holidaySet, useBusinessDaysForProgressBand);
         return {
             value: active ? activeBandMarker(task) : "",
             border: "thin",
@@ -10141,6 +10249,63 @@ if (!customElements.get("lht-page-menu")) {
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildDisplayDateBand(startDate, finishDate, baseDate, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, holidaySet, useBusinessDaysForDisplayRange) {
+        const fullBand = buildDateBand(startDate, finishDate);
+        const before = normalizeDisplayDayCount(displayDaysBeforeBaseDate);
+        const after = normalizeDisplayDayCount(displayDaysAfterBaseDate);
+        if (before === null && after === null) {
+            return fullBand;
+        }
+        const base = parseDateOnly(baseDate);
+        if (!base || fullBand.length === 0) {
+            return fullBand;
+        }
+        const projectStart = parseDateOnly(startDate);
+        const projectFinish = parseDateOnly(finishDate);
+        if (!projectStart || !projectFinish) {
+            return fullBand;
+        }
+        const from = useBusinessDaysForDisplayRange
+            ? shiftBusinessDays(base, -(before || 0), holidaySet)
+            : shiftCalendarDays(base, -(before || 0));
+        const to = useBusinessDaysForDisplayRange
+            ? shiftBusinessDays(base, after || 0, holidaySet)
+            : shiftCalendarDays(base, after || 0);
+        const clampedStart = from.getTime() < projectStart.getTime() ? projectStart : from;
+        const clampedFinish = to.getTime() > projectFinish.getTime() ? projectFinish : to;
+        if (clampedStart.getTime() > clampedFinish.getTime()) {
+            return fullBand;
+        }
+        return buildDateBand(formatDateOnly(clampedStart), formatDateOnly(clampedFinish));
+    }
+    function normalizeDisplayDayCount(value) {
+        if (value === undefined || value === null || !Number.isFinite(value)) {
+            return null;
+        }
+        return Math.max(0, Math.floor(value));
+    }
+    function countBusinessDays(dateBand, holidaySet) {
+        return dateBand.filter((day) => !isWeekend(day) && !holidaySet.has(day)).length;
+    }
+    function shiftCalendarDays(base, offset) {
+        const result = new Date(base.getTime());
+        result.setDate(result.getDate() + offset);
+        return result;
+    }
+    function shiftBusinessDays(base, offset, holidaySet) {
+        const result = new Date(base.getTime());
+        const direction = offset < 0 ? -1 : 1;
+        let remaining = Math.abs(offset);
+        while (remaining > 0) {
+            result.setDate(result.getDate() + direction);
+            const day = formatDateOnly(result);
+            if (isWeekend(day) || holidaySet.has(day)) {
+                continue;
+            }
+            remaining -= 1;
+        }
+        return result;
     }
     function buildWeekBandRanges(dateBand, startColumnIndex, rowNumber) {
         const ranges = [];
@@ -10176,12 +10341,23 @@ if (!customElements.get("lht-page-menu")) {
         }
         return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
     }
-    function isCompletedDay(task, day) {
+    function isCompletedDay(task, day, holidaySet, useBusinessDaysForProgressBand) {
         const start = parseDateOnly(task.start);
         const finish = parseDateOnly(task.finish);
         const target = parseDateOnly(day);
         if (!start || !finish || !target) {
             return false;
+        }
+        if (useBusinessDaysForProgressBand) {
+            const activeBusinessDays = enumerateBusinessDays(task.start, task.finish, holidaySet);
+            if (activeBusinessDays.length === 0) {
+                return false;
+            }
+            const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+            const completedDays = Math.floor(activeBusinessDays.length * (percent / 100));
+            const dayKey = formatDateOnly(target);
+            const dayIndex = activeBusinessDays.indexOf(dayKey);
+            return dayIndex >= 0 && dayIndex < completedDays;
         }
         const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
         if (totalDays <= 0) {
@@ -10191,6 +10367,9 @@ if (!customElements.get("lht-page-menu")) {
         const completedDays = Math.floor(totalDays * (percent / 100));
         const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
         return dayIndex >= 0 && dayIndex < completedDays;
+    }
+    function enumerateBusinessDays(startDate, finishDate, holidaySet) {
+        return buildDateBand(startDate, finishDate).filter((day) => !isWeekend(day) && !holidaySet.has(day));
     }
     function isSameDay(day, other) {
         return day === (other || "").slice(0, 10);
@@ -10280,25 +10459,24 @@ if (!customElements.get("lht-page-menu")) {
     }
     function formatWeekLabel(days) {
         if (days.length === 0) {
-            return "Week";
+            return "週";
         }
         const start = parseDateOnly(days[0]);
         if (!start) {
             return days[0];
         }
-        const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
         const monthSet = new Set(days.map((day) => {
             const target = parseDateOnly(day);
             return target ? target.getMonth() : -1;
         }));
-        const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+        const startLabel = `${String(start.getMonth() + 1).padStart(2, "0")}/${String(start.getDate()).padStart(2, "0")}`;
         if (monthSet.size <= 1) {
-            return `Week of ${startLabel}`;
+            return `週 ${startLabel}`;
         }
         const tailMonths = Array.from(monthSet)
             .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
-            .map((monthIndex) => monthNames[monthIndex]);
-        return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+            .map((monthIndex) => String(monthIndex + 1).padStart(2, "0"));
+        return `週 ${startLabel} / ${tailMonths.join(" / ")}`;
     }
     function columnName(index) {
         let current = index;
@@ -10351,6 +10529,9 @@ if (!customElements.get("lht-page-menu")) {
     function getTextArea(id) {
         return getElement(id);
     }
+    function getInput(id) {
+        return getElement(id);
+    }
     function parseHolidayDateList(raw) {
         if (!raw) {
             return [];
@@ -10380,6 +10561,29 @@ if (!customElements.get("lht-page-menu")) {
     }
     function parseWbsAdditionalHolidayDates() {
         return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+    }
+    function parseOptionalNonNegativeInteger(raw) {
+        const value = raw.trim();
+        if (!value) {
+            return undefined;
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+            return undefined;
+        }
+        return Math.max(0, Math.floor(parsed));
+    }
+    function parseWbsDisplayDaysBeforeBaseDate() {
+        return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
+    }
+    function parseWbsDisplayDaysAfterBaseDate() {
+        return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
+    }
+    function useBusinessDaysForWbsDisplayRange() {
+        return getInput("wbsBusinessDayRangeInput").checked;
+    }
+    function useBusinessDaysForWbsProgressBand() {
+        return getInput("wbsBusinessDayProgressInput").checked;
     }
     function syncWbsHolidayDatesInput(model) {
         const input = getTextArea("wbsHolidayDatesInput");
@@ -10936,8 +11140,18 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const model = ensureCurrentModel();
         const defaultHolidayDates = parseWbsDefaultHolidayDates();
         const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+        const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
+        const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
+        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
+        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
         const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
+            holidayDates: effectiveHolidayDates,
+            displayDaysBeforeBaseDate,
+            displayDaysAfterBaseDate,
+            useBusinessDaysForDisplayRange,
+            useBusinessDaysForProgressBand
+        });
         if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
             getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
         }
@@ -10952,7 +11166,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
+        const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
+            ? ` / 表示期間 ${useBusinessDaysForDisplayRange ? "営業日" : "暦日"} 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+            : "";
+        const progressBandText = useBusinessDaysForProgressBand ? " / 進捗帯 営業日" : "";
+        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
         showToast("WBS XLSX を保存しました");
     }
     async function importXlsxFromFile(file) {

--- a/docs/project/src/mikuproject/js/main.js
+++ b/docs/project/src/mikuproject/js/main.js
@@ -31,6 +31,9 @@
     function getTextArea(id) {
         return getElement(id);
     }
+    function getInput(id) {
+        return getElement(id);
+    }
     function parseHolidayDateList(raw) {
         if (!raw) {
             return [];
@@ -60,6 +63,29 @@
     }
     function parseWbsAdditionalHolidayDates() {
         return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+    }
+    function parseOptionalNonNegativeInteger(raw) {
+        const value = raw.trim();
+        if (!value) {
+            return undefined;
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+            return undefined;
+        }
+        return Math.max(0, Math.floor(parsed));
+    }
+    function parseWbsDisplayDaysBeforeBaseDate() {
+        return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
+    }
+    function parseWbsDisplayDaysAfterBaseDate() {
+        return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
+    }
+    function useBusinessDaysForWbsDisplayRange() {
+        return getInput("wbsBusinessDayRangeInput").checked;
+    }
+    function useBusinessDaysForWbsProgressBand() {
+        return getInput("wbsBusinessDayProgressInput").checked;
     }
     function syncWbsHolidayDatesInput(model) {
         const input = getTextArea("wbsHolidayDatesInput");
@@ -616,8 +642,18 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const model = ensureCurrentModel();
         const defaultHolidayDates = parseWbsDefaultHolidayDates();
         const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+        const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
+        const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
+        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
+        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
         const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
+            holidayDates: effectiveHolidayDates,
+            displayDaysBeforeBaseDate,
+            displayDaysAfterBaseDate,
+            useBusinessDaysForDisplayRange,
+            useBusinessDaysForProgressBand
+        });
         if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
             getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
         }
@@ -632,7 +668,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
+        const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
+            ? ` / 表示期間 ${useBusinessDaysForDisplayRange ? "営業日" : "暦日"} 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+            : "";
+        const progressBandText = useBusinessDaysForProgressBand ? " / 進捗帯 営業日" : "";
+        setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
         showToast("WBS XLSX を保存しました");
     }
     async function importXlsxFromFile(file) {

--- a/docs/project/src/mikuproject/js/msproject-xml.js
+++ b/docs/project/src/mikuproject/js/msproject-xml.js
@@ -10,7 +10,7 @@
   <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
-  <FinishDate>2026-03-20T18:00:00</FinishDate>
+  <FinishDate>2026-03-31T18:00:00</FinishDate>
   <ScheduleFromStart>1</ScheduleFromStart>
   <DefaultStartTime>09:00:00</DefaultStartTime>
   <DefaultFinishTime>18:00:00</DefaultFinishTime>

--- a/docs/project/src/mikuproject/js/wbs-xlsx.js
+++ b/docs/project/src/mikuproject/js/wbs-xlsx.js
@@ -1,10 +1,12 @@
 (() => {
     const HEADER_FILL = "#D9EAF7";
-    const HEADER_ID_FILL = "#D7E7F6";
+    const HEADER_ID_FILL = "#E1EDF8";
     const HEADER_STRUCTURE_FILL = "#E6F0DF";
     const HEADER_SCHEDULE_FILL = "#FDE7D3";
     const HEADER_STATUS_FILL = "#FBE4EC";
     const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
+    const SUMMARY_SCHEDULE_FILL = "#FDF1E4";
+    const SUMMARY_ASSIGNMENT_FILL = "#E8F4F1";
     const PHASE_FILL = "#EEF7E8";
     const TASK_KIND_FILL = "#EEF2F6";
     const MILESTONE_FILL = "#FFF4E0";
@@ -21,8 +23,12 @@
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
     const HOLIDAY_BAND_FILL = "#FCE4EC";
-    const DIVIDER_FILL = "#C5D1DB";
+    const DIVIDER_FILL = "#D9E2EA";
     const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
+    const NAME_COLUMN_FILL = "#FBFCFE";
+    const SCHEDULE_COLUMN_FILL = "#FCFAF7";
+    const PROGRESS_COLUMN_FILL = "#FCF8FB";
+    const REFERENCE_COLUMN_FILL = "#F8FBFB";
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -54,117 +60,126 @@
             }
             resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
         }
-        const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+        const dateBand = buildDisplayDateBand(model.project.startDate, model.project.finishDate, model.project.currentDate, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, holidaySet, options.useBusinessDaysForDisplayRange);
         const fixedHeaders = [
             "UID",
             "ID",
             "WBS",
-            "Kind",
-            "OutlineLevel",
-            "Name",
-            "Start",
-            "Finish",
-            "Duration",
-            "PercentComplete",
-            "PercentWorkComplete",
-            "Milestone",
-            "Summary",
-            "Critical",
-            "Owner",
-            "Calendar",
-            "Resources",
-            "Predecessors"
+            "種別",
+            "階層",
+            "名称",
+            "開始",
+            "終了",
+            "期間",
+            "進捗",
+            "作業進捗",
+            "マイル",
+            "サマリ",
+            "クリティカル",
+            "担当",
+            "カレンダ",
+            "リソース",
+            "先行"
         ];
         const dividerColumnIndex = fixedHeaders.length + 1;
         const dateBandStartColumnIndex = dividerColumnIndex + 1;
         const totalColumns = fixedHeaders.length + 1 + dateBand.length;
         const lastColumnRef = columnName(totalColumns);
-        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
+        const rows = [
+            sheetTitleRow("WBS", totalColumns),
+            sheetSubtitleRow(model.project.name || "Project", totalColumns)
+        ];
+        const mergedRanges = [
+            `A1:${lastColumnRef}1`,
+            `A2:${lastColumnRef}2`
+        ];
+        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 5, rows.length + 1);
+        rows.push(...projectInfoBlock.rows);
+        mergedRanges.push(...projectInfoBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        rows.push(...summaryBlock.rows);
+        mergedRanges.push(...summaryBlock.mergedRanges);
+        rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
+        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
+        rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
+        rows.push(todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
+        rows.push(headerRow([
+            ...fixedHeaders.map((label) => label === "名称"
+                ? {
+                    value: label,
+                    bold: true,
+                    fillColor: headerFillForLabel(label),
+                    border: "thin",
+                    horizontalAlign: "left"
+                }
+                : label),
+            dividerCell(),
+            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+        ]));
+        rows.push(...model.tasks.map((task) => ({
+            cells: [
+                identifierCell(task, task.uid),
+                identifierCell(task, task.id),
+                identifierCell(task, task.wbs || task.outlineNumber),
+                kindCell(task),
+                identifierCell(task, task.outlineLevel),
+                taskCell(task, formatTaskLabel(task)),
+                taskCell(task, formatWbsDate(task.start), "center"),
+                taskCell(task, formatWbsDate(task.finish), "center"),
+                taskCell(task, formatDurationLabel(task, holidaySet, options.useBusinessDaysForProgressBand), "center"),
+                progressCell(task, task.percentComplete),
+                progressCell(task, task.percentWorkComplete),
+                flagCell(task, task.milestone, "Mil"),
+                flagCell(task, task.summary, "Sum"),
+                flagCell(task, task.critical, "Crit"),
+                referenceCell(task, truncateWbsReference(firstResourceName(resourceNamesByTaskUid.get(task.uid)), 14), "center"),
+                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+                referenceCell(task, truncateWbsReference((resourceNamesByTaskUid.get(task.uid) || []).join(", "), 18)),
+                referenceCell(task, truncateWbsReference(task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", "), 18)),
+                dividerCell(),
+                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet, options.useBusinessDaysForProgressBand))
+            ]
+        })));
+        rows.push(emptyRow(totalColumns, 28));
+        const legendBlock = legendRows(totalColumns, rows.length + 1);
+        rows.push(...legendBlock.rows);
+        mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
         return {
             sheets: [
                 {
                     name: "WBS",
-                    freezePane: {
-                        rowSplit: 10,
-                        colSplit: 19
-                    },
                     columns: [
                         { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-                        { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
+                        { width: 20 }, { width: 18 }, { width: 12 }, { width: 14 },
                         { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
                         { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
-                    mergedRanges: [
-                        `A1:${lastColumnRef}1`,
-                        `A2:${lastColumnRef}2`,
-                        `A3:${lastColumnRef}3`,
-                        `A4:${lastColumnRef}4`,
-                        ...weekBandRanges.map((item) => item.range)
-                    ],
-                    rows: [
-                        sectionTitleRow("WBS", totalColumns),
-                        sectionTitleRow(model.project.name || "Project", totalColumns),
-                        infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
-                        infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-                        displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
-                        legendRow(totalColumns),
-                        taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
-                        weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
-                        todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
-                        headerRow([
-                            ...fixedHeaders.map((label) => label === "Name"
-                                ? {
-                                    value: label,
-                                    bold: true,
-                                    fillColor: headerFillForLabel(label),
-                                    border: "thin",
-                                    horizontalAlign: "left"
-                                }
-                                : label),
-                            dividerCell(),
-                            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
-                        ]),
-                        ...model.tasks.map((task) => ({
-                            cells: [
-                                identifierCell(task, task.uid),
-                                identifierCell(task, task.id),
-                                identifierCell(task, task.wbs || task.outlineNumber),
-                                kindCell(task),
-                                identifierCell(task, task.outlineLevel),
-                                taskCell(task, formatTaskLabel(task)),
-                                taskCell(task, task.start, "center"),
-                                taskCell(task, task.finish, "center"),
-                                taskCell(task, task.duration, "center"),
-                                progressCell(task, task.percentComplete),
-                                progressCell(task, task.percentWorkComplete),
-                                flagCell(task, task.milestone, "M"),
-                                flagCell(task, task.summary, "S"),
-                                flagCell(task, task.critical, "!"),
-                                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
-                                dividerCell(),
-                                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
-                            ]
-                        }))
-                    ]
+                    mergedRanges,
+                    rows
                 }
             ]
         };
     }
+    function emptyRow(columnCount, height = 22) {
+        return {
+            height,
+            cells: Array.from({ length: columnCount }, () => ({}))
+        };
+    }
     function formatTaskLabel(task) {
-        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+        const prefix = task.summary ? "> " : (task.milestone ? "* " : "- ");
+        return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${prefix}${task.name}`;
     }
     function classifyTaskKind(task) {
         if (task.summary) {
-            return "phase";
+            return "フェーズ";
         }
         if (task.milestone) {
-            return "milestone";
+            return "マイル";
         }
-        return "task";
+        return "タスク";
     }
     function firstResourceName(resourceNames) {
         if (!resourceNames || resourceNames.length === 0) {
@@ -177,10 +192,20 @@
             return "-";
         }
         const calendarName = calendarNameByUid.get(calendarUID);
-        return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+        return calendarName ? `${calendarUID} ${truncateWbsReference(calendarName, 9)}` : calendarUID;
     }
     function displayReferenceValue(value) {
         return value && value.trim() ? value : "-";
+    }
+    function truncateWbsReference(value, maxLength) {
+        const normalized = (value === null || value === void 0 ? void 0 : value.trim()) || "";
+        if (!normalized) {
+            return "";
+        }
+        if (normalized.length <= maxLength) {
+            return normalized;
+        }
+        return `${normalized.slice(0, Math.max(1, maxLength - 3))}...`;
     }
     function referenceCell(task, value, horizontalAlign = "left") {
         const displayValue = displayReferenceValue(value);
@@ -190,19 +215,38 @@
             border: "thin",
             horizontalAlign: placeholder ? "center" : horizontalAlign,
             bold: task.summary || task.milestone || false,
-            fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+            fillColor: placeholder
+                ? PLACEHOLDER_FILL
+                : (task.summary
+                    ? PHASE_FILL
+                    : (task.milestone ? MILESTONE_FILL : REFERENCE_COLUMN_FILL))
         };
     }
-    function sectionTitleRow(title, columnCount) {
+    function sheetTitleRow(title, columnCount) {
         return {
-            height: 28,
+            height: 24,
             cells: [
                 {
                     value: title,
                     bold: true,
-                    fillColor: HEADER_FILL,
+                    fillColor: "#EEF4FA",
                     border: "thin",
-                    horizontalAlign: "center"
+                    horizontalAlign: "left"
+                },
+                ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+            ]
+        };
+    }
+    function sheetSubtitleRow(title, columnCount) {
+        return {
+            height: 22,
+            cells: [
+                {
+                    value: title,
+                    bold: true,
+                    fillColor: "#F6F9FC",
+                    border: "thin",
+                    horizontalAlign: "left"
                 },
                 ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
             ]
@@ -212,19 +256,28 @@
         return {
             height: 26,
             cells: Array.from({ length: columnCount }, (_, index) => {
-                if (index === 0) {
+                if (index === 5) {
                     return {
-                        value: `Task View | BaseDate=${baseDate}`,
+                        value: "タスク表",
                         bold: true,
-                        fillColor: "#EAF3FB",
+                        fillColor: "#E6F1FB",
                         border: "thin",
-                        horizontalAlign: "left"
+                        horizontalAlign: "center"
                     };
                 }
-                if (index < 12) {
+                if (index === 6) {
+                    return {
+                        value: `基準日 ${baseDate}`,
+                        bold: true,
+                        fillColor: "#E6F1FB",
+                        border: "thin",
+                        horizontalAlign: "center"
+                    };
+                }
+                if (index > 5 && index < 12) {
                     return {
                         value: "",
-                        fillColor: "#EAF3FB",
+                        fillColor: "#E6F1FB",
                         border: "thin"
                     };
                 }
@@ -245,98 +298,51 @@
             ]
         };
     }
-    function legendRow(columnCount) {
+    function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
+        const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
-            {
-                value: "Legend / 記号",
-                bold: true,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "進捗済み",
-                fillColor: PROGRESS_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "予定帯",
-                fillColor: ACTIVE_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "Today",
-                fillColor: TODAY_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "週頭",
-                fillColor: WEEK_START_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "週末",
-                fillColor: WEEKEND_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "祝日",
-                fillColor: HOLIDAY_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "━:phase",
-                fillColor: PHASE_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "■:task",
-                fillColor: ACTIVE_BAND_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "◆:milestone",
-                fillColor: MILESTONE_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "M:Milestone",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "S:Summary",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "!:Critical",
-                fillColor: HEADER_STATUS_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            },
-            {
-                value: "-:未設定",
-                fillColor: PLACEHOLDER_FILL,
-                border: "thin",
-                horizontalAlign: "center"
-            }
+            { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            height: 22,
-            cells: [
-                ...items,
-                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            rows: [
+                blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+            ]
+        };
+    }
+    function legendRows(columnCount, startRowNumber) {
+        const items = [
+            { value: "進捗済み", fillColor: PROGRESS_BAND_FILL },
+            { value: "予定帯", fillColor: ACTIVE_BAND_FILL },
+            { value: "当日", fillColor: TODAY_BAND_FILL },
+            { value: "週頭", fillColor: WEEK_START_BAND_FILL },
+            { value: "週末", fillColor: WEEKEND_BAND_FILL },
+            { value: "祝日", fillColor: HOLIDAY_BAND_FILL },
+            { value: "━:フェーズ", fillColor: PHASE_FILL },
+            { value: "■:タスク", fillColor: ACTIVE_BAND_FILL },
+            { value: "◆:マイルストーン", fillColor: MILESTONE_FILL },
+            { value: "Mil:マイルストーン", fillColor: "#FBE4EC" },
+            { value: "Sum:サマリ", fillColor: "#F7EAF0" },
+            { value: "Crit:クリティカル", fillColor: "#F3E1E9" },
+            { value: "-:未設定", fillColor: PLACEHOLDER_FILL }
+        ];
+        const startColumnRef = columnName(6);
+        const endColumnRef = columnName(7);
+        return {
+            mergedRanges: [
+                `${startColumnRef}${startRowNumber}:${endColumnRef}${startRowNumber}`,
+                ...items.map((_, index) => `${startColumnRef}${startRowNumber + index + 1}:${endColumnRef}${startRowNumber + index + 1}`)
+            ],
+            rows: [
+                blockHeaderRow(columnCount, 5, "凡例"),
+                ...items.map((item) => mergedLabelRow(columnCount, 5, item.value, item.fillColor))
             ]
         };
     }
@@ -352,15 +358,22 @@
             };
         });
         return {
-            height: 22,
+            height: 24,
             cells: [
                 ...Array.from({ length: fixedColumnCount }, (_, index) => {
                     if (index === 5) {
                         return {
-                            value: "Week",
+                            value: "週",
                             bold: true,
                             border: "thin",
                             horizontalAlign: "right",
+                            fillColor: "#E3EEF9"
+                        };
+                    }
+                    if (index === 6) {
+                        return {
+                            value: "",
+                            border: "thin",
                             fillColor: "#E3EEF9"
                         };
                     }
@@ -384,39 +397,74 @@
             ]
         };
     }
-    function displaySummaryRow(displayDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount) {
+    function displaySummaryRows(displayDays, businessDays, baseDate, taskCount, resourceCount, assignmentCount, calendarCount, columnCount, startColumnIndex = 5, startRowNumber = 5, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, useBusinessDaysForDisplayRange, useBusinessDaysForProgressBand) {
         const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
         const items = [
-            summaryStatCell("Summary", HEADER_ID_FILL),
-            summaryStatCell("", HEADER_FILL),
-            summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
-            summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
-            summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
-            summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
-            summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
-            summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
-            summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
-            summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+            { label: "表示日", value: displayDays, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "表示週", value: displayWeeks, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "営業日", value: businessDays, fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "前日数", value: displayDaysBeforeBaseDate !== null && displayDaysBeforeBaseDate !== void 0 ? displayDaysBeforeBaseDate : "-", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "後日数", value: displayDaysAfterBaseDate !== null && displayDaysAfterBaseDate !== void 0 ? displayDaysAfterBaseDate : "-", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "表示", value: useBusinessDaysForDisplayRange ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "進捗", value: useBusinessDaysForProgressBand ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+            { label: "タスク", value: taskCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "リソース", value: resourceCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "割当", value: assignmentCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "カレンダ", value: calendarCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "基準日", value: (baseDate || "-").slice(0, 10), fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            height: 22,
-            cells: [
-                ...items,
-                ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            rows: [
+                blockHeaderRow(columnCount, startColumnIndex, "サマリ"),
+                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
     }
-    function summaryStatCell(value, fillColor) {
-        return {
+    function blockHeaderRow(columnCount, startColumnIndex, title) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: title,
+            border: "thin",
+            horizontalAlign: "left",
+            bold: true,
+            fillColor: HEADER_ID_FILL
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor: HEADER_ID_FILL
+        };
+        return { height: 24, cells };
+    }
+    function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
+        cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+        return { height: 22, cells };
+    }
+    function mergedLabelRow(columnCount, startColumnIndex, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
             value,
             border: "thin",
             horizontalAlign: "center",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        return { height: 24, cells };
+    }
+    function summaryStatCell(value, fillColor, isValueCell) {
+        const valueAlign = typeof value === "number" ? "center" : "left";
+        return {
+            value,
+            border: "thin",
+            horizontalAlign: isValueCell ? valueAlign : "right",
             bold: true,
             fillColor
         };
@@ -454,31 +502,38 @@
         if (label === "UID" || label === "ID") {
             return HEADER_ID_FILL;
         }
-        if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+        if (label === "WBS" || label === "種別" || label === "階層" || label === "名称") {
             return HEADER_STRUCTURE_FILL;
         }
-        if (label === "Start" || label === "Finish" || label === "Duration") {
+        if (label === "開始" || label === "終了" || label === "期間") {
             return HEADER_SCHEDULE_FILL;
         }
-        if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+        if (label === "進捗" || label === "作業進捗" || label === "マイル" || label === "サマリ" || label === "クリティカル") {
             return HEADER_STATUS_FILL;
         }
-        if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+        if (label === "担当" || label === "カレンダ" || label === "リソース" || label === "先行") {
             return HEADER_ASSIGNMENT_FILL;
         }
         return HEADER_FILL;
     }
     function todayGuideRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
         return {
-            height: 22,
+            height: 24,
             cells: [
                 ...Array.from({ length: fixedColumnCount }, (_, index) => {
                     if (index === 5) {
                         return {
-                            value: "BaseDate",
+                            value: "基準日",
                             bold: true,
                             border: "thin",
                             horizontalAlign: "right",
+                            fillColor: "#FFEFC2"
+                        };
+                    }
+                    if (index === 6) {
+                        return {
+                            value: "",
+                            border: "thin",
                             fillColor: "#FFEFC2"
                         };
                     }
@@ -499,7 +554,7 @@
                     return {};
                 }),
                 ...dateBand.map((day, index) => ({
-                    value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
+                    value: isSameDay(day, currentDate) ? "▼基準日" : "",
                     bold: true,
                     border: "thin",
                     horizontalAlign: "center",
@@ -532,7 +587,13 @@
             border: "thin",
             horizontalAlign,
             bold: task.summary || task.milestone || false,
-            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+            fillColor: task.summary
+                ? PHASE_FILL
+                : (task.milestone
+                    ? MILESTONE_FILL
+                    : (horizontalAlign === "left"
+                        ? NAME_COLUMN_FILL
+                        : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
         };
     }
     function kindCell(task) {
@@ -566,13 +627,34 @@
         };
     }
     function progressCell(task, value) {
+        const progressValue = formatProgressLabel(value);
         return {
-            value: value === undefined || value === null ? "" : `${value}%`,
+            value: progressValue,
             border: "thin",
             horizontalAlign: "center",
             bold: task.summary || task.milestone || false,
-            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+            fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : PROGRESS_COLUMN_FILL)
         };
+    }
+    function formatProgressLabel(value) {
+        if (value === undefined || value === null || !Number.isFinite(value)) {
+            return "";
+        }
+        const clamped = Math.max(0, Math.min(100, Math.round(value)));
+        const filled = Math.round(clamped / 10);
+        const bar = `${"#".repeat(filled)}${"-".repeat(10 - filled)}`;
+        return `${String(clamped).padStart(3, " ")}% [${bar}]`;
+    }
+    function formatDurationLabel(task, holidaySet, useBusinessDaysForProgressBand) {
+        if (useBusinessDaysForProgressBand) {
+            const businessDays = enumerateBusinessDays(task.start, task.finish, holidaySet).length;
+            return businessDays > 0 ? `${businessDays}営業日` : "-";
+        }
+        const calendarDays = buildDateBand(task.start, task.finish).length;
+        return calendarDays > 0 ? `${calendarDays}日` : "-";
+    }
+    function formatWbsDate(value) {
+        return value ? value.slice(0, 10) : "-";
     }
     function dateHeaderCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
@@ -588,13 +670,13 @@
             fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
-    function dateBandCell(task, day, currentDate, holidaySet) {
+    function dateBandCell(task, day, currentDate, holidaySet, useBusinessDaysForProgressBand) {
         const active = includesDay(task.start, task.finish, day);
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
-        const complete = active && isCompletedDay(task, day);
+        const complete = active && isCompletedDay(task, day, holidaySet, useBusinessDaysForProgressBand);
         return {
             value: active ? activeBandMarker(task) : "",
             border: "thin",
@@ -628,6 +710,63 @@
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildDisplayDateBand(startDate, finishDate, baseDate, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, holidaySet, useBusinessDaysForDisplayRange) {
+        const fullBand = buildDateBand(startDate, finishDate);
+        const before = normalizeDisplayDayCount(displayDaysBeforeBaseDate);
+        const after = normalizeDisplayDayCount(displayDaysAfterBaseDate);
+        if (before === null && after === null) {
+            return fullBand;
+        }
+        const base = parseDateOnly(baseDate);
+        if (!base || fullBand.length === 0) {
+            return fullBand;
+        }
+        const projectStart = parseDateOnly(startDate);
+        const projectFinish = parseDateOnly(finishDate);
+        if (!projectStart || !projectFinish) {
+            return fullBand;
+        }
+        const from = useBusinessDaysForDisplayRange
+            ? shiftBusinessDays(base, -(before || 0), holidaySet)
+            : shiftCalendarDays(base, -(before || 0));
+        const to = useBusinessDaysForDisplayRange
+            ? shiftBusinessDays(base, after || 0, holidaySet)
+            : shiftCalendarDays(base, after || 0);
+        const clampedStart = from.getTime() < projectStart.getTime() ? projectStart : from;
+        const clampedFinish = to.getTime() > projectFinish.getTime() ? projectFinish : to;
+        if (clampedStart.getTime() > clampedFinish.getTime()) {
+            return fullBand;
+        }
+        return buildDateBand(formatDateOnly(clampedStart), formatDateOnly(clampedFinish));
+    }
+    function normalizeDisplayDayCount(value) {
+        if (value === undefined || value === null || !Number.isFinite(value)) {
+            return null;
+        }
+        return Math.max(0, Math.floor(value));
+    }
+    function countBusinessDays(dateBand, holidaySet) {
+        return dateBand.filter((day) => !isWeekend(day) && !holidaySet.has(day)).length;
+    }
+    function shiftCalendarDays(base, offset) {
+        const result = new Date(base.getTime());
+        result.setDate(result.getDate() + offset);
+        return result;
+    }
+    function shiftBusinessDays(base, offset, holidaySet) {
+        const result = new Date(base.getTime());
+        const direction = offset < 0 ? -1 : 1;
+        let remaining = Math.abs(offset);
+        while (remaining > 0) {
+            result.setDate(result.getDate() + direction);
+            const day = formatDateOnly(result);
+            if (isWeekend(day) || holidaySet.has(day)) {
+                continue;
+            }
+            remaining -= 1;
+        }
+        return result;
     }
     function buildWeekBandRanges(dateBand, startColumnIndex, rowNumber) {
         const ranges = [];
@@ -663,12 +802,23 @@
         }
         return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
     }
-    function isCompletedDay(task, day) {
+    function isCompletedDay(task, day, holidaySet, useBusinessDaysForProgressBand) {
         const start = parseDateOnly(task.start);
         const finish = parseDateOnly(task.finish);
         const target = parseDateOnly(day);
         if (!start || !finish || !target) {
             return false;
+        }
+        if (useBusinessDaysForProgressBand) {
+            const activeBusinessDays = enumerateBusinessDays(task.start, task.finish, holidaySet);
+            if (activeBusinessDays.length === 0) {
+                return false;
+            }
+            const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+            const completedDays = Math.floor(activeBusinessDays.length * (percent / 100));
+            const dayKey = formatDateOnly(target);
+            const dayIndex = activeBusinessDays.indexOf(dayKey);
+            return dayIndex >= 0 && dayIndex < completedDays;
         }
         const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
         if (totalDays <= 0) {
@@ -678,6 +828,9 @@
         const completedDays = Math.floor(totalDays * (percent / 100));
         const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
         return dayIndex >= 0 && dayIndex < completedDays;
+    }
+    function enumerateBusinessDays(startDate, finishDate, holidaySet) {
+        return buildDateBand(startDate, finishDate).filter((day) => !isWeekend(day) && !holidaySet.has(day));
     }
     function isSameDay(day, other) {
         return day === (other || "").slice(0, 10);
@@ -767,25 +920,24 @@
     }
     function formatWeekLabel(days) {
         if (days.length === 0) {
-            return "Week";
+            return "週";
         }
         const start = parseDateOnly(days[0]);
         if (!start) {
             return days[0];
         }
-        const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
         const monthSet = new Set(days.map((day) => {
             const target = parseDateOnly(day);
             return target ? target.getMonth() : -1;
         }));
-        const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+        const startLabel = `${String(start.getMonth() + 1).padStart(2, "0")}/${String(start.getDate()).padStart(2, "0")}`;
         if (monthSet.size <= 1) {
-            return `Week of ${startLabel}`;
+            return `週 ${startLabel}`;
         }
         const tailMonths = Array.from(monthSet)
             .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
-            .map((monthIndex) => monthNames[monthIndex]);
-        return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+            .map((monthIndex) => String(monthIndex + 1).padStart(2, "0"));
+        return `週 ${startLabel} / ${tailMonths.join(" / ")}`;
     }
     function columnName(index) {
         let current = index;

--- a/docs/project/src/mikuproject/ts/main.ts
+++ b/docs/project/src/mikuproject/ts/main.ts
@@ -54,7 +54,16 @@
   const mikuprojectWbsXlsx = (globalThis as typeof globalThis & {
     __mikuprojectWbsXlsx?: {
       collectWbsHolidayDates: (model: ProjectModel) => string[];
-      exportWbsWorkbook: (model: ProjectModel, options?: { holidayDates?: string[] }) => unknown;
+      exportWbsWorkbook: (
+        model: ProjectModel,
+        options?: {
+          holidayDates?: string[];
+          displayDaysBeforeBaseDate?: number;
+          displayDaysAfterBaseDate?: number;
+          useBusinessDaysForDisplayRange?: boolean;
+          useBusinessDaysForProgressBand?: boolean;
+        }
+      ) => unknown;
     };
   }).__mikuprojectWbsXlsx;
 
@@ -85,6 +94,10 @@
 
   function getTextArea(id: string): HTMLTextAreaElement {
     return getElement<HTMLTextAreaElement>(id);
+  }
+
+  function getInput(id: string): HTMLInputElement {
+    return getElement<HTMLInputElement>(id);
   }
 
   function parseHolidayDateList(raw: string): string[] {
@@ -118,6 +131,34 @@
 
   function parseWbsAdditionalHolidayDates(): string[] {
     return parseHolidayDateList(getTextArea("wbsExtraHolidayDatesInput").value.trim());
+  }
+
+  function parseOptionalNonNegativeInteger(raw: string): number | undefined {
+    const value = raw.trim();
+    if (!value) {
+      return undefined;
+    }
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return undefined;
+    }
+    return Math.max(0, Math.floor(parsed));
+  }
+
+  function parseWbsDisplayDaysBeforeBaseDate(): number | undefined {
+    return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
+  }
+
+  function parseWbsDisplayDaysAfterBaseDate(): number | undefined {
+    return parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
+  }
+
+  function useBusinessDaysForWbsDisplayRange(): boolean {
+    return getInput("wbsBusinessDayRangeInput").checked;
+  }
+
+  function useBusinessDaysForWbsProgressBand(): boolean {
+    return getInput("wbsBusinessDayProgressInput").checked;
   }
 
   function syncWbsHolidayDatesInput(model: ProjectModel | null): void {
@@ -745,8 +786,18 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const model = ensureCurrentModel();
     const defaultHolidayDates = parseWbsDefaultHolidayDates();
     const additionalHolidayDates = parseWbsAdditionalHolidayDates();
+    const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
+    const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
+    const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
+    const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
     const effectiveHolidayDates = Array.from(new Set([...defaultHolidayDates, ...additionalHolidayDates]));
-    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, { holidayDates: effectiveHolidayDates });
+    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
+      holidayDates: effectiveHolidayDates,
+      displayDaysBeforeBaseDate,
+      displayDaysAfterBaseDate,
+      useBusinessDaysForDisplayRange,
+      useBusinessDaysForProgressBand
+    });
     if (defaultHolidayDates.length === 0 && effectiveHolidayDates.length > 0) {
       getTextArea("wbsHolidayDatesInput").value = effectiveHolidayDates.join("\n");
     }
@@ -764,7 +815,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }),
       `mikuproject-wbs-${stamp}.xlsx`
     );
-    setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}`);
+    const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
+      ? ` / 表示期間 ${useBusinessDaysForDisplayRange ? "営業日" : "暦日"} 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+      : "";
+    const progressBandText = useBusinessDaysForProgressBand ? " / 進捗帯 営業日" : "";
+    setStatus(`WBS XLSX ファイルをエクスポートしました${effectiveHolidayDates.length > 0 ? ` (祝日 ${effectiveHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
     showToast("WBS XLSX を保存しました");
   }
 

--- a/docs/project/src/mikuproject/ts/msproject-xml.ts
+++ b/docs/project/src/mikuproject/ts/msproject-xml.ts
@@ -10,7 +10,7 @@
   <SaveVersion>14</SaveVersion>
   <CurrentDate>2026-03-16T09:00:00</CurrentDate>
   <StartDate>2026-03-16T09:00:00</StartDate>
-  <FinishDate>2026-03-20T18:00:00</FinishDate>
+  <FinishDate>2026-03-31T18:00:00</FinishDate>
   <ScheduleFromStart>1</ScheduleFromStart>
   <DefaultStartTime>09:00:00</DefaultStartTime>
   <DefaultFinishTime>18:00:00</DefaultFinishTime>

--- a/docs/project/src/mikuproject/ts/wbs-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/wbs-xlsx.ts
@@ -12,10 +12,6 @@
     sheets: Array<{
       name: string;
       columns?: Array<{ width?: number }>;
-      freezePane?: {
-        rowSplit?: number;
-        colSplit?: number;
-      };
       mergedRanges?: string[];
       rows: Array<{
         height?: number;
@@ -26,14 +22,20 @@
 
   type WbsExportOptions = {
     holidayDates?: string[];
+    displayDaysBeforeBaseDate?: number;
+    displayDaysAfterBaseDate?: number;
+    useBusinessDaysForDisplayRange?: boolean;
+    useBusinessDaysForProgressBand?: boolean;
   };
 
   const HEADER_FILL = "#D9EAF7";
-  const HEADER_ID_FILL = "#D7E7F6";
+  const HEADER_ID_FILL = "#E1EDF8";
   const HEADER_STRUCTURE_FILL = "#E6F0DF";
   const HEADER_SCHEDULE_FILL = "#FDE7D3";
   const HEADER_STATUS_FILL = "#FBE4EC";
   const HEADER_ASSIGNMENT_FILL = "#E2F1EF";
+  const SUMMARY_SCHEDULE_FILL = "#FDF1E4";
+  const SUMMARY_ASSIGNMENT_FILL = "#E8F4F1";
   const PHASE_FILL = "#EEF7E8";
   const TASK_KIND_FILL = "#EEF2F6";
   const MILESTONE_FILL = "#FFF4E0";
@@ -50,8 +52,12 @@
   const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
   const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
   const HOLIDAY_BAND_FILL = "#FCE4EC";
-  const DIVIDER_FILL = "#C5D1DB";
+  const DIVIDER_FILL = "#D9E2EA";
   const BASEDATE_GUIDE_TAIL_FILL = "#FFF8E1";
+  const NAME_COLUMN_FILL = "#FBFCFE";
+  const SCHEDULE_COLUMN_FILL = "#FCFAF7";
+  const PROGRESS_COLUMN_FILL = "#FCF8FB";
+  const REFERENCE_COLUMN_FILL = "#F8FBFB";
 
   function collectWbsHolidayDates(model: ProjectModel): string[] {
     const holidaySet = new Set<string>();
@@ -87,120 +93,160 @@
       resourceNamesByTaskUid.set(assignment.taskUid, resourceNames);
     }
 
-    const dateBand = buildDateBand(model.project.startDate, model.project.finishDate);
+    const dateBand = buildDisplayDateBand(
+      model.project.startDate,
+      model.project.finishDate,
+      model.project.currentDate,
+      options.displayDaysBeforeBaseDate,
+      options.displayDaysAfterBaseDate,
+      holidaySet,
+      options.useBusinessDaysForDisplayRange
+    );
     const fixedHeaders = [
       "UID",
       "ID",
       "WBS",
-      "Kind",
-      "OutlineLevel",
-      "Name",
-      "Start",
-      "Finish",
-      "Duration",
-      "PercentComplete",
-      "PercentWorkComplete",
-      "Milestone",
-      "Summary",
-      "Critical",
-      "Owner",
-      "Calendar",
-      "Resources",
-      "Predecessors"
+      "種別",
+      "階層",
+      "名称",
+      "開始",
+      "終了",
+      "期間",
+      "進捗",
+      "作業進捗",
+      "マイル",
+      "サマリ",
+      "クリティカル",
+      "担当",
+      "カレンダ",
+      "リソース",
+      "先行"
     ];
     const dividerColumnIndex = fixedHeaders.length + 1;
     const dateBandStartColumnIndex = dividerColumnIndex + 1;
     const totalColumns = fixedHeaders.length + 1 + dateBand.length;
     const lastColumnRef = columnName(totalColumns);
-    const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, 8);
+    const rows = [
+      sheetTitleRow("WBS", totalColumns),
+      sheetSubtitleRow(model.project.name || "Project", totalColumns)
+    ];
+    const mergedRanges = [
+      `A1:${lastColumnRef}1`,
+      `A2:${lastColumnRef}2`
+    ];
+    const projectInfoBlock = projectInfoRows(
+      model.project,
+      calendarNameByUid,
+      holidaySet.size,
+      totalColumns,
+      5,
+      rows.length + 1
+    );
+    rows.push(...projectInfoBlock.rows);
+    mergedRanges.push(...projectInfoBlock.mergedRanges);
+    rows.push(emptyRow(totalColumns, 28));
+    const summaryBlock = displaySummaryRows(
+      dateBand.length,
+      countBusinessDays(dateBand, holidaySet),
+      model.project.currentDate,
+      model.tasks.length,
+      model.resources.length,
+      model.assignments.length,
+      model.calendars.length,
+      totalColumns,
+      5,
+      rows.length + 1,
+      options.displayDaysBeforeBaseDate,
+      options.displayDaysAfterBaseDate,
+      options.useBusinessDaysForDisplayRange,
+      options.useBusinessDaysForProgressBand
+    );
+    rows.push(...summaryBlock.rows);
+    mergedRanges.push(...summaryBlock.mergedRanges);
+    rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
+    const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
+    rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
+    rows.push(todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
+    rows.push(headerRow([
+      ...fixedHeaders.map((label) => label === "名称"
+        ? {
+            value: label,
+            bold: true,
+            fillColor: headerFillForLabel(label),
+            border: "thin" as const,
+            horizontalAlign: "left" as const
+          }
+        : label),
+      dividerCell(),
+      ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+    ]));
+    rows.push(...model.tasks.map((task) => ({
+      cells: [
+        identifierCell(task, task.uid),
+        identifierCell(task, task.id),
+        identifierCell(task, task.wbs || task.outlineNumber),
+        kindCell(task),
+        identifierCell(task, task.outlineLevel),
+        taskCell(task, formatTaskLabel(task)),
+        taskCell(task, formatWbsDate(task.start), "center"),
+        taskCell(task, formatWbsDate(task.finish), "center"),
+        taskCell(task, formatDurationLabel(task, holidaySet, options.useBusinessDaysForProgressBand), "center"),
+        progressCell(task, task.percentComplete),
+        progressCell(task, task.percentWorkComplete),
+        flagCell(task, task.milestone, "Mil"),
+        flagCell(task, task.summary, "Sum"),
+        flagCell(task, task.critical, "Crit"),
+        referenceCell(task, truncateWbsReference(firstResourceName(resourceNamesByTaskUid.get(task.uid)), 14), "center"),
+        referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
+        referenceCell(task, truncateWbsReference((resourceNamesByTaskUid.get(task.uid) || []).join(", "), 18)),
+        referenceCell(task, truncateWbsReference(task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", "), 18)),
+        dividerCell(),
+        ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet, options.useBusinessDaysForProgressBand))
+      ]
+    })));
+    rows.push(emptyRow(totalColumns, 28));
+    const legendBlock = legendRows(totalColumns, rows.length + 1);
+    rows.push(...legendBlock.rows);
+    mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
 
     return {
       sheets: [
         {
           name: "WBS",
-          freezePane: {
-            rowSplit: 10,
-            colSplit: 19
-          },
           columns: [
             { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-            { width: 18 }, { width: 18 }, { width: 12 }, { width: 14 },
+            { width: 20 }, { width: 18 }, { width: 12 }, { width: 14 },
             { width: 18 }, { width: 12 }, { width: 12 }, { width: 12 },
             { width: 16 }, { width: 12 }, { width: 20 }, { width: 18 }, { width: 3 },
             ...dateBand.map(() => ({ width: 6 }))
           ],
-          mergedRanges: [
-            `A1:${lastColumnRef}1`,
-            `A2:${lastColumnRef}2`,
-            `A3:${lastColumnRef}3`,
-            `A4:${lastColumnRef}4`,
-            ...weekBandRanges.map((item) => item.range)
-          ],
-          rows: [
-            sectionTitleRow("WBS", totalColumns),
-            sectionTitleRow(model.project.name || "Project", totalColumns),
-            infoRow(`Title=${model.project.title || "-"} / Calendar=${model.project.calendarUID || "-"} / ScheduleFromStart=${model.project.scheduleFromStart ? "true" : "false"}`, totalColumns),
-            infoRow(`Start=${model.project.startDate || "-"} / Finish=${model.project.finishDate || "-"} / CurrentDate=${model.project.currentDate || "-"} / Holidays=${holidaySet.size}`, totalColumns),
-            displaySummaryRow(dateBand.length, model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns),
-            legendRow(totalColumns),
-            taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns),
-            weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length),
-            todayGuideRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet),
-            headerRow([
-              ...fixedHeaders.map((label) => label === "Name"
-                ? {
-                    value: label,
-                    bold: true,
-                    fillColor: headerFillForLabel(label),
-                    border: "thin" as const,
-                    horizontalAlign: "left" as const
-                  }
-                : label),
-              dividerCell(),
-              ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
-            ]),
-            ...model.tasks.map((task) => ({
-              cells: [
-                identifierCell(task, task.uid),
-                identifierCell(task, task.id),
-                identifierCell(task, task.wbs || task.outlineNumber),
-                kindCell(task),
-                identifierCell(task, task.outlineLevel),
-                taskCell(task, formatTaskLabel(task)),
-                taskCell(task, task.start, "center"),
-                taskCell(task, task.finish, "center"),
-                taskCell(task, task.duration, "center"),
-                progressCell(task, task.percentComplete),
-                progressCell(task, task.percentWorkComplete),
-                flagCell(task, task.milestone, "M"),
-                flagCell(task, task.summary, "S"),
-                flagCell(task, task.critical, "!"),
-                referenceCell(task, firstResourceName(resourceNamesByTaskUid.get(task.uid)), "center"),
-                referenceCell(task, formatCalendarLabel(task.calendarUID || model.project.calendarUID, calendarNameByUid), "center"),
-                referenceCell(task, (resourceNamesByTaskUid.get(task.uid) || []).join(", ")),
-                referenceCell(task, task.predecessors.map((item) => predecessorNameByUid.get(item.predecessorUid) || item.predecessorUid).join(", ")),
-                dividerCell(),
-                ...dateBand.map((day) => dateBandCell(task, day, model.project.currentDate, holidaySet))
-              ]
-            }))
-          ]
+          mergedRanges,
+          rows
         }
       ]
     };
   }
 
+  function emptyRow(columnCount: number, height = 22) {
+    return {
+      height,
+      cells: Array.from({ length: columnCount }, () => ({}))
+    };
+  }
+
   function formatTaskLabel(task: TaskModel): string {
-    return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${task.name}`;
+    const prefix = task.summary ? "> " : (task.milestone ? "* " : "- ");
+    return `${"  ".repeat(Math.max(0, task.outlineLevel - 1))}${prefix}${task.name}`;
   }
 
   function classifyTaskKind(task: TaskModel): string {
     if (task.summary) {
-      return "phase";
+      return "フェーズ";
     }
     if (task.milestone) {
-      return "milestone";
+      return "マイル";
     }
-    return "task";
+    return "タスク";
   }
 
   function firstResourceName(resourceNames: string[] | undefined): string {
@@ -218,11 +264,22 @@
       return "-";
     }
     const calendarName = calendarNameByUid.get(calendarUID);
-    return calendarName ? `${calendarUID} ${calendarName}` : calendarUID;
+    return calendarName ? `${calendarUID} ${truncateWbsReference(calendarName, 9)}` : calendarUID;
   }
 
   function displayReferenceValue(value: string | undefined): string {
     return value && value.trim() ? value : "-";
+  }
+
+  function truncateWbsReference(value: string | undefined, maxLength: number): string {
+    const normalized = value?.trim() || "";
+    if (!normalized) {
+      return "";
+    }
+    if (normalized.length <= maxLength) {
+      return normalized;
+    }
+    return `${normalized.slice(0, Math.max(1, maxLength - 3))}...`;
   }
 
   function referenceCell(
@@ -237,20 +294,40 @@
       border: "thin",
       horizontalAlign: placeholder ? "center" : horizontalAlign,
       bold: task.summary || task.milestone || false,
-      fillColor: placeholder ? PLACEHOLDER_FILL : (task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined))
+      fillColor: placeholder
+        ? PLACEHOLDER_FILL
+        : (task.summary
+          ? PHASE_FILL
+          : (task.milestone ? MILESTONE_FILL : REFERENCE_COLUMN_FILL))
     };
   }
 
-  function sectionTitleRow(title: string, columnCount: number) {
+  function sheetTitleRow(title: string, columnCount: number) {
     return {
-      height: 28,
+      height: 24,
       cells: [
         {
           value: title,
           bold: true,
-          fillColor: HEADER_FILL,
+          fillColor: "#EEF4FA",
           border: "thin",
-          horizontalAlign: "center"
+          horizontalAlign: "left"
+        },
+        ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
+      ]
+    };
+  }
+
+  function sheetSubtitleRow(title: string, columnCount: number) {
+    return {
+      height: 22,
+      cells: [
+        {
+          value: title,
+          bold: true,
+          fillColor: "#F6F9FC",
+          border: "thin",
+          horizontalAlign: "left"
         },
         ...Array.from({ length: Math.max(0, columnCount - 1) }, () => ({}))
       ]
@@ -261,19 +338,28 @@
     return {
       height: 26,
       cells: Array.from({ length: columnCount }, (_, index) => {
-        if (index === 0) {
+        if (index === 5) {
           return {
-            value: `Task View | BaseDate=${baseDate}`,
+            value: "タスク表",
             bold: true,
-            fillColor: "#EAF3FB",
+            fillColor: "#E6F1FB",
             border: "thin" as const,
-            horizontalAlign: "left" as const
+            horizontalAlign: "center" as const
           };
         }
-        if (index < 12) {
+        if (index === 6) {
+          return {
+            value: `基準日 ${baseDate}`,
+            bold: true,
+            fillColor: "#E6F1FB",
+            border: "thin" as const,
+            horizontalAlign: "center" as const
+          };
+        }
+        if (index > 5 && index < 12) {
           return {
             value: "",
-            fillColor: "#EAF3FB",
+            fillColor: "#E6F1FB",
             border: "thin" as const
           };
         }
@@ -296,98 +382,59 @@
     };
   }
 
-  function legendRow(columnCount: number) {
-    const items: WbsXlsxCellLike[] = [
-      {
-        value: "Legend / 記号",
-        bold: true,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "進捗済み",
-        fillColor: PROGRESS_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "予定帯",
-        fillColor: ACTIVE_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "Today",
-        fillColor: TODAY_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "週頭",
-        fillColor: WEEK_START_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "週末",
-        fillColor: WEEKEND_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "祝日",
-        fillColor: HOLIDAY_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "━:phase",
-        fillColor: PHASE_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "■:task",
-        fillColor: ACTIVE_BAND_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "◆:milestone",
-        fillColor: MILESTONE_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "M:Milestone",
-        fillColor: HEADER_STATUS_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "S:Summary",
-        fillColor: HEADER_STATUS_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "!:Critical",
-        fillColor: HEADER_STATUS_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      },
-      {
-        value: "-:未設定",
-        fillColor: PLACEHOLDER_FILL,
-        border: "thin",
-        horizontalAlign: "center"
-      }
+  function projectInfoRows(
+    project: ProjectModel["project"],
+    calendarNameByUid: Map<string, string>,
+    holidayCount: number,
+    columnCount: number,
+    startColumnIndex: number,
+    startRowNumber: number
+  ) {
+    const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
+    const items: Array<{ label: string; value: string | number; fillColor: string }> = [
+      { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
     ];
     return {
-      height: 22,
-      cells: [
-        ...items,
-        ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+      mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+      rows: [
+        blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+        ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+      ]
+    };
+  }
+
+  function legendRows(columnCount: number, startRowNumber: number) {
+    const items: Array<{ value: string; fillColor: string }> = [
+      { value: "進捗済み", fillColor: PROGRESS_BAND_FILL },
+      { value: "予定帯", fillColor: ACTIVE_BAND_FILL },
+      { value: "当日", fillColor: TODAY_BAND_FILL },
+      { value: "週頭", fillColor: WEEK_START_BAND_FILL },
+      { value: "週末", fillColor: WEEKEND_BAND_FILL },
+      { value: "祝日", fillColor: HOLIDAY_BAND_FILL },
+      { value: "━:フェーズ", fillColor: PHASE_FILL },
+      { value: "■:タスク", fillColor: ACTIVE_BAND_FILL },
+      { value: "◆:マイルストーン", fillColor: MILESTONE_FILL },
+      { value: "Mil:マイルストーン", fillColor: "#FBE4EC" },
+      { value: "Sum:サマリ", fillColor: "#F7EAF0" },
+      { value: "Crit:クリティカル", fillColor: "#F3E1E9" },
+      { value: "-:未設定", fillColor: PLACEHOLDER_FILL }
+    ];
+    const startColumnRef = columnName(6);
+    const endColumnRef = columnName(7);
+    return {
+      mergedRanges: [
+        `${startColumnRef}${startRowNumber}:${endColumnRef}${startRowNumber}`,
+        ...items.map((_, index) => `${startColumnRef}${startRowNumber + index + 1}:${endColumnRef}${startRowNumber + index + 1}`)
+      ],
+      rows: [
+        blockHeaderRow(columnCount, 5, "凡例"),
+        ...items.map((item) => mergedLabelRow(columnCount, 5, item.value, item.fillColor))
       ]
     };
   }
@@ -408,15 +455,22 @@
       };
     });
     return {
-      height: 22,
+      height: 24,
       cells: [
         ...Array.from({ length: fixedColumnCount }, (_, index) => {
           if (index === 5) {
             return {
-              value: "Week",
+              value: "週",
               bold: true,
               border: "thin" as const,
               horizontalAlign: "right" as const,
+              fillColor: "#E3EEF9"
+            };
+          }
+          if (index === 6) {
+            return {
+              value: "",
+              border: "thin" as const,
               fillColor: "#E3EEF9"
             };
           }
@@ -441,48 +495,104 @@
     };
   }
 
-  function displaySummaryRow(
+  function displaySummaryRows(
     displayDays: number,
+    businessDays: number,
     baseDate: string | undefined,
     taskCount: number,
     resourceCount: number,
     assignmentCount: number,
     calendarCount: number,
-    columnCount: number
+    columnCount: number,
+    startColumnIndex = 5,
+    startRowNumber = 5,
+    displayDaysBeforeBaseDate?: number,
+    displayDaysAfterBaseDate?: number,
+    useBusinessDaysForDisplayRange?: boolean,
+    useBusinessDaysForProgressBand?: boolean
   ) {
     const displayWeeks = displayDays > 0 ? Math.ceil(displayDays / 7) : 0;
-    const items: WbsXlsxCellLike[] = [
-      summaryStatCell("Summary", HEADER_ID_FILL),
-      summaryStatCell("", HEADER_FILL),
-      summaryStatCell("DisplayDays", HEADER_SCHEDULE_FILL),
-      summaryStatCell(displayDays, HEADER_SCHEDULE_FILL),
-      summaryStatCell("DisplayWeeks", HEADER_SCHEDULE_FILL),
-      summaryStatCell(displayWeeks, HEADER_SCHEDULE_FILL),
-      summaryStatCell("Tasks", HEADER_ASSIGNMENT_FILL),
-      summaryStatCell(taskCount, HEADER_ASSIGNMENT_FILL),
-      summaryStatCell("Resources", HEADER_ASSIGNMENT_FILL),
-      summaryStatCell(resourceCount, HEADER_ASSIGNMENT_FILL),
-      summaryStatCell("Assignments", HEADER_ASSIGNMENT_FILL),
-      summaryStatCell(assignmentCount, HEADER_ASSIGNMENT_FILL),
-      summaryStatCell("Calendars", HEADER_ASSIGNMENT_FILL),
-      summaryStatCell(calendarCount, HEADER_ASSIGNMENT_FILL),
-      summaryStatCell("BaseDate", HEADER_SCHEDULE_FILL),
-      summaryStatCell((baseDate || "-").slice(0, 10), HEADER_SCHEDULE_FILL)
+    const items: Array<{ label: string; value: string | number; fillColor: string }> = [
+      { label: "表示日", value: displayDays, fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "表示週", value: displayWeeks, fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "営業日", value: businessDays, fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "前日数", value: displayDaysBeforeBaseDate ?? "-", fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "後日数", value: displayDaysAfterBaseDate ?? "-", fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "表示", value: useBusinessDaysForDisplayRange ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "進捗", value: useBusinessDaysForProgressBand ? "営業日" : "暦日", fillColor: SUMMARY_SCHEDULE_FILL },
+      { label: "タスク", value: taskCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "リソース", value: resourceCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "割当", value: assignmentCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "カレンダ", value: calendarCount, fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "基準日", value: (baseDate || "-").slice(0, 10), fillColor: SUMMARY_SCHEDULE_FILL }
     ];
     return {
-      height: 22,
-      cells: [
-        ...items,
-        ...Array.from({ length: Math.max(0, columnCount - items.length) }, () => ({}))
+      mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+      rows: [
+        blockHeaderRow(columnCount, startColumnIndex, "サマリ"),
+        ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
       ]
     };
   }
 
-  function summaryStatCell(value: string | number, fillColor: string): WbsXlsxCellLike {
-    return {
+  function blockHeaderRow(columnCount: number, startColumnIndex: number, title: string) {
+    const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
+    cells[startColumnIndex] = {
+      value: title,
+      border: "thin",
+      horizontalAlign: "left",
+      bold: true,
+      fillColor: HEADER_ID_FILL
+    };
+    cells[startColumnIndex + 1] = {
+      value: "",
+      border: "thin",
+      fillColor: HEADER_ID_FILL
+    };
+    return { height: 24, cells };
+  }
+
+  function summaryPairRow(
+    columnCount: number,
+    startColumnIndex: number,
+    label: string,
+    value: string | number,
+    fillColor: string
+  ) {
+    const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
+    cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
+    cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+    return { height: 22, cells };
+  }
+
+  function mergedLabelRow(
+    columnCount: number,
+    startColumnIndex: number,
+    value: string,
+    fillColor: string
+  ) {
+    const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
+    cells[startColumnIndex] = {
       value,
       border: "thin",
       horizontalAlign: "center",
+      bold: true,
+      fillColor
+    };
+    cells[startColumnIndex + 1] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
+    return { height: 24, cells };
+  }
+
+  function summaryStatCell(value: string | number, fillColor: string, isValueCell: boolean): WbsXlsxCellLike {
+    const valueAlign = typeof value === "number" ? "center" : "left";
+    return {
+      value,
+      border: "thin",
+      horizontalAlign: isValueCell ? valueAlign : "right",
       bold: true,
       fillColor
     };
@@ -523,16 +633,16 @@
     if (label === "UID" || label === "ID") {
       return HEADER_ID_FILL;
     }
-    if (label === "WBS" || label === "Kind" || label === "OutlineLevel" || label === "Name") {
+    if (label === "WBS" || label === "種別" || label === "階層" || label === "名称") {
       return HEADER_STRUCTURE_FILL;
     }
-    if (label === "Start" || label === "Finish" || label === "Duration") {
+    if (label === "開始" || label === "終了" || label === "期間") {
       return HEADER_SCHEDULE_FILL;
     }
-    if (label === "PercentComplete" || label === "PercentWorkComplete" || label === "Milestone" || label === "Summary" || label === "Critical") {
+    if (label === "進捗" || label === "作業進捗" || label === "マイル" || label === "サマリ" || label === "クリティカル") {
       return HEADER_STATUS_FILL;
     }
-    if (label === "Owner" || label === "Calendar" || label === "Resources" || label === "Predecessors") {
+    if (label === "担当" || label === "カレンダ" || label === "リソース" || label === "先行") {
       return HEADER_ASSIGNMENT_FILL;
     }
     return HEADER_FILL;
@@ -545,15 +655,22 @@
     holidaySet: Set<string>
   ) {
     return {
-      height: 22,
+      height: 24,
       cells: [
         ...Array.from({ length: fixedColumnCount }, (_, index) => {
           if (index === 5) {
             return {
-              value: "BaseDate",
+              value: "基準日",
               bold: true,
               border: "thin" as const,
               horizontalAlign: "right" as const,
+              fillColor: "#FFEFC2"
+            };
+          }
+          if (index === 6) {
+            return {
+              value: "",
+              border: "thin" as const,
               fillColor: "#FFEFC2"
             };
           }
@@ -574,7 +691,7 @@
           return {};
         }),
         ...dateBand.map((day, index) => ({
-          value: isSameDay(day, currentDate) ? "▼BaseDate" : "",
+          value: isSameDay(day, currentDate) ? "▼基準日" : "",
           bold: true,
           border: "thin" as const,
           horizontalAlign: "center" as const,
@@ -613,7 +730,13 @@
       border: "thin",
       horizontalAlign,
       bold: task.summary || task.milestone || false,
-      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+      fillColor: task.summary
+        ? PHASE_FILL
+        : (task.milestone
+          ? MILESTONE_FILL
+          : (horizontalAlign === "left"
+            ? NAME_COLUMN_FILL
+            : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
     };
   }
 
@@ -651,13 +774,41 @@
   }
 
   function progressCell(task: TaskModel, value: number | undefined): WbsXlsxCellLike {
+    const progressValue = formatProgressLabel(value);
     return {
-      value: value === undefined || value === null ? "" : `${value}%`,
+      value: progressValue,
       border: "thin",
       horizontalAlign: "center",
       bold: task.summary || task.milestone || false,
-      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : undefined)
+      fillColor: task.summary ? PHASE_FILL : (task.milestone ? MILESTONE_FILL : PROGRESS_COLUMN_FILL)
     };
+  }
+
+  function formatProgressLabel(value: number | undefined): string {
+    if (value === undefined || value === null || !Number.isFinite(value)) {
+      return "";
+    }
+    const clamped = Math.max(0, Math.min(100, Math.round(value)));
+    const filled = Math.round(clamped / 10);
+    const bar = `${"#".repeat(filled)}${"-".repeat(10 - filled)}`;
+    return `${String(clamped).padStart(3, " ")}% [${bar}]`;
+  }
+
+  function formatDurationLabel(
+    task: TaskModel,
+    holidaySet: Set<string>,
+    useBusinessDaysForProgressBand: boolean | undefined
+  ): string {
+    if (useBusinessDaysForProgressBand) {
+      const businessDays = enumerateBusinessDays(task.start, task.finish, holidaySet).length;
+      return businessDays > 0 ? `${businessDays}営業日` : "-";
+    }
+    const calendarDays = buildDateBand(task.start, task.finish).length;
+    return calendarDays > 0 ? `${calendarDays}日` : "-";
+  }
+
+  function formatWbsDate(value: string | undefined): string {
+    return value ? value.slice(0, 10) : "-";
   }
 
   function dateHeaderCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
@@ -675,13 +826,19 @@
     };
   }
 
-  function dateBandCell(task: TaskModel, day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
+  function dateBandCell(
+    task: TaskModel,
+    day: string,
+    currentDate: string | undefined,
+    holidaySet: Set<string>,
+    useBusinessDaysForProgressBand: boolean | undefined
+  ): WbsXlsxCellLike {
     const active = includesDay(task.start, task.finish, day);
     const isToday = isSameDay(day, currentDate);
     const isWeekendDay = isWeekend(day);
     const isHoliday = holidaySet.has(day);
     const weekStart = isWeekStart(day);
-    const complete = active && isCompletedDay(task, day);
+    const complete = active && isCompletedDay(task, day, holidaySet, useBusinessDaysForProgressBand);
     return {
       value: active ? activeBandMarker(task) : "",
       border: "thin",
@@ -717,6 +874,76 @@
       cursor.setDate(cursor.getDate() + 1);
     }
     return days;
+  }
+
+  function buildDisplayDateBand(
+    startDate: string | undefined,
+    finishDate: string | undefined,
+    baseDate: string | undefined,
+    displayDaysBeforeBaseDate: number | undefined,
+    displayDaysAfterBaseDate: number | undefined,
+    holidaySet: Set<string>,
+    useBusinessDaysForDisplayRange: boolean | undefined
+  ): string[] {
+    const fullBand = buildDateBand(startDate, finishDate);
+    const before = normalizeDisplayDayCount(displayDaysBeforeBaseDate);
+    const after = normalizeDisplayDayCount(displayDaysAfterBaseDate);
+    if (before === null && after === null) {
+      return fullBand;
+    }
+    const base = parseDateOnly(baseDate);
+    if (!base || fullBand.length === 0) {
+      return fullBand;
+    }
+    const projectStart = parseDateOnly(startDate);
+    const projectFinish = parseDateOnly(finishDate);
+    if (!projectStart || !projectFinish) {
+      return fullBand;
+    }
+    const from = useBusinessDaysForDisplayRange
+      ? shiftBusinessDays(base, -(before || 0), holidaySet)
+      : shiftCalendarDays(base, -(before || 0));
+    const to = useBusinessDaysForDisplayRange
+      ? shiftBusinessDays(base, after || 0, holidaySet)
+      : shiftCalendarDays(base, after || 0);
+    const clampedStart = from.getTime() < projectStart.getTime() ? projectStart : from;
+    const clampedFinish = to.getTime() > projectFinish.getTime() ? projectFinish : to;
+    if (clampedStart.getTime() > clampedFinish.getTime()) {
+      return fullBand;
+    }
+    return buildDateBand(formatDateOnly(clampedStart), formatDateOnly(clampedFinish));
+  }
+
+  function normalizeDisplayDayCount(value: number | undefined): number | null {
+    if (value === undefined || value === null || !Number.isFinite(value)) {
+      return null;
+    }
+    return Math.max(0, Math.floor(value));
+  }
+
+  function countBusinessDays(dateBand: string[], holidaySet: Set<string>): number {
+    return dateBand.filter((day) => !isWeekend(day) && !holidaySet.has(day)).length;
+  }
+
+  function shiftCalendarDays(base: Date, offset: number): Date {
+    const result = new Date(base.getTime());
+    result.setDate(result.getDate() + offset);
+    return result;
+  }
+
+  function shiftBusinessDays(base: Date, offset: number, holidaySet: Set<string>): Date {
+    const result = new Date(base.getTime());
+    const direction = offset < 0 ? -1 : 1;
+    let remaining = Math.abs(offset);
+    while (remaining > 0) {
+      result.setDate(result.getDate() + direction);
+      const day = formatDateOnly(result);
+      if (isWeekend(day) || holidaySet.has(day)) {
+        continue;
+      }
+      remaining -= 1;
+    }
+    return result;
   }
 
   function buildWeekBandRanges(dateBand: string[], startColumnIndex: number, rowNumber: number) {
@@ -755,12 +982,28 @@
     return start.getTime() <= target.getTime() && target.getTime() <= finish.getTime();
   }
 
-  function isCompletedDay(task: TaskModel, day: string): boolean {
+  function isCompletedDay(
+    task: TaskModel,
+    day: string,
+    holidaySet: Set<string>,
+    useBusinessDaysForProgressBand: boolean | undefined
+  ): boolean {
     const start = parseDateOnly(task.start);
     const finish = parseDateOnly(task.finish);
     const target = parseDateOnly(day);
     if (!start || !finish || !target) {
       return false;
+    }
+    if (useBusinessDaysForProgressBand) {
+      const activeBusinessDays = enumerateBusinessDays(task.start, task.finish, holidaySet);
+      if (activeBusinessDays.length === 0) {
+        return false;
+      }
+      const percent = Math.max(0, Math.min(100, task.percentComplete || 0));
+      const completedDays = Math.floor(activeBusinessDays.length * (percent / 100));
+      const dayKey = formatDateOnly(target);
+      const dayIndex = activeBusinessDays.indexOf(dayKey);
+      return dayIndex >= 0 && dayIndex < completedDays;
     }
     const totalDays = Math.floor((finish.getTime() - start.getTime()) / 86400000) + 1;
     if (totalDays <= 0) {
@@ -770,6 +1013,14 @@
     const completedDays = Math.floor(totalDays * (percent / 100));
     const dayIndex = Math.floor((target.getTime() - start.getTime()) / 86400000);
     return dayIndex >= 0 && dayIndex < completedDays;
+  }
+
+  function enumerateBusinessDays(
+    startDate: string | undefined,
+    finishDate: string | undefined,
+    holidaySet: Set<string>
+  ): string[] {
+    return buildDateBand(startDate, finishDate).filter((day) => !isWeekend(day) && !holidaySet.has(day));
   }
 
   function isSameDay(day: string, other: string | undefined): boolean {
@@ -869,25 +1120,24 @@
 
   function formatWeekLabel(days: string[]): string {
     if (days.length === 0) {
-      return "Week";
+      return "週";
     }
     const start = parseDateOnly(days[0]);
     if (!start) {
       return days[0];
     }
-    const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
     const monthSet = new Set(days.map((day) => {
       const target = parseDateOnly(day);
       return target ? target.getMonth() : -1;
     }));
-    const startLabel = `${monthNames[start.getMonth()]} ${String(start.getDate()).padStart(2, "0")}`;
+    const startLabel = `${String(start.getMonth() + 1).padStart(2, "0")}/${String(start.getDate()).padStart(2, "0")}`;
     if (monthSet.size <= 1) {
-      return `Week of ${startLabel}`;
+      return `週 ${startLabel}`;
     }
     const tailMonths = Array.from(monthSet)
       .filter((monthIndex) => monthIndex >= 0 && monthIndex !== start.getMonth())
-      .map((monthIndex) => monthNames[monthIndex]);
-    return `Week of ${startLabel} / ${tailMonths.join(" / ")}`;
+      .map((monthIndex) => String(monthIndex + 1).padStart(2, "0"));
+    return `週 ${startLabel} / ${tailMonths.join(" / ")}`;
   }
 
   function columnName(index: number): string {

--- a/docs/project/tests/mikuproject-main.test.js
+++ b/docs/project/tests/mikuproject-main.test.js
@@ -96,8 +96,12 @@ function mountDom() {
     <section class="md-note-card">
       <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
       <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日と、YYYY-MM-DD 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。</p>
-      <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。</p>
+      <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。</p>
     </section>
+    <input id="wbsDisplayDaysBeforeInput" />
+    <input id="wbsDisplayDaysAfterInput" />
+    <input id="wbsBusinessDayRangeInput" type="checkbox" />
+    <input id="wbsBusinessDayProgressInput" type="checkbox" />
     <textarea id="wbsHolidayDatesInput"></textarea>
     <textarea id="wbsExtraHolidayDatesInput"></textarea>
     <textarea id="xmlInput"></textarea>
@@ -184,8 +188,15 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).toContain("既定祝日と");
     expect(document.body.textContent).toContain("追加祝日を合成");
     expect(document.body.textContent).toContain("非稼働日例外から補完");
+    expect(document.body.textContent).toContain("BaseDate 前後の日数で切り出します");
+    expect(document.body.textContent).toContain("営業日ベースを選ぶと土日祝を飛ばします");
+    expect(document.body.textContent).toContain("進捗帯も営業日基準へ切り替えられます");
     expect(document.getElementById("wbsHolidayDatesInput").value).toBe("");
     expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("wbsDisplayDaysBeforeInput").value).toBe("");
+    expect(document.getElementById("wbsDisplayDaysAfterInput").value).toBe("");
+    expect(document.getElementById("wbsBusinessDayRangeInput").checked).toBe(false);
+    expect(document.getElementById("wbsBusinessDayProgressInput").checked).toBe(false);
     expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(true);
   });
 
@@ -702,7 +713,11 @@ describe("mikuproject main", () => {
     expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
     expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
     expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
-      holidayDates: ["2026-03-20"]
+      holidayDates: ["2026-03-20"],
+      displayDaysBeforeBaseDate: undefined,
+      displayDaysAfterBaseDate: undefined,
+      useBusinessDaysForDisplayRange: false,
+      useBusinessDaysForProgressBand: false
     });
     expect(document.getElementById("statusMessage").textContent).toContain("WBS XLSX ファイルをエクスポートしました");
     expect(document.getElementById("statusMessage").textContent).toContain("祝日 1 件");
@@ -718,13 +733,78 @@ describe("mikuproject main", () => {
 
     expect(exportSpy).toHaveBeenCalled();
     expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
-      holidayDates: ["2026-03-20", "2026-03-21"]
+      holidayDates: ["2026-03-20", "2026-03-21"],
+      displayDaysBeforeBaseDate: undefined,
+      displayDaysAfterBaseDate: undefined,
+      useBusinessDaysForDisplayRange: false,
+      useBusinessDaysForProgressBand: false
     });
     const workbook = exportSpy.mock.results.at(-1)?.value;
     const sheet = workbook.sheets[0];
-    expect(sheet.rows[3].cells[0].value).toContain("Holidays=2");
-    expect(sheet.rows[9].cells[23].fillColor).toBe("#FCE4EC");
+    const projectInfoHeaderIndex = sheet.rows.findIndex((row) => row.cells[5]?.value === "プロジェクト / 情報");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(2);
+    const headerRowIndex = sheet.rows.findIndex((row) => row.cells[0]?.value === "UID");
+    const holidayColumnIndex = sheet.rows[headerRowIndex].cells.findIndex((cell) => cell.value === "03/20 Fri");
+    expect(sheet.rows[headerRowIndex].cells[holidayColumnIndex].fillColor).toBe("#FCE4EC");
     expect(document.getElementById("statusMessage").textContent).toContain("祝日 2 件");
+  });
+
+  it("downloads current wbs xlsx with configured display range", async () => {
+    bootPage();
+    const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("wbsDisplayDaysBeforeInput").value = "1";
+    document.getElementById("wbsDisplayDaysAfterInput").value = "2";
+    document.getElementById("exportWbsXlsxBtn").click();
+
+    expect(exportSpy).toHaveBeenCalled();
+    expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
+      holidayDates: ["2026-03-20"],
+      displayDaysBeforeBaseDate: 1,
+      displayDaysAfterBaseDate: 2,
+      useBusinessDaysForDisplayRange: false,
+      useBusinessDaysForProgressBand: false
+    });
+    expect(document.getElementById("statusMessage").textContent).toContain("表示期間 暦日 基準日前 1 日, 基準日後 2 日");
+  });
+
+  it("downloads current wbs xlsx with business-day display range", async () => {
+    bootPage();
+    const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("wbsDisplayDaysBeforeInput").value = "1";
+    document.getElementById("wbsDisplayDaysAfterInput").value = "2";
+    document.getElementById("wbsBusinessDayRangeInput").checked = true;
+    document.getElementById("exportWbsXlsxBtn").click();
+
+    expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
+      holidayDates: ["2026-03-20"],
+      displayDaysBeforeBaseDate: 1,
+      displayDaysAfterBaseDate: 2,
+      useBusinessDaysForDisplayRange: true,
+      useBusinessDaysForProgressBand: false
+    });
+    expect(document.getElementById("statusMessage").textContent).toContain("表示期間 営業日 基準日前 1 日, 基準日後 2 日");
+  });
+
+  it("downloads current wbs xlsx with business-day progress band", async () => {
+    bootPage();
+    const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
+
+    document.getElementById("parseXmlBtn").click();
+    document.getElementById("wbsBusinessDayProgressInput").checked = true;
+    document.getElementById("exportWbsXlsxBtn").click();
+
+    expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
+      holidayDates: ["2026-03-20"],
+      displayDaysBeforeBaseDate: undefined,
+      displayDaysAfterBaseDate: undefined,
+      useBusinessDaysForDisplayRange: false,
+      useBusinessDaysForProgressBand: true
+    });
+    expect(document.getElementById("statusMessage").textContent).toContain("進捗帯 営業日");
   });
 
   it("fills wbs holiday input from model defaults when xml is parsed", () => {
@@ -924,7 +1004,7 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Title: Sample Project Title -> Title From XLSX");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Company: Local HTML Tools -> Company From XLSX");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("StartDate: 2026-03-16T09:00:00 -> 2026-03-15T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("FinishDate: 2026-03-20T18:00:00 -> 2026-03-28T18:00:00");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("FinishDate: 2026-03-31T18:00:00 -> 2026-03-28T18:00:00");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
   });

--- a/docs/project/tests/mikuproject-wbs-xlsx.test.js
+++ b/docs/project/tests/mikuproject-wbs-xlsx.test.js
@@ -35,6 +35,14 @@ function bootModules() {
   };
 }
 
+function findRowIndexByCellValue(sheet, value, columnIndex = 0) {
+  return sheet.rows.findIndex((row) => row.cells[columnIndex]?.value === value);
+}
+
+function findRowIndexByPredicate(sheet, predicate) {
+  return sheet.rows.findIndex((row) => predicate(row.cells));
+}
+
 describe("mikuproject wbs xlsx", () => {
   it("collects holiday dates from calendar exceptions", () => {
     const { xml, wbsXlsx } = bootModules();
@@ -55,181 +63,195 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.columns[3].width).toBe(10);
     expect(sheet.columns[4].width).toBe(10);
     expect(sheet.columns[5].width).toBe(42);
-    expect(sheet.columns[6].width).toBe(18);
+    expect(sheet.columns[6].width).toBe(20);
     expect(sheet.columns[7].width).toBe(18);
     expect(sheet.columns[8].width).toBe(12);
     expect(sheet.columns[14].width).toBe(16);
     expect(sheet.columns[15].width).toBe(12);
     expect(sheet.columns[16].width).toBe(20);
     expect(sheet.columns[17].width).toBe(18);
-    expect(sheet.freezePane).toEqual({ rowSplit: 10, colSplit: 19 });
-    expect(sheet.mergedRanges).toEqual(["A1:X1", "A2:X2", "A3:X3", "A4:X4", "T8:X8"]);
+    expect(sheet.mergedRanges).toContain("A1:AI1");
+    expect(sheet.mergedRanges).toContain("A2:AI2");
+    expect(sheet.mergedRanges).toContain("F3:G3");
+    expect(sheet.mergedRanges).toContain("F12:G12");
     expect(sheet.rows[0].cells[0].value).toBe("WBS");
     expect(sheet.rows[1].cells[0].value).toBe("Sample Project");
-    expect(String(sheet.rows[2].cells[0].value)).toContain("Title=Sample Project Title");
-    expect(String(sheet.rows[3].cells[0].value)).toContain("Start=2026-03-16T09:00:00");
-    expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=0");
-    expect(sheet.rows[4].cells[0].value).toBe("Summary");
-    expect(sheet.rows[4].cells[1].value).toBe("");
-    expect(sheet.rows[4].cells[0].fillColor).toBe("#D7E7F6");
-    expect(sheet.rows[4].cells[1].fillColor).toBe("#D9EAF7");
-    expect(sheet.rows[4].cells[2].value).toBe("DisplayDays");
-    expect(sheet.rows[4].cells[3].value).toBe(5);
-    expect(sheet.rows[4].cells[2].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[3].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[4].value).toBe("DisplayWeeks");
-    expect(sheet.rows[4].cells[5].value).toBe(1);
-    expect(sheet.rows[4].cells[4].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[5].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[6].value).toBe("Tasks");
-    expect(sheet.rows[4].cells[7].value).toBe(3);
-    expect(sheet.rows[4].cells[6].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[7].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[8].value).toBe("Resources");
-    expect(sheet.rows[4].cells[9].value).toBe(1);
-    expect(sheet.rows[4].cells[8].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[9].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[10].value).toBe("Assignments");
-    expect(sheet.rows[4].cells[11].value).toBe(2);
-    expect(sheet.rows[4].cells[10].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[11].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[12].value).toBe("Calendars");
-    expect(sheet.rows[4].cells[13].value).toBe(2);
-    expect(sheet.rows[4].cells[12].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[13].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[4].cells[14].value).toBe("BaseDate");
-    expect(sheet.rows[4].cells[15].value).toBe("2026-03-16");
-    expect(sheet.rows[4].cells[14].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[4].cells[15].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[5].cells[0].value).toBe("Legend / 記号");
-    expect(sheet.rows[5].cells[1].value).toBe("進捗済み");
-    expect(sheet.rows[5].cells[1].fillColor).toBe("#5BAE9C");
-    expect(sheet.rows[5].cells[4].value).toBe("週頭");
-    expect(sheet.rows[5].cells[4].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[5].cells[6].value).toBe("祝日");
-    expect(sheet.rows[5].cells[6].fillColor).toBe("#FCE4EC");
-    expect(sheet.rows[5].cells[7].value).toBe("━:phase");
-    expect(sheet.rows[5].cells[7].fillColor).toBe("#EEF7E8");
-    expect(sheet.rows[5].cells[8].value).toBe("■:task");
-    expect(sheet.rows[5].cells[8].fillColor).toBe("#9FD5C9");
-    expect(sheet.rows[5].cells[9].value).toBe("◆:milestone");
-    expect(sheet.rows[5].cells[9].fillColor).toBe("#FFF4E0");
-    expect(sheet.rows[5].cells[10].value).toBe("M:Milestone");
-    expect(sheet.rows[5].cells[10].fillColor).toBe("#FBE4EC");
-    expect(sheet.rows[5].cells[11].value).toBe("S:Summary");
-    expect(sheet.rows[5].cells[11].fillColor).toBe("#FBE4EC");
-    expect(sheet.rows[5].cells[12].value).toBe("!:Critical");
-    expect(sheet.rows[5].cells[12].fillColor).toBe("#FBE4EC");
-    expect(sheet.rows[5].cells[13].value).toBe("-:未設定");
-    expect(sheet.rows[5].cells[13].fillColor).toBe("#F5F7FA");
-    expect(sheet.rows[6].cells[0].value).toBe("Task View | BaseDate=2026-03-16");
-    expect(sheet.rows[6].cells[0].fillColor).toBe("#EAF3FB");
-    expect(sheet.rows[6].cells[1].fillColor).toBe("#EAF3FB");
-    expect(sheet.rows[6].cells[8].fillColor).toBe("#EAF3FB");
-    expect(sheet.rows[6].cells[11].fillColor).toBe("#EAF3FB");
-    expect(sheet.rows[7].cells[5].value).toBe("Week");
-    expect(sheet.rows[7].cells[5].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[7].cells[6].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[7].cells[7].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[7].cells[8].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[7].cells[9].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[7].cells[19].value).toBe("Week of Mar 16");
-    expect(sheet.rows[8].cells[5].value).toBe("BaseDate");
-    expect(sheet.rows[8].cells[5].fillColor).toBe("#FFEFC2");
-    expect(sheet.rows[8].cells[6].fillColor).toBe("#FFEFC2");
-    expect(sheet.rows[8].cells[7].fillColor).toBe("#FFEFC2");
-    expect(sheet.rows[8].cells[8].fillColor).toBe("#FFEFC2");
-    expect(sheet.rows[8].cells[9].fillColor).toBe("#FFEFC2");
-    expect(sheet.rows[8].cells[19].value).toBe("▼BaseDate");
-    expect(sheet.rows[8].cells[20].fillColor).toBe("#FFF8E1");
-    expect(sheet.rows[8].cells[21].fillColor).toBe("#FFF8E1");
-    expect(sheet.rows[9].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
+    expect(projectInfoHeaderIndex).toBe(2);
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[5].value).toBe("題名");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].value).toBe("Sample Project ...");
+    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[5].value).toBe("カレンダ");
+    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[6].value).toBe("1 Standard");
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[5].value).toBe("基準");
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[6].value).toBe("開始基準");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[5].value).toBe("開始日");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[6].value).toBe("2026-03-16");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[5].value).toBe("終了日");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[6].value).toBe("2026-03-31");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[5].value).toBe("現在日");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[6].value).toBe("2026-03-16");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[5].value).toBe("祝日");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(0);
+    expect(sheet.rows[projectInfoHeaderIndex + 8].height).toBe(28);
+    expect(sheet.rows[projectInfoHeaderIndex + 8].cells[5].value).toBeUndefined();
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    expect(summaryHeaderIndex).toBe(11);
+    expect(sheet.rows[summaryHeaderIndex].height).toBe(24);
+    expect(sheet.rows[summaryHeaderIndex].cells[5].fillColor).toBe("#E1EDF8");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[5].value).toBe("表示日");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].value).toBe(16);
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[5].horizontalAlign).toBe("right");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].horizontalAlign).toBe("center");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].bold).toBe(true);
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].horizontalAlign).toBe("left");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[6].horizontalAlign).toBe("left");
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[5].value).toBe("営業日");
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(12);
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[5].value).toBe("前日数");
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe("-");
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[5].value).toBe("後日数");
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe("-");
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[5].value).toBe("表示");
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[5].value).toBe("進捗");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 12].cells[5].value).toBe("基準日");
+    expect(sheet.rows[summaryHeaderIndex + 12].cells[6].value).toBe("2026-03-16");
+    const taskViewIndex = findRowIndexByCellValue(sheet, "タスク表", 5);
+    const weekRowIndex = findRowIndexByCellValue(sheet, "週", 5);
+    const baseDateRowIndex = findRowIndexByPredicate(
+      sheet,
+      (cells) => cells[5]?.value === "基準日" && cells.some((cell) => cell.value === "▼基準日")
+    );
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    expect(taskViewIndex).toBe(24);
+    expect(weekRowIndex).toBe(25);
+    expect(baseDateRowIndex).toBe(26);
+    expect(headerRowIndex).toBe(27);
+    expect(sheet.rows[weekRowIndex].height).toBe(24);
+    expect(sheet.rows[baseDateRowIndex].height).toBe(24);
+    expect(sheet.rows[taskViewIndex].cells[5].fillColor).toBe("#E6F1FB");
+    expect(sheet.rows[taskViewIndex].cells[6].value).toBe("基準日 2026-03-16");
+    expect(sheet.rows[taskViewIndex].cells[8].fillColor).toBe("#E6F1FB");
+    expect(sheet.rows[weekRowIndex].cells[5].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[weekRowIndex].cells[6].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/16");
+    expect(sheet.rows[baseDateRowIndex].cells[19].value).toBe("▼基準日");
+    expect(sheet.rows[baseDateRowIndex].cells[6].fillColor).toBe("#FFEFC2");
+    expect(sheet.rows[baseDateRowIndex].cells[20].fillColor).toBe("#FFF8E1");
+    expect(sheet.rows[baseDateRowIndex].cells[21].fillColor).toBe("#FFF8E1");
+    expect(sheet.rows[headerRowIndex].cells.slice(0, 18).map((cell) => cell.value)).toEqual([
       "UID",
       "ID",
       "WBS",
-      "Kind",
-      "OutlineLevel",
-      "Name",
-      "Start",
-      "Finish",
-      "Duration",
-      "PercentComplete",
-      "PercentWorkComplete",
-      "Milestone",
-      "Summary",
-      "Critical",
-      "Owner",
-      "Calendar",
-      "Resources",
-      "Predecessors"
+      "種別",
+      "階層",
+      "名称",
+      "開始",
+      "終了",
+      "期間",
+      "進捗",
+      "作業進捗",
+      "マイル",
+      "サマリ",
+      "クリティカル",
+      "担当",
+      "カレンダ",
+      "リソース",
+      "先行"
     ]);
-    expect(sheet.rows[9].cells[18].fillColor).toBe("#C5D1DB");
-    expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
+    expect(sheet.rows[headerRowIndex].cells[18].fillColor).toBe("#D9E2EA");
+    expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
       "[03/16 Mon *]",
       "03/17 Tue",
       "03/18 Wed",
       "03/19 Thu",
-      "03/20 Fri"
+      "03/20 Fri",
+      "03/21 Sat",
+      "03/22 Sun",
+      "03/23 Mon",
+      "03/24 Tue",
+      "03/25 Wed",
+      "03/26 Thu",
+      "03/27 Fri",
+      "03/28 Sat",
+      "03/29 Sun",
+      "03/30 Mon",
+      "03/31 Tue"
     ]);
-    expect(sheet.rows[9].cells[0].fillColor).toBe("#D7E7F6");
-    expect(sheet.rows[9].cells[2].fillColor).toBe("#E6F0DF");
-    expect(sheet.rows[9].cells[5].horizontalAlign).toBe("left");
-    expect(sheet.rows[9].cells[6].fillColor).toBe("#FDE7D3");
-    expect(sheet.rows[10].cells[6].horizontalAlign).toBe("center");
-    expect(sheet.rows[10].cells[7].horizontalAlign).toBe("center");
-    expect(sheet.rows[10].cells[8].horizontalAlign).toBe("center");
-    expect(sheet.rows[9].cells[9].fillColor).toBe("#FBE4EC");
-    expect(sheet.rows[9].cells[14].fillColor).toBe("#E2F1EF");
-    expect(sheet.rows[9].cells[19].fillColor).toBe("#FFE6A7");
-    expect(sheet.rows[11].cells[23].fillColor).toBe("#F4F7FB");
-    expect(sheet.rows[10].cells[3].value).toBe("phase");
-    expect(sheet.rows[10].cells[3].fillColor).toBe("#EEF7E8");
-    expect(sheet.rows[10].cells[0].fillColor).toBe("#EEF7E8");
-    expect(sheet.rows[10].cells[5].bold).toBe(true);
-    expect(sheet.rows[10].cells[14].value).toBe("-");
-    expect(sheet.rows[10].cells[14].fillColor).toBe("#F5F7FA");
-    expect(sheet.rows[10].cells[14].horizontalAlign).toBe("center");
-    expect(sheet.rows[10].cells[16].value).toBe("-");
-    expect(sheet.rows[10].cells[16].fillColor).toBe("#F5F7FA");
-    expect(sheet.rows[10].cells[16].horizontalAlign).toBe("center");
-    expect(sheet.rows[10].cells[17].value).toBe("-");
-    expect(sheet.rows[10].cells[17].fillColor).toBe("#F5F7FA");
-    expect(sheet.rows[10].cells[17].horizontalAlign).toBe("center");
-    expect(sheet.rows[10].cells[9].value).toBe("50%");
-    expect(sheet.rows[10].cells[10].value).toBe("50%");
-    expect(sheet.rows[10].cells[11].value).toBe("");
-    expect(sheet.rows[10].cells[12].value).toBe("S");
-    expect(sheet.rows[10].cells[13].value).toBe("");
-    expect(sheet.rows[10].cells[19].value).toBe("━");
-    expect(sheet.rows[10].cells[20].value).toBe("━");
-    expect(sheet.rows[11].cells[3].value).toBe("task");
-    expect(sheet.rows[11].cells[3].fillColor).toBe("#EEF2F6");
-    expect(sheet.rows[11].cells[0].fillColor).toBe("#F7F9FC");
-    expect(sheet.rows[11].cells[1].fillColor).toBe("#F7F9FC");
-    expect(sheet.rows[11].cells[2].fillColor).toBe("#F7F9FC");
-    expect(sheet.rows[11].cells[4].fillColor).toBe("#F7F9FC");
-    expect(sheet.rows[11].cells[4].value).toBe(2);
-    expect(sheet.rows[11].cells[5].value).toBe("  Design");
-    expect(sheet.rows[11].cells[14].value).toBe("Miku");
-    expect(sheet.rows[11].cells[15].value).toBe("1 Standard");
-    expect(sheet.rows[11].cells[16].value).toBe("Miku");
-    expect(sheet.rows[11].cells[9].value).toBe("100%");
-    expect(sheet.rows[11].cells[10].value).toBe("100%");
-    expect(sheet.rows[11].cells[11].value).toBe("");
-    expect(sheet.rows[11].cells[12].value).toBe("");
-    expect(sheet.rows[11].cells[13].value).toBe("");
-    expect(sheet.rows[12].cells[17].value).toBe("Design");
-    expect(sheet.rows[12].cells[9].value).toBe("0%");
-    expect(sheet.rows[12].cells[10].value).toBe("0%");
-    expect(sheet.rows[11].cells[5].bold).toBe(false);
-    expect(sheet.rows[11].cells[18].fillColor).toBe("#C5D1DB");
-    expect(sheet.rows[11].cells[19].value).toBe("■");
-    expect(sheet.rows[11].cells[19].fillColor).toBe("#D89A2B");
-    expect(sheet.rows[11].cells[20].value).toBe("■");
-    expect(sheet.rows[11].cells[20].fillColor).toBe("#5BAE9C");
-    expect(sheet.rows[11].cells[21].value).toBe("");
-    expect(sheet.rows[11].cells[22].value).toBe("");
-    expect(sheet.rows[12].cells[23].value).toBe("■");
+    expect(sheet.rows[headerRowIndex].cells[0].fillColor).toBe("#E1EDF8");
+    expect(sheet.rows[headerRowIndex].cells[2].fillColor).toBe("#E6F0DF");
+    expect(sheet.rows[headerRowIndex].cells[5].horizontalAlign).toBe("left");
+    expect(sheet.rows[headerRowIndex].cells[6].fillColor).toBe("#FDE7D3");
+    expect(sheet.rows[headerRowIndex].cells[9].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[headerRowIndex].cells[14].fillColor).toBe("#E2F1EF");
+    expect(sheet.rows[headerRowIndex].cells[19].fillColor).toBe("#FFE6A7");
+    const firstTaskRow = sheet.rows[headerRowIndex + 1];
+    const secondTaskRow = sheet.rows[headerRowIndex + 2];
+    const thirdTaskRow = sheet.rows[headerRowIndex + 3];
+    expect(firstTaskRow.cells[3].value).toBe("フェーズ");
+    expect(firstTaskRow.cells[3].fillColor).toBe("#EEF7E8");
+    expect(firstTaskRow.cells[0].fillColor).toBe("#EEF7E8");
+    expect(firstTaskRow.cells[5].bold).toBe(true);
+    expect(firstTaskRow.cells[14].value).toBe("-");
+    expect(firstTaskRow.cells[14].fillColor).toBe("#F5F7FA");
+    expect(firstTaskRow.cells[14].horizontalAlign).toBe("center");
+    expect(firstTaskRow.cells[16].value).toBe("-");
+    expect(firstTaskRow.cells[17].value).toBe("-");
+    expect(firstTaskRow.cells[9].value).toBe(" 50% [#####-----]");
+    expect(firstTaskRow.cells[10].value).toBe(" 50% [#####-----]");
+    expect(firstTaskRow.cells[12].value).toBe("Sum");
+    expect(firstTaskRow.cells[6].value).toBe("2026-03-16");
+    expect(firstTaskRow.cells[7].value).toBe("2026-03-20");
+    expect(firstTaskRow.cells[8].value).toBe("5日");
+    expect(firstTaskRow.cells[19].value).toBe("━");
+    expect(firstTaskRow.cells[20].value).toBe("━");
+    expect(secondTaskRow.cells[3].value).toBe("タスク");
+    expect(secondTaskRow.cells[3].fillColor).toBe("#EEF2F6");
+    expect(secondTaskRow.cells[0].fillColor).toBe("#F7F9FC");
+    expect(firstTaskRow.cells[5].value).toBe("> Project Summary");
+    expect(secondTaskRow.cells[5].value).toBe("  - Design");
+    expect(secondTaskRow.cells[5].fillColor).toBe("#FBFCFE");
+    expect(secondTaskRow.cells[6].fillColor).toBe("#FCFAF7");
+    expect(secondTaskRow.cells[14].value).toBe("Miku");
+    expect(secondTaskRow.cells[14].fillColor).toBe("#F8FBFB");
+    expect(secondTaskRow.cells[15].value).toBe("1 Standard");
+    expect(secondTaskRow.cells[16].value).toBe("Miku");
+    expect(secondTaskRow.cells[6].value).toBe("2026-03-16");
+    expect(secondTaskRow.cells[7].value).toBe("2026-03-17");
+    expect(secondTaskRow.cells[8].value).toBe("2日");
+    expect(secondTaskRow.cells[9].value).toBe("100% [##########]");
+    expect(secondTaskRow.cells[9].fillColor).toBe("#FCF8FB");
+    expect(secondTaskRow.cells[10].value).toBe("100% [##########]");
+    expect(secondTaskRow.cells[19].value).toBe("■");
+    expect(secondTaskRow.cells[19].fillColor).toBe("#D89A2B");
+    expect(secondTaskRow.cells[20].value).toBe("■");
+    expect(secondTaskRow.cells[20].fillColor).toBe("#5BAE9C");
+    expect(thirdTaskRow.cells[5].value).toBe("  - Implementation");
+    expect(thirdTaskRow.cells[17].value).toBe("Design");
+    expect(thirdTaskRow.cells[6].value).toBe("2026-03-18");
+    expect(thirdTaskRow.cells[7].value).toBe("2026-03-20");
+    expect(thirdTaskRow.cells[8].value).toBe("3日");
+    expect(thirdTaskRow.cells[9].value).toBe("  0% [----------]");
+    expect(thirdTaskRow.cells[10].value).toBe("  0% [----------]");
+    expect(thirdTaskRow.cells[23].value).toBe("■");
+    const legendHeaderIndex = findRowIndexByCellValue(sheet, "凡例", 5);
+    expect(legendHeaderIndex).toBe(headerRowIndex + 5);
+    expect(sheet.rows[legendHeaderIndex - 1].height).toBe(28);
+    expect(sheet.rows[legendHeaderIndex - 1].cells[5].value).toBeUndefined();
+    expect(sheet.rows[legendHeaderIndex].height).toBe(24);
+    expect(sheet.rows[legendHeaderIndex + 1].height).toBe(24);
+    expect(sheet.rows[legendHeaderIndex + 1].cells[5].value).toBe("進捗済み");
+    expect(sheet.rows[legendHeaderIndex + 1].cells[5].bold).toBe(true);
+    expect(sheet.rows[legendHeaderIndex + 1].cells[5].fillColor).toBe("#5BAE9C");
+    expect(sheet.rows[legendHeaderIndex + 7].cells[5].value).toBe("━:フェーズ");
+    expect(sheet.rows[legendHeaderIndex + 10].cells[5].fillColor).toBe("#FBE4EC");
+    expect(sheet.rows[legendHeaderIndex + 11].cells[5].fillColor).toBe("#F7EAF0");
+    expect(sheet.rows[legendHeaderIndex + 12].cells[5].fillColor).toBe("#F3E1E9");
+    expect(sheet.rows[legendHeaderIndex + 10].cells[5].value).toBe("Mil:マイルストーン");
+    expect(sheet.rows[legendHeaderIndex + 11].cells[5].value).toBe("Sum:サマリ");
+    expect(sheet.rows[legendHeaderIndex + 12].cells[5].value).toBe("Crit:クリティカル");
+    expect(sheet.rows[legendHeaderIndex + 13].cells[5].value).toBe("-:未設定");
   });
 
   it("can generate a real xlsx from the dedicated WBS workbook", () => {
@@ -244,18 +266,19 @@ describe("mikuproject wbs xlsx", () => {
 
     expect(entries).toContain("xl/workbook.xml");
     expect(entries).toContain("xl/worksheets/sheet1.xml");
-    expect(sheetXml).toContain('ref="A1:X1"');
-    expect(sheetXml).toContain('ref="A4:X4"');
-    expect(sheetXml).toContain('ref="T8:X8"');
-    expect(sheetXml).toContain("<pane");
-    expect(sheetXml).toContain('xSplit="19"');
-    expect(sheetXml).toContain('ySplit="10"');
-    expect(sheetXml).toContain('topLeftCell="T11"');
-    expect(sheetXml).toContain("Legend / 記号");
-    expect(sheetXml).toContain("Week of Mar 16");
-    expect(sheetXml).toContain("Task View | BaseDate=2026-03-16");
+    expect(sheetXml).toContain('ref="A1:AI1"');
+    expect(sheetXml).toContain('ref="A2:AI2"');
+    expect(sheetXml).toContain('ref="F3:G3"');
+    expect(sheetXml).toContain('ref="F12:G12"');
+    expect(sheetXml).toContain('ref="T26:Z26"');
+    expect(sheetXml).not.toContain("<pane");
+    expect(sheetXml).toContain("凡例");
+    expect(sheetXml).toContain("プロジェクト");
+    expect(sheetXml).toContain("週 03/16");
+    expect(sheetXml).toContain("タスク表");
+    expect(sheetXml).toContain("基準日 2026-03-16");
     expect(sheetXml).toContain("Sample Project");
-    expect(sheetXml).toContain("OutlineLevel");
+    expect(sheetXml).toContain("階層");
     expect(sheetXml).toContain("[03/16 Mon *]");
   });
 
@@ -270,15 +293,21 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[9].cells.slice(19).map((cell) => cell.value)).toEqual([
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const baseDateRowIndex = findRowIndexByPredicate(
+      sheet,
+      (cells) => cells[5]?.value === "基準日" && cells.some((cell) => cell.value === "▼基準日")
+    );
+    expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
       "03/20 Fri",
       "[03/21 Sat *]",
       "03/22 Sun",
       "03/23 Mon"
     ]);
-    expect(sheet.rows[8].cells[20].value).toBe("▼BaseDate");
-    expect(sheet.rows[9].cells[20].fillColor).toBe("#FFE6A7");
-    expect(sheet.rows[9].cells[21].fillColor).toBe("#F1F1F1");
+    const baseDateMarkerIndex = sheet.rows[baseDateRowIndex].cells.findIndex((cell) => cell.value === "▼基準日");
+    expect(baseDateMarkerIndex).toBe(20);
+    expect(sheet.rows[headerRowIndex].cells[baseDateMarkerIndex].fillColor).toBe("#FFE6A7");
+    expect(sheet.rows[headerRowIndex].cells[baseDateMarkerIndex + 1].fillColor).toBe("#F1F1F1");
   });
 
   it("marks week-start date-band cells with week-start fill", () => {
@@ -292,9 +321,10 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[9].cells[26].value).toBe("03/23 Mon");
-    expect(sheet.rows[9].cells[26].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[11].cells[26].fillColor).toBe("#E3EEF9");
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    expect(sheet.rows[headerRowIndex].cells[26].value).toBe("03/23 Mon");
+    expect(sheet.rows[headerRowIndex].cells[26].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[headerRowIndex + 2].cells[26].fillColor).toBe("#E3EEF9");
   });
 
   it("emphasizes week labels that contain a month boundary", () => {
@@ -308,9 +338,10 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.mergedRanges).toContain("T8:X8");
-    expect(sheet.rows[7].cells[19].value).toBe("Week of Mar 30 / Apr");
-    expect(sheet.rows[7].cells[19].fillColor).toBe("#D6E7F8");
+    const weekRowIndex = findRowIndexByCellValue(sheet, "週", 5);
+    expect(sheet.mergedRanges).toContain("T26:X26");
+    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/30 / 04");
+    expect(sheet.rows[weekRowIndex].cells[19].fillColor).toBe("#D6E7F8");
   });
 
   it("emphasizes month-start date headers", () => {
@@ -324,8 +355,9 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[9].cells[21].value).toBe("04/01 Wed");
-    expect(sheet.rows[9].cells[21].fillColor).toBe("#DCEAF7");
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    expect(sheet.rows[headerRowIndex].cells[21].value).toBe("04/01 Wed");
+    expect(sheet.rows[headerRowIndex].cells[21].fillColor).toBe("#DCEAF7");
   });
 
   it("renders milestone bands with a diamond marker", () => {
@@ -338,10 +370,12 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[12].cells[3].value).toBe("milestone");
-    expect(sheet.rows[12].cells[3].fillColor).toBe("#FFF4E0");
-    expect(sheet.rows[12].cells[11].value).toBe("M");
-    expect(sheet.rows[12].cells[21].value).toBe("◆");
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const milestoneRow = sheet.rows[headerRowIndex + 3];
+    expect(milestoneRow.cells[3].value).toBe("マイル");
+    expect(milestoneRow.cells[3].fillColor).toBe("#FFF4E0");
+    expect(milestoneRow.cells[11].value).toBe("Mil");
+    expect(milestoneRow.cells[21].value).toBe("◆");
   });
 
   it("renders critical flags with an exclamation marker", () => {
@@ -353,7 +387,8 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    expect(sheet.rows[11].cells[13].value).toBe("!");
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    expect(sheet.rows[headerRowIndex + 2].cells[13].value).toBe("Crit");
   });
 
   it("marks configured holidays in the date band", () => {
@@ -365,10 +400,118 @@ describe("mikuproject wbs xlsx", () => {
     });
     const sheet = workbook.sheets[0];
 
-    expect(String(sheet.rows[3].cells[0].value)).toContain("Holidays=1");
-    expect(sheet.rows[9].cells[23].value).toBe("03/20 Fri");
-    expect(sheet.rows[9].cells[23].fillColor).toBe("#FCE4EC");
-    expect(sheet.rows[11].cells[23].value).toBe("");
-    expect(sheet.rows[11].cells[23].fillColor).toBe("#FCE4EC");
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(1);
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    expect(sheet.rows[headerRowIndex].cells[23].value).toBe("03/20 Fri");
+    expect(sheet.rows[headerRowIndex].cells[23].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[headerRowIndex + 2].cells[23].value).toBe("");
+    expect(sheet.rows[headerRowIndex + 2].cells[23].fillColor).toBe("#FCE4EC");
+  });
+
+  it("can limit the displayed date band around base date", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model, {
+      displayDaysBeforeBaseDate: 1,
+      displayDaysAfterBaseDate: 2
+    });
+    const sheet = workbook.sheets[0];
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+
+    expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
+      "[03/16 Mon *]",
+      "03/17 Tue",
+      "03/18 Wed"
+    ]);
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe(1);
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe(2);
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
+  });
+
+  it("can limit the displayed date band around base date using business days", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-16T09:00:00";
+    model.project.finishDate = "2026-03-24T18:00:00";
+    model.project.currentDate = "2026-03-18T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model, {
+      holidayDates: ["2026-03-20"],
+      displayDaysBeforeBaseDate: 1,
+      displayDaysAfterBaseDate: 2,
+      useBusinessDaysForDisplayRange: true
+    });
+    const sheet = workbook.sheets[0];
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+
+    expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
+      "03/17 Tue",
+      "[03/18 Wed *]",
+      "03/19 Thu",
+      "03/20 Fri",
+      "03/21 Sat",
+      "03/22 Sun",
+      "03/23 Mon"
+    ]);
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(4);
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("営業日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
+  });
+
+  it("can calculate progress band using business days", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.currentDate = "2026-03-25T09:00:00";
+    model.tasks[1].start = "2026-03-16T09:00:00";
+    model.tasks[1].finish = "2026-03-22T18:00:00";
+    model.tasks[1].percentComplete = 50;
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model, {
+      holidayDates: ["2026-03-20"],
+      useBusinessDaysForProgressBand: true
+    });
+    const sheet = workbook.sheets[0];
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const designRow = sheet.rows[headerRowIndex + 2];
+
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("営業日");
+    expect(designRow.cells[8].value).toBe("4営業日");
+    expect(designRow.cells[19].fillColor).toBe("#5BAE9C");
+    expect(designRow.cells[20].fillColor).toBe("#5BAE9C");
+    expect(designRow.cells[21].fillColor).toBe("#9FD5C9");
+    expect(designRow.cells[23].fillColor).toBe("#9FD5C9");
+    expect(designRow.cells[24].fillColor).toBe("#9FD5C9");
+    expect(designRow.cells[25].fillColor).toBe("#9FD5C9");
+  });
+
+  it("truncates long owner, resources, and predecessors labels for wbs display", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.title = "Sample Project Title Very Long";
+    model.resources[0].name = "Resource Alpha Very Long";
+    model.calendars[0].name = "Standard Calendar Very Long";
+    model.tasks[2].predecessors = [{ predecessorUid: "1", type: 1, lag: "0" }];
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const secondTaskRow = sheet.rows[headerRowIndex + 2];
+    const thirdTaskRow = sheet.rows[headerRowIndex + 3];
+
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].value).toBe("Sample Project ...");
+    expect(secondTaskRow.cells[14].value).toBe("Resource Al...");
+    expect(secondTaskRow.cells[15].value).toBe("1 Standa...");
+    expect(secondTaskRow.cells[16].value).toBe("Resource Alpha ...");
+    expect(thirdTaskRow.cells[17].value).toBe("Project Summary");
   });
 });


### PR DESCRIPTION
## 概要

`mikuproject` の `WBS XLSX Export` を見直し、WBS シートのレイアウトを横持ち中心から縦ブロック中心へ再設計します。 あわせて、`BaseDate` 前後での表示期間制御、営業日ベースの表示期間・進捗帯計算、サンプル期間延長、UI とテストの追随を行います。

## 変更内容

### WBS workbook レイアウトの再設計
- `wbs-xlsx.ts` / `wbs-xlsx.js` を更新
- 上部の情報表示を横並び文字列から縦ブロックへ変更
- `プロジェクト`、`サマリ`、`凡例` の各ブロックを `F/G` 列ベースで縦配置
- `タスク表`、`週`、`基準日` のガイド行を日本語表記へ整理
- `Kind`、ヘッダ名、凡例表記を日本語寄りへ変更
- `Name`、日程列、進捗列、参照列の配色と表示を見直し
- `Legend / 記号` の横持ち構成をやめ、縦積みの凡例ブロックへ変更
- タスク一覧と凡例の間、および `プロジェクト` と `サマリ` の間に余白行を追加
- freeze pane 指定を削除し、固定スクロールは当面採用しない構成へ変更

### WBS 表示期間オプションの追加
- `displayDaysBeforeBaseDate`
- `displayDaysAfterBaseDate`
- `useBusinessDaysForDisplayRange`
- `useBusinessDaysForProgressBand`

を `WBS XLSX Export` に追加し、`BaseDate` 前後の日数で日付帯を切り出せるように変更しました。

### 営業日ベース表示の追加
- 表示期間を営業日ベースで数える処理を追加
- 進捗帯を営業日ベースで計算する処理を追加
- `Duration` 表示を WBS 向けに `N日` / `N営業日` へ変更
- `サマリ` ブロックに `営業日`、`表示`、`進捗` などの情報を追加

### WBS 表示内容の整理
- `Start / Finish` を日付のみ表示へ変更
- `PercentComplete / PercentWorkComplete` を簡易バー付き表示へ変更
- `Owner / Calendar / Resources / Predecessors` の長い値を省略表示へ変更
- `Calendar` は UID と短縮名で表示
- `Name` 列に種別に応じた接頭辞を追加
- `Milestone / Summary / Critical` は `Mil / Sum / Crit` 表示へ変更

### UI の拡張
- `mikuproject-src.html` と `main.ts / js` を更新
- `WBS XLSX Export` に以下を追加
  - `表示期間: 基準日前`
  - `表示期間: 基準日後`
  - `表示期間を営業日ベースで数える`
  - `進捗帯を営業日ベースで計算する`
- ステータス文にも表示期間条件と進捗帯基準を反映

### サンプルデータの更新
- `msproject-xml.ts / js` の `SAMPLE_XML` で `FinishDate` を `2026-03-31T18:00:00` に変更
- 既定 sample で週末や月末寄りの表示確認がしやすいように調整

### テスト更新
- `mikuproject-wbs-xlsx.test.js` を大幅に更新
- `mikuproject-main.test.js` を更新
- WBS レイアウト、祝日反映、表示期間切り出し、営業日ベース表示、進捗帯計算、UI オプション連携を確認するテストを追加・更新

## 影響範囲

- `docs/project` 配下の WBS 向け `.xlsx` 出力
- `WBS XLSX Export` の UI
- sample `.xlsx` と sample XML
- WBS 関連テスト

## 補足

- `WBS XLSX Export` は表示専用 workbook の改善です
- 固定スクロールはこの変更では採用していません
- `MS Project XML` 由来の sample 期間を延長しています