### PR TITLE
mikuproject の WBS XLSX レイアウトを再整理し、表示ヘッダと上部情報ブロックを改善

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2121,7 +2121,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-03-27</div>
+        <div class="md-app-meta">更新日: 2026-03-28</div>
       </div>
     </header>
 

--- a/docs/project/mikuproject-src.html
+++ b/docs/project/mikuproject-src.html
@@ -114,6 +114,7 @@
           </label>
         </div>
         <div class="md-form-grid">
+          <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"
             label="WBS 既定祝日"

--- a/docs/project/mikuproject.html
+++ b/docs/project/mikuproject.html
@@ -1588,6 +1588,7 @@ lht-index-card-link {
           </label>
         </div>
         <div class="md-form-grid">
+          <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
           <lht-text-field-help
             field-id="wbsHolidayDatesInput"
             label="WBS 既定祝日"
@@ -6006,6 +6007,7 @@ if (!customElements.get("lht-page-menu")) {
             formula: cell.formula,
             numberFormat: cell.numberFormat,
             horizontalAlign: cell.horizontalAlign,
+            wrapText: cell.wrapText === true ? true : undefined,
             bold: cell.bold === true ? true : undefined,
             fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
             border: cell.border
@@ -6240,12 +6242,13 @@ if (!customElements.get("lht-page-menu")) {
         return { styles, styleIndexByKey };
     }
     function getStyleDescriptor(cell) {
-        if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+        if (!cell.numberFormat && !cell.horizontalAlign && !cell.wrapText && !cell.bold && !cell.fillColor && !cell.border) {
             return null;
         }
         return {
             numberFormat: cell.numberFormat || "general",
             horizontalAlign: cell.horizontalAlign,
+            wrapText: cell.wrapText === true ? true : undefined,
             bold: cell.bold === true ? true : undefined,
             fillColor: cell.fillColor,
             border: cell.border
@@ -6255,6 +6258,7 @@ if (!customElements.get("lht-page-menu")) {
         return [
             style.numberFormat,
             style.horizontalAlign || "",
+            style.wrapText ? "wrap" : "",
             style.bold ? "bold" : "",
             style.fillColor || "",
             style.border || ""
@@ -6277,12 +6281,16 @@ if (!customElements.get("lht-page-menu")) {
             const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
             const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
             const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
-            const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+            const applyAlignment = style.horizontalAlign || style.wrapText ? ` applyAlignment="1"` : "";
             const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
             const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
             const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
-            const alignmentNode = style.horizontalAlign
-                ? `<alignment horizontal="${style.horizontalAlign}"/>`
+            const alignmentAttributes = [
+                style.horizontalAlign ? ` horizontal="${style.horizontalAlign}"` : "",
+                style.wrapText ? ` wrapText="1"` : ""
+            ].join("");
+            const alignmentNode = alignmentAttributes
+                ? `<alignment${alignmentAttributes}/>`
                 : "";
             return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
         }).join("");
@@ -6498,6 +6506,9 @@ if (!customElements.get("lht-page-menu")) {
         if (style.horizontalAlign) {
             cell.horizontalAlign = style.horizontalAlign;
         }
+        if (style.wrapText) {
+            cell.wrapText = true;
+        }
         if (style.bold) {
             cell.bold = true;
         }
@@ -6538,6 +6549,7 @@ if (!customElements.get("lht-page-menu")) {
             return {
                 numberFormat: parseNumberFormatId(numFmtId),
                 horizontalAlign: horizontalAlign || undefined,
+                wrapText: (alignmentElement === null || alignmentElement === void 0 ? void 0 : alignmentElement.getAttribute("wrapText")) === "1" ? true : undefined,
                 bold: ((_a = fonts[fontId]) === null || _a === void 0 ? void 0 : _a.bold) ? true : undefined,
                 fillColor: (_b = fills[fillId]) === null || _b === void 0 ? void 0 : _b.fillColor,
                 border: (_c = borders[borderId]) === null || _c === void 0 ? void 0 : _c.border
@@ -9554,7 +9566,7 @@ if (!customElements.get("lht-page-menu")) {
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
     const PROGRESS_BAND_FILL = "#5BAE9C";
-    const WEEKEND_BAND_FILL = "#F1F1F1";
+    const WEEKEND_BAND_FILL = "#C9D3E1";
     const WEEK_START_BAND_FILL = "#E3EEF9";
     const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
     const MONTH_START_HEADER_FILL = "#DCEAF7";
@@ -9632,13 +9644,13 @@ if (!customElements.get("lht-page-menu")) {
             `A1:${lastColumnRef}1`,
             `A2:${lastColumnRef}2`
         ];
-        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 5, rows.length + 1);
-        rows.push(...projectInfoBlock.rows);
+        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 0, rows.length + 1);
+        overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
         mergedRanges.push(...projectInfoBlock.mergedRanges);
-        rows.push(emptyRow(totalColumns, 28));
-        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
-        rows.push(...summaryBlock.rows);
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, 3, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        overlayRows(rows, 2, summaryBlock.rows, totalColumns);
         mergedRanges.push(...summaryBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
         rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
         const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
         rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
@@ -9654,9 +9666,11 @@ if (!customElements.get("lht-page-menu")) {
                 }
                 : label),
             dividerCell(),
-            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+            ...dateBand.map((day) => dateNumberCell(day, model.project.currentDate, holidaySet))
         ]));
+        rows.push(weekdayRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
         rows.push(...model.tasks.map((task) => ({
+            height: taskRowHeight(task),
             cells: [
                 identifierCell(task, task.uid),
                 identifierCell(task, task.id),
@@ -9706,6 +9720,26 @@ if (!customElements.get("lht-page-menu")) {
             height,
             cells: Array.from({ length: columnCount }, () => ({}))
         };
+    }
+    function overlayRows(rows, startIndex, blockRows, columnCount) {
+        blockRows.forEach((blockRow, offset) => {
+            const rowIndex = startIndex + offset;
+            if (!rows[rowIndex]) {
+                rows[rowIndex] = emptyRow(columnCount);
+            }
+            const targetRow = rows[rowIndex];
+            if ((blockRow.height || 0) > (targetRow.height || 0)) {
+                targetRow.height = blockRow.height;
+            }
+            blockRow.cells.forEach((cell, cellIndex) => {
+                if (hasCellContent(cell)) {
+                    targetRow.cells[cellIndex] = cell;
+                }
+            });
+        });
+    }
+    function hasCellContent(cell) {
+        return !!cell && Object.keys(cell).length > 0;
     }
     function formatTaskLabel(task) {
         const prefix = task.summary ? "> " : (task.milestone ? "* " : "- ");
@@ -9849,10 +9883,19 @@ if (!customElements.get("lht-page-menu")) {
             { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            mergedRanges: [
+                `${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 4)}${startRowNumber}`,
+                ...items.map((_, index) => {
+                    const rowNumber = startRowNumber + index + 1;
+                    return [
+                        `${columnName(startColumnIndex + 1)}${rowNumber}:${columnName(startColumnIndex + 2)}${rowNumber}`,
+                        `${columnName(startColumnIndex + 3)}${rowNumber}:${columnName(startColumnIndex + 4)}${rowNumber}`
+                    ];
+                }).flat()
+            ],
             rows: [
-                blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
-                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
     }
@@ -9976,6 +10019,52 @@ if (!customElements.get("lht-page-menu")) {
         };
         return { height: 24, cells };
     }
+    function projectBlockHeaderRow(columnCount, startColumnIndex, title) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: title,
+            border: "thin",
+            horizontalAlign: "left",
+            bold: true,
+            fillColor: HEADER_ID_FILL
+        };
+        for (let offset = 1; offset < 4; offset += 1) {
+            cells[startColumnIndex + offset] = {
+                value: "",
+                border: "thin",
+                fillColor: HEADER_ID_FILL
+            };
+        }
+        return { height: 24, cells };
+    }
+    function projectPairRow(columnCount, startColumnIndex, label, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: label,
+            border: "thin",
+            horizontalAlign: "right",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        cells[startColumnIndex + 2] = {
+            value,
+            border: "thin",
+            horizontalAlign: typeof value === "number" ? "center" : "left",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 3] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        return { height: 22, cells };
+    }
     function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
         const cells = Array.from({ length: columnCount }, () => ({}));
         cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
@@ -10027,6 +10116,15 @@ if (!customElements.get("lht-page-menu")) {
                     ...label
                 };
             })
+        };
+    }
+    function weekdayRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
+        return {
+            height: 24,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...dateBand.map((day) => weekdayCell(day, currentDate, holidaySet))
+            ]
         };
     }
     function dividerCell() {
@@ -10125,6 +10223,7 @@ if (!customElements.get("lht-page-menu")) {
             value,
             border: "thin",
             horizontalAlign,
+            wrapText: horizontalAlign === "left" ? true : undefined,
             bold: task.summary || task.milestone || false,
             fillColor: task.summary
                 ? PHASE_FILL
@@ -10134,6 +10233,16 @@ if (!customElements.get("lht-page-menu")) {
                         ? NAME_COLUMN_FILL
                         : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
         };
+    }
+    function taskRowHeight(task) {
+        const labelLength = formatTaskLabel(task).length;
+        if (labelLength > 36) {
+            return 34;
+        }
+        if (labelLength > 24) {
+            return 28;
+        }
+        return undefined;
     }
     function kindCell(task) {
         return {
@@ -10195,14 +10304,28 @@ if (!customElements.get("lht-page-menu")) {
     function formatWbsDate(value) {
         return value ? value.slice(0, 10) : "-";
     }
-    function dateHeaderCell(day, currentDate, holidaySet) {
+    function dateNumberCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
         return {
-            value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
+            value: formatDateValue(day),
+            bold: true,
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+        };
+    }
+    function weekdayCell(day, currentDate, holidaySet) {
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
+        const monthStart = isMonthStart(day);
+        return {
+            value: formatWeekdayValue(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
@@ -10325,7 +10448,7 @@ if (!customElements.get("lht-page-menu")) {
             ranges.push({
                 range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
                 startIndex: chunkStart,
-                label: formatWeekLabel(chunkDays),
+                label: formatWeekLabel(weekStart, chunkDays),
                 hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
             });
             chunkStart = chunkEnd + 1;
@@ -10387,7 +10510,7 @@ if (!customElements.get("lht-page-menu")) {
         if (!target) {
             return false;
         }
-        return target.getDay() === 1;
+        return target.getDay() === 0;
     }
     function isMonthStart(day) {
         const target = parseDateOnly(day);
@@ -10439,31 +10562,38 @@ if (!customElements.get("lht-page-menu")) {
             String(value.getDate()).padStart(2, "0")
         ].join("-");
     }
-    function formatDateLabel(day) {
+    function formatDateValue(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        return `${target.getMonth() + 1}/${target.getDate()}`;
+    }
+    function formatWeekdayValue(day) {
         const target = parseDateOnly(day);
         if (!target) {
             return day;
         }
         const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-        return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+        return weekdays[target.getDay()];
     }
     function formatWeekKey(day) {
         const target = parseDateOnly(day);
         if (!target) {
             return day;
         }
-        const monday = new Date(target.getTime());
-        const offset = (monday.getDay() + 6) % 7;
-        monday.setDate(monday.getDate() - offset);
-        return formatDateOnly(monday);
+        const sunday = new Date(target.getTime());
+        const offset = sunday.getDay();
+        sunday.setDate(sunday.getDate() - offset);
+        return formatDateOnly(sunday);
     }
-    function formatWeekLabel(days) {
+    function formatWeekLabel(weekKey, days) {
         if (days.length === 0) {
             return "週";
         }
-        const start = parseDateOnly(days[0]);
+        const start = parseDateOnly(weekKey);
         if (!start) {
-            return days[0];
+            return weekKey;
         }
         const monthSet = new Set(days.map((day) => {
             const target = parseDateOnly(day);
@@ -10585,20 +10715,32 @@ if (!customElements.get("lht-page-menu")) {
     function useBusinessDaysForWbsProgressBand() {
         return getInput("wbsBusinessDayProgressInput").checked;
     }
+    function updateWbsHolidaySummary(holidayDates) {
+        const summary = getElement("wbsHolidaySummary");
+        if (holidayDates.length === 0) {
+            summary.textContent = "既定祝日: 0 件";
+            return;
+        }
+        summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
+    }
     function syncWbsHolidayDatesInput(model) {
         const input = getTextArea("wbsHolidayDatesInput");
         if (!model) {
             input.value = "";
             getTextArea("wbsExtraHolidayDatesInput").value = "";
+            updateWbsHolidaySummary([]);
             return;
         }
-        input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+        input.value = holidayDates.join("\n");
+        updateWbsHolidaySummary(holidayDates);
     }
     function resetWbsHolidayDatesInput() {
         const model = ensureCurrentModel();
         const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
         getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
         getTextArea("wbsExtraHolidayDatesInput").value = "";
+        updateWbsHolidaySummary(holidayDates);
         setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
         showToast("WBS 祝日を既定値へ戻しました");
     }

--- a/docs/project/src/mikuproject/js/excel-io.js
+++ b/docs/project/src/mikuproject/js/excel-io.js
@@ -145,6 +145,7 @@
             formula: cell.formula,
             numberFormat: cell.numberFormat,
             horizontalAlign: cell.horizontalAlign,
+            wrapText: cell.wrapText === true ? true : undefined,
             bold: cell.bold === true ? true : undefined,
             fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
             border: cell.border
@@ -379,12 +380,13 @@
         return { styles, styleIndexByKey };
     }
     function getStyleDescriptor(cell) {
-        if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+        if (!cell.numberFormat && !cell.horizontalAlign && !cell.wrapText && !cell.bold && !cell.fillColor && !cell.border) {
             return null;
         }
         return {
             numberFormat: cell.numberFormat || "general",
             horizontalAlign: cell.horizontalAlign,
+            wrapText: cell.wrapText === true ? true : undefined,
             bold: cell.bold === true ? true : undefined,
             fillColor: cell.fillColor,
             border: cell.border
@@ -394,6 +396,7 @@
         return [
             style.numberFormat,
             style.horizontalAlign || "",
+            style.wrapText ? "wrap" : "",
             style.bold ? "bold" : "",
             style.fillColor || "",
             style.border || ""
@@ -416,12 +419,16 @@
             const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
             const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
             const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
-            const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+            const applyAlignment = style.horizontalAlign || style.wrapText ? ` applyAlignment="1"` : "";
             const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
             const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
             const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
-            const alignmentNode = style.horizontalAlign
-                ? `<alignment horizontal="${style.horizontalAlign}"/>`
+            const alignmentAttributes = [
+                style.horizontalAlign ? ` horizontal="${style.horizontalAlign}"` : "",
+                style.wrapText ? ` wrapText="1"` : ""
+            ].join("");
+            const alignmentNode = alignmentAttributes
+                ? `<alignment${alignmentAttributes}/>`
                 : "";
             return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
         }).join("");
@@ -637,6 +644,9 @@
         if (style.horizontalAlign) {
             cell.horizontalAlign = style.horizontalAlign;
         }
+        if (style.wrapText) {
+            cell.wrapText = true;
+        }
         if (style.bold) {
             cell.bold = true;
         }
@@ -677,6 +687,7 @@
             return {
                 numberFormat: parseNumberFormatId(numFmtId),
                 horizontalAlign: horizontalAlign || undefined,
+                wrapText: (alignmentElement === null || alignmentElement === void 0 ? void 0 : alignmentElement.getAttribute("wrapText")) === "1" ? true : undefined,
                 bold: ((_a = fonts[fontId]) === null || _a === void 0 ? void 0 : _a.bold) ? true : undefined,
                 fillColor: (_b = fills[fillId]) === null || _b === void 0 ? void 0 : _b.fillColor,
                 border: (_c = borders[borderId]) === null || _c === void 0 ? void 0 : _c.border

--- a/docs/project/src/mikuproject/js/main.js
+++ b/docs/project/src/mikuproject/js/main.js
@@ -87,20 +87,32 @@
     function useBusinessDaysForWbsProgressBand() {
         return getInput("wbsBusinessDayProgressInput").checked;
     }
+    function updateWbsHolidaySummary(holidayDates) {
+        const summary = getElement("wbsHolidaySummary");
+        if (holidayDates.length === 0) {
+            summary.textContent = "既定祝日: 0 件";
+            return;
+        }
+        summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
+    }
     function syncWbsHolidayDatesInput(model) {
         const input = getTextArea("wbsHolidayDatesInput");
         if (!model) {
             input.value = "";
             getTextArea("wbsExtraHolidayDatesInput").value = "";
+            updateWbsHolidaySummary([]);
             return;
         }
-        input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+        input.value = holidayDates.join("\n");
+        updateWbsHolidaySummary(holidayDates);
     }
     function resetWbsHolidayDatesInput() {
         const model = ensureCurrentModel();
         const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
         getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
         getTextArea("wbsExtraHolidayDatesInput").value = "";
+        updateWbsHolidaySummary(holidayDates);
         setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
         showToast("WBS 祝日を既定値へ戻しました");
     }

--- a/docs/project/src/mikuproject/js/wbs-xlsx.js
+++ b/docs/project/src/mikuproject/js/wbs-xlsx.js
@@ -15,7 +15,7 @@
     const BAND_FILL = "#F4F7FB";
     const ACTIVE_BAND_FILL = "#9FD5C9";
     const PROGRESS_BAND_FILL = "#5BAE9C";
-    const WEEKEND_BAND_FILL = "#F1F1F1";
+    const WEEKEND_BAND_FILL = "#C9D3E1";
     const WEEK_START_BAND_FILL = "#E3EEF9";
     const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
     const MONTH_START_HEADER_FILL = "#DCEAF7";
@@ -93,13 +93,13 @@
             `A1:${lastColumnRef}1`,
             `A2:${lastColumnRef}2`
         ];
-        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 5, rows.length + 1);
-        rows.push(...projectInfoBlock.rows);
+        const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 0, rows.length + 1);
+        overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
         mergedRanges.push(...projectInfoBlock.mergedRanges);
-        rows.push(emptyRow(totalColumns, 28));
-        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
-        rows.push(...summaryBlock.rows);
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, 3, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        overlayRows(rows, 2, summaryBlock.rows, totalColumns);
         mergedRanges.push(...summaryBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
         rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
         const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
         rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
@@ -115,9 +115,11 @@
                 }
                 : label),
             dividerCell(),
-            ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+            ...dateBand.map((day) => dateNumberCell(day, model.project.currentDate, holidaySet))
         ]));
+        rows.push(weekdayRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
         rows.push(...model.tasks.map((task) => ({
+            height: taskRowHeight(task),
             cells: [
                 identifierCell(task, task.uid),
                 identifierCell(task, task.id),
@@ -167,6 +169,26 @@
             height,
             cells: Array.from({ length: columnCount }, () => ({}))
         };
+    }
+    function overlayRows(rows, startIndex, blockRows, columnCount) {
+        blockRows.forEach((blockRow, offset) => {
+            const rowIndex = startIndex + offset;
+            if (!rows[rowIndex]) {
+                rows[rowIndex] = emptyRow(columnCount);
+            }
+            const targetRow = rows[rowIndex];
+            if ((blockRow.height || 0) > (targetRow.height || 0)) {
+                targetRow.height = blockRow.height;
+            }
+            blockRow.cells.forEach((cell, cellIndex) => {
+                if (hasCellContent(cell)) {
+                    targetRow.cells[cellIndex] = cell;
+                }
+            });
+        });
+    }
+    function hasCellContent(cell) {
+        return !!cell && Object.keys(cell).length > 0;
     }
     function formatTaskLabel(task) {
         const prefix = task.summary ? "> " : (task.milestone ? "* " : "- ");
@@ -310,10 +332,19 @@
             { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
         ];
         return {
-            mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+            mergedRanges: [
+                `${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 4)}${startRowNumber}`,
+                ...items.map((_, index) => {
+                    const rowNumber = startRowNumber + index + 1;
+                    return [
+                        `${columnName(startColumnIndex + 1)}${rowNumber}:${columnName(startColumnIndex + 2)}${rowNumber}`,
+                        `${columnName(startColumnIndex + 3)}${rowNumber}:${columnName(startColumnIndex + 4)}${rowNumber}`
+                    ];
+                }).flat()
+            ],
             rows: [
-                blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
-                ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
     }
@@ -437,6 +468,52 @@
         };
         return { height: 24, cells };
     }
+    function projectBlockHeaderRow(columnCount, startColumnIndex, title) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: title,
+            border: "thin",
+            horizontalAlign: "left",
+            bold: true,
+            fillColor: HEADER_ID_FILL
+        };
+        for (let offset = 1; offset < 4; offset += 1) {
+            cells[startColumnIndex + offset] = {
+                value: "",
+                border: "thin",
+                fillColor: HEADER_ID_FILL
+            };
+        }
+        return { height: 24, cells };
+    }
+    function projectPairRow(columnCount, startColumnIndex, label, value, fillColor) {
+        const cells = Array.from({ length: columnCount }, () => ({}));
+        cells[startColumnIndex] = {
+            value: label,
+            border: "thin",
+            horizontalAlign: "right",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        cells[startColumnIndex + 2] = {
+            value,
+            border: "thin",
+            horizontalAlign: typeof value === "number" ? "center" : "left",
+            bold: true,
+            fillColor
+        };
+        cells[startColumnIndex + 3] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        return { height: 22, cells };
+    }
     function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
         const cells = Array.from({ length: columnCount }, () => ({}));
         cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
@@ -488,6 +565,15 @@
                     ...label
                 };
             })
+        };
+    }
+    function weekdayRow(fixedColumnCount, dateBand, currentDate, holidaySet) {
+        return {
+            height: 24,
+            cells: [
+                ...Array.from({ length: fixedColumnCount }, () => ({})),
+                ...dateBand.map((day) => weekdayCell(day, currentDate, holidaySet))
+            ]
         };
     }
     function dividerCell() {
@@ -586,6 +672,7 @@
             value,
             border: "thin",
             horizontalAlign,
+            wrapText: horizontalAlign === "left" ? true : undefined,
             bold: task.summary || task.milestone || false,
             fillColor: task.summary
                 ? PHASE_FILL
@@ -595,6 +682,16 @@
                         ? NAME_COLUMN_FILL
                         : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
         };
+    }
+    function taskRowHeight(task) {
+        const labelLength = formatTaskLabel(task).length;
+        if (labelLength > 36) {
+            return 34;
+        }
+        if (labelLength > 24) {
+            return 28;
+        }
+        return undefined;
     }
     function kindCell(task) {
         return {
@@ -656,14 +753,28 @@
     function formatWbsDate(value) {
         return value ? value.slice(0, 10) : "-";
     }
-    function dateHeaderCell(day, currentDate, holidaySet) {
+    function dateNumberCell(day, currentDate, holidaySet) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeekend(day);
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
         return {
-            value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
+            value: formatDateValue(day),
+            bold: true,
+            border: "thin",
+            horizontalAlign: "center",
+            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+        };
+    }
+    function weekdayCell(day, currentDate, holidaySet) {
+        const isToday = isSameDay(day, currentDate);
+        const isWeekendDay = isWeekend(day);
+        const isHoliday = holidaySet.has(day);
+        const weekStart = isWeekStart(day);
+        const monthStart = isMonthStart(day);
+        return {
+            value: formatWeekdayValue(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
@@ -786,7 +897,7 @@
             ranges.push({
                 range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
                 startIndex: chunkStart,
-                label: formatWeekLabel(chunkDays),
+                label: formatWeekLabel(weekStart, chunkDays),
                 hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
             });
             chunkStart = chunkEnd + 1;
@@ -848,7 +959,7 @@
         if (!target) {
             return false;
         }
-        return target.getDay() === 1;
+        return target.getDay() === 0;
     }
     function isMonthStart(day) {
         const target = parseDateOnly(day);
@@ -900,31 +1011,38 @@
             String(value.getDate()).padStart(2, "0")
         ].join("-");
     }
-    function formatDateLabel(day) {
+    function formatDateValue(day) {
+        const target = parseDateOnly(day);
+        if (!target) {
+            return day;
+        }
+        return `${target.getMonth() + 1}/${target.getDate()}`;
+    }
+    function formatWeekdayValue(day) {
         const target = parseDateOnly(day);
         if (!target) {
             return day;
         }
         const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-        return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+        return weekdays[target.getDay()];
     }
     function formatWeekKey(day) {
         const target = parseDateOnly(day);
         if (!target) {
             return day;
         }
-        const monday = new Date(target.getTime());
-        const offset = (monday.getDay() + 6) % 7;
-        monday.setDate(monday.getDate() - offset);
-        return formatDateOnly(monday);
+        const sunday = new Date(target.getTime());
+        const offset = sunday.getDay();
+        sunday.setDate(sunday.getDate() - offset);
+        return formatDateOnly(sunday);
     }
-    function formatWeekLabel(days) {
+    function formatWeekLabel(weekKey, days) {
         if (days.length === 0) {
             return "週";
         }
-        const start = parseDateOnly(days[0]);
+        const start = parseDateOnly(weekKey);
         if (!start) {
-            return days[0];
+            return weekKey;
         }
         const monthSet = new Set(days.map((day) => {
             const target = parseDateOnly(day);

--- a/docs/project/src/mikuproject/ts/excel-io.ts
+++ b/docs/project/src/mikuproject/ts/excel-io.ts
@@ -9,6 +9,7 @@
     formula?: string;
     numberFormat?: XlsxNumberFormat;
     horizontalAlign?: XlsxHorizontalAlign;
+    wrapText?: boolean;
     bold?: boolean;
     fillColor?: string;
     border?: XlsxBorderStyle;
@@ -48,6 +49,7 @@
   type StyleDescriptor = {
     numberFormat: XlsxNumberFormat;
     horizontalAlign?: XlsxHorizontalAlign;
+    wrapText?: boolean;
     bold?: boolean;
     fillColor?: string;
     border?: XlsxBorderStyle;
@@ -229,6 +231,7 @@
       formula: cell.formula,
       numberFormat: cell.numberFormat,
       horizontalAlign: cell.horizontalAlign,
+      wrapText: cell.wrapText === true ? true : undefined,
       bold: cell.bold === true ? true : undefined,
       fillColor: cell.fillColor ? normalizeColor(cell.fillColor) : undefined,
       border: cell.border
@@ -508,12 +511,13 @@
   }
 
   function getStyleDescriptor(cell: XlsxCellModel): StyleDescriptor | null {
-    if (!cell.numberFormat && !cell.horizontalAlign && !cell.bold && !cell.fillColor && !cell.border) {
+    if (!cell.numberFormat && !cell.horizontalAlign && !cell.wrapText && !cell.bold && !cell.fillColor && !cell.border) {
       return null;
     }
     return {
       numberFormat: cell.numberFormat || "general",
       horizontalAlign: cell.horizontalAlign,
+      wrapText: cell.wrapText === true ? true : undefined,
       bold: cell.bold === true ? true : undefined,
       fillColor: cell.fillColor,
       border: cell.border
@@ -524,6 +528,7 @@
     return [
       style.numberFormat,
       style.horizontalAlign || "",
+      style.wrapText ? "wrap" : "",
       style.bold ? "bold" : "",
       style.fillColor || "",
       style.border || ""
@@ -549,12 +554,16 @@
       const fillId = fills.indexByKey.get(fillKey({ fillColor: style.fillColor })) || 0;
       const borderId = borders.indexByKey.get(borderKey({ border: style.border })) || 0;
       const applyNumberFormat = numFmtId !== 0 ? ` applyNumberFormat="1"` : "";
-      const applyAlignment = style.horizontalAlign ? ` applyAlignment="1"` : "";
+      const applyAlignment = style.horizontalAlign || style.wrapText ? ` applyAlignment="1"` : "";
       const applyFont = fontId !== 0 ? ` applyFont="1"` : "";
       const applyFill = fillId !== 0 ? ` applyFill="1"` : "";
       const applyBorder = borderId !== 0 ? ` applyBorder="1"` : "";
-      const alignmentNode = style.horizontalAlign
-        ? `<alignment horizontal="${style.horizontalAlign}"/>`
+      const alignmentAttributes = [
+        style.horizontalAlign ? ` horizontal="${style.horizontalAlign}"` : "",
+        style.wrapText ? ` wrapText="1"` : ""
+      ].join("");
+      const alignmentNode = alignmentAttributes
+        ? `<alignment${alignmentAttributes}/>`
         : "";
       return `<xf numFmtId="${numFmtId}" fontId="${fontId}" fillId="${fillId}" borderId="${borderId}" xfId="0"${applyNumberFormat}${applyAlignment}${applyFont}${applyFill}${applyBorder}>${alignmentNode}</xf>`;
     }).join("");
@@ -816,6 +825,9 @@
     if (style.horizontalAlign) {
       cell.horizontalAlign = style.horizontalAlign;
     }
+    if (style.wrapText) {
+      cell.wrapText = true;
+    }
     if (style.bold) {
       cell.bold = true;
     }
@@ -861,6 +873,7 @@
       return {
         numberFormat: parseNumberFormatId(numFmtId),
         horizontalAlign: horizontalAlign || undefined,
+        wrapText: alignmentElement?.getAttribute("wrapText") === "1" ? true : undefined,
         bold: fonts[fontId]?.bold ? true : undefined,
         fillColor: fills[fillId]?.fillColor,
         border: borders[borderId]?.border

--- a/docs/project/src/mikuproject/ts/main.ts
+++ b/docs/project/src/mikuproject/ts/main.ts
@@ -161,14 +161,26 @@
     return getInput("wbsBusinessDayProgressInput").checked;
   }
 
+  function updateWbsHolidaySummary(holidayDates: string[]): void {
+    const summary = getElement<HTMLElement>("wbsHolidaySummary");
+    if (holidayDates.length === 0) {
+      summary.textContent = "既定祝日: 0 件";
+      return;
+    }
+    summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
+  }
+
   function syncWbsHolidayDatesInput(model: ProjectModel | null): void {
     const input = getTextArea("wbsHolidayDatesInput");
     if (!model) {
       input.value = "";
       getTextArea("wbsExtraHolidayDatesInput").value = "";
+      updateWbsHolidaySummary([]);
       return;
     }
-    input.value = mikuprojectWbsXlsx.collectWbsHolidayDates(model).join("\n");
+    const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
+    input.value = holidayDates.join("\n");
+    updateWbsHolidaySummary(holidayDates);
   }
 
   function resetWbsHolidayDatesInput(): void {
@@ -176,6 +188,7 @@
     const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
     getTextArea("wbsHolidayDatesInput").value = holidayDates.join("\n");
     getTextArea("wbsExtraHolidayDatesInput").value = "";
+    updateWbsHolidaySummary(holidayDates);
     setStatus(`WBS 祝日入力を既定値へ戻しました${holidayDates.length > 0 ? ` (${holidayDates.length} 件)` : ""}`);
     showToast("WBS 祝日を既定値へ戻しました");
   }

--- a/docs/project/src/mikuproject/ts/wbs-xlsx.ts
+++ b/docs/project/src/mikuproject/ts/wbs-xlsx.ts
@@ -3,6 +3,7 @@
     value?: string | number | boolean;
     numberFormat?: "general" | "integer" | "decimal" | "date" | "datetime" | "percent";
     horizontalAlign?: "left" | "center" | "right";
+    wrapText?: boolean;
     bold?: boolean;
     fillColor?: string;
     border?: "thin";
@@ -44,7 +45,7 @@
   const BAND_FILL = "#F4F7FB";
   const ACTIVE_BAND_FILL = "#9FD5C9";
   const PROGRESS_BAND_FILL = "#5BAE9C";
-  const WEEKEND_BAND_FILL = "#F1F1F1";
+  const WEEKEND_BAND_FILL = "#C9D3E1";
   const WEEK_START_BAND_FILL = "#E3EEF9";
   const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
   const MONTH_START_HEADER_FILL = "#DCEAF7";
@@ -139,12 +140,11 @@
       calendarNameByUid,
       holidaySet.size,
       totalColumns,
-      5,
+      0,
       rows.length + 1
     );
-    rows.push(...projectInfoBlock.rows);
+    overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
     mergedRanges.push(...projectInfoBlock.mergedRanges);
-    rows.push(emptyRow(totalColumns, 28));
     const summaryBlock = displaySummaryRows(
       dateBand.length,
       countBusinessDays(dateBand, holidaySet),
@@ -155,14 +155,15 @@
       model.calendars.length,
       totalColumns,
       5,
-      rows.length + 1,
+      3,
       options.displayDaysBeforeBaseDate,
       options.displayDaysAfterBaseDate,
       options.useBusinessDaysForDisplayRange,
       options.useBusinessDaysForProgressBand
     );
-    rows.push(...summaryBlock.rows);
+    overlayRows(rows, 2, summaryBlock.rows, totalColumns);
     mergedRanges.push(...summaryBlock.mergedRanges);
+    rows.push(emptyRow(totalColumns, 28));
     rows.push(taskViewRow((model.project.currentDate || "-").slice(0, 10) || "-", totalColumns));
     const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
     rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
@@ -178,9 +179,11 @@
           }
         : label),
       dividerCell(),
-      ...dateBand.map((day) => dateHeaderCell(day, model.project.currentDate, holidaySet))
+      ...dateBand.map((day) => dateNumberCell(day, model.project.currentDate, holidaySet))
     ]));
+    rows.push(weekdayRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet));
     rows.push(...model.tasks.map((task) => ({
+      height: taskRowHeight(task),
       cells: [
         identifierCell(task, task.uid),
         identifierCell(task, task.id),
@@ -232,6 +235,33 @@
       height,
       cells: Array.from({ length: columnCount }, () => ({}))
     };
+  }
+
+  function overlayRows(
+    rows: Array<{ height?: number; cells: WbsXlsxCellLike[] }>,
+    startIndex: number,
+    blockRows: Array<{ height?: number; cells: WbsXlsxCellLike[] }>,
+    columnCount: number
+  ) {
+    blockRows.forEach((blockRow, offset) => {
+      const rowIndex = startIndex + offset;
+      if (!rows[rowIndex]) {
+        rows[rowIndex] = emptyRow(columnCount);
+      }
+      const targetRow = rows[rowIndex];
+      if ((blockRow.height || 0) > (targetRow.height || 0)) {
+        targetRow.height = blockRow.height;
+      }
+      blockRow.cells.forEach((cell, cellIndex) => {
+        if (hasCellContent(cell)) {
+          targetRow.cells[cellIndex] = cell;
+        }
+      });
+    });
+  }
+
+  function hasCellContent(cell: WbsXlsxCellLike | undefined): boolean {
+    return !!cell && Object.keys(cell).length > 0;
   }
 
   function formatTaskLabel(task: TaskModel): string {
@@ -401,10 +431,19 @@
       { label: "祝日", value: holidayCount, fillColor: SUMMARY_SCHEDULE_FILL }
     ];
     return {
-      mergedRanges: [`${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 2)}${startRowNumber}`],
+      mergedRanges: [
+        `${columnName(startColumnIndex + 1)}${startRowNumber}:${columnName(startColumnIndex + 4)}${startRowNumber}`,
+        ...items.map((_, index) => {
+          const rowNumber = startRowNumber + index + 1;
+          return [
+            `${columnName(startColumnIndex + 1)}${rowNumber}:${columnName(startColumnIndex + 2)}${rowNumber}`,
+            `${columnName(startColumnIndex + 3)}${rowNumber}:${columnName(startColumnIndex + 4)}${rowNumber}`
+          ];
+        }).flat()
+      ],
       rows: [
-        blockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
-        ...items.map((item) => summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
+        projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+        ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
       ]
     };
   }
@@ -552,6 +591,60 @@
     return { height: 24, cells };
   }
 
+  function projectBlockHeaderRow(columnCount: number, startColumnIndex: number, title: string) {
+    const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
+    cells[startColumnIndex] = {
+      value: title,
+      border: "thin",
+      horizontalAlign: "left",
+      bold: true,
+      fillColor: HEADER_ID_FILL
+    };
+    for (let offset = 1; offset < 4; offset += 1) {
+      cells[startColumnIndex + offset] = {
+        value: "",
+        border: "thin",
+        fillColor: HEADER_ID_FILL
+      };
+    }
+    return { height: 24, cells };
+  }
+
+  function projectPairRow(
+    columnCount: number,
+    startColumnIndex: number,
+    label: string,
+    value: string | number,
+    fillColor: string
+  ) {
+    const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
+    cells[startColumnIndex] = {
+      value: label,
+      border: "thin",
+      horizontalAlign: "right",
+      bold: true,
+      fillColor
+    };
+    cells[startColumnIndex + 1] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
+    cells[startColumnIndex + 2] = {
+      value,
+      border: "thin",
+      horizontalAlign: typeof value === "number" ? "center" : "left",
+      bold: true,
+      fillColor
+    };
+    cells[startColumnIndex + 3] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
+    return { height: 22, cells };
+  }
+
   function summaryPairRow(
     columnCount: number,
     startColumnIndex: number,
@@ -617,6 +710,21 @@
           ...label
         };
       })
+    };
+  }
+
+  function weekdayRow(
+    fixedColumnCount: number,
+    dateBand: string[],
+    currentDate: string | undefined,
+    holidaySet: Set<string>
+  ) {
+    return {
+      height: 24,
+      cells: [
+        ...Array.from({ length: fixedColumnCount }, () => ({} as WbsXlsxCellLike)),
+        ...dateBand.map((day) => weekdayCell(day, currentDate, holidaySet))
+      ]
     };
   }
 
@@ -729,6 +837,7 @@
       value,
       border: "thin",
       horizontalAlign,
+      wrapText: horizontalAlign === "left" ? true : undefined,
       bold: task.summary || task.milestone || false,
       fillColor: task.summary
         ? PHASE_FILL
@@ -738,6 +847,17 @@
             ? NAME_COLUMN_FILL
             : (horizontalAlign === "center" ? SCHEDULE_COLUMN_FILL : undefined)))
     };
+  }
+
+  function taskRowHeight(task: TaskModel): number | undefined {
+    const labelLength = formatTaskLabel(task).length;
+    if (labelLength > 36) {
+      return 34;
+    }
+    if (labelLength > 24) {
+      return 28;
+    }
+    return undefined;
   }
 
   function kindCell(task: TaskModel): WbsXlsxCellLike {
@@ -811,14 +931,29 @@
     return value ? value.slice(0, 10) : "-";
   }
 
-  function dateHeaderCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
+  function dateNumberCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
     const isToday = isSameDay(day, currentDate);
     const isWeekendDay = isWeekend(day);
     const isHoliday = holidaySet.has(day);
     const weekStart = isWeekStart(day);
     const monthStart = isMonthStart(day);
     return {
-      value: isToday ? `[${formatDateLabel(day)} *]` : formatDateLabel(day),
+      value: formatDateValue(day),
+      bold: true,
+      border: "thin",
+      horizontalAlign: "center",
+      fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+    };
+  }
+
+  function weekdayCell(day: string, currentDate: string | undefined, holidaySet: Set<string>): WbsXlsxCellLike {
+    const isToday = isSameDay(day, currentDate);
+    const isWeekendDay = isWeekend(day);
+    const isHoliday = holidaySet.has(day);
+    const weekStart = isWeekStart(day);
+    const monthStart = isMonthStart(day);
+    return {
+      value: formatWeekdayValue(day),
       bold: true,
       border: "thin",
       horizontalAlign: "center",
@@ -964,7 +1099,7 @@
       ranges.push({
         range: `${startColumn}${rowNumber}:${endColumn}${rowNumber}`,
         startIndex: chunkStart,
-        label: formatWeekLabel(chunkDays),
+        label: formatWeekLabel(weekStart, chunkDays),
         hasMonthBoundary: chunkDays.some((day) => isMonthStart(day))
       });
       chunkStart = chunkEnd + 1;
@@ -1041,7 +1176,7 @@
     if (!target) {
       return false;
     }
-    return target.getDay() === 1;
+    return target.getDay() === 0;
   }
 
   function isMonthStart(day: string): boolean {
@@ -1098,13 +1233,21 @@
     ].join("-");
   }
 
-  function formatDateLabel(day: string): string {
+  function formatDateValue(day: string): string {
+    const target = parseDateOnly(day);
+    if (!target) {
+      return day;
+    }
+    return `${target.getMonth() + 1}/${target.getDate()}`;
+  }
+
+  function formatWeekdayValue(day: string): string {
     const target = parseDateOnly(day);
     if (!target) {
       return day;
     }
     const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-    return `${String(target.getMonth() + 1).padStart(2, "0")}/${String(target.getDate()).padStart(2, "0")} ${weekdays[target.getDay()]}`;
+    return weekdays[target.getDay()];
   }
 
   function formatWeekKey(day: string): string {
@@ -1112,19 +1255,19 @@
     if (!target) {
       return day;
     }
-    const monday = new Date(target.getTime());
-    const offset = (monday.getDay() + 6) % 7;
-    monday.setDate(monday.getDate() - offset);
-    return formatDateOnly(monday);
+    const sunday = new Date(target.getTime());
+    const offset = sunday.getDay();
+    sunday.setDate(sunday.getDate() - offset);
+    return formatDateOnly(sunday);
   }
 
-  function formatWeekLabel(days: string[]): string {
+  function formatWeekLabel(weekKey: string, days: string[]): string {
     if (days.length === 0) {
       return "週";
     }
-    const start = parseDateOnly(days[0]);
+    const start = parseDateOnly(weekKey);
     if (!start) {
-      return days[0];
+      return weekKey;
     }
     const monthSet = new Set(days.map((day) => {
       const target = parseDateOnly(day);

--- a/docs/project/tests/mikuproject-excel-io.test.js
+++ b/docs/project/tests/mikuproject-excel-io.test.js
@@ -160,6 +160,32 @@ describe("mikuproject excel io", () => {
     expect(imported).toEqual(workbook);
   });
 
+  it("round-trips wrapped text alignment", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [
+        {
+          name: "Wrapped",
+          rows: [
+            {
+              cells: [
+                { value: "Long task name", horizontalAlign: "left", wrapText: true }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+    const stylesXml = decodeUtf8(codec.unpackEntries(bytes)["xl/styles.xml"]);
+
+    expect(imported).toEqual(workbook);
+    expect(stylesXml).toContain('wrapText="1"');
+  });
+
   it("round-trips bold, fill color, and border styles", () => {
     const excelIo = bootExcelIoModule();
     const codec = new excelIo.XlsxWorkbookCodec();

--- a/docs/project/tests/mikuproject-main.test.js
+++ b/docs/project/tests/mikuproject-main.test.js
@@ -102,6 +102,7 @@ function mountDom() {
     <input id="wbsDisplayDaysAfterInput" />
     <input id="wbsBusinessDayRangeInput" type="checkbox" />
     <input id="wbsBusinessDayProgressInput" type="checkbox" />
+    <div id="wbsHolidaySummary"></div>
     <textarea id="wbsHolidayDatesInput"></textarea>
     <textarea id="wbsExtraHolidayDatesInput"></textarea>
     <textarea id="xmlInput"></textarea>
@@ -193,6 +194,7 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).toContain("進捗帯も営業日基準へ切り替えられます");
     expect(document.getElementById("wbsHolidayDatesInput").value).toBe("");
     expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("wbsHolidaySummary").textContent).toBe("既定祝日: 0 件");
     expect(document.getElementById("wbsDisplayDaysBeforeInput").value).toBe("");
     expect(document.getElementById("wbsDisplayDaysAfterInput").value).toBe("");
     expect(document.getElementById("wbsBusinessDayRangeInput").checked).toBe(false);
@@ -741,10 +743,10 @@ describe("mikuproject main", () => {
     });
     const workbook = exportSpy.mock.results.at(-1)?.value;
     const sheet = workbook.sheets[0];
-    const projectInfoHeaderIndex = sheet.rows.findIndex((row) => row.cells[5]?.value === "プロジェクト / 情報");
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(2);
+    const projectInfoHeaderIndex = sheet.rows.findIndex((row) => row.cells[0]?.value === "プロジェクト");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBe(2);
     const headerRowIndex = sheet.rows.findIndex((row) => row.cells[0]?.value === "UID");
-    const holidayColumnIndex = sheet.rows[headerRowIndex].cells.findIndex((cell) => cell.value === "03/20 Fri");
+    const holidayColumnIndex = sheet.rows[headerRowIndex].cells.findIndex((cell) => cell.value === "3/20");
     expect(sheet.rows[headerRowIndex].cells[holidayColumnIndex].fillColor).toBe("#FCE4EC");
     expect(document.getElementById("statusMessage").textContent).toContain("祝日 2 件");
   });
@@ -814,6 +816,8 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
     expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("wbsHolidaySummary").textContent).toContain("既定祝日: 1 件");
+    expect(document.getElementById("wbsHolidaySummary").textContent).toContain("2026-03-20");
   });
 
   it("resets wbs holiday input back to model defaults", () => {
@@ -825,6 +829,7 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
     expect(document.getElementById("wbsExtraHolidayDatesInput").value).toBe("");
+    expect(document.getElementById("wbsHolidaySummary").textContent).toContain("既定祝日: 1 件");
     expect(document.getElementById("statusMessage").textContent).toContain("WBS 祝日入力を既定値へ戻しました");
     expect(document.getElementById("statusMessage").textContent).toContain("1 件");
   });

--- a/docs/project/tests/mikuproject-wbs-xlsx.test.js
+++ b/docs/project/tests/mikuproject-wbs-xlsx.test.js
@@ -72,30 +72,28 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.columns[17].width).toBe(18);
     expect(sheet.mergedRanges).toContain("A1:AI1");
     expect(sheet.mergedRanges).toContain("A2:AI2");
+    expect(sheet.mergedRanges).toContain("A3:D3");
     expect(sheet.mergedRanges).toContain("F3:G3");
-    expect(sheet.mergedRanges).toContain("F12:G12");
     expect(sheet.rows[0].cells[0].value).toBe("WBS");
     expect(sheet.rows[1].cells[0].value).toBe("Sample Project");
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
     expect(projectInfoHeaderIndex).toBe(2);
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[5].value).toBe("題名");
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].value).toBe("Sample Project ...");
-    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[5].value).toBe("カレンダ");
-    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[6].value).toBe("1 Standard");
-    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[5].value).toBe("基準");
-    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[6].value).toBe("開始基準");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[5].value).toBe("開始日");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[6].value).toBe("2026-03-16");
-    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[5].value).toBe("終了日");
-    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[6].value).toBe("2026-03-31");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[5].value).toBe("現在日");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[6].value).toBe("2026-03-16");
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[5].value).toBe("祝日");
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(0);
-    expect(sheet.rows[projectInfoHeaderIndex + 8].height).toBe(28);
-    expect(sheet.rows[projectInfoHeaderIndex + 8].cells[5].value).toBeUndefined();
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("題名");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("Sample Project ...");
+    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[0].value).toBe("カレンダ");
+    expect(sheet.rows[projectInfoHeaderIndex + 2].cells[2].value).toBe("1 Standard");
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[0].value).toBe("基準");
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[2].value).toBe("開始基準");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[0].value).toBe("開始日");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[2].value).toBe("2026-03-16");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[0].value).toBe("終了日");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[2].value).toBe("2026-03-31");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[0].value).toBe("現在日");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("2026-03-16");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[0].value).toBe("祝日");
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBe(0);
     const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
