### PR TITLE
git-pseudo-squash の作業ブランチ自動生成に基点ブランチ名を付与

### DIFF
--- a/docs/git/git-pseudo-squash-spec.md
+++ b/docs/git/git-pseudo-squash-spec.md
@@ -23,7 +23,7 @@
 | ID | ラベル | 型 | 初期値 | 現行挙動 |
 |---|---|---|---|---|
 | `squashBaseBranch` | 基点ブランチ | text | `devel` | datalist候補あり。履歴クリアボタンあり。 |
-| `workBranch` | 作業ブランチ | text | 空 | 初期化時、空なら `tigaMMddxxx` 形式で自動補完。 |
+| `workBranch` | 作業ブランチ | text | 空 | 初期化時、空なら `<squashBaseBranch>-tigaMMddxxx` 形式で自動補完。基点ブランチが空なら `tigaMMddxxx`。 |
 | `shellEnvPowerShell` | PowerShell | checkbox | OFF | ONでPowerShell向け、OFFでPOSIX向けコマンド。 |
 | `lockOrigin` | リモート + origin と作業 | checkbox | ON | ONで `baseRemote`/`squashRemote` を `origin` に固定して入力を隠す。 |
 | `squashBaseScope` | 基点の参照先 | select | `remote` | `remote`/`local` 切替。 |

--- a/docs/git/git-pseudo-squash-src.html
+++ b/docs/git/git-pseudo-squash-src.html
@@ -104,7 +104,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <div class="md-form-row md-form-row--nowrap">
           <div class="md-input-wrap md-input-wrap--inline">
-            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
+            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: devel-tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
             <button type="button" class="md-icon-btn md-icon-btn--prominent md-input-action--inline" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>

