### PR TITLE
git-pseudo-squash の PR整形で `# PR Body` を除去し、A501 の PR文面プロンプトを改善

### DIFF
--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -5558,7 +5558,7 @@ if (!customElements.get("lht-page-menu")) {
         return false;
       }
       const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]?$/.test(headingText);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文|pr\s*body)\s*[:：]?$/.test(headingText);
     }
 
     function isPrTitleLabelLine(line) {
@@ -5568,7 +5568,7 @@ if (!customElements.get("lht-page-menu")) {
 
     function isPrTextLabelLine(line) {
       const normalized = String(line || "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]\s*$/.test(normalized);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文|pr\s*body)\s*[:：]\s*$/.test(normalized);
     }
 
     function isTildeFenceStartLine(line) {

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -560,7 +560,7 @@
         return false;
       }
       const headingText = normalized.replace(/^#{1,6}\s*/, "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]?$/.test(headingText);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文|pr\s*body)\s*[:：]?$/.test(headingText);
     }
 
     function isPrTitleLabelLine(line) {
@@ -570,7 +570,7 @@
 
     function isPrTextLabelLine(line) {
       const normalized = String(line || "").trim().toLowerCase();
-      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文)\s*[:：]\s*$/.test(normalized);
+      return /^(?:pr\s*テキスト|pr\s*text|pr\s*本文|pr\s*body)\s*[:：]\s*$/.test(normalized);
     }
 
     function isTildeFenceStartLine(line) {

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -242,6 +242,32 @@ PR本文:
     expect(rebaseCmd.textContent).not.toContain("PR本文:");
   });
 
+  it("normalizes English PR headings by removing # PR Title and # PR Body lines", () => {
+    bootGitPseudoSquashPage();
+
+    const commitMessage = document.getElementById("commitMessage");
+    const rebaseCmd = document.getElementById("rebaseCmd");
+    commitMessage.value = `# PR Title
+
+prompt-gen の GitHub 導線追加
+
+# PR Body
+
+変更内容です。
+補足です。`;
+
+    window.__gitPseudoSquashTest.normalizeCommitMessageForPr();
+
+    expect(commitMessage.value).toBe(`prompt-gen の GitHub 導線追加
+
+変更内容です。
+補足です。`);
+    expect(rebaseCmd.textContent).toContain("prompt-gen の GitHub 導線追加");
+    expect(rebaseCmd.textContent).toContain("変更内容です。");
+    expect(rebaseCmd.textContent).not.toContain("# PR Title");
+    expect(rebaseCmd.textContent).not.toContain("# PR Body");
+  });
+
   it("generates PowerShell rebase command with here-string and no git switch in current branch mode", () => {
     bootGitPseudoSquashPage();
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2174,7 +2174,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-04-11</div>
+        <div class="md-app-meta">更新日: 2026-04-16</div>
       </div>
     </header>
 

--- a/docs/prompt/prompt-gen.html
+++ b/docs/prompt/prompt-gen.html
@@ -4195,6 +4195,19 @@ const promptDefinitions = [
 # Rules
 
 - 絶対パス、ホームディレクトリ、作業ディレクトリは出力しないでください。
+- 回答は日本語で記述してください。
+
+# Examples
+
+\`\`\`markdown
+# PR Title
+
+(Title of PR)
+
+# PR Body
+
+(Body of PR)
+\`\`\`
 
 ${getStrictHallucinationPreventionInstruction()}
 
@@ -4207,7 +4220,7 @@ ${getMarkdownFenceInstruction()}`
         keywords: ["release", "github release", "release notes", "github", "markdown", "tilde", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "りりーすのーと", "まーくだうん", "ちるだ", "ぶんめん", "さくせい", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `${commitId} 以降に行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文を作成してください。
+            ? `${commitId} から HEAD までに行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。
 
 ${getStrictHallucinationPreventionInstruction()}
 

--- a/docs/prompt/src/prompt-gen/js/prompt-definitions.js
+++ b/docs/prompt/src/prompt-gen/js/prompt-definitions.js
@@ -39,6 +39,19 @@ const promptDefinitions = [
 # Rules
 
 - 絶対パス、ホームディレクトリ、作業ディレクトリは出力しないでください。
+- 回答は日本語で記述してください。
+
+# Examples
+
+\`\`\`markdown
+# PR Title
+
+(Title of PR)
+
+# PR Body
+
+(Body of PR)
+\`\`\`
 
 ${getStrictHallucinationPreventionInstruction()}
 
@@ -51,7 +64,7 @@ ${getMarkdownFenceInstruction()}`
         keywords: ["release", "github release", "release notes", "github", "markdown", "tilde", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "りりーすのーと", "まーくだうん", "ちるだ", "ぶんめん", "さくせい", "ぎっとはぶ"],
         requiresCommitId: true,
         buildBody: (commitId) => commitId
-            ? `${commitId} 以降に行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文を作成してください。
+            ? `${commitId} から HEAD までに行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。
 
 ${getStrictHallucinationPreventionInstruction()}
 

--- a/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
+++ b/docs/prompt/src/prompt-gen/ts/prompt-definitions.ts
@@ -69,6 +69,19 @@ const promptDefinitions: PromptDefinition[] = [
 # Rules
 
 - 絶対パス、ホームディレクトリ、作業ディレクトリは出力しないでください。
+- 回答は日本語で記述してください。
+
+# Examples
+
+\`\`\`markdown
+# PR Title
+
+(Title of PR)
+
+# PR Body
+
+(Body of PR)
+\`\`\`
 
 ${getStrictHallucinationPreventionInstruction()}
 
@@ -81,7 +94,7 @@ ${getMarkdownFenceInstruction()}`
     keywords: ["release", "github release", "release notes", "github", "markdown", "tilde", "リリース", "release文面", "release本文", "文面", "作成", "りりーす", "りりーすのーと", "まーくだうん", "ちるだ", "ぶんめん", "さくせい", "ぎっとはぶ"],
     requiresCommitId: true,
     buildBody: (commitId: string) => commitId
-      ? `${commitId} 以降に行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。リリースタイトルとリリース本文を作成してください。
+      ? `${commitId} から HEAD までに行われた変更(${commitId}での変更内容も含む)について、GitHub Release 用のリリースタイトルとリリース本文を markdown テキスト形式で作文してください。
 
 ${getStrictHallucinationPreventionInstruction()}
 


### PR DESCRIPTION
## 概要

以下の変更を含むコミットです。

- `git-pseudo-squash` の `PR整形` で、英語見出し `# PR Body` を除去できるよう調整
- `生成AIプロンプト作成` の `A501: GitHub PR 文面の作成` に、日本語回答ルールと出力例を追加

## 変更内容

- `docs/git/src/git-pseudo-squash/js/main.js`
  - `PR整形` の除去対象に `PR Body` を追加
- `docs/git/tests/git-pseudo-squash-main.test.js`
  - `# PR Title` / `# PR Body` を含む英語見出しの整形テストを追加
- `docs/git/git-pseudo-squash.html`
  - 上記変更を反映
- `docs/prompt/src/prompt-gen/ts/prompt-definitions.ts`
  - A501 の `# Rules` に「回答は日本語で記述してください。」を追加
  - A501 に `# Examples` を追加
  - `# PR Title` / `# PR Body` の出力例を追加
- `docs/prompt/src/prompt-gen/js/prompt-definitions.js`
  - 上記変更を反映
- `docs/prompt/prompt-gen.html`
  - 上記変更を反映
- `docs/index.html`
  - 更新日表示を `2026-04-16` に更新