-    expect(summaryHeaderIndex).toBe(11);
+    expect(summaryHeaderIndex).toBe(2);
     expect(sheet.rows[summaryHeaderIndex].height).toBe(24);
     expect(sheet.rows[summaryHeaderIndex].cells[5].fillColor).toBe("#E1EDF8");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[5].value).toBe("表示日");
@@ -103,8 +101,8 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[summaryHeaderIndex + 1].cells[5].horizontalAlign).toBe("right");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[6].horizontalAlign).toBe("center");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[6].bold).toBe(true);
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].horizontalAlign).toBe("left");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[6].horizontalAlign).toBe("left");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].horizontalAlign).toBe("left");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[2].horizontalAlign).toBe("left");
     expect(sheet.rows[summaryHeaderIndex + 3].cells[5].value).toBe("営業日");
     expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(12);
     expect(sheet.rows[summaryHeaderIndex + 4].cells[5].value).toBe("前日数");
@@ -124,10 +122,12 @@ describe("mikuproject wbs xlsx", () => {
       (cells) => cells[5]?.value === "基準日" && cells.some((cell) => cell.value === "▼基準日")
     );
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    expect(taskViewIndex).toBe(24);
-    expect(weekRowIndex).toBe(25);
-    expect(baseDateRowIndex).toBe(26);
-    expect(headerRowIndex).toBe(27);
+    const weekdayRowIndex = headerRowIndex + 1;
+    expect(taskViewIndex).toBe(16);
+    expect(weekRowIndex).toBe(17);
+    expect(baseDateRowIndex).toBe(18);
+    expect(headerRowIndex).toBe(19);
+    expect(weekdayRowIndex).toBe(20);
     expect(sheet.rows[weekRowIndex].height).toBe(24);
     expect(sheet.rows[baseDateRowIndex].height).toBe(24);
     expect(sheet.rows[taskViewIndex].cells[5].fillColor).toBe("#E6F1FB");
@@ -135,7 +135,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[taskViewIndex].cells[8].fillColor).toBe("#E6F1FB");
     expect(sheet.rows[weekRowIndex].cells[5].fillColor).toBe("#E3EEF9");
     expect(sheet.rows[weekRowIndex].cells[6].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/16");
+    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/15");
     expect(sheet.rows[baseDateRowIndex].cells[19].value).toBe("▼基準日");
     expect(sheet.rows[baseDateRowIndex].cells[6].fillColor).toBe("#FFEFC2");
     expect(sheet.rows[baseDateRowIndex].cells[20].fillColor).toBe("#FFF8E1");
@@ -162,22 +162,40 @@ describe("mikuproject wbs xlsx", () => {
     ]);
     expect(sheet.rows[headerRowIndex].cells[18].fillColor).toBe("#D9E2EA");
     expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
-      "[03/16 Mon *]",
-      "03/17 Tue",
-      "03/18 Wed",
-      "03/19 Thu",
-      "03/20 Fri",
-      "03/21 Sat",
-      "03/22 Sun",
-      "03/23 Mon",
-      "03/24 Tue",
-      "03/25 Wed",
-      "03/26 Thu",
-      "03/27 Fri",
-      "03/28 Sat",
-      "03/29 Sun",
-      "03/30 Mon",
-      "03/31 Tue"
+      "3/16",
+      "3/17",
+      "3/18",
+      "3/19",
+      "3/20",
+      "3/21",
+      "3/22",
+      "3/23",
+      "3/24",
+      "3/25",
+      "3/26",
+      "3/27",
+      "3/28",
+      "3/29",
+      "3/30",
+      "3/31"
+    ]);
+    expect(sheet.rows[weekdayRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+      "Sun",
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+      "Sun",
+      "Mon",
+      "Tue"
     ]);
     expect(sheet.rows[headerRowIndex].cells[0].fillColor).toBe("#E1EDF8");
     expect(sheet.rows[headerRowIndex].cells[2].fillColor).toBe("#E6F0DF");
@@ -186,9 +204,9 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[headerRowIndex].cells[9].fillColor).toBe("#FBE4EC");
     expect(sheet.rows[headerRowIndex].cells[14].fillColor).toBe("#E2F1EF");
     expect(sheet.rows[headerRowIndex].cells[19].fillColor).toBe("#FFE6A7");
-    const firstTaskRow = sheet.rows[headerRowIndex + 1];
-    const secondTaskRow = sheet.rows[headerRowIndex + 2];
-    const thirdTaskRow = sheet.rows[headerRowIndex + 3];
+    const firstTaskRow = sheet.rows[headerRowIndex + 2];
+    const secondTaskRow = sheet.rows[headerRowIndex + 3];
+    const thirdTaskRow = sheet.rows[headerRowIndex + 4];
     expect(firstTaskRow.cells[3].value).toBe("フェーズ");
     expect(firstTaskRow.cells[3].fillColor).toBe("#EEF7E8");
     expect(firstTaskRow.cells[0].fillColor).toBe("#EEF7E8");
@@ -212,6 +230,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(firstTaskRow.cells[5].value).toBe("> Project Summary");
     expect(secondTaskRow.cells[5].value).toBe("  - Design");
     expect(secondTaskRow.cells[5].fillColor).toBe("#FBFCFE");
+    expect(secondTaskRow.cells[5].wrapText).toBe(true);
     expect(secondTaskRow.cells[6].fillColor).toBe("#FCFAF7");
     expect(secondTaskRow.cells[14].value).toBe("Miku");
     expect(secondTaskRow.cells[14].fillColor).toBe("#F8FBFB");
@@ -236,7 +255,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(thirdTaskRow.cells[10].value).toBe("  0% [----------]");
     expect(thirdTaskRow.cells[23].value).toBe("■");
     const legendHeaderIndex = findRowIndexByCellValue(sheet, "凡例", 5);
-    expect(legendHeaderIndex).toBe(headerRowIndex + 5);
+    expect(legendHeaderIndex).toBe(headerRowIndex + 6);
     expect(sheet.rows[legendHeaderIndex - 1].height).toBe(28);
     expect(sheet.rows[legendHeaderIndex - 1].cells[5].value).toBeUndefined();
     expect(sheet.rows[legendHeaderIndex].height).toBe(24);
@@ -268,18 +287,19 @@ describe("mikuproject wbs xlsx", () => {
     expect(entries).toContain("xl/worksheets/sheet1.xml");
     expect(sheetXml).toContain('ref="A1:AI1"');
     expect(sheetXml).toContain('ref="A2:AI2"');
+    expect(sheetXml).toContain('ref="A3:D3"');
     expect(sheetXml).toContain('ref="F3:G3"');
-    expect(sheetXml).toContain('ref="F12:G12"');
-    expect(sheetXml).toContain('ref="T26:Z26"');
+    expect(sheetXml).toContain('ref="T18:Y18"');
     expect(sheetXml).not.toContain("<pane");
     expect(sheetXml).toContain("凡例");
     expect(sheetXml).toContain("プロジェクト");
-    expect(sheetXml).toContain("週 03/16");
+    expect(sheetXml).toContain("週 03/15");
     expect(sheetXml).toContain("タスク表");
     expect(sheetXml).toContain("基準日 2026-03-16");
     expect(sheetXml).toContain("Sample Project");
     expect(sheetXml).toContain("階層");
-    expect(sheetXml).toContain("[03/16 Mon *]");
+    expect(sheetXml).toContain("3/16");
+    expect(sheetXml).toContain("Mon");
   });
 
   it("marks weekend date-band cells with weekend fill", () => {
@@ -298,16 +318,23 @@ describe("mikuproject wbs xlsx", () => {
       sheet,
       (cells) => cells[5]?.value === "基準日" && cells.some((cell) => cell.value === "▼基準日")
     );
+    const weekdayRowIndex = headerRowIndex + 1;
     expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
-      "03/20 Fri",
-      "[03/21 Sat *]",
-      "03/22 Sun",
-      "03/23 Mon"
+      "3/20",
+      "3/21",
+      "3/22",
+      "3/23"
+    ]);
+    expect(sheet.rows[weekdayRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
+      "Fri",
+      "Sat",
+      "Sun",
+      "Mon"
     ]);
     const baseDateMarkerIndex = sheet.rows[baseDateRowIndex].cells.findIndex((cell) => cell.value === "▼基準日");
     expect(baseDateMarkerIndex).toBe(20);
     expect(sheet.rows[headerRowIndex].cells[baseDateMarkerIndex].fillColor).toBe("#FFE6A7");
-    expect(sheet.rows[headerRowIndex].cells[baseDateMarkerIndex + 1].fillColor).toBe("#F1F1F1");
+    expect(sheet.rows[headerRowIndex].cells[baseDateMarkerIndex + 1].fillColor).toBe("#C9D3E1");
   });
 
   it("marks week-start date-band cells with week-start fill", () => {
@@ -322,9 +349,10 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    expect(sheet.rows[headerRowIndex].cells[26].value).toBe("03/23 Mon");
-    expect(sheet.rows[headerRowIndex].cells[26].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[headerRowIndex + 2].cells[26].fillColor).toBe("#E3EEF9");
+    expect(sheet.rows[headerRowIndex].cells[26].value).toBe("3/23");
+    expect(sheet.rows[headerRowIndex + 1].cells[26].value).toBe("Mon");
+    expect(sheet.rows[headerRowIndex].cells[26].fillColor).toBe("#D9EAF7");
+    expect(sheet.rows[headerRowIndex + 2].cells[26].fillColor).toBe("#F4F7FB");
   });
 
   it("emphasizes week labels that contain a month boundary", () => {
@@ -339,8 +367,8 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const weekRowIndex = findRowIndexByCellValue(sheet, "週", 5);
-    expect(sheet.mergedRanges).toContain("T26:X26");
-    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/30 / 04");
+    expect(sheet.mergedRanges).toContain("T18:X18");
+    expect(sheet.rows[weekRowIndex].cells[19].value).toBe("週 03/29 / 04");
     expect(sheet.rows[weekRowIndex].cells[19].fillColor).toBe("#D6E7F8");
   });
 
