### PR TITLE
Git 作業一覧の入力順を見直し、index の外部アプリ導線を更新

### DIFF
--- a/docs/git/git-work-list-src.html
+++ b/docs/git/git-work-list-src.html
@@ -81,6 +81,10 @@ SPDX-License-Identifier: Apache-2.0
 
         <div class="md-dialog__body md-stack-md">
           <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" required placeholder="例: https://github.com/igapyon/local-html-tools" help-text="リポジトリを識別する URL や clone URL を入力します。HTTPS / SSH / ローカルパスのどれでも構いません。表示名は URL の末尾から自動で組み立てます。"></lht-text-field-help>
+          </div>
+
+          <div class="md-form-grid md-form-grid-1">
             <lht-select-help field-id="entryType" label="種別" help-text="Git 連携を使う通常登録か、URL とメモだけを管理する登録かを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "git", "label": "Git連携あり", "selected": true },
@@ -89,25 +93,21 @@ SPDX-License-Identifier: Apache-2.0
             </lht-select-help>
           </div>
 
-          <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" required placeholder="例: https://github.com/igapyon/local-html-tools" help-text="リポジトリを識別する URL や clone URL を入力します。HTTPS / SSH / ローカルパスのどれでも構いません。表示名は URL の末尾から自動で組み立てます。"></lht-text-field-help>
-          </div>
-
           <div id="gitFields" class="md-form-grid md-form-grid-4">
-            <lht-text-field-help field-id="baseBranch" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。"></lht-text-field-help>
             <lht-select-help field-id="baseScope" label="基準の扱い" help-text="基準ブランチをローカルとして扱うか、リモート参照として扱うかを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "remote", "label": "リモート", "selected": true },
                 { "value": "local", "label": "ローカル" }
               ]</script>
             </lht-select-help>
-            <lht-text-field-help field-id="compareBranch" label="作業ブランチ" required placeholder="例: feature" help-text="いま確認したい作業対象ブランチです。"></lht-text-field-help>
+            <lht-text-field-help field-id="baseBranch" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。"></lht-text-field-help>
             <lht-select-help field-id="compareScope" label="作業の扱い" help-text="作業ブランチをローカルとして扱うか、リモート参照として扱うかを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "remote", "label": "リモート" },
                 { "value": "local", "label": "ローカル", "selected": true }
               ]</script>
             </lht-select-help>
+            <lht-text-field-help field-id="compareBranch" label="作業ブランチ" required placeholder="例: feature" help-text="いま確認したい作業対象ブランチです。"></lht-text-field-help>
           </div>
 
           <div id="gitRemoteField" class="md-form-grid md-form-grid-1">
@@ -139,10 +139,10 @@ SPDX-License-Identifier: Apache-2.0
 
         <div class="md-dialog__body md-stack-md">
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
+            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
           </div>
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
           </div>
         </div>
 