--- a/docs/git/git-pseudo-squash.html
+++ b/docs/git/git-pseudo-squash.html
@@ -2664,7 +2664,7 @@ lht-index-card-link {
         </div>
         <div class="md-form-row md-form-row--nowrap">
           <div class="md-input-wrap md-input-wrap--inline">
-            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
+            <lht-text-field-help field-id="workBranch" label="作業ブランチ" required placeholder="例: devel-tiga0129a" field-class="md-outlined-field" help-text="これから作業するブランチ名です。未作成なら作成先として使います。生成コマンドにそのまま反映されます。"></lht-text-field-help>
             <button type="button" class="md-icon-btn md-icon-btn--prominent md-input-action--inline" onclick="updateWorkBranchWithCurrentTime()" title="現在日時で更新" aria-label="現在日時で作業ブランチを更新">
               <svg viewBox="0 0 24 24" class="md-icon-small" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <use href="#md-icon-refresh" xlink:href="#md-icon-refresh"></use>
@@ -5045,6 +5045,18 @@ if (!customElements.get("lht-page-menu")) {
       return s1 + s2 + s3;
     }
 
+    function buildTimedWorkBranchName(date = new Date()) {
+      const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
+      const pad = (num) => String(num).padStart(2, "0");
+      const mm = pad(date.getMonth() + 1);
+      const dd = pad(date.getDate());
+      const hh = date.getHours();
+      const min = date.getMinutes();
+      const timeStr = convertTimeToThreeChars(hh, min);
+      const suffix = `tiga${mm}${dd}${timeStr}`;
+      return baseBranch ? `${baseBranch}-${suffix}` : suffix;
+    }
+
     function getUseCurrentBranchSelected() {
       const useCurrentBranch = document.getElementById("useCurrentBranch");
       if (!useCurrentBranch) return true;
@@ -5191,28 +5203,14 @@ if (!customElements.get("lht-page-menu")) {
     function setDefaultWorkBranch() {
       const input = document.getElementById("workBranch");
       if (!input || input.value.trim()) return;
-      const now = new Date();
-      const pad = (num) => String(num).padStart(2, "0");
-      const mm = pad(now.getMonth() + 1);
-      const dd = pad(now.getDate());
-      const hh = now.getHours();
-      const min = now.getMinutes();
-      const timeStr = convertTimeToThreeChars(hh, min);
-      input.value = `tiga${mm}${dd}${timeStr}`;
+      input.value = buildTimedWorkBranchName();
       regenerateAllCommands();
     }
 
     function updateWorkBranchWithCurrentTime() {
       const input = document.getElementById("workBranch");
       if (!input) return;
-      const now = new Date();
-      const pad = (num) => String(num).padStart(2, "0");
-      const mm = pad(now.getMonth() + 1);
-      const dd = pad(now.getDate());
-      const hh = now.getHours();
-      const min = now.getMinutes();
-      const timeStr = convertTimeToThreeChars(hh, min);
-      input.value = `tiga${mm}${dd}${timeStr}`;
+      input.value = buildTimedWorkBranchName();
       regenerateAllCommands();
       const saved = upsertWorkBranchListEntry({
         requireRepoUrl: false,

--- a/docs/git/src/git-pseudo-squash/js/main.js
+++ b/docs/git/src/git-pseudo-squash/js/main.js
@@ -47,6 +47,18 @@
       return s1 + s2 + s3;
     }
 
+    function buildTimedWorkBranchName(date = new Date()) {
+      const baseBranch = document.getElementById("squashBaseBranch")?.value.trim() || "";
+      const pad = (num) => String(num).padStart(2, "0");
+      const mm = pad(date.getMonth() + 1);
+      const dd = pad(date.getDate());
+      const hh = date.getHours();
+      const min = date.getMinutes();
+      const timeStr = convertTimeToThreeChars(hh, min);
+      const suffix = `tiga${mm}${dd}${timeStr}`;
+      return baseBranch ? `${baseBranch}-${suffix}` : suffix;
+    }
+
     function getUseCurrentBranchSelected() {
       const useCurrentBranch = document.getElementById("useCurrentBranch");
       if (!useCurrentBranch) return true;
@@ -193,28 +205,14 @@
     function setDefaultWorkBranch() {
       const input = document.getElementById("workBranch");
       if (!input || input.value.trim()) return;
-      const now = new Date();
-      const pad = (num) => String(num).padStart(2, "0");
-      const mm = pad(now.getMonth() + 1);
-      const dd = pad(now.getDate());
-      const hh = now.getHours();
-      const min = now.getMinutes();
-      const timeStr = convertTimeToThreeChars(hh, min);
-      input.value = `tiga${mm}${dd}${timeStr}`;
+      input.value = buildTimedWorkBranchName();
       regenerateAllCommands();
     }
 
     function updateWorkBranchWithCurrentTime() {
       const input = document.getElementById("workBranch");
       if (!input) return;
-      const now = new Date();
-      const pad = (num) => String(num).padStart(2, "0");
-      const mm = pad(now.getMonth() + 1);
-      const dd = pad(now.getDate());
-      const hh = now.getHours();
-      const min = now.getMinutes();
-      const timeStr = convertTimeToThreeChars(hh, min);
-      input.value = `tiga${mm}${dd}${timeStr}`;
+      input.value = buildTimedWorkBranchName();
       regenerateAllCommands();
       const saved = upsertWorkBranchListEntry({
         requireRepoUrl: false,

--- a/docs/git/tests/git-pseudo-squash-main.test.js
+++ b/docs/git/tests/git-pseudo-squash-main.test.js
@@ -355,7 +355,7 @@ prompt-gen の GitHub 導線追加
     expect(window.__gitPseudoSquashTest.getUseCurrentBranchSelected()).toBe(true);
     expect(document.getElementById("squashBaseBranch").value).toBe("devel");
     expect(document.getElementById("commitMessage").value).toBe("");
-    expect(document.getElementById("workBranch").value).toMatch(/^tiga\d{4}[a-z]{3}$/);
+    expect(document.getElementById("workBranch").value).toMatch(/^devel-tiga\d{4}[a-z]{3}$/);
     expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.baseRemote");
     expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.squashRemote");
     expect(localStorage.removeItem).toHaveBeenCalledWith("gitPseudoSquash.ui.useCurrentBranch");

--- a/docs/index.html
+++ b/docs/index.html
@@ -2174,7 +2174,7 @@ lht-index-card-link {
             </lht-help-tooltip>
           </div>
         </div>
-        <div class="md-app-meta">更新日: 2026-04-16</div>
+        <div class="md-app-meta">更新日: 2026-06-06</div>
       </div>
     </header>
 


### PR DESCRIPTION
  ## 概要

  git-pseudo-squash で作業ブランチ名を自動生成する際、基点ブランチ名をプレフィッ
  クスとして含めるように変更しました。

  ## 変更内容

  - 作業ブランチ名の生成処理を `buildTimedWorkBranchName()` に共通化
  - 基点ブランチが入力されている場合、作業ブランチ名を `<基点ブランチ
  >-tigaMMddxxx` 形式で生成
  - 基点ブランチが空の場合は従来どおり `tigaMMddxxx` 形式で生成
  - 作業ブランチ入力欄の placeholder を `devel-tiga0129a` の例に更新
  - 仕様書の作業ブランチ初期化仕様を新しい命名形式に更新
  - テストの期待値を `devel-tiga...` 形式に更新
  - `docs/index.html` の更新日を `2026-06-06` に更新