@@ -356,7 +384,8 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    expect(sheet.rows[headerRowIndex].cells[21].value).toBe("04/01 Wed");
+    expect(sheet.rows[headerRowIndex].cells[21].value).toBe("4/1");
+    expect(sheet.rows[headerRowIndex + 1].cells[21].value).toBe("Wed");
     expect(sheet.rows[headerRowIndex].cells[21].fillColor).toBe("#DCEAF7");
   });
 
@@ -371,7 +400,7 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    const milestoneRow = sheet.rows[headerRowIndex + 3];
+    const milestoneRow = sheet.rows[headerRowIndex + 4];
     expect(milestoneRow.cells[3].value).toBe("マイル");
     expect(milestoneRow.cells[3].fillColor).toBe("#FFF4E0");
     expect(milestoneRow.cells[11].value).toBe("Mil");
@@ -388,7 +417,7 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    expect(sheet.rows[headerRowIndex + 2].cells[13].value).toBe("Crit");
+    expect(sheet.rows[headerRowIndex + 3].cells[13].value).toBe("Crit");
   });
 
   it("marks configured holidays in the date band", () => {
@@ -400,13 +429,14 @@ describe("mikuproject wbs xlsx", () => {
     });
     const sheet = workbook.sheets[0];
 
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[6].value).toBe(1);
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
+    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBe(1);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    expect(sheet.rows[headerRowIndex].cells[23].value).toBe("03/20 Fri");
+    expect(sheet.rows[headerRowIndex].cells[23].value).toBe("3/20");
+    expect(sheet.rows[headerRowIndex + 1].cells[23].value).toBe("Fri");
     expect(sheet.rows[headerRowIndex].cells[23].fillColor).toBe("#FCE4EC");
-    expect(sheet.rows[headerRowIndex + 2].cells[23].value).toBe("");
-    expect(sheet.rows[headerRowIndex + 2].cells[23].fillColor).toBe("#FCE4EC");
+    expect(sheet.rows[headerRowIndex + 2].cells[23].value).toBe("━");
+    expect(sheet.rows[headerRowIndex + 2].cells[23].fillColor).toBe("#9FD5C9");
   });
 
   it("can limit the displayed date band around base date", () => {
@@ -422,9 +452,9 @@ describe("mikuproject wbs xlsx", () => {
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
 
     expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
-      "[03/16 Mon *]",
-      "03/17 Tue",
-      "03/18 Wed"
+      "3/16",
+      "3/17",
+      "3/18"
     ]);
     expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe(1);
     expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe(2);
@@ -451,13 +481,13 @@ describe("mikuproject wbs xlsx", () => {
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
 
     expect(sheet.rows[headerRowIndex].cells.slice(19).map((cell) => cell.value)).toEqual([
-      "03/17 Tue",
-      "[03/18 Wed *]",
-      "03/19 Thu",
-      "03/20 Fri",
-      "03/21 Sat",
-      "03/22 Sun",
-      "03/23 Mon"
+      "3/17",
+      "3/18",
+      "3/19",
+      "3/20",
+      "3/21",
+      "3/22",
+      "3/23"
     ]);
     expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(4);
     expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("営業日");
@@ -480,7 +510,7 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
     const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    const designRow = sheet.rows[headerRowIndex + 2];
+    const designRow = sheet.rows[headerRowIndex + 3];
 
     expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("営業日");
     expect(designRow.cells[8].value).toBe("4営業日");
@@ -503,15 +533,30 @@ describe("mikuproject wbs xlsx", () => {
 
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 5);
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
-    const secondTaskRow = sheet.rows[headerRowIndex + 2];
-    const thirdTaskRow = sheet.rows[headerRowIndex + 3];
+    const secondTaskRow = sheet.rows[headerRowIndex + 3];
+    const thirdTaskRow = sheet.rows[headerRowIndex + 4];
 
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[6].value).toBe("Sample Project ...");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("Sample Project ...");
     expect(secondTaskRow.cells[14].value).toBe("Resource Al...");
     expect(secondTaskRow.cells[15].value).toBe("1 Standa...");
     expect(secondTaskRow.cells[16].value).toBe("Resource Alpha ...");
     expect(thirdTaskRow.cells[17].value).toBe("Project Summary");
+  });
+
+  it("uses taller rows for long task names in wbs display", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.tasks[1].name = "Design task with a very long title for wrapped display";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model);
+    const sheet = workbook.sheets[0];
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const designRow = sheet.rows[headerRowIndex + 3];
+
+    expect(designRow.height).toBe(34);
+    expect(designRow.cells[5].wrapText).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要

`mikuproject` の `WBS XLSX Export` について、WBS シートの見た目と操作性を継続改善します。 主に、日付ヘッダの分離、週の扱いの見直し、上部の `プロジェクト` / `サマリ` ブロック再配置、長い名称や祝日表示の改善を行います。

## 変更内容

### WBS ヘッダと日付帯の改善
- `wbs-xlsx.ts` / `wbs-xlsx.js` を更新
- 日付ヘッダを `日付` 行と `曜日` 行に分離
- 週ラベルと `週頭` 判定を日曜始まりへ変更
- 土日の色をより濃くして視認性を改善
- `基準日`、週ラベル、日付帯の見え方を調整

### 上部情報ブロックの再配置
- `プロジェクト` ブロックを左上に移動
- `A3:D3` を `プロジェクト` 見出しの結合セルに変更
- `A:B` をラベル、`C:D` を値とする構成に変更
- `サマリ` ブロックを `F3` 起点に移動
- `プロジェクト` と `サマリ` を同じ上段に並べるレイアウトへ変更

### WBS 一覧の表示改善
- `名称` 列に折り返し表示を追加
- 長いタスク名に応じて行高を調整
- `Start / Finish` は日付のみ表示
- `Duration` は WBS 向けの読みやすい表記に変更
- `Owner / Calendar / Resources / Predecessors` の長い表示を省略
- `Calendar` 表示を短縮しつつ UID と名前を保持
- 進捗表示や各列のトーンを整理

### 祝日表示の改善
- `WBS XLSX Export` 用の既定祝日サマリ表示を UI に追加
- 祝日件数と一覧が見えるように更新
- WBS sample にも祝日反映を継続

### `.xlsx` workbook 基盤の改善
- `excel-io.ts` / `excel-io.js` に `wrapText` を追加
- style export/import と XML 出力に `wrapText` を反映

### テストと sample 更新
- `mikuproject-wbs-xlsx.test.js` を更新
- `mikuproject-main.test.js` を更新
- `mikuproject-excel-io.test.js` を更新
- `mikuproject-wbs-sample.xlsx` と `mikuproject-sample.xlsx` を再生成
- 変更後レイアウトと UI 連携を確認

## 影響範囲

- `docs/project` 配下の `WBS XLSX Export`
- `.xlsx` workbook スタイル基盤
- `mikuproject` の WBS 関連 UI
- WBS / main / excel-io のテストと sample

## 補足

- `WBS XLSX Export` は引き続き表示専用 workbook です
- 固定スクロールはこの変更には含みません
- 週の既定は日曜始まりです