--- a/docs/git/git-work-list.html
+++ b/docs/git/git-work-list.html
@@ -1814,6 +1814,10 @@ lht-index-card-link {
 
         <div class="md-dialog__body md-stack-md">
           <div class="md-form-grid md-form-grid-1">
+            <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" required placeholder="例: https://github.com/igapyon/local-html-tools" help-text="リポジトリを識別する URL や clone URL を入力します。HTTPS / SSH / ローカルパスのどれでも構いません。表示名は URL の末尾から自動で組み立てます。"></lht-text-field-help>
+          </div>
+
+          <div class="md-form-grid md-form-grid-1">
             <lht-select-help field-id="entryType" label="種別" help-text="Git 連携を使う通常登録か、URL とメモだけを管理する登録かを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "git", "label": "Git連携あり", "selected": true },
@@ -1822,25 +1826,21 @@ lht-index-card-link {
             </lht-select-help>
           </div>
 
-          <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="repoUrl" label="リポジトリ URL" required placeholder="例: https://github.com/igapyon/local-html-tools" help-text="リポジトリを識別する URL や clone URL を入力します。HTTPS / SSH / ローカルパスのどれでも構いません。表示名は URL の末尾から自動で組み立てます。"></lht-text-field-help>
-          </div>
-
           <div id="gitFields" class="md-form-grid md-form-grid-4">
-            <lht-text-field-help field-id="baseBranch" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。"></lht-text-field-help>
             <lht-select-help field-id="baseScope" label="基準の扱い" help-text="基準ブランチをローカルとして扱うか、リモート参照として扱うかを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "remote", "label": "リモート", "selected": true },
                 { "value": "local", "label": "ローカル" }
               ]</script>
             </lht-select-help>
-            <lht-text-field-help field-id="compareBranch" label="作業ブランチ" required placeholder="例: feature" help-text="いま確認したい作業対象ブランチです。"></lht-text-field-help>
+            <lht-text-field-help field-id="baseBranch" label="基準ブランチ" required placeholder="例: main" help-text="比較の基準にするブランチです。"></lht-text-field-help>
             <lht-select-help field-id="compareScope" label="作業の扱い" help-text="作業ブランチをローカルとして扱うか、リモート参照として扱うかを選びます。">
               <script type="application/json" slot="options">[
                 { "value": "remote", "label": "リモート" },
                 { "value": "local", "label": "ローカル", "selected": true }
               ]</script>
             </lht-select-help>
+            <lht-text-field-help field-id="compareBranch" label="作業ブランチ" required placeholder="例: feature" help-text="いま確認したい作業対象ブランチです。"></lht-text-field-help>
           </div>
 
           <div id="gitRemoteField" class="md-form-grid md-form-grid-1">
@@ -1872,10 +1872,10 @@ lht-index-card-link {
 
         <div class="md-dialog__body md-stack-md">
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
+            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
           </div>
           <div class="md-form-grid md-form-grid-1">
-            <lht-text-field-help field-id="gitCurrentDirectory" label="カレントディレクトリ" placeholder="例: /path/to/repo" help-text="この作業を行うローカルの git カレントディレクトリを記録します。"></lht-text-field-help>
+            <lht-text-field-help field-id="memoText" label="メモ" placeholder="必要なメモを入力" help-text="保存は全文、一覧表示は先頭 16 文字までです。長い内容は hover で全文を確認できます。"></lht-text-field-help>
           </div>
         </div>
 

--- a/docs/index-src.html
+++ b/docs/index-src.html
@@ -1148,7 +1148,7 @@ SPDX-License-Identifier: Apache-2.0
         <lht-index-card-link href="text/file-rename-cmdline-gen.html" icon="🏷️" title="ファイル名連番リネーム" desc="ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。"></lht-index-card-link>
         <lht-index-card-link href="text/text2spreadsheetml.html" icon="📊" title="text2spreadsheetml" desc="ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。MVP では全セルを String として安全側へ出力します。"></lht-index-card-link>
         <lht-index-card-link href="text/japanese-romaji-guide.html" icon="🔤" title="日本語ローマ字メモ" desc="旅券ローマ字を中心に、ヘボン式・訓令式・日本式（理論寄り）を比較しながら、かなをローマ字に変換します。"></lht-index-card-link>
-        <lht-index-card-link href="https://igapyon.github.io/xlsx2md/xlsx2md.html" icon="📘" title="xlsx2md" badge="external" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
+        <lht-index-card-link href="https://igapyon.github.io/miku-xlsx2md/miku-xlsx2md.html" icon="📘" title="miku-xlsx2md" badge="external" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
       </div>
       </section>
 
@@ -1164,6 +1164,7 @@ SPDX-License-Identifier: Apache-2.0
         <lht-index-card-link href="music/musicxml-to-abc.html" icon="🎶" title="MusicXML → ABC 変換" desc="MusicXMLからABC記法を生成し、ABCとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="music/abc-to-musicxml.html" icon="🎵" title="ABC → MusicXML 変換" desc="ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="https://igapyon.github.io/mikuscore/mikuscore.html" icon="🎼" title="mikuscore" badge="external" desc="mikuscore is a browser-based score format converter centered on MusicXML. It runs offline as a single-file web app."></lht-index-card-link>
+        <lht-index-card-link href="https://igapyon.github.io/miku-abc-player/miku-abc-player.html" icon="🎧" title="miku-abc-player" badge="external" desc="miku-abc-player is a browser-based ABC notation player. It runs offline as a single-file web app."></lht-index-card-link>
       </div>
       </section>
 
@@ -1233,6 +1234,7 @@ SPDX-License-Identifier: Apache-2.0
       </h3>
       <p class="md-section-subtitle">図表の作成・変換</p>
       <div class="md-grid md-grid-3 md-section">
+        <lht-index-card-link href="https://igapyon.github.io/mikuproject/mikuproject.html" icon="📋" title="mikuproject" badge="external" desc="MS Project XML を扱う実験ツールです。独立プロジェクトとして別リポジトリへ移管しました。"></lht-index-card-link>
         <lht-index-card-link href="diagram/mermaid-to-svg.html" icon="🧭" title="Mermaid → SVG 変換" desc="Mermaid記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="diagram/graphviz-dot-to-svg.html" icon="🕸️" title="Graphviz DOT → SVG 変換" desc="Graphviz DOT記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
       </div>
@@ -1287,7 +1289,6 @@ SPDX-License-Identifier: Apache-2.0
       </h2>
       <p class="md-section-subtitle">実験段階・育成中のツール</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="https://github.com/igapyon/mikuproject" icon="📋" title="mikuproject" badge="external" desc="MS Project XML を扱う実験ツールです。独立プロジェクトとして別リポジトリへ移管しました。"></lht-index-card-link>
       </div>
       </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2174,7 +2174,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-04-06</div>
+        <div class="md-app-meta">更新日: 2026-04-11</div>
       </div>
     </header>
 
@@ -2223,7 +2223,7 @@ lht-index-card-link {
         <lht-index-card-link href="text/file-rename-cmdline-gen.html" icon="🏷️" title="ファイル名連番リネーム" desc="ファイル名リストから連番にリネームするコマンドを生成します。bashまたはPowerShellで実行できるコマンドを出力します。"></lht-index-card-link>
         <lht-index-card-link href="text/text2spreadsheetml.html" icon="📊" title="text2spreadsheetml" desc="ベタテキスト、CSV、TAB区切りファイルを SpreadsheetML 2003 XML に変換します。MVP では全セルを String として安全側へ出力します。"></lht-index-card-link>
         <lht-index-card-link href="text/japanese-romaji-guide.html" icon="🔤" title="日本語ローマ字メモ" desc="旅券ローマ字を中心に、ヘボン式・訓令式・日本式（理論寄り）を比較しながら、かなをローマ字に変換します。"></lht-index-card-link>
-        <lht-index-card-link href="https://igapyon.github.io/xlsx2md/xlsx2md.html" icon="📘" title="xlsx2md" badge="external" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
+        <lht-index-card-link href="https://igapyon.github.io/miku-xlsx2md/miku-xlsx2md.html" icon="📘" title="miku-xlsx2md" badge="external" desc="Excel 設計書 (.xlsx) をローカルで解析し、地の文・表・結合セル情報を保ちながら Markdown へ変換します。"></lht-index-card-link>
       </div>
       </section>
 
@@ -2239,6 +2239,7 @@ lht-index-card-link {
         <lht-index-card-link href="music/musicxml-to-abc.html" icon="🎶" title="MusicXML → ABC 変換" desc="MusicXMLからABC記法を生成し、ABCとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="music/abc-to-musicxml.html" icon="🎵" title="ABC → MusicXML 変換" desc="ABC記法をMusicXMLへ変換し、MusicXMLとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="https://igapyon.github.io/mikuscore/mikuscore.html" icon="🎼" title="mikuscore" badge="external" desc="mikuscore is a browser-based score format converter centered on MusicXML. It runs offline as a single-file web app."></lht-index-card-link>
+        <lht-index-card-link href="https://igapyon.github.io/miku-abc-player/miku-abc-player.html" icon="🎧" title="miku-abc-player" badge="external" desc="miku-abc-player is a browser-based ABC notation player. It runs offline as a single-file web app."></lht-index-card-link>
       </div>
       </section>
 
@@ -2308,6 +2309,7 @@ lht-index-card-link {
       </h3>
       <p class="md-section-subtitle">図表の作成・変換</p>
       <div class="md-grid md-grid-3 md-section">
+        <lht-index-card-link href="https://igapyon.github.io/mikuproject/mikuproject.html" icon="📋" title="mikuproject" badge="external" desc="MS Project XML を扱う実験ツールです。独立プロジェクトとして別リポジトリへ移管しました。"></lht-index-card-link>
         <lht-index-card-link href="diagram/mermaid-to-svg.html" icon="🧭" title="Mermaid → SVG 変換" desc="Mermaid記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
         <lht-index-card-link href="diagram/graphviz-dot-to-svg.html" icon="🕸️" title="Graphviz DOT → SVG 変換" desc="Graphviz DOT記法からSVGを生成し、SVGとして保存できます。"></lht-index-card-link>
       </div>
@@ -2362,7 +2364,6 @@ lht-index-card-link {
       </h2>
       <p class="md-section-subtitle">実験段階・育成中のツール</p>
       <div class="md-grid md-grid-3 md-section">
-        <lht-index-card-link href="https://github.com/igapyon/mikuproject" icon="📋" title="mikuproject" badge="external" desc="MS Project XML を扱う実験ツールです。独立プロジェクトとして別リポジトリへ移管しました。"></lht-index-card-link>
       </div>
       </section>
 


### PR DESCRIPTION
## 概要

- `Git 作業一覧` のダイアログ内で、入力項目の並び順を調整しました。
- `index` の外部アプリ掲載内容を更新しました。

## 変更内容

### Git 作業一覧

- 登録ダイアログで、`リポジトリ URL` を `種別` より前に移動
- 登録ダイアログで、以下の順に並び替え
  - `基準の扱い`
  - `基準ブランチ`
  - `作業の扱い`
  - `作業ブランチ`
- `リポジトリ情報` ダイアログで、`カレントディレクトリ` を `メモ` より前に移動

### index の更新

- `xlsx2md` を `miku-xlsx2md` に名称変更
- `miku-xlsx2md` のリンク先を更新
- `mikuscore` の次に `miku-abc-player` を追加
- `mikuproject` を `Diagram` セクションへ移動し、先頭に配置
- `mikuproject` のリンク先を更新

## 反映対象

- `docs/git/git-work-list-src.html`
- `docs/git/git-work-list.html`
- `docs/index-src.html`
- `docs/index